### PR TITLE
Add source info to each widget

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -319,6 +319,12 @@ pub fn demo() !void {
         try dvui.debugFontAtlases(@src(), .{});
     }
 
+    if (try dvui.expander(@src(), "(Debug) duplicate id", .{ .expand = .horizontal })) {
+        for (0..2) |_| {
+            try dvui.label(@src(), "i should be highlighted", .{}, .{});
+        }
+    }
+
     if (show_dialog) {
         try dialogDirect();
     }

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1298,12 +1298,17 @@ pub fn minSizeGet(id: u32) ?Size {
     }
 }
 
-pub fn minSizeSet(src: std.builtin.SourceLocation, id: u32, s: Size) !void {
+pub fn minSizeSet(maybe_src: ?std.builtin.SourceLocation, id: u32, s: Size) !void {
     debug("{x} minSizeSet {}", .{ id, s });
     var cw = currentWindow();
     if (try cw.min_sizes.fetchPut(id, .{ .size = s })) |ss| {
         if (ss.value.used) {
-            std.log.warn("({s}:{}:{}) id {x} already used this frame (highlighting), may need to pass .id_extra = <loop index> into Options", .{ src.file, src.line, src.column, id });
+            if (maybe_src) |src| {
+                std.debug.print("({s}:{}:{}) ", .{ src.file, src.line, src.column });
+            } else {
+                std.debug.print("(unknown) ", .{});
+            }
+            std.debug.print("id {x} already used this frame (highlighting), may need to pass .id_extra = <loop index> into Options\n", .{id});
             cw.debug_widget_id = id;
         }
     }
@@ -9562,7 +9567,7 @@ pub const WidgetData = struct {
     rect: Rect = Rect{},
     min_size: Size = Size{},
     options: Options = undefined,
-    src: std.builtin.SourceLocation,
+    src: ?std.builtin.SourceLocation,
 
     pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Options) WidgetData {
         var self = WidgetData{ .src = src };

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -9570,7 +9570,7 @@ pub const WidgetData = struct {
     src: ?std.builtin.SourceLocation,
 
     pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Options) WidgetData {
-        var self = WidgetData{ .src = src };
+        var self = WidgetData{ .src = if (builtin.mode != .Debug) src else null };
         self.init_options = init_options;
         self.options = opts;
 


### PR DESCRIPTION
Remember `.id_extra`? Now the error message includes source location as well!

todo

- [ ] discard source info in release mode

Also, instead of `std.debug.print`, this might be better.

```zig
const logger = std.log.scoped(.dvui);
logger.warn(...);
logger.info(...);
logger.debug(...);
```

We can also just have a function like `log(..., .{...})` that handles prefixing "dvui:" to messages and add color.