### PR TITLE
A fix for text entry widgets crashing after upgrading to zig-0.12

### DIFF
--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -322,7 +322,7 @@ pub fn textTyped(self: *TextEntryWidget, new: []const u8) void {
     }
 
     // insert
-    @memcpy(self.init_opts.text[sel.cursor..], new[0..new_len]);
+    std.mem.copyBackwards(u8, self.init_opts.text[sel.cursor..], new[0..new_len]);
     sel.cursor += new_len;
     sel.end = sel.cursor;
     sel.start = sel.cursor;
@@ -370,7 +370,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
                         var sel = self.textLayout.selectionGet(self.len);
                         if (!sel.empty()) {
                             // just delete selection
-                            @memcpy(self.init_opts.text[sel.start..], self.init_opts.text[sel.end..self.len]);
+                            std.mem.copyBackwards(u8, self.init_opts.text[sel.start..], self.init_opts.text[sel.end..self.len]);
                             self.len -= (sel.end - sel.start);
                             self.init_opts.text[self.len] = 0;
                             sel.end = sel.start;
@@ -385,7 +385,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
                             // does not have the pattern 10xxxxxx.
                             var i: usize = 1;
                             while (self.init_opts.text[sel.cursor - i] & 0xc0 == 0x80) : (i += 1) {}
-                            @memcpy(self.init_opts.text[sel.cursor - i ..], self.init_opts.text[sel.cursor..self.len]);
+                            std.mem.copyBackwards(u8, self.init_opts.text[sel.cursor - i ..], self.init_opts.text[sel.cursor..self.len]);
                             self.len -= i;
                             self.init_opts.text[self.len] = 0;
                             sel.cursor -= i;
@@ -401,7 +401,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
                         var sel = self.textLayout.selectionGet(self.len);
                         if (!sel.empty()) {
                             // just delete selection
-                            @memcpy(self.init_opts.text[sel.start..], self.init_opts.text[sel.end..self.len]);
+                            std.mem.copyBackwards(u8, self.init_opts.text[sel.start..], self.init_opts.text[sel.end..self.len]);
                             self.len -= (sel.end - sel.start);
                             self.init_opts.text[self.len] = 0;
                             sel.end = sel.start;
@@ -412,7 +412,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
                             //
                             // A utf8 char might consist of more than one byte.
                             const i = std.unicode.utf8ByteSequenceLength(self.init_opts.text[sel.cursor]) catch 1;
-                            @memcpy(self.init_opts.text[sel.cursor..], self.init_opts.text[sel.cursor + i .. self.len]);
+                            std.mem.copyBackwards(u8, self.init_opts.text[sel.cursor..], self.init_opts.text[sel.cursor + i .. self.len]);
                             self.len -= i;
                             self.init_opts.text[self.len] = 0;
                         }


### PR DESCRIPTION
Not sure if this is the way to do it, but this seems to fix the problems I am seeing. Any letter entered into a text entry was crashing with "@memcpy arguments have non-equal lengths". Then the enter key or hitting the end of a buffer was also causing the same crash, so I just changed these occurrences of @memcpy.