### PR TITLE
Build raylib from source using the zig build system

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,7 +13,7 @@
             .hash = "12203988c200e30d2fbc2678bb3e49eb3f117cc79faf8d228b63e54d8cdf278378e1",
             .lazy = true,
         },
-        // raylib is still experimental, and this is not being properly used yet
+        // raylib is still experimental
         .raylib = .{
             .url = "https://github.com/raysan5/raylib/archive/9e39788e077f1d35c5fe54600f2143423a80bb3d.tar.gz",
             .hash = "122051da01fbb000a51f6e03bba5b4177667d374c87720c9a353b1e270c60e118055",

--- a/src/backends/RaylibBackend.zig
+++ b/src/backends/RaylibBackend.zig
@@ -6,7 +6,7 @@ pub const c = @cImport({
     @cInclude("raylib.h");
     @cInclude("raymath.h");
     @cInclude("rlgl.h");
-    @cInclude("GLES3/gl3.h");
+    @cInclude("glad.h");
 });
 
 const RaylibBackend = @This();
@@ -158,15 +158,15 @@ pub fn drawClippedTriangles(self: *RaylibBackend, texture: ?*anyopaque, vtx: []c
     const EBO = c.rlLoadVertexBufferElement(idx.ptr, @intCast(idx.len * @sizeOf(u32)), false);
     c.rlEnableVertexBufferElement(EBO);
 
-    const pos = @as(?*anyopaque, @ptrFromInt(@offsetOf(dvui.Vertex, "pos")));
+    const pos = @offsetOf(dvui.Vertex, "pos");
     c.rlSetVertexAttribute(@intCast(shader.locs[c.RL_SHADER_LOC_VERTEX_POSITION]), 2, c.RL_FLOAT, false, @sizeOf(dvui.Vertex), pos);
     c.rlEnableVertexAttribute(@intCast(shader.locs[c.RL_SHADER_LOC_VERTEX_POSITION]));
 
-    const col = @as(?*anyopaque, @ptrFromInt(@offsetOf(dvui.Vertex, "col")));
+    const col = @offsetOf(dvui.Vertex, "col");
     c.rlSetVertexAttribute(@intCast(shader.locs[c.RL_SHADER_LOC_VERTEX_COLOR]), 4, c.RL_UNSIGNED_BYTE, false, @sizeOf(dvui.Vertex), col);
     c.rlEnableVertexAttribute(@intCast(shader.locs[c.RL_SHADER_LOC_VERTEX_COLOR]));
 
-    const uv = @as(?*anyopaque, @ptrFromInt(@offsetOf(dvui.Vertex, "uv")));
+    const uv = @offsetOf(dvui.Vertex, "uv");
     c.rlSetVertexAttribute(@intCast(shader.locs[c.RL_SHADER_LOC_VERTEX_TEXCOORD01]), 2, c.RL_FLOAT, false, @sizeOf(dvui.Vertex), uv);
     c.rlEnableVertexAttribute(@intCast(shader.locs[c.RL_SHADER_LOC_VERTEX_TEXCOORD01]));
 


### PR DESCRIPTION
Raylib now fetched using the zig build rather than relying on system installed libraries. Also removed linux-specific include paths in favor of raylib-bundled headers. 