### PR TITLE
Text entry number improvements

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -733,14 +733,29 @@ pub fn textEntryWidgets() !void {
         defer hbox_aligned.deinit();
         left_alignment.record(hbox.data().id, hbox_aligned.data());
 
-        const buf: []u8 = dvui.dataGetSliceDefault(null, hbox.wd.id, "buffer", []u8, &[_]u8{0} ** 20);
-
-        const num = try dvui.textEntryNumber(@src(), T, .{ .text = buf }, .{});
+        const num = try dvui.textEntryNumber(@src(), T, .{}, .{});
 
         if (num) |n| {
             try dvui.label(@src(), "{d}", .{n}, .{ .gravity_y = 0.5 });
-        } else if (std.mem.sliceTo(buf, 0).len == 0) {
-            try dvui.label(@src(), "empty", .{}, .{ .gravity_y = 0.5 });
+        } else {
+            try dvui.label(@src(), "invalid", .{}, .{ .gravity_y = 0.5 });
+        }
+    }
+    {
+        var hbox = try dvui.box(@src(), .horizontal, .{});
+        defer hbox.deinit();
+
+        try dvui.label(@src(), "Parse Normal", .{}, .{ .gravity_y = 0.5 });
+
+        // align text entry
+        var hbox_aligned = try dvui.box(@src(), .horizontal, .{ .margin = left_alignment.margin(hbox.data().id) });
+        defer hbox_aligned.deinit();
+        left_alignment.record(hbox.data().id, hbox_aligned.data());
+
+        const num = try dvui.textEntryNumber(@src(), f32, .{ .min = 0, .max = 1 }, .{});
+
+        if (num) |n| {
+            try dvui.label(@src(), "{d}", .{n}, .{ .gravity_y = 0.5 });
         } else {
             try dvui.label(@src(), "invalid", .{}, .{ .gravity_y = 0.5 });
         }

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -733,25 +733,8 @@ pub fn textEntryWidgets() !void {
         defer hbox_aligned.deinit();
         left_alignment.record(hbox.data().id, hbox_aligned.data());
 
-        const result = try dvui.textEntryNumber(@src(), f32, .{}, .{});
-
-        switch (result) {
-            .TooBig => {
-                try dvui.label(@src(), "Too Big", .{}, .{ .gravity_y = 0.5 });
-            },
-            .TooSmall => {
-                try dvui.label(@src(), "Too Small", .{}, .{ .gravity_y = 0.5 });
-            },
-            .Empty => {
-                try dvui.label(@src(), "Empty", .{}, .{ .gravity_y = 0.5 });
-            },
-            .ParseFailure => {
-                try dvui.label(@src(), "Invalid", .{}, .{ .gravity_y = 0.5 });
-            },
-            .Valid => |num| {
-                try dvui.label(@src(), "{d}", .{num}, .{ .gravity_y = 0.5 });
-            },
-        }
+        const result = try dvui.textEntryNumber(@src(), T, .{}, .{});
+        try displayTextEntryNumberResult(result);
     }
 
     try dvui.label(@src(), "Parse f32 with Min and Max", .{}, .{ .gravity_y = 0.5 });
@@ -767,28 +750,31 @@ pub fn textEntryWidgets() !void {
             left_alignment.record(hbox.data().id, hbox_aligned.data());
 
             const result = try dvui.textEntryNumber(@src(), f32, opt, .{});
-
-            switch (result) {
-                .TooBig => {
-                    try dvui.label(@src(), "Too Big", .{}, .{ .gravity_y = 0.5 });
-                },
-                .TooSmall => {
-                    try dvui.label(@src(), "Too Small", .{}, .{ .gravity_y = 0.5 });
-                },
-                .Empty => {
-                    try dvui.label(@src(), "Empty", .{}, .{ .gravity_y = 0.5 });
-                },
-                .ParseFailure => {
-                    try dvui.label(@src(), "Invalid", .{}, .{ .gravity_y = 0.5 });
-                },
-                .Valid => |num| {
-                    try dvui.label(@src(), "{d}", .{num}, .{ .gravity_y = 0.5 });
-                },
-            }
+            try displayTextEntryNumberResult(result);
         }
     }
 
     try dvui.label(@src(), "The text entries in this section are left-aligned", .{}, .{});
+}
+
+pub fn displayTextEntryNumberResult(result: anytype) !void {
+    switch (result) {
+        .TooBig => {
+            try dvui.label(@src(), "Too Big", .{}, .{ .gravity_y = 0.5 });
+        },
+        .TooSmall => {
+            try dvui.label(@src(), "Too Small", .{}, .{ .gravity_y = 0.5 });
+        },
+        .Empty => {
+            try dvui.label(@src(), "Empty", .{}, .{ .gravity_y = 0.5 });
+        },
+        .Invalid => {
+            try dvui.label(@src(), "Invalid", .{}, .{ .gravity_y = 0.5 });
+        },
+        .Valid => |num| {
+            try dvui.label(@src(), "{d}", .{num}, .{ .gravity_y = 0.5 });
+        },
+    }
 }
 
 pub fn styling() !void {

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -741,23 +741,26 @@ pub fn textEntryWidgets() !void {
             try dvui.label(@src(), "invalid", .{}, .{ .gravity_y = 0.5 });
         }
     }
-    {
-        var hbox = try dvui.box(@src(), .horizontal, .{});
-        defer hbox.deinit();
 
-        try dvui.label(@src(), "Parse Normal", .{}, .{ .gravity_y = 0.5 });
+    try dvui.label(@src(), "Parse f32 With Min and Max", .{}, .{ .gravity_y = 0.5 });
+    const init_options: [3]dvui.TextEntryNumberInitOptions(f32) = .{ .{ .min = 0 }, .{ .max = 1 }, .{ .min = 0, .max = 1 } };
+    inline for (init_options, 0..) |opt, i| {
+        {
+            var hbox = try dvui.box(@src(), .horizontal, .{ .id_extra = i });
+            defer hbox.deinit();
 
-        // align text entry
-        var hbox_aligned = try dvui.box(@src(), .horizontal, .{ .margin = left_alignment.margin(hbox.data().id) });
-        defer hbox_aligned.deinit();
-        left_alignment.record(hbox.data().id, hbox_aligned.data());
+            // align text entry
+            var hbox_aligned = try dvui.box(@src(), .horizontal, .{ .margin = left_alignment.margin(hbox.data().id) });
+            defer hbox_aligned.deinit();
+            left_alignment.record(hbox.data().id, hbox_aligned.data());
 
-        const num = try dvui.textEntryNumber(@src(), f32, .{ .min = 0, .max = 1 }, .{});
+            const num = try dvui.textEntryNumber(@src(), f32, opt, .{});
 
-        if (num) |n| {
-            try dvui.label(@src(), "{d}", .{n}, .{ .gravity_y = 0.5 });
-        } else {
-            try dvui.label(@src(), "invalid", .{}, .{ .gravity_y = 0.5 });
+            if (num) |n| {
+                try dvui.label(@src(), "{d}", .{n}, .{ .gravity_y = 0.5 });
+            } else {
+                try dvui.label(@src(), "invalid", .{}, .{ .gravity_y = 0.5 });
+            }
         }
     }
 

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -742,7 +742,7 @@ pub fn textEntryWidgets() !void {
         }
     }
 
-    try dvui.label(@src(), "Parse f32 With Min and Max", .{}, .{ .gravity_y = 0.5 });
+    try dvui.label(@src(), "Parse f32 with Min and Max", .{}, .{ .gravity_y = 0.5 });
     const init_options: [3]dvui.TextEntryNumberInitOptions(f32) = .{ .{ .min = 0 }, .{ .max = 1 }, .{ .min = 0, .max = 1 } };
     inline for (init_options, 0..) |opt, i| {
         {

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -733,12 +733,24 @@ pub fn textEntryWidgets() !void {
         defer hbox_aligned.deinit();
         left_alignment.record(hbox.data().id, hbox_aligned.data());
 
-        const num = try dvui.textEntryNumber(@src(), T, .{}, .{});
+        const result = try dvui.textEntryNumber(@src(), f32, .{}, .{});
 
-        if (num) |n| {
-            try dvui.label(@src(), "{d}", .{n}, .{ .gravity_y = 0.5 });
-        } else {
-            try dvui.label(@src(), "invalid", .{}, .{ .gravity_y = 0.5 });
+        switch (result) {
+            .TooBig => {
+                try dvui.label(@src(), "Too Big", .{}, .{ .gravity_y = 0.5 });
+            },
+            .TooSmall => {
+                try dvui.label(@src(), "Too Small", .{}, .{ .gravity_y = 0.5 });
+            },
+            .Empty => {
+                try dvui.label(@src(), "Empty", .{}, .{ .gravity_y = 0.5 });
+            },
+            .ParseFailure => {
+                try dvui.label(@src(), "Invalid", .{}, .{ .gravity_y = 0.5 });
+            },
+            .Valid => |num| {
+                try dvui.label(@src(), "{d}", .{num}, .{ .gravity_y = 0.5 });
+            },
         }
     }
 
@@ -754,12 +766,24 @@ pub fn textEntryWidgets() !void {
             defer hbox_aligned.deinit();
             left_alignment.record(hbox.data().id, hbox_aligned.data());
 
-            const num = try dvui.textEntryNumber(@src(), f32, opt, .{});
+            const result = try dvui.textEntryNumber(@src(), f32, opt, .{});
 
-            if (num) |n| {
-                try dvui.label(@src(), "{d}", .{n}, .{ .gravity_y = 0.5 });
-            } else {
-                try dvui.label(@src(), "invalid", .{}, .{ .gravity_y = 0.5 });
+            switch (result) {
+                .TooBig => {
+                    try dvui.label(@src(), "Too Big", .{}, .{ .gravity_y = 0.5 });
+                },
+                .TooSmall => {
+                    try dvui.label(@src(), "Too Small", .{}, .{ .gravity_y = 0.5 });
+                },
+                .Empty => {
+                    try dvui.label(@src(), "Empty", .{}, .{ .gravity_y = 0.5 });
+                },
+                .ParseFailure => {
+                    try dvui.label(@src(), "Invalid", .{}, .{ .gravity_y = 0.5 });
+                },
+                .Valid => |num| {
+                    try dvui.label(@src(), "{d}", .{num}, .{ .gravity_y = 0.5 });
+                },
             }
         }
     }

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5271,7 +5271,7 @@ pub fn TextEntryNumberInitOptions(comptime T: type) type {
     return struct {
         min: ?T = null,
         max: ?T = null,
-        initialize: ?T = null,
+        value: ?*T = null,
     };
 }
 
@@ -5302,8 +5302,8 @@ pub fn textEntryNumber(src: std.builtin.SourceLocation, comptime T: type, init_o
     const buffer = dataGetSliceDefault(currentWindow(), hbox.widget().data().id, "buffer", []u8, &[_]u8{0} ** 32);
 
     //initialize with input number
-    if (init_opts.initialize) |num| {
-        _ = try std.fmt.bufPrint(buffer, "{d}", .{num});
+    if (init_opts.value) |num| {
+        _ = try std.fmt.bufPrint(buffer, "{d}", .{num.*});
     }
 
     const cw = currentWindow();
@@ -5336,6 +5336,9 @@ pub fn textEntryNumber(src: std.builtin.SourceLocation, comptime T: type, init_o
         result = .TooBig;
     } else {
         result = .{ .Valid = num.? };
+        if (init_opts.value) |value_ptr| {
+            value_ptr.* = num.?;
+        }
     }
 
     try te.draw();

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5278,7 +5278,7 @@ pub fn TextEntryNumberInitOptions(comptime T: type) type {
 pub fn TextEntryNumberResult(comptime T: type) type {
     return union(enum) {
         Valid: T,
-        ParseFailure: void,
+        Invalid: void,
         TooBig: void,
         TooSmall: void,
         Empty: void,
@@ -5303,7 +5303,7 @@ pub fn textEntryNumber(src: std.builtin.SourceLocation, comptime T: type, init_o
 
     //initialize with input number
     if (init_opts.initialize) |num| {
-        _ = try std.fmt.bufPrint(buffer, "{}", .{num});
+        _ = try std.fmt.bufPrint(buffer, "{d}", .{num});
     }
 
     const cw = currentWindow();
@@ -5315,7 +5315,7 @@ pub fn textEntryNumber(src: std.builtin.SourceLocation, comptime T: type, init_o
     // filter before drawing
     te.filterIn(filter);
 
-    var result: TextEntryNumberResult(T) = .Empty;
+    var result: TextEntryNumberResult(T) = .Invalid;
 
     // validation
     const text = te.getText();
@@ -5329,15 +5329,13 @@ pub fn textEntryNumber(src: std.builtin.SourceLocation, comptime T: type, init_o
     if (text.len == 0 and num == null) {
         result = .Empty;
     } else if (num == null) {
-        result = .ParseFailure;
-    } else if (num != null) {
-        if (init_opts.min != null and num.? < init_opts.min.?) {
-            result = .TooSmall;
-        } else if (init_opts.max != null and num.? > init_opts.max.?) {
-            result = .TooBig;
-        }
+        result = .Invalid;
+    } else if (num != null and init_opts.min != null and num.? < init_opts.min.?) {
+        result = .TooSmall;
+    } else if (num != null and init_opts.max != null and num.? > init_opts.max.?) {
+        result = .TooBig;
     } else {
-        result.Valid = num.?;
+        result = .{ .Valid = num.? };
     }
 
     try te.draw();


### PR DESCRIPTION
When working on my struct-ui branch it seemed evident that being able to set a minimum and maximum value for a `textEntryNumber` would be useful

Example use cases,
- A f32 normalized value constrained between 0 and 1
- A f32 percent constrained between 0 and 100
- A f32 "seconds" value constrained between 0 and 60
- An integer "hours" value needing to be constrained between 0 and 12
- An integer "degrees" value needing to be constrained between 0 and 360
- etc...

**Screenshots:**

(Empty)
<img width="271" alt="Screenshot 2024-08-18 at 3 46 18 PM" src="https://github.com/user-attachments/assets/84731b95-9308-4dd2-8232-bd2fb82691ff">

(With both valid and invalid numbers entered)
<img width="274" alt="Screenshot 2024-08-18 at 3 46 35 PM" src="https://github.com/user-attachments/assets/5870acde-7191-44c6-b2e2-6bf659da2dac">

I also changed the widget to create its own buffer rather than requiring the user to provide one, as this simplifies usage. 