### PR TITLE
autodoc

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -92,6 +92,22 @@ pub fn build(b: *std.Build) !void {
 
         b.getInstallStep().dependOn(compile_step);
     }
+
+    const docs = b.addObject(.{
+        .name = "dvui",
+        .root_source_file = b.path("src/dvui.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const install_docs = b.addInstallDirectory(.{
+        .source_dir = docs.getEmittedDocs(),
+        .install_dir = .prefix,
+        .install_subdir = "docs",
+    });
+
+    const docs_step = b.step("docs", "Build and install the documentation");
+    docs_step.dependOn(&install_docs.step);
 }
 
 const Backend = enum {


### PR DESCRIPTION
Added autodocs generation

To test autodocs locally, you need to run a http server on localhost and connect in your browser. The easiest way I've discovered to do this is to run `python -m http.server` in `zig-out/docs`. Then you can connect to `http://localhost:8000` in your browser


![2024-10-09-092235_hyprshot](https://github.com/user-attachments/assets/4b0c7e30-9adf-41cb-9d11-77b99479ba10)
