### PR TITLE
make DPI work nice on Windows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -220,6 +220,7 @@ fn addExample(
         .root_source_file = b.path("examples/" ++ name ++ ".zig"),
         .target = target,
         .optimize = optimize,
+        .win32_manifest = b.path("./src/main.manifest"),
     });
     exe.root_module.addImport("dvui", dvui_mod);
 

--- a/src/main.manifest
+++ b/src/main.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>


### PR DESCRIPTION
I have a PR pending that fixes the DPI issues on Windows.

First real hint was here
https://martincaine.com/blog/dpi_scaling_in_windows_with_sdl2
which led me to the beloved @squeek502 (you're awesome, dude)
https://github.com/ziglang/zig/pull/17448#issuecomment-1754608112

TL:DR; Windows will ignore your request to be DPI aware unless you play its special manifest game.