### PR TITLE
calculator: reset digits_after_dot for second number

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -269,10 +269,10 @@ pub fn calculator() !void {
                     digits_after_dot = 0;
                 }
 
-                if (letter == '/') active_op = '/';
-                if (letter == 'x') active_op = 'x';
-                if (letter == '-') active_op = '-';
-                if (letter == '+') active_op = '+';
+                if (letter == '/') { active_op = '/'; digits_after_dot = 0; }
+                if (letter == 'x') { active_op = 'x'; digits_after_dot = 0; }
+                if (letter == '-') { active_op = '-'; digits_after_dot = 0; }
+                if (letter == '+') { active_op = '+'; digits_after_dot = 0; }
                 if (letter == '.') digits_after_dot = 1;
 
                 if (letter == 'N') calculation = -calculation;


### PR DESCRIPTION
oops, probably should've tested this a bit more thoroughly

Before: Click `9` then `.`, then `9`, click `+`, then `5`

Expected result: `14.9`
Actual result: `9.95`