### PR TITLE
Update to zig version 0.14.0-dev.2802+257054a14

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -105,7 +105,7 @@ pub fn build(b: *std.Build) !void {
         const cb = b.addExecutable(.{
             .name = "cacheBuster",
             .root_source_file = b.path("src/cacheBuster.zig"),
-            .target = b.host,
+            .target = b.graph.host,
         });
         const cb_run = b.addRunArtifact(cb);
         cb_run.addFileArg(b.path("src/backends/index.html"));

--- a/build.zig
+++ b/build.zig
@@ -44,7 +44,12 @@ pub fn build(b: *std.Build) !void {
 
     // web test
     {
-        const webtarget = std.Target.Query{
+        const webtarget_library = std.Target.Query{
+            .cpu_arch = .wasm32,
+            .os_tag = .wasi,
+            .abi = .musl,
+        };
+        const webtarget_exe = std.Target.Query{
             .cpu_arch = .wasm32,
             .os_tag = .freestanding,
             .abi = .musl,
@@ -52,7 +57,7 @@ pub fn build(b: *std.Build) !void {
 
         const dvui_mod_web = b.addModule("dvui_web", .{
             .root_source_file = b.path("src/dvui.zig"),
-            .target = b.resolveTargetQuery(webtarget),
+            .target = b.resolveTargetQuery(webtarget_library),
             .optimize = optimize,
         });
 
@@ -69,7 +74,7 @@ pub fn build(b: *std.Build) !void {
         const wasm = b.addExecutable(.{
             .name = "web-test",
             .root_source_file = b.path("examples/web-test.zig"),
-            .target = b.resolveTargetQuery(webtarget),
+            .target = b.resolveTargetQuery(webtarget_exe),
             .optimize = optimize,
             .link_libc = true,
             .strip = if (optimize == .ReleaseFast or optimize == .ReleaseSmall) true else false,

--- a/build.zig
+++ b/build.zig
@@ -51,7 +51,7 @@ pub fn build(b: *std.Build) !void {
         };
         const webtarget_exe = std.Target.Query{
             .cpu_arch = .wasm32,
-            .os_tag = .freestanding, //change to .wasi once, build fails, change back to .freestanding, build succeeds
+            .os_tag = .freestanding, //the initial build of this fails for me. => change to .wasi once, build fails, change back to .freestanding, build succeeds
             .abi = .musl,
         };
 

--- a/build.zig
+++ b/build.zig
@@ -51,7 +51,7 @@ pub fn build(b: *std.Build) !void {
         };
         const webtarget_exe = std.Target.Query{
             .cpu_arch = .wasm32,
-            .os_tag = .freestanding,
+            .os_tag = .freestanding, //change to .wasi once, build fails, change back to .freestanding, build succeeds
             .abi = .musl,
         };
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,23 +4,22 @@
     .paths = .{""},
     .dependencies = .{
         .sdl = .{
-            .url = "https://github.com/allyourcodebase/SDL/archive/a9107e9ab042a2d6c76c73c0a485352ccb216ffc.tar.gz",
-            .hash = "1220fb0249c15493882350f135bc8b56c389a7f5131cc1b1a5208db472fa00e26b52",
+            .url = "git+https://github.com/allyourcodebase/SDL#a13d7e80e8d847db2b2ff8f334d57eb5bbb489dd",
+            .hash = "12200aa79b05aaeefff144b9e376371e2e7ddc982b9207d146163baf56361331a834",
             .lazy = true,
         },
         .sdl3 = .{
-            .lazy = true,
-            .url = "https://github.com/swan-www/zig_sdl3/archive/refs/tags/3.1.6.tar.gz",
-            .hash = "12203db5d6acf22b69b929ee32194e6352ca9406f0192e7d72dbc2907a1df4e32d8c",
+            .url = "git+https://github.com/rohlem/zig_sdl3-update-zig#8737ef1810285b95b3aa04f534dd85b6e016afbc",
+            .hash = "12207ab67f1a9f7994f5ffcba0b8294360d95ab583026934e750848179fc48dab735",
         },
         .freetype = .{
-            .url = "https://github.com/david-vanderson/freetype/archive/a62b6192d81952e64b8c16504427f3e28ef10e5f.tar.gz",
-            .hash = "12203988c200e30d2fbc2678bb3e49eb3f117cc79faf8d228b63e54d8cdf278378e1",
+            .url = "git+https://github.com/rohlem/freetype-update-zig#a50182dc5787a8d49dd1ad922699a1c8771aa34a",
+            .hash = "12203811b00197ba9f939a8114941bdb18d421c3fa498ec4045bc9ce0c91a5a20b9f",
             .lazy = true,
         },
         .raylib = .{
-            .url = "https://github.com/raysan5/raylib/archive/63ae57d2e31afa8bc8cab7f17f0e44afa4e7552d.tar.gz",
-            .hash = "122078aed9bcba3e2319105d04324bf923a52c65405c3662457cf73e7ef28f445e52",
+            .url = "git+https://github.com/raysan5/raylib#433cc23ea4511fbeddc0fccc597cde91f5756d59",
+            .hash = "1220d18e6fba0a609f3afb055c2876d93e19b3f54f3e2e730c3fd261efd78ccd6002",
             .lazy = true,
         },
         //used in the raylib-ontop example
@@ -31,8 +30,8 @@
         },
         // required for the directx11 backend
         .zigwin32 = .{
-            .url = "git+https://github.com/marlersoft/zigwin32#407a4c7b869ee3d10db520fdfae8b9faf9b2adb5",
-            .hash = "1220cc9c9028e20f4ec2ece1155ae3479acc1cc509f9ab93acb74e8f5bbf8eefd2a9",
+            .url = "git+https://github.com/rohlem/zigwin32-update-zig#406caae350880d15da93d7087f7560897f1a532d",
+            .hash = "1220327265a70f5a41aac138b1571985a7b135c0a3014043be6976a758dfd726fc5d",
             .lazy = true,
         },
     },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,6 +11,7 @@
         .sdl3 = .{
             .url = "git+https://github.com/rohlem/zig_sdl3-update-zig#8737ef1810285b95b3aa04f534dd85b6e016afbc",
             .hash = "12207ab67f1a9f7994f5ffcba0b8294360d95ab583026934e750848179fc48dab735",
+            .lazy = true,
         },
         .freetype = .{
             .url = "git+https://github.com/rohlem/freetype-update-zig#a50182dc5787a8d49dd1ad922699a1c8771aa34a",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .paths = .{""},
     .dependencies = .{
         .sdl = .{
-            .url = "git+https://github.com/allyourcodebase/SDL#a13d7e80e8d847db2b2ff8f334d57eb5bbb489dd",
-            .hash = "12200aa79b05aaeefff144b9e376371e2e7ddc982b9207d146163baf56361331a834",
+            .url = "git+https://github.com/rohlem/SDL#4abe06a7497eea7e5aeb3705951c2fced0491cb4",
+            .hash = "1220647b4508a0226ad9825586e683d68aef6d227fdab84b3c3b029366eec9ef18dd",
             .lazy = true,
         },
         .sdl3 = .{
@@ -31,8 +31,8 @@
         },
         // required for the directx11 backend
         .zigwin32 = .{
-            .url = "git+https://github.com/rohlem/zigwin32-update-zig#406caae350880d15da93d7087f7560897f1a532d",
-            .hash = "1220327265a70f5a41aac138b1571985a7b135c0a3014043be6976a758dfd726fc5d",
+            .url = "git+https://github.com/rohlem/zigwin32-update-zig#5d6055e7c8cea4c508f33c0d8641fdf1fe30f9ea",
+            .hash = "122073b611033d3660fca78fb588d2fd97bbdad96be8c688c5a00f8b85c4a5e3d871",
             .lazy = true,
         },
     },

--- a/examples/dx11-ontop.zig
+++ b/examples/dx11-ontop.zig
@@ -203,9 +203,9 @@ fn createDeviceD3D(hWnd: HWND) ?Backend.Directx11Options {
     var featureLevel: d3d.D3D_FEATURE_LEVEL = undefined;
     const featureLevelArray = &[_]d3d.D3D_FEATURE_LEVEL{ d3d.D3D_FEATURE_LEVEL_11_0, d3d.D3D_FEATURE_LEVEL_10_0 };
 
-    var device: ?*dx.ID3D11Device = null;
-    var device_context: ?*dx.ID3D11DeviceContext = null;
-    var swap_chain: ?*dxgi.IDXGISwapChain = null;
+    var device: *dx.ID3D11Device = undefined;
+    var device_context: *dx.ID3D11DeviceContext = undefined;
+    var swap_chain: *dxgi.IDXGISwapChain = undefined;
 
     var res: zwin.foundation.HRESULT = dx.D3D11CreateDeviceAndSwapChain(
         null,
@@ -242,9 +242,9 @@ fn createDeviceD3D(hWnd: HWND) ?Backend.Directx11Options {
         return null;
 
     return Backend.Directx11Options{
-        .device = device.?,
-        .device_context = device_context.?,
-        .swap_chain = swap_chain.?,
+        .device = device,
+        .device_context = device_context,
+        .swap_chain = swap_chain,
     };
 }
 

--- a/examples/web-test.zig
+++ b/examples/web-test.zig
@@ -13,7 +13,7 @@ fn writeLog(_: void, msg: []const u8) WriteError!usize {
 
 pub fn logFn(
     comptime message_level: std.log.Level,
-    comptime scope: @Type(.EnumLiteral),
+    comptime scope: @Type(.enum_literal),
     comptime format: []const u8,
     args: anytype,
 ) void {

--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -125,7 +125,7 @@ pub fn init(
 
     comptime var vtable: VTable = undefined;
 
-    inline for (@typeInfo(I).Struct.decls) |decl| {
+    inline for (@typeInfo(I).@"struct".decls) |decl| {
         const hasField = @hasDecl(implementation, decl.name);
         const DeclType = @field(I, decl.name);
         compile_assert(hasField, "Backend type " ++ @typeName(implementation) ++ " has no declaration '" ++ decl.name ++ ": " ++ @typeName(DeclType) ++ "'");

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -421,7 +421,7 @@ pub fn demo() !void {
         var fbox = try dvui.flexbox(@src(), .{}, .{ .expand = .both, .background = true });
         defer fbox.deinit();
 
-        inline for (0..@typeInfo(demoKind).Enum.fields.len) |i| {
+        inline for (0..@typeInfo(demoKind).@"enum".fields.len) |i| {
             const e = @as(demoKind, @enumFromInt(i));
             var bw = dvui.ButtonWidget.init(@src(), .{}, .{ .id_extra = i, .border = Rect.all(1), .background = true, .min_size_content = dvui.Size.all(120), .max_size_content = dvui.Size.all(120), .margin = Rect.all(5), .color_fill = .{ .name = .fill } });
             try bw.install();
@@ -658,7 +658,7 @@ pub fn themeEditor() !void {
     var b2 = try dvui.box(@src(), .vertical, .{ .expand = .horizontal, .margin = .{ .x = 10 } });
     defer b2.deinit();
 
-    const color_field_options = .{ .fields = .{
+    const color_field_options = dvui.StructFieldOptions(dvui.Color){ .fields = .{
         .r = .{ .min = 0, .max = 255, .widget_type = .slider },
         .g = .{ .min = 0, .max = 255, .widget_type = .slider },
         .b = .{ .min = 0, .max = 255, .widget_type = .slider },
@@ -1201,7 +1201,7 @@ pub fn textEntryWidgets(demo_win_id: u32) !void {
         inline for (parse_types, 0..) |T, i| {
             if (i == S.type_dropdown_val) {
                 var value: T = undefined;
-                if (@typeInfo(T) == .Int) {
+                if (@typeInfo(T) == .int) {
                     S.value = std.math.clamp(S.value, std.math.minInt(T), std.math.maxInt(T));
                     value = @intFromFloat(S.value);
                     S.value = @floatFromInt(value);
@@ -1212,7 +1212,7 @@ pub fn textEntryWidgets(demo_win_id: u32) !void {
                 try displayTextEntryNumberResult(result);
 
                 if (result.changed) {
-                    if (@typeInfo(T) == .Int) {
+                    if (@typeInfo(T) == .int) {
                         S.value = @floatFromInt(value);
                     } else {
                         S.value = @floatCast(value);

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -774,7 +774,7 @@ pub fn basicWidgets(demo_win_id: u32) !void {
         te.deinit();
     }
 
-    inline for (@typeInfo(RadioChoice).Enum.fields, 0..) |field, i| {
+    inline for (@typeInfo(RadioChoice).@"enum".fields, 0..) |field, i| {
         if (try dvui.radio(@src(), radio_choice == @as(RadioChoice, @enumFromInt(field.value)), "Radio " ++ field.name, .{ .id_extra = i })) {
             radio_choice = @enumFromInt(field.value);
         }
@@ -3044,17 +3044,17 @@ pub fn dialogDirect() !void {
     }
 }
 
-const icon_names: [@typeInfo(entypo).Struct.decls.len][]const u8 = blk: {
-    var blah: [@typeInfo(entypo).Struct.decls.len][]const u8 = undefined;
-    for (@typeInfo(entypo).Struct.decls, 0..) |d, i| {
+const icon_names: [@typeInfo(entypo).@"struct".decls.len][]const u8 = blk: {
+    var blah: [@typeInfo(entypo).@"struct".decls.len][]const u8 = undefined;
+    for (@typeInfo(entypo).@"struct".decls, 0..) |d, i| {
         blah[i] = d.name;
     }
     break :blk blah;
 };
 
-const icon_fields: [@typeInfo(entypo).Struct.decls.len][]const u8 = blk: {
-    var blah: [@typeInfo(entypo).Struct.decls.len][]const u8 = undefined;
-    for (@typeInfo(entypo).Struct.decls, 0..) |d, i| {
+const icon_fields: [@typeInfo(entypo).@"struct".decls.len][]const u8 = blk: {
+    var blah: [@typeInfo(entypo).@"struct".decls.len][]const u8 = undefined;
+    for (@typeInfo(entypo).@"struct".decls, 0..) |d, i| {
         blah[i] = @field(entypo, d.name);
     }
     break :blk blah;
@@ -3065,7 +3065,7 @@ pub fn icon_browser() !void {
     defer fwin.deinit();
     try dvui.windowHeader("Icon Browser", "", &IconBrowser.show);
 
-    const num_icons = @typeInfo(entypo).Struct.decls.len;
+    const num_icons = @typeInfo(entypo).@"struct".decls.len;
     const height = @as(f32, @floatFromInt(num_icons)) * IconBrowser.row_height;
 
     // we won't have the height the first frame, so always set it

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -131,7 +131,7 @@ pub const TTFBytes = struct {
 
 pub fn initTTFBytesDatabase(allocator: std.mem.Allocator) !std.StringHashMap(dvui.FontBytesEntry) {
     var result = std.StringHashMap(dvui.FontBytesEntry).init(allocator);
-    inline for (@typeInfo(TTFBytes).Struct.decls) |decl| {
+    inline for (@typeInfo(TTFBytes).@"struct".decls) |decl| {
         try result.put(decl.name, dvui.FontBytesEntry{ .ttf_bytes = @field(TTFBytes, decl.name), .allocator = null });
     }
 

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -331,7 +331,7 @@ pub fn wrapInner(self: *const Options) Options {
 pub fn override(self: *const Options, over: Options) Options {
     var ret = self.*;
 
-    inline for (@typeInfo(Options).Struct.fields) |f| {
+    inline for (@typeInfo(Options).@"struct".fields) |f| {
         if (@field(over, f.name)) |fval| {
             @field(ret, f.name) = fval;
         }

--- a/src/Widget.zig
+++ b/src/Widget.zig
@@ -31,8 +31,8 @@ pub fn init(
 ) Widget {
     const Ptr = @TypeOf(pointer);
     const ptr_info = @typeInfo(Ptr);
-    std.debug.assert(ptr_info == .Pointer); // Must be a pointer
-    std.debug.assert(ptr_info.Pointer.size == .One); // Must be a single-item pointer
+    std.debug.assert(ptr_info == .pointer); // Must be a pointer
+    std.debug.assert(ptr_info.pointer.size == .One); // Must be a single-item pointer
 
     const gen = struct {
         fn dataImpl(ptr: *anyopaque) *WidgetData {

--- a/src/Widget.zig
+++ b/src/Widget.zig
@@ -32,7 +32,7 @@ pub fn init(
     const Ptr = @TypeOf(pointer);
     const ptr_info = @typeInfo(Ptr);
     std.debug.assert(ptr_info == .pointer); // Must be a pointer
-    std.debug.assert(ptr_info.pointer.size == .One); // Must be a single-item pointer
+    std.debug.assert(ptr_info.pointer.size == .one); // Must be a single-item pointer
 
     const gen = struct {
         fn dataImpl(ptr: *anyopaque) *WidgetData {

--- a/src/backends/sdl_backend.zig
+++ b/src/backends/sdl_backend.zig
@@ -27,8 +27,8 @@ touch_mouse_events: bool = false,
 log_events: bool = false,
 initial_scale: f32 = 1.0,
 cursor_last: dvui.enums.Cursor = .arrow,
-cursor_backing: [@typeInfo(dvui.enums.Cursor).Enum.fields.len]?*c.SDL_Cursor = [_]?*c.SDL_Cursor{null} ** @typeInfo(dvui.enums.Cursor).Enum.fields.len,
-cursor_backing_tried: [@typeInfo(dvui.enums.Cursor).Enum.fields.len]bool = [_]bool{false} ** @typeInfo(dvui.enums.Cursor).Enum.fields.len,
+cursor_backing: [@typeInfo(dvui.enums.Cursor).@"enum".fields.len]?*c.SDL_Cursor = [_]?*c.SDL_Cursor{null} ** @typeInfo(dvui.enums.Cursor).@"enum".fields.len,
+cursor_backing_tried: [@typeInfo(dvui.enums.Cursor).@"enum".fields.len]bool = [_]bool{false} ** @typeInfo(dvui.enums.Cursor).@"enum".fields.len,
 arena: std.mem.Allocator = undefined,
 
 pub const InitOptions = struct {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -54,6 +54,7 @@ pub const structEntry = se.structEntry;
 pub const structEntryEx = se.structEntryEx;
 pub const structEntryAlloc = se.structEntryAlloc;
 pub const structEntryExAlloc = se.structEntryExAlloc;
+pub const StructFieldOptions = se.StructFieldOptions;
 
 pub const enums = @import("enums.zig");
 
@@ -565,7 +566,7 @@ pub fn fontCacheGet(font: Font) !*FontCacheEntry {
     var entry: FontCacheEntry = undefined;
 
     // make debug texture atlas so we can see if something later goes wrong
-    const size = .{ .w = 10, .h = 10 };
+    const size = Size{ .w = 10, .h = 10 };
     const pixels = try cw.arena().alloc(u8, @as(usize, @intFromFloat(size.w * size.h)) * 4);
     @memset(pixels, 255);
 
@@ -970,7 +971,7 @@ pub fn pathFillConvex(color: Color) !void {
     var idx = try std.ArrayList(u16).initCapacity(cw.arena(), idx_count);
     defer idx.deinit();
     const col = color.alphaMultiply();
-    const col_trans = .{ .r = 0, .g = 0, .b = 0, .a = 0 };
+    const col_trans = Color{ .r = 0, .g = 0, .b = 0, .a = 0 };
 
     var bounds = Rect{}; // w and h are maxx and maxy for now
     bounds.x = std.math.floatMax(f32);
@@ -1132,7 +1133,7 @@ pub fn pathStrokeRaw(closed_in: bool, thickness: f32, endcap_style: EndCapStyle,
     var idx = try std.ArrayList(u16).initCapacity(cw.arena(), idx_count);
     defer idx.deinit();
     const col = color.alphaMultiply();
-    const col_trans = .{ .r = 0, .g = 0, .b = 0, .a = 0 };
+    const col_trans = Color{ .r = 0, .g = 0, .b = 0, .a = 0 };
 
     var bounds = Rect{}; // w and h are maxx and maxy for now
     bounds.x = std.math.floatMax(f32);
@@ -2677,7 +2678,7 @@ pub const Window = struct {
         try self.themes.putNoClobber("Adwaita Light", @import("themes/Adwaita.zig").light);
         try self.themes.putNoClobber("Adwaita Dark", @import("themes/Adwaita.zig").dark);
 
-        inline for (@typeInfo(Theme.QuickTheme.builtin).Struct.decls) |decl| {
+        inline for (@typeInfo(Theme.QuickTheme.builtin).@"struct".decls) |decl| {
             const quick_theme = Theme.QuickTheme.fromString(self.arena(), @field(Theme.QuickTheme.builtin, decl.name)) catch {
                 @panic("Failure loading builtin theme. This is a problem with DVUI.");
             };
@@ -3954,7 +3955,7 @@ pub const Window = struct {
         var scroll = try dvui.scrollArea(@src(), .{}, .{ .expand = .both, .background = false });
         defer scroll.deinit();
 
-        var iter = std.mem.split(u8, self.debug_under_mouse_info, "\n");
+        var iter = std.mem.splitScalar(u8, self.debug_under_mouse_info, '\n');
         var i: usize = 0;
         while (iter.next()) |line| : (i += 1) {
             if (line.len > 0) {
@@ -6130,7 +6131,7 @@ pub fn sliderVector(line: std.builtin.SourceLocation, comptime fmt: []const u8, 
 
     var any_changed = false;
     inline for (0..num_components) |i| {
-        const component_opts = .{
+        const component_opts = dvui.SliderEntryInitOptions{
             .value = &data_arr[i],
             .min = init_opts.min,
             .max = init_opts.max,

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1912,18 +1912,18 @@ pub fn dataSetSlice(win: ?*Window, id: u32, key: []const u8, data: anytype) void
 /// entries that you want to fill in after.
 pub fn dataSetSliceCopies(win: ?*Window, id: u32, key: []const u8, data: anytype, num_copies: usize) void {
     const dt = @typeInfo(@TypeOf(data));
-    if (dt == .Pointer and dt.Pointer.size == .Slice) {
-        if (dt.Pointer.sentinel) |s| {
-            dataSetAdvanced(win, id, key, @as([:@as(*const dt.Pointer.child, @alignCast(@ptrCast(s))).*]dt.Pointer.child, @constCast(data)), true, num_copies);
+    if (dt == .pointer and dt.pointer.size == .Slice) {
+        if (dt.pointer.sentinel) |s| {
+            dataSetAdvanced(win, id, key, @as([:@as(*const dt.pointer.child, @alignCast(@ptrCast(s))).*]dt.pointer.child, @constCast(data)), true, num_copies);
         } else {
-            dataSetAdvanced(win, id, key, @as([]dt.Pointer.child, @constCast(data)), true, num_copies);
+            dataSetAdvanced(win, id, key, @as([]dt.pointer.child, @constCast(data)), true, num_copies);
         }
-    } else if (dt == .Pointer and dt.Pointer.size == .One and @typeInfo(dt.Pointer.child) == .Array) {
-        const child_type = @typeInfo(dt.Pointer.child);
-        if (child_type.Array.sentinel) |s| {
-            dataSetAdvanced(win, id, key, @as([:@as(*const child_type.Array.child, @alignCast(@ptrCast(s))).*]child_type.Array.child, @constCast(data)), true, num_copies);
+    } else if (dt == .pointer and dt.pointer.size == .One and @typeInfo(dt.pointer.child) == .array) {
+        const child_type = @typeInfo(dt.pointer.child);
+        if (child_type.array.sentinel) |s| {
+            dataSetAdvanced(win, id, key, @as([:@as(*const child_type.array.child, @alignCast(@ptrCast(s))).*]child_type.array.child, @constCast(data)), true, num_copies);
         } else {
-            dataSetAdvanced(win, id, key, @as([]child_type.Array.child, @constCast(data)), true, num_copies);
+            dataSetAdvanced(win, id, key, @as([]child_type.array.child, @constCast(data)), true, num_copies);
         }
     } else {
         @compileError("dataSetSlice needs a slice or pointer to array, given " ++ @typeName(@TypeOf(data)));
@@ -2048,15 +2048,15 @@ pub fn dataGetPtr(win: ?*Window, id: u32, key: []const u8, comptime T: type) ?*T
 /// id/key combination.
 pub fn dataGetSlice(win: ?*Window, id: u32, key: []const u8, comptime T: type) ?T {
     const dt = @typeInfo(T);
-    if (dt != .Pointer or dt.Pointer.size != .Slice) {
+    if (dt != .pointer or dt.pointer.size != .Slice) {
         @compileError("dataGetSlice needs a slice, given " ++ @typeName(T));
     }
 
     if (dataGetInternal(win, id, key, T, true)) |bytes| {
-        if (dt.Pointer.sentinel) |sentinel| {
-            return @as([:@as(*const dt.Pointer.child, @alignCast(@ptrCast(sentinel))).*]align(@alignOf(dt.Pointer.child)) dt.Pointer.child, @alignCast(@ptrCast(std.mem.bytesAsSlice(dt.Pointer.child, bytes[0 .. bytes.len - @sizeOf(dt.Pointer.child)]))));
+        if (dt.pointer.sentinel) |sentinel| {
+            return @as([:@as(*const dt.pointer.child, @alignCast(@ptrCast(sentinel))).*]align(@alignOf(dt.pointer.child)) dt.pointer.child, @alignCast(@ptrCast(std.mem.bytesAsSlice(dt.pointer.child, bytes[0 .. bytes.len - @sizeOf(dt.pointer.child)]))));
         } else {
-            return @as([]align(@alignOf(dt.Pointer.child)) dt.Pointer.child, @alignCast(std.mem.bytesAsSlice(dt.Pointer.child, bytes)));
+            return @as([]align(@alignOf(dt.pointer.child)) dt.pointer.child, @alignCast(std.mem.bytesAsSlice(dt.pointer.child, bytes)));
         }
     } else {
         return null;
@@ -2076,7 +2076,7 @@ pub fn dataGetSlice(win: ?*Window, id: u32, key: []const u8, comptime T: type) ?
 /// The returned slice points to internal storage, which will be freed after
 /// a frame where there is no call to any dataGet/dataSet functions for that
 /// id/key combination.
-pub fn dataGetSliceDefault(win: ?*Window, id: u32, key: []const u8, comptime T: type, default: []const @typeInfo(T).Pointer.child) T {
+pub fn dataGetSliceDefault(win: ?*Window, id: u32, key: []const u8, comptime T: type, default: []const @typeInfo(T).pointer.child) T {
     return dataGetSlice(win, id, key, T) orelse blk: {
         dataSetSlice(win, id, key, default);
         break :blk dataGetSlice(win, id, key, T).?;
@@ -3655,8 +3655,8 @@ pub const Window = struct {
         var bytes: []const u8 = undefined;
         if (copy_slice) {
             bytes = std.mem.sliceAsBytes(data_in);
-            if (dt.Pointer.sentinel != null) {
-                bytes.len += @sizeOf(dt.Pointer.child);
+            if (dt.pointer.sentinel != null) {
+                bytes.len += @sizeOf(dt.pointer.child);
             }
         } else {
             bytes = std.mem.asBytes(&data_in);
@@ -3664,7 +3664,7 @@ pub const Window = struct {
 
         const alignment = comptime blk: {
             if (copy_slice) {
-                break :blk dt.Pointer.alignment;
+                break :blk dt.pointer.alignment;
             } else {
                 break :blk @alignOf(@TypeOf(data_in));
             }
@@ -6074,7 +6074,7 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
 fn isF32Slice(comptime ptr: std.builtin.Type.Pointer, comptime child_info: std.builtin.Type) bool {
     const is_slice = ptr.size == .Slice;
     const holds_f32 = switch (child_info) {
-        .Float => |f| f.bits == 32,
+        .float => |f| f.bits == 32,
         else => false,
     };
 
@@ -6091,7 +6091,7 @@ fn isF32Slice(comptime ptr: std.builtin.Type.Pointer, comptime child_info: std.b
 
 fn checkAndCastDataPtr(comptime num_components: u32, value: anytype) *[num_components]f32 {
     switch (@typeInfo(@TypeOf(value))) {
-        .Pointer => |ptr| {
+        .pointer => |ptr| {
             const child_info = @typeInfo(ptr.child);
             const is_f32_slice = comptime isF32Slice(ptr, child_info);
 
@@ -6102,8 +6102,8 @@ fn checkAndCastDataPtr(comptime num_components: u32, value: anytype) *[num_compo
             // If not slice, need to check for arrays and vectors.
             // Need to also check the length.
             const data_len = switch (child_info) {
-                .Vector => |vec| vec.len,
-                .Array => |arr| arr.len,
+                .vector => |vec| vec.len,
+                .array => |arr| arr.len,
                 else => @compileError("Must supply a pointer to a vector or array!"),
             };
 
@@ -6408,11 +6408,11 @@ pub fn TextEntryNumberResult(comptime T: type) type {
 pub fn textEntryNumber(src: std.builtin.SourceLocation, comptime T: type, init_opts: TextEntryNumberInitOptions(T), opts: Options) !TextEntryNumberResult(T) {
     const base_filter = "1234567890";
     const filter = switch (@typeInfo(T)) {
-        .Int => |int| switch (int.signedness) {
+        .int => |int| switch (int.signedness) {
             .signed => base_filter ++ "+-",
             .unsigned => base_filter ++ "+",
         },
-        .Float => base_filter ++ "+-.e",
+        .float => base_filter ++ "+-.e",
         else => unreachable,
     };
 
@@ -6444,8 +6444,8 @@ pub fn textEntryNumber(src: std.builtin.SourceLocation, comptime T: type, init_o
     // validation
     const text = te.getText();
     const num = switch (@typeInfo(T)) {
-        .Int => std.fmt.parseInt(T, text, 10) catch null,
-        .Float => std.fmt.parseFloat(T, text) catch null,
+        .int => std.fmt.parseInt(T, text, 10) catch null,
+        .float => std.fmt.parseFloat(T, text) catch null,
         else => unreachable,
     };
 

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1913,16 +1913,16 @@ pub fn dataSetSlice(win: ?*Window, id: u32, key: []const u8, data: anytype) void
 /// entries that you want to fill in after.
 pub fn dataSetSliceCopies(win: ?*Window, id: u32, key: []const u8, data: anytype, num_copies: usize) void {
     const dt = @typeInfo(@TypeOf(data));
-    if (dt == .pointer and dt.pointer.size == .Slice) {
-        if (dt.pointer.sentinel) |s| {
-            dataSetAdvanced(win, id, key, @as([:@as(*const dt.pointer.child, @alignCast(@ptrCast(s))).*]dt.pointer.child, @constCast(data)), true, num_copies);
+    if (dt == .pointer and dt.pointer.size == .slice) {
+        if (dt.pointer.sentinel()) |s| {
+            dataSetAdvanced(win, id, key, @as([:s]dt.pointer.child, @constCast(data)), true, num_copies);
         } else {
             dataSetAdvanced(win, id, key, @as([]dt.pointer.child, @constCast(data)), true, num_copies);
         }
-    } else if (dt == .pointer and dt.pointer.size == .One and @typeInfo(dt.pointer.child) == .array) {
+    } else if (dt == .pointer and dt.pointer.size == .one and @typeInfo(dt.pointer.child) == .array) {
         const child_type = @typeInfo(dt.pointer.child);
-        if (child_type.array.sentinel) |s| {
-            dataSetAdvanced(win, id, key, @as([:@as(*const child_type.array.child, @alignCast(@ptrCast(s))).*]child_type.array.child, @constCast(data)), true, num_copies);
+        if (child_type.array.sentinel()) |s| {
+            dataSetAdvanced(win, id, key, @as([:s]child_type.array.child, @constCast(data)), true, num_copies);
         } else {
             dataSetAdvanced(win, id, key, @as([]child_type.array.child, @constCast(data)), true, num_copies);
         }
@@ -2049,13 +2049,13 @@ pub fn dataGetPtr(win: ?*Window, id: u32, key: []const u8, comptime T: type) ?*T
 /// id/key combination.
 pub fn dataGetSlice(win: ?*Window, id: u32, key: []const u8, comptime T: type) ?T {
     const dt = @typeInfo(T);
-    if (dt != .pointer or dt.pointer.size != .Slice) {
+    if (dt != .pointer or dt.pointer.size != .slice) {
         @compileError("dataGetSlice needs a slice, given " ++ @typeName(T));
     }
 
     if (dataGetInternal(win, id, key, T, true)) |bytes| {
-        if (dt.pointer.sentinel) |sentinel| {
-            return @as([:@as(*const dt.pointer.child, @alignCast(@ptrCast(sentinel))).*]align(@alignOf(dt.pointer.child)) dt.pointer.child, @alignCast(@ptrCast(std.mem.bytesAsSlice(dt.pointer.child, bytes[0 .. bytes.len - @sizeOf(dt.pointer.child)]))));
+        if (dt.pointer.sentinel()) |sentinel| {
+            return @as([:sentinel]align(@alignOf(dt.pointer.child)) dt.pointer.child, @alignCast(@ptrCast(std.mem.bytesAsSlice(dt.pointer.child, bytes[0 .. bytes.len - @sizeOf(dt.pointer.child)]))));
         } else {
             return @as([]align(@alignOf(dt.pointer.child)) dt.pointer.child, @alignCast(std.mem.bytesAsSlice(dt.pointer.child, bytes)));
         }
@@ -3656,7 +3656,7 @@ pub const Window = struct {
         var bytes: []const u8 = undefined;
         if (copy_slice) {
             bytes = std.mem.sliceAsBytes(data_in);
-            if (dt.pointer.sentinel != null) {
+            if (dt.pointer.sentinel() != null) {
                 bytes.len += @sizeOf(dt.pointer.child);
             }
         } else {
@@ -6073,7 +6073,7 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
 }
 
 fn isF32Slice(comptime ptr: std.builtin.Type.Pointer, comptime child_info: std.builtin.Type) bool {
-    const is_slice = ptr.size == .Slice;
+    const is_slice = ptr.size == .slice;
     const holds_f32 = switch (child_info) {
         .float => |f| f.bits == 32,
         else => false,

--- a/src/structEntry.zig
+++ b/src/structEntry.zig
@@ -435,13 +435,13 @@ pub fn optionalFieldWidget(
 pub fn PointerFieldOptions(comptime T: type) type {
     const info = @typeInfo(T).pointer;
 
-    if (info.size == .Slice and info.child == u8) {
+    if (info.size == .slice and info.child == u8) {
         return TextFieldOptions;
-    } else if (info.size == .Slice) {
+    } else if (info.size == .slice) {
         return SliceFieldOptions(T);
-    } else if (info.size == .One) {
+    } else if (info.size == .one) {
         return SinglePointerFieldOptions(T);
-    } else if (info.size == .C or info.size == .Many) {
+    } else if (info.size == .c or info.size == .many) {
         @compileError("Many item pointers disallowed");
     }
 }
@@ -457,13 +457,13 @@ pub fn pointerFieldWidget(
 ) !void {
     const info = @typeInfo(T).pointer;
 
-    if (info.size == .Slice and info.child == u8) {
+    if (info.size == .slice and info.child == u8) {
         try textFieldWidget(name, T, result, opt, alloc, allocator, alignment);
-    } else if (info.size == .Slice) {
+    } else if (info.size == .slice) {
         try sliceFieldWidget(name, T, result, opt, alloc, allocator, alignment);
-    } else if (info.size == .One) {
+    } else if (info.size == .one) {
         try singlePointerFieldWidget(name, T, result, opt, alloc, allocator, alignment);
-    } else if (info.size == .C or info.size == .Many) {
+    } else if (info.size == .c or info.size == .many) {
         @compileError("structEntry does not support *C or Many pointers");
     }
 }
@@ -574,7 +574,7 @@ pub fn sliceFieldWidget(
     allocator: ?std.mem.Allocator,
     alignment: *dvui.Alignment,
 ) !void {
-    if (@typeInfo(T).pointer.size != .Slice) @compileError("must be called with slice");
+    if (@typeInfo(T).pointer.size != .slice) @compileError("must be called with slice");
 
     const Child = @typeInfo(T).pointer.child;
 
@@ -804,7 +804,7 @@ pub fn NamespaceFieldOptions(comptime T: type) type {
         const FieldType = FieldOptions(field.type);
         fields[i] = .{
             .alignment = 1,
-            .default_value = @alignCast(@ptrCast(&(@as(FieldType, FieldType{})))),
+            .default_value_ptr = &(@as(FieldType, FieldType{})),
             .is_comptime = false,
             .name = field.name,
             .type = FieldType,
@@ -936,7 +936,7 @@ pub fn structEntryExAlloc(
 //        const info = @typeInfo(field.type);
 //        if (info == .pointer) {
 //            switch (info.size) {
-//                .Slice => {
+//                .slice => {
 //                    @field(result, field.name) = try allocator.dupe(info.child, @field(value, field.name));
 //                    if (@typeInfo(info.child) == .@"struct") {
 //                        for (@field(result, field.name), 0..) |*val, i| {
@@ -944,7 +944,7 @@ pub fn structEntryExAlloc(
 //                        }
 //                    }
 //                },
-//                .One => {
+//                .one => {
 //                    @field(result, field.name) = try allocator.create(info.child);
 //                    if (@typeInfo(info.child) == .@"struct") {
 //                        @field(result, field.name).* = try deepCopyStruct(allocator, @field(value, field.name));

--- a/src/structEntry.zig
+++ b/src/structEntry.zig
@@ -254,13 +254,13 @@ fn textFieldWidget(
 
     comptime var treatment: ProvidedPointerTreatment = .display_only;
     comptime if (!alloc) {
-        if (@typeInfo(T).Pointer.is_const) {
+        if (@typeInfo(T).pointer.is_const) {
             treatment = .display_only;
         } else {
             treatment = .mutate_value_in_place_only;
         }
     } else {
-        if (@typeInfo(T).Pointer.is_const) {
+        if (@typeInfo(T).pointer.is_const) {
             treatment = .copy_value_and_alloc_new;
         } else {
             treatment = .mutate_value_and_realloc;
@@ -471,7 +471,7 @@ pub fn pointerFieldWidget(
 //=======Single Item pointer and options=======
 pub fn SinglePointerFieldOptions(comptime T: type) type {
     return struct {
-        child: FieldOptions(@typeInfo(T).Pointer.child) = .{},
+        child: FieldOptions(@typeInfo(T).pointer.child) = .{},
         disabled: bool = false,
         //label_override: ?[]const u8 = null,
     };
@@ -490,7 +490,7 @@ pub fn singlePointerFieldWidget(
     var box = try dvui.box(@src(), .horizontal, .{});
     defer box.deinit();
 
-    const Child = @typeInfo(T).Pointer.child;
+    const Child = @typeInfo(T).pointer.child;
 
     const ProvidedPointerTreatment = enum {
         mutate_value_in_place,
@@ -500,13 +500,13 @@ pub fn singlePointerFieldWidget(
 
     comptime var treatment: ProvidedPointerTreatment = .display_only;
     comptime if (alloc == false) {
-        if (@typeInfo(T).Pointer.is_const) {
+        if (@typeInfo(T).pointer.is_const) {
             treatment = .display_only;
         } else {
             treatment = .mutate_value_in_place;
         }
     } else if (alloc == true) {
-        if (@typeInfo(T).Pointer.is_const) {
+        if (@typeInfo(T).pointer.is_const) {
             treatment = .copy_value_and_alloc_new;
         } else {
             treatment = .mutate_value_in_place;
@@ -559,7 +559,7 @@ pub fn arrayFieldWidget(
 //=======Single Item pointer and options=======
 pub fn SliceFieldOptions(comptime T: type) type {
     return struct {
-        child: FieldOptions(@typeInfo(T).Pointer.child) = .{},
+        child: FieldOptions(@typeInfo(T).pointer.child) = .{},
         label_override: ?[]const u8 = null,
         disabled: bool = false,
     };
@@ -574,9 +574,9 @@ pub fn sliceFieldWidget(
     allocator: ?std.mem.Allocator,
     alignment: *dvui.Alignment,
 ) !void {
-    if (@typeInfo(T).Pointer.size != .Slice) @compileError("must be called with slice");
+    if (@typeInfo(T).pointer.size != .Slice) @compileError("must be called with slice");
 
-    const Child = @typeInfo(T).Pointer.child;
+    const Child = @typeInfo(T).pointer.child;
 
     const ProvidedPointerTreatment = enum {
         mutate_value_and_realloc,
@@ -587,13 +587,13 @@ pub fn sliceFieldWidget(
 
     comptime var treatment: ProvidedPointerTreatment = .display_only;
     comptime if (alloc == false) {
-        if (@typeInfo(T).Pointer.is_const) {
+        if (@typeInfo(T).pointer.is_const) {
             treatment = .display_only;
         } else {
             treatment = .mutate_value_in_place_only;
         }
     } else if (alloc == true) {
-        if (@typeInfo(T).Pointer.is_const) {
+        if (@typeInfo(T).pointer.is_const) {
             treatment = .copy_value_and_alloc_new;
         } else {
             treatment = .mutate_value_and_realloc;
@@ -719,7 +719,7 @@ fn structFieldWidget(
 ) !void {
     if (@typeInfo(T) != .@"struct") @compileError("Input Type Must Be A Struct");
     if (opt.disabled) return;
-    const fields = @typeInfo(T).Struct.fields;
+    const fields = @typeInfo(T).@"struct".fields;
 
     var box = try dvui.box(@src(), .vertical, .{ .expand = .both });
     defer box.deinit();
@@ -932,13 +932,13 @@ pub fn structEntryExAlloc(
 //    const T = @TypeOf(value);
 //    var result: T = undefined;
 //
-//    inline for (@typeInfo(T).Struct.fields) |field| {
+//    inline for (@typeInfo(T).@"struct".fields) |field| {
 //        const info = @typeInfo(field.type);
-//        if (info == .Pointer) {
+//        if (info == .pointer) {
 //            switch (info.size) {
 //                .Slice => {
 //                    @field(result, field.name) = try allocator.dupe(info.child, @field(value, field.name));
-//                    if (@typeInfo(info.child) == .Struct) {
+//                    if (@typeInfo(info.child) == .@"struct") {
 //                        for (@field(result, field.name), 0..) |*val, i| {
 //                            val.* = try deepCopyStruct(allocator, @field(value, field.name)[i]);
 //                        }
@@ -946,7 +946,7 @@ pub fn structEntryExAlloc(
 //                },
 //                .One => {
 //                    @field(result, field.name) = try allocator.create(info.child);
-//                    if (@typeInfo(info.child) == .Struct) {
+//                    if (@typeInfo(info.child) == .@"struct") {
 //                        @field(result, field.name).* = try deepCopyStruct(allocator, @field(value, field.name));
 //                    } else {
 //                        @field(result, field.name).* = @field(value, field.name);
@@ -954,7 +954,7 @@ pub fn structEntryExAlloc(
 //                },
 //                else => @compileError("Cannot copy *C and Many pointers"),
 //            }
-//        } else if (info == .Struct) {
+//        } else if (info == .@"struct") {
 //            @field(result, field.name) = try deepCopyStruct(allocator, @field(value, field.name));
 //        } else {
 //            @field(result, field.name) = @field(value, field.name);

--- a/src/themes/Adwaita.zig
+++ b/src/themes/Adwaita.zig
@@ -22,50 +22,53 @@ const light_err_fill = err_hsl.color();
 const light_err_fill_hover = err_hsl.lighten(-10).color();
 const light_err_border = err_hsl.lighten(-20).color();
 
-pub const light = Theme{
-    .name = "Adwaita Light",
-    .dark = false,
+pub const light = light: {
+    @setEvalBranchQuota(3123);
+    break :light Theme{
+        .name = "Adwaita Light",
+        .dark = false,
 
-    .font_body = .{ .size = 16, .name = "Vera" },
-    .font_heading = .{ .size = 16, .name = "VeraBd" },
-    .font_caption = .{ .size = 13, .name = "Vera", .line_height_factor = 1.1 },
-    .font_caption_heading = .{ .size = 13, .name = "VeraBd", .line_height_factor = 1.1 },
-    .font_title = .{ .size = 28, .name = "Vera" },
-    .font_title_1 = .{ .size = 24, .name = "VeraBd" },
-    .font_title_2 = .{ .size = 22, .name = "VeraBd" },
-    .font_title_3 = .{ .size = 20, .name = "VeraBd" },
-    .font_title_4 = .{ .size = 18, .name = "VeraBd" },
+        .font_body = .{ .size = 16, .name = "Vera" },
+        .font_heading = .{ .size = 16, .name = "VeraBd" },
+        .font_caption = .{ .size = 13, .name = "Vera", .line_height_factor = 1.1 },
+        .font_caption_heading = .{ .size = 13, .name = "VeraBd", .line_height_factor = 1.1 },
+        .font_title = .{ .size = 28, .name = "Vera" },
+        .font_title_1 = .{ .size = 24, .name = "VeraBd" },
+        .font_title_2 = .{ .size = 22, .name = "VeraBd" },
+        .font_title_3 = .{ .size = 20, .name = "VeraBd" },
+        .font_title_4 = .{ .size = 18, .name = "VeraBd" },
 
-    .color_accent = accent_hsl.color(),
-    .color_err = err_hsl.color(),
-    .color_text = Color.black,
-    .color_text_press = Color.black,
-    .color_fill = Color.white,
-    .color_fill_window = .{ .r = 0xf0, .g = 0xf0, .b = 0xf0 },
-    .color_fill_control = .{ .r = 0xe0, .g = 0xe0, .b = 0xe0 },
-    .color_fill_hover = (Color.HSLuv{ .s = 0, .l = 82 }).color(),
-    .color_fill_press = (Color.HSLuv{ .s = 0, .l = 72 }).color(),
-    .color_border = (Color.HSLuv{ .s = 0, .l = 63 }).color(),
+        .color_accent = accent_hsl.color(),
+        .color_err = err_hsl.color(),
+        .color_text = Color.black,
+        .color_text_press = Color.black,
+        .color_fill = Color.white,
+        .color_fill_window = .{ .r = 0xf0, .g = 0xf0, .b = 0xf0 },
+        .color_fill_control = .{ .r = 0xe0, .g = 0xe0, .b = 0xe0 },
+        .color_fill_hover = (Color.HSLuv{ .s = 0, .l = 82 }).color(),
+        .color_fill_press = (Color.HSLuv{ .s = 0, .l = 72 }).color(),
+        .color_border = (Color.HSLuv{ .s = 0, .l = 63 }).color(),
 
-    .style_accent = Options{
-        .color_accent = .{ .color = light_accent_accent },
-        .color_text = .{ .color = Color.white },
-        .color_text_press = .{ .color = Color.white },
-        .color_fill = .{ .color = light_accent_fill },
-        .color_fill_hover = .{ .color = light_accent_fill_hover },
-        .color_fill_press = .{ .color = light_accent_accent },
-        .color_border = .{ .color = light_accent_border },
-    },
+        .style_accent = Options{
+            .color_accent = .{ .color = light_accent_accent },
+            .color_text = .{ .color = Color.white },
+            .color_text_press = .{ .color = Color.white },
+            .color_fill = .{ .color = light_accent_fill },
+            .color_fill_hover = .{ .color = light_accent_fill_hover },
+            .color_fill_press = .{ .color = light_accent_accent },
+            .color_border = .{ .color = light_accent_border },
+        },
 
-    .style_err = Options{
-        .color_accent = .{ .color = light_err_accent },
-        .color_text = .{ .color = Color.white },
-        .color_text_press = .{ .color = Color.white },
-        .color_fill = .{ .color = light_err_fill },
-        .color_fill_hover = .{ .color = light_err_fill_hover },
-        .color_fill_press = .{ .color = light_err_accent },
-        .color_border = .{ .color = light_err_border },
-    },
+        .style_err = Options{
+            .color_accent = .{ .color = light_err_accent },
+            .color_text = .{ .color = Color.white },
+            .color_text_press = .{ .color = Color.white },
+            .color_fill = .{ .color = light_err_fill },
+            .color_fill_hover = .{ .color = light_err_fill_hover },
+            .color_fill_press = .{ .color = light_err_accent },
+            .color_border = .{ .color = light_err_border },
+        },
+    };
 };
 
 const dark_fill = Color{ .r = 0x1e, .g = 0x1e, .b = 0x1e };
@@ -82,48 +85,51 @@ const dark_err_fill_hover = err_hsl.lighten(9).color();
 const dark_err_fill_press = err_hsl.lighten(16).color();
 const dark_err_border = err_hsl.lighten(20).color();
 
-pub const dark = Theme{
-    .name = "Adwaita Dark",
-    .dark = true,
+pub const dark = dark: {
+    @setEvalBranchQuota(3023);
+    break :dark Theme{
+        .name = "Adwaita Dark",
+        .dark = true,
 
-    .font_body = .{ .size = 16, .name = "Vera" },
-    .font_heading = .{ .size = 16, .name = "VeraBd" },
-    .font_caption = .{ .size = 13, .name = "Vera", .line_height_factor = 1.1 },
-    .font_caption_heading = .{ .size = 13, .name = "VeraBd", .line_height_factor = 1.1 },
-    .font_title = .{ .size = 28, .name = "Vera" },
-    .font_title_1 = .{ .size = 24, .name = "VeraBd" },
-    .font_title_2 = .{ .size = 22, .name = "VeraBd" },
-    .font_title_3 = .{ .size = 20, .name = "VeraBd" },
-    .font_title_4 = .{ .size = 18, .name = "VeraBd" },
+        .font_body = .{ .size = 16, .name = "Vera" },
+        .font_heading = .{ .size = 16, .name = "VeraBd" },
+        .font_caption = .{ .size = 13, .name = "Vera", .line_height_factor = 1.1 },
+        .font_caption_heading = .{ .size = 13, .name = "VeraBd", .line_height_factor = 1.1 },
+        .font_title = .{ .size = 28, .name = "Vera" },
+        .font_title_1 = .{ .size = 24, .name = "VeraBd" },
+        .font_title_2 = .{ .size = 22, .name = "VeraBd" },
+        .font_title_3 = .{ .size = 20, .name = "VeraBd" },
+        .font_title_4 = .{ .size = 18, .name = "VeraBd" },
 
-    .color_accent = accent_hsl.color(),
-    .color_err = dark_err,
-    .color_text = Color.white,
-    .color_text_press = Color.white,
-    .color_fill = dark_fill,
-    .color_fill_window = .{ .r = 0x2b, .g = 0x2b, .b = 0x2b },
-    .color_fill_control = .{ .r = 0x40, .g = 0x40, .b = 0x40 },
-    .color_fill_hover = dark_fill_hsl.lighten(21).color(),
-    .color_fill_press = dark_fill_hsl.lighten(30).color(),
-    .color_border = dark_fill_hsl.lighten(39).color(),
+        .color_accent = accent_hsl.color(),
+        .color_err = dark_err,
+        .color_text = Color.white,
+        .color_text_press = Color.white,
+        .color_fill = dark_fill,
+        .color_fill_window = .{ .r = 0x2b, .g = 0x2b, .b = 0x2b },
+        .color_fill_control = .{ .r = 0x40, .g = 0x40, .b = 0x40 },
+        .color_fill_hover = dark_fill_hsl.lighten(21).color(),
+        .color_fill_press = dark_fill_hsl.lighten(30).color(),
+        .color_border = dark_fill_hsl.lighten(39).color(),
 
-    .style_accent = Options{
-        .color_accent = .{ .color = dark_accent_accent },
-        .color_text = .{ .color = Color.white },
-        .color_text_press = .{ .color = Color.white },
-        .color_fill = .{ .color = accent },
-        .color_fill_hover = .{ .color = dark_accent_fill_hover },
-        .color_fill_press = .{ .color = dark_accent_accent },
-        .color_border = .{ .color = dark_accent_border },
-    },
+        .style_accent = Options{
+            .color_accent = .{ .color = dark_accent_accent },
+            .color_text = .{ .color = Color.white },
+            .color_text_press = .{ .color = Color.white },
+            .color_fill = .{ .color = accent },
+            .color_fill_hover = .{ .color = dark_accent_fill_hover },
+            .color_fill_press = .{ .color = dark_accent_accent },
+            .color_border = .{ .color = dark_accent_border },
+        },
 
-    .style_err = Options{
-        .color_accent = .{ .color = dark_err_accent },
-        .color_text = .{ .color = Color.white },
-        .color_text_press = .{ .color = Color.white },
-        .color_fill = .{ .color = dark_err },
-        .color_fill_hover = .{ .color = dark_err_fill_hover },
-        .color_fill_press = .{ .color = dark_err_fill_press },
-        .color_border = .{ .color = dark_err_border },
-    },
+        .style_err = Options{
+            .color_accent = .{ .color = dark_err_accent },
+            .color_text = .{ .color = Color.white },
+            .color_text_press = .{ .color = Color.white },
+            .color_fill = .{ .color = dark_err },
+            .color_fill_hover = .{ .color = dark_err_fill_hover },
+            .color_fill_press = .{ .color = dark_err_fill_press },
+            .color_border = .{ .color = dark_err_border },
+        },
+    };
 };

--- a/src/tinyvg/parsing.zig
+++ b/src/tinyvg/parsing.zig
@@ -629,7 +629,7 @@ fn convertStyleType(value: u2) !StyleType {
 }
 
 fn MapZeroToMax(comptime T: type) type {
-    const info = @typeInfo(T).Int;
+    const info = @typeInfo(T).int;
     return std.meta.Int(.unsigned, info.bits + 1);
 }
 fn mapZeroToMax(value: anytype) MapZeroToMax(@TypeOf(value)) {

--- a/src/tinyvg/parsing.zig
+++ b/src/tinyvg/parsing.zig
@@ -215,13 +215,16 @@ pub fn Parser(comptime Reader: type) type {
             return items;
         }
 
+        fn SetDualTempStorageResult(comptime T1: type, comptime T2: type) type {
+            return struct { first: []T1, second: []T2 };
+        }
         fn setDualTempStorage(
             self: *Self,
             comptime T1: type,
             length1: usize,
             comptime T2: type,
             length2: usize,
-        ) !struct { first: []T1, second: []T2 } {
+        ) !SetDualTempStorageResult(T1, T2) {
             // temp_buffer is aligned to 16, so we don't have to worry about
             // alignment for T1
             try self.temp_buffer.resize(@sizeOf(T1) * length1 + @sizeOf(T2) * length2 + (@alignOf(T2) - 1));
@@ -229,7 +232,7 @@ pub fn Parser(comptime Reader: type) type {
             // T2 alignment could be larger than T1
             const offset = std.mem.alignForward(usize, @sizeOf(T1) * length1, @alignOf(T2));
 
-            const result = .{
+            const result = SetDualTempStorageResult(T1, T2){
                 .first = std.mem.bytesAsSlice(T1, self.temp_buffer.items[0 .. @sizeOf(T1) * length1]),
                 .second = @as([]T2, @alignCast(std.mem.bytesAsSlice(T2, self.temp_buffer.items[offset..][0 .. @sizeOf(T2) * length2]))),
             };

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -48,7 +48,7 @@ pub fn draw(self: *LabelWidget) !void {
     const rect = dvui.placeIn(self.wd.contentRect(), self.wd.options.min_size_contentGet(), .none, self.wd.options.gravityGet());
     var rs = self.wd.parent.screenRectScale(rect);
     const oldclip = dvui.clip(rs.r);
-    var iter = std.mem.split(u8, self.label_str, "\n");
+    var iter = std.mem.splitScalar(u8, self.label_str, '\n');
     var line_height_adj: f32 = undefined;
     var first: bool = true;
     while (iter.next()) |line| {


### PR DESCRIPTION
Continuation of #119 .
Some dependencies also aren't upstream-updated yet, so I created updated forks and linked to them in `build.zig.zon` for now.

With this, on Windows 11 I was able to build and run all examples (`sdl-(standalone|ontop)`, `dx11-(standalone|ontop)`, `raylib-(standalone|ontop)`, `web-test`).
I also tried to get the `-Dsdl3` flag working, and got it from compile errors to "`unable to find artifact 'sdl3'`".
EDIT: However, `web-test` currently requires a workaround that breaks for non-`Debug` optimization modes. (See below.)

Most of the changes should be straightforward, the main motivators being https://github.com/ziglang/zig/pull/21225 and https://github.com/ziglang/zig/issues/16865 / https://github.com/ziglang/zig/pull/21817 .

The only unfortunate change/workaround is in `build.zig`:
https://github.com/ziglang/zig/pull/22240 removed libc support for the target `wasm32-freestanding-musl`.
This means for `web-test`, when compiling module `dvui_mod_web` for this target, libc headers aren't found:

```
...\dvui\src/stb/stb_truetype.h:441:13: error: 'math.h' file not found
   #include <math.h>
            ^~~~~~~~~
...\dvui\src/stb/stb_truetype_impl.c:8:10: note: in file included from ...\dvui\src/stb/stb_truetype_impl.c:8:
#include "stb_truetype.h"
         ^
...\dvui\src/stb/stb_image.h:385:10: error: 'stdlib.h' file not found
#include <stdlib.h>
         ^~~~~~~~~~~
...\dvui\src/stb/stb_image_impl.c:10:10: note: in file included from ...\dvui\src/stb/stb_image_impl.c:10:
#include "stb_image.h"
         ^
src\dvui.zig:63:15: error: C import failed
pub const c = @cImport({
              ^~~~~~~~
...\dvui\src\stb/stb_image.h:370:10: error: 'stdio.h' file not found
#include <stdio.h>
         ^
```

Fwict the primary motivation for this was that `freestanding` means having no system interface, while `musl` as an ABI implies a particular system interface.
However, the headers here are primarily math helper functions. Previously zig would provide these for this target, now it doesn't anymore.

The fix should be to instead specify a libc-available target, such as `wasm32-wasi-musl`, however linking two objects for this target together currently results in a duplicate symbol error:
```
error: wasm-ld: duplicate symbol: __stack_chk_guard
    note: defined in ...\zig\o\19a6733837159280ecaa4b92d137e967\libc.a(>..\zig\o\f831e7109012a241701a8177894b04e1\__stack_chk_fail.o)
    note: defined in ...\dvui\.zig-cache\o\c632e504dcd72bcac6a51b59beb9385f\web-test.wasm.o
error: wasm-ld: duplicate symbol: __stack_chk_fail
    note: defined in ...\zig\o\19a6733837159280ecaa4b92d137e967\libc.a(...\zig\o\f831e7109012a241701a8177894b04e1\__stack_chk_fail.o)
    note: defined in ...\dvui\.zig-cache\o\c632e504dcd72bcac6a51b59beb9385f\web-test.wasm.o
```

I think this might well be an upstream zig issue (those two symbols should be weak or something).
I haven't found mention of this on the GitHub issue tracker (though there's similar issue https://github.com/ziglang/zig/issues/22096 ),
however someone reported it in a `#zig-help` discord thread: https://discord.com/channels/605571803288698900/1302304150792568862

The workaround for now seems to be to target `wasi` for only one object, and `freestanding` for all others.
An upstream report would probably be good, however I don't know much about wasm, so if someone else were able to reduce it to a minimal example, that would be great.

Also note that the target workaround actually **only seems to work for Debug** optimization mode.
With any other optimization mode, zig refuses to link because wasm-ld warns `wasm-ld: warning: Linking two modules of different target triples: '...\dvui\.zig-cache\o\6222e68294243b2dfd92cc297ecb1962\web-test.wasm.o' is 'wasm32-unknown-unknown-musl' whereas 'ld-temp.o' is 'wasm32-unknown-wasi0.1.0-musl'`.
So this really is just a brittle, temporary workaround.