### PR TITLE
Better SDL3 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,9 @@ How to run the built-in examples:
   - then load `zig-out/bin/index.html`
   - [online demo](https://david-vanderson.github.io)
 - SDL3:
-  - Windows (SDL3 built from source): 
-    - ```zig build sdl-standalone -Dsdl3```
-    - ```zig build sdl-ontop -Dsdl3```
-  - Linux (SDL3 dev must be installed on system):
-    - ```zig build sdl-standalone  -fsys=sdl3```
-    - ```zig build sdl-ontop -fsys=sdl3```
-    - if you encounter error `No Wayland` also add flag `-Dlinux_display_backend=X11`
+  - ```zig build sdl-standalone -Dsdl3```
+  - ```zig build sdl-ontop -Dsdl3```
+  - if you encounter error `No Wayland` also add flag `-Dlinux_display_backend=X11`
   
 
 [Online Docs](https://david-vanderson.github.io/docs) This document is a broad overview.  See [implementation details](readme-implementation.md) for how to write and modify widgets.

--- a/build.zig
+++ b/build.zig
@@ -230,7 +230,10 @@ fn addDvuiModule(
                 } else if (b.option(bool, "sdl3", "Use SDL3 compiled from source") orelse false) {
                     // SDL3 compiled from source
                     sdl_options.addOption(std.SemanticVersion, "version", .{ .major = 3, .minor = 0, .patch = 0 });
-                    if (b.lazyDependency("sdl3", .{})) |sdl3| {
+                    if (b.lazyDependency("sdl3", .{
+                        .target = target,
+                        .optimize = optimize,
+                    })) |sdl3| {
                         backend_mod.linkLibrary(sdl3.artifact("SDL3"));
                     }
                 } else if (b.systemIntegrationOption("sdl3", .{})) {

--- a/build.zig
+++ b/build.zig
@@ -231,8 +231,7 @@ fn addDvuiModule(
                     // SDL3 compiled from source
                     sdl_options.addOption(std.SemanticVersion, "version", .{ .major = 3, .minor = 0, .patch = 0 });
                     if (b.lazyDependency("sdl3", .{})) |sdl3| {
-                        backend_mod.linkLibrary(sdl3.artifact("sdl3"));
-                        backend_mod.addImport("sdl3_c", sdl3.module("sdl"));
+                        backend_mod.linkLibrary(sdl3.artifact("SDL3"));
                     }
                 } else if (b.systemIntegrationOption("sdl3", .{})) {
                     // SDL3 from system

--- a/build.zig
+++ b/build.zig
@@ -236,11 +236,6 @@ fn addDvuiModule(
                     })) |sdl3| {
                         backend_mod.linkLibrary(sdl3.artifact("SDL3"));
                     }
-                } else if (b.systemIntegrationOption("sdl3", .{})) {
-                    // SDL3 from system
-                    sdl_options.addOption(std.SemanticVersion, "version", .{ .major = 3, .minor = 0, .patch = 0 });
-                    sdl_options.addOption(bool, "from_system", true);
-                    backend_mod.linkSystemLibrary("SDL3", .{});
                 } else {
                     // SDL2 compiled from source
                     sdl_options.addOption(std.SemanticVersion, "version", .{ .major = 2, .minor = 0, .patch = 0 });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,7 +10,7 @@
         },
         .sdl3 = .{
             .lazy = true,
-            .url = "git+https://github.com/castholm/SDL.git#0f9b915d86e948d7fa09de1a5bb912a0d7d203f1",
+            .url = "https://github.com/castholm/SDL.git#0f9b915d86e948d7fa09de1a5bb912a0d7d203f1",
             .hash = "1220eb863a14352c788fee12d7e9158a47af176bbef1070263edbb344cc1c3b72fdf",
         },
         .freetype = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,8 +10,8 @@
         },
         .sdl3 = .{
             .lazy = true,
-            .url = "https://github.com/swan-www/zig_sdl3/archive/refs/tags/3.1.6.tar.gz",
-            .hash = "12203db5d6acf22b69b929ee32194e6352ca9406f0192e7d72dbc2907a1df4e32d8c",
+            .url = "git+https://github.com/castholm/SDL.git#0f9b915d86e948d7fa09de1a5bb912a0d7d203f1",
+            .hash = "1220eb863a14352c788fee12d7e9158a47af176bbef1070263edbb344cc1c3b72fdf",
         },
         .freetype = .{
             .url = "https://github.com/david-vanderson/freetype/archive/a62b6192d81952e64b8c16504427f3e28ef10e5f.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,7 +10,7 @@
         },
         .sdl3 = .{
             .lazy = true,
-            .url = "https://github.com/castholm/SDL.git#0f9b915d86e948d7fa09de1a5bb912a0d7d203f1",
+            .url = "git+https://github.com/castholm/SDL.git#0f9b915d86e948d7fa09de1a5bb912a0d7d203f1",
             .hash = "1220eb863a14352c788fee12d7e9158a47af176bbef1070263edbb344cc1c3b72fdf",
         },
         .freetype = .{

--- a/src/backends/sdl_backend.zig
+++ b/src/backends/sdl_backend.zig
@@ -6,11 +6,10 @@ const sdl_options = @import("sdl_options");
 pub const sdl3 = sdl_options.version.major == 3;
 pub const c = blk: {
     if (sdl3) {
-        if (@hasDecl(sdl_options, "from_system") and sdl_options.from_system) {
-            break :blk @cImport({
-                @cInclude("SDL3/SDL.h");
-            });
-        } else break :blk @import("sdl3_c");
+        break :blk @cImport({
+            @cDefine("SDL_DISABLE_OLD_NAMES", {});
+            @cInclude("SDL3/SDL.h");
+        });
     }
     break :blk @cImport({
         @cInclude("SDL2/SDL.h");
@@ -693,7 +692,7 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
             return try win.addEventText(txt);
         },
         if (sdl3) c.SDL_EVENT_TEXT_EDITING else c.SDL_TEXTEDITING => {
-            const strlen: u8 = @intCast(c.SDL_strlen(&event.edit.text));
+            const strlen: u8 = @intCast(c.SDL_strlen(if (sdl3) event.edit.text else &event.edit.text));
             if (self.log_events) {
                 std.debug.print("sdl event TEXTEDITING {s} start {d} len {d} strlen {d}\n", .{ event.edit.text, event.edit.start, event.edit.length, strlen });
             }


### PR DESCRIPTION
Replace current SDL3 source upstream for [castholm/SDL](https://github.com/castholm/SDL) as it allows for better support.