### PR TITLE
fix "invalid option: -Dsdl3" with -fsys=sdl3

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -245,6 +245,7 @@ fn addDvuiModule(
                     "src/stb/stb_image_write_impl.c",
                 } });
                 var sdl_options = b.addOptions();
+                const compile_sdl3 = b.option(bool, "sdl3", "Use SDL3 compiled from source") orelse false;
                 if (b.systemIntegrationOption("sdl2", .{})) {
                     // SDL2 from system
                     sdl_options.addOption(std.SemanticVersion, "version", .{ .major = 2, .minor = 0, .patch = 0 });
@@ -253,7 +254,7 @@ fn addDvuiModule(
                     // SDL3 from system
                     sdl_options.addOption(std.SemanticVersion, "version", .{ .major = 3, .minor = 0, .patch = 0 });
                     backend_mod.linkSystemLibrary("SDL3", .{});
-                } else if (b.option(bool, "sdl3", "Use SDL3 compiled from source") orelse false) {
+                } else if (compile_sdl3) {
                     // SDL3 compiled from source
                     sdl_options.addOption(std.SemanticVersion, "version", .{ .major = 3, .minor = 0, .patch = 0 });
                     if (b.lazyDependency("sdl3", .{


### PR DESCRIPTION
This error pops up when compiling https://github.com/david-vanderson/dvui-demo with `-fsys=sdl3`:

```
$ zig build sdl-standalone -fsys=sdl3
error: invalid option: -Dsdl3
/home/nhanb/zig/lib/std/Build.zig:2230:35: 0x142d026 in dependency__anon_8703 (build)
            return dependencyInner(b, name, pkg.build_root, if (@hasDecl(pkg, "build_zig")) pkg.build_zig else null, pkg_hash, pkg.deps, args);
                                  ^
/home/nhanb/oss/dvui-demo/build.zig:7:34: 0x142c41a in build (build)
    const dvui_dep = b.dependency("dvui", .{ .target = target, .optimize = optimize, .sdl3 = true });
```

This is because when `-fsys=sdl3` is enabled, the if clause that calls `b.option(... "sdl3" ...)` is never reached.

This PR makes sure that the `sdl3` build option is always defined so that applications can use `.sdl3=true` without triggering an error message when compiling with `-fsys=sdl3`.