### PR TITLE
fix for zig 0.14.0-dev.3271+bd237bced

### DIFF
--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2506,7 +2506,11 @@ pub const Window = struct {
 
         pub fn free(self: *const SavedData, allocator: std.mem.Allocator) void {
             if (self.data.len != 0) {
-                allocator.rawFree(self.data, @ctz(self.alignment), @returnAddress());
+                allocator.rawFree(
+                    self.data,
+                    std.mem.Alignment.fromByteUnits(self.alignment),
+                    @returnAddress(),
+                );
             }
         }
     };
@@ -3524,9 +3528,10 @@ pub const Window = struct {
     }
 
     fn positionMouseEventRemove(self: *Self) void {
-        const e = self.events.pop();
-        if (e.evt != .mouse or e.evt.mouse.action != .position) {
-            log.err("positionMouseEventRemove removed a non-mouse or non-position event\n", .{});
+        if (self.events.pop()) |e| {
+            if (e.evt != .mouse or e.evt.mouse.action != .position) {
+                log.err("positionMouseEventRemove removed a non-mouse or non-position event\n", .{});
+            }
         }
     }
 

--- a/src/tinyvg/rendering.zig
+++ b/src/tinyvg/rendering.zig
@@ -1175,7 +1175,7 @@ pub fn FixedBufferList(comptime T: type, comptime N: usize) type {
 
         pub fn popBack(self: *Self) ?T {
             if (self.large) |*large| {
-                return large.popOrNull();
+                return large.*.pop();
             }
 
             if (self.count == 0)


### PR DESCRIPTION
- `Allocator.rawFree()` now takes `alignment` as an enum, probably an example of <https://ziglang.org/devlog/2024/#2024-11-04>
- `popOrNull()` is now just `pop()`