### PR TITLE
structEntry: adapt to zig 0.14.0

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -652,6 +652,7 @@ pub fn structUI() !void {
         a_struct: TopChild = .{ .a_dir = .vertical },
         a_str: []const u8 = &[_]u8{0} ** 20,
         a_slice: []TopChild = undefined,
+        an_array: [4]u8 = .{ 1, 2, 3, 4 },
 
         var instance: @This() = .{ .a_slice = &mut_array, .a_ptr = &ptr };
     };

--- a/src/structEntry.zig
+++ b/src/structEntry.zig
@@ -532,7 +532,7 @@ pub fn singlePointerFieldWidget(
 
 pub fn ArrayFieldOptions(comptime T: type) type {
     return struct {
-        child: FieldOptions(@typeInfo(T).Array.child) = .{},
+        child: FieldOptions(@typeInfo(T).array.child) = .{},
         label_override: ?[]const u8 = null,
         disabled: bool = false,
     };
@@ -545,15 +545,16 @@ pub fn arrayFieldWidget(
     opt: ArrayFieldOptions(T),
     comptime alloc: bool,
     allocator: ?std.mem.Allocator,
+    alignment: *dvui.Alignment,
 ) !void {
-    const SliceType = []@typeInfo(T).Array.child;
+    const SliceType = []@typeInfo(T).array.child;
     var slice_result: SliceType = &(result.*);
     const slice_opts = SliceFieldOptions(SliceType){
         .child = opt.child,
         .label_override = opt.label_override,
         .disabled = opt.disabled,
     };
-    try sliceFieldWidget(name, SliceType, &slice_result, slice_opts, alloc, allocator);
+    try sliceFieldWidget(name, SliceType, &slice_result, slice_opts, alloc, allocator, alignment);
 }
 
 //=======Single Item pointer and options=======
@@ -836,7 +837,7 @@ pub fn fieldWidget(
         .optional => try optionalFieldWidget(name, T, result, options, alloc, allocator, alignment),
         .@"union" => try unionFieldWidget(name, T, result, options, alloc, allocator, alignment),
         .@"struct" => try structFieldWidget(name, T, result, options, alloc, allocator),
-        .array => try arrayFieldWidget(name, T, result, options, alloc, allocator),
+        .array => try arrayFieldWidget(name, T, result, options, alloc, allocator, alignment),
         else => @compileError("Invalid type: " ++ @typeName(T)),
     }
 }


### PR DESCRIPTION
Fix naming and add missing alignment arg.

PS: Love dvui so far :) 

---

Fixes build error when trying to build web-test:

```
$ zig build web-test
web-test
└─ install web-test
   └─ zig build-exe web-test Debug wasm32-freestanding 1 errors
src/structEntry.zig:549:38: error: no field named 'Array' in union 'builtin.Type'
    const SliceType = []@typeInfo(T).Array.child;
                                     ^~~~~
.../zig-linux-x86_64-0.14.0/lib/std/builtin.zig:563:18: note: union declared here
pub const Type = union(enum) {
``` 