### PR TITLE
update zigwin32 and point to upstream

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -159,8 +159,8 @@ pub fn build(b: *std.Build) !void {
                 .link_libc = true,
             });
 
-            if (b.lazyDependency("zigwin32", .{})) |zigwin32| {
-                dx11_mod.addImport("zigwin32", zigwin32.module("zigwin32"));
+            if (b.lazyDependency("win32", .{})) |zigwin32| {
+                dx11_mod.addImport("win32", zigwin32.module("win32"));
             }
 
             const dvui_dx11 = addDvuiModule(b, target, optimize, "dvui_dx11", true);
@@ -337,8 +337,8 @@ fn addExample(
         exe.win32_manifest = b.path("./src/main.manifest");
         exe.subsystem = .Windows;
         // TODO: This may just be only used for directx
-        if (b.lazyDependency("zigwin32", .{})) |zigwin32| {
-            exe.root_module.addImport("zigwin32", zigwin32.module("zigwin32"));
+        if (b.lazyDependency("win32", .{})) |zigwin32| {
+            exe.root_module.addImport("win32", zigwin32.module("win32"));
         }
     }
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -34,9 +34,9 @@
             .lazy = true,
         },
         // required for the directx11 backend
-        .zigwin32 = .{
-            .url = "git+https://github.com/rohlem/zigwin32-update-zig#5d6055e7c8cea4c508f33c0d8641fdf1fe30f9ea",
-            .hash = "zigwin32-25.0.28-preview-AAAAAHnw-wNzthEDPTZg_KePtYjS_Ze72tlr6MaIxaAP",
+        .win32 = .{
+            .url = "git+https://github.com/marlersoft/zigwin32#be58d3816810c1e4c20781cc7223a60906467d3c",
+            .hash = "zigwin32-25.0.28-preview-AAAAAHsJ-wPA4nREAzT_OOkF6gLrornNuHqREfHDADoS",
             .lazy = true,
         },
     },

--- a/examples/dx11-ontop.zig
+++ b/examples/dx11-ontop.zig
@@ -5,7 +5,7 @@ comptime {
     std.debug.assert(@hasDecl(Backend, "Dx11Backend"));
 }
 
-const zwin = @import("zigwin32");
+const zwin = @import("win32");
 const ui = zwin.ui.windows_and_messaging;
 
 const dxgi = zwin.graphics.dxgi;

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const dvui = @import("dvui");
-const win = @import("zigwin32");
+const win = @import("win32");
 
 const w = std.os.windows;
 const UINT = w.UINT;


### PR DESCRIPTION
Updates to the latest zigwin32 and switches to the upstream repository. Also note that the module was renamed from "zigwin32" to "win32" per the zig guidance in naming packages/modules.