### PR TITLE
TextEntryWidget Deletion bugs

### DIFF
--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -722,11 +722,11 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
                             if (self.len > 0) {
                                 self.text[self.len] = 0;
                             }
+                            self.text_changed = (sel.cursor != oldcur);
                             sel.cursor = oldcur;
                             sel.end = sel.cursor;
                             sel.start = sel.cursor;
                             self.textLayout.scroll_to_cursor = true;
-                            self.text_changed = (sel.cursor != oldcur);
                         } else if (sel.cursor < self.len) {
                             // delete the character just after the cursor
                             //

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -660,7 +660,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
                             // delete from sel.cursor to oldcur
                             std.mem.copyForwards(u8, self.text[sel.cursor..], self.text[oldcur..self.len]);
                             self.len -= (oldcur - sel.cursor);
-                            if (self.len > 0) {
+                            if (self.len >= 0) {
                                 self.text[self.len] = 0;
                             }
                             sel.end = sel.cursor;
@@ -719,7 +719,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
                             // delete from oldcur to sel.cursor
                             std.mem.copyForwards(u8, self.text[oldcur..], self.text[sel.cursor..self.len]);
                             self.len -= (sel.cursor - oldcur);
-                            if (self.len > 0) {
+                            if (self.len >= 0) {
                                 self.text[self.len] = 0;
                             }
                             self.text_changed = (sel.cursor != oldcur);


### PR DESCRIPTION
There where two bugs when deleting whole words:

1. When deleting a word backwards, using `ctrl+delete`, `text_changed` was set by testing `self.cursor`, which  was reset a couple of lines above
2. When deleting the last word and setting `len` to 0, the null terminator wasn't added. When using a buffer, and possible other backing storages, this caused one frame to have the correct frame but the text to appear again on the next frame but with the cursor moved

The TextEntryWidget now works as expected in these scenarios!