### PR TITLE
Suggetions widget

### DIFF
--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -44,6 +44,7 @@ pub const ScaleWidget = @import("widgets/ScaleWidget.zig");
 pub const ScrollAreaWidget = @import("widgets/ScrollAreaWidget.zig");
 pub const ScrollBarWidget = @import("widgets/ScrollBarWidget.zig");
 pub const ScrollContainerWidget = @import("widgets/ScrollContainerWidget.zig");
+pub const SuggestionsWidget = @import("widgets/SuggestionsWidget.zig");
 pub const TextEntryWidget = @import("widgets/TextEntryWidget.zig");
 pub const TextLayoutWidget = @import("widgets/TextLayoutWidget.zig");
 pub const VirtualParentWidget = @import("widgets/VirtualParentWidget.zig");
@@ -4969,157 +4970,13 @@ pub fn dropdown(src: std.builtin.SourceLocation, entries: []const []const u8, ch
     return ret;
 }
 
-pub const SuggestionsWidget = struct {
-    pub var defaults: Options = .{
-        .corner_radius = Rect.all(5),
-        .padding = Rect.all(6),
-        .name = "Suggestions",
-    };
-
-    id: u32 = undefined,
-    options: Options = undefined,
-    text_entry: *TextEntryWidget = undefined,
-    drop: ?FloatingMenuWidget = null,
-    drop_first_frame: bool = false,
-    drop_mi: ?MenuItemWidget = null,
-    drop_mi_index: usize = 0,
-
-    pub fn init(src: std.builtin.SourceLocation, text_entry: *TextEntryWidget, opts: Options) SuggestionsWidget {
-        var self = SuggestionsWidget{};
-        if (text_entry.init_opts.break_lines or text_entry.init_opts.multiline) {
-            log.err("SuggestionsWidget does not support multiline TextEntryWidgets, initialized at [{s}:{d}:{d}]", .{ src.file, src.line, src.column });
-        }
-
-        self.id = dvui.hashSrc(0, src, opts.idExtra());
-        self.text_entry = text_entry;
-        self.options = defaults.override(opts);
-        return self;
-    }
-
-    pub fn dropped(self: *SuggestionsWidget) !bool {
-        if (self.drop != null) {
-            // protect against calling this multiple times
-            return true;
-        }
-
-        const entry_rect = self.text_entry.data().contentRectScale();
-        const start = entry_rect.rectToRectScale(entry_rect.r.justSize()).r.offset(.{ .y = entry_rect.r.h + self.options.marginGet().y });
-        self.drop = .init(@src(), start, self.options.override(.{
-            .min_size_content = .{
-                .w = entry_rect.r
-                    .inset(self.options.paddingGet())
-                    .inset(self.options.borderGet())
-                    .inset(self.options.marginGet()).w,
-            },
-        }));
-        var drop = &self.drop.?;
-        self.drop_first_frame = firstFrame(drop.wd.id);
-
-        const cw = currentWindow();
-        if (cw.focused_subwindowId != drop.wd.id and focusedWidgetId() != self.text_entry.wd.id) {
-            // Hide the suggestions when the textfield and suggestions window doesn't have focus
-            self.drop = null;
-            return false;
-        }
-
-        try drop.install();
-        if (self.drop_first_frame) {
-            // don't take focus away from text_entry when showing the suggestions
-            focusWidget(self.text_entry.wd.id, null, null);
-        } else {
-            const sw = cw.subwindowCurrent();
-            if (cw.focused_subwindowId != sw.id) {
-                // reset focus of suggestions to always start at the first item
-                sw.focused_widgetId = null;
-            } else if (sw.focused_widgetId == null or sw.focused_widgetId == drop.menu.wd.id) {
-                // Focus text_entry if we have no suggestion focused
-                focusWidget(self.text_entry.wd.id, null, null);
-            }
-        }
-
-        // without this, if you trigger the dropdown with the keyboard and then
-        // move the mouse, the entries are highlighted but not focused
-        drop.menu.submenus_activated = true;
-
-        const evts = events();
-        for (evts) |*e| {
-            if (e.evt == .key and self.text_entry.matchEvent(e)) {
-                if (e.evt.key.action == .down and e.evt.key.matchBind("char_down")) {
-                    focusWidget(drop.menu.wd.id, null, null);
-                    // Focus next tab item to select the first item in the menu immediately
-                    tabIndexNext(e.num);
-                }
-            }
-        }
-
-        if (self.drop != null) {
-            return true;
-        }
-
-        return false;
-    }
-
-    pub fn addSuggestionLabel(self: *SuggestionsWidget, label_text: []const u8) !bool {
-        var mi = try self.addSuggestion();
-        defer mi.deinit();
-
-        var opts = self.options.strip();
-        if (mi.show_active) {
-            opts = opts.override(dvui.themeGet().style_accent);
-        }
-
-        try labelNoFmt(@src(), label_text, opts);
-
-        if (mi.activeRect()) |_| {
-            return true;
-        }
-
-        return false;
-    }
-
-    pub fn addSuggestion(self: *SuggestionsWidget) !*MenuItemWidget {
-        self.drop_mi = MenuItemWidget.init(@src(), .{}, .{ .id_extra = self.drop_mi_index, .expand = .horizontal });
-        try self.drop_mi.?.install();
-        self.drop_mi.?.processEvents();
-        try self.drop_mi.?.drawBackground(.{});
-
-        self.drop_mi_index += 1;
-
-        return &self.drop_mi.?;
-    }
-
-    // TODO: Add close function to call once a suggestion has been choosen.
-    //       Should remain closed until text_entry changes again
-
-    pub fn chooseText(self: *SuggestionsWidget, text: []const u8) void {
-        if (text.len == 0) {
-            self.text_entry.len = 0;
-            self.text_entry.addNullTerminator();
-            return;
-        }
-        // Set the TextEntryWidgets text data assuming an internal buffer
-        dataSetSlice(null, self.text_entry.wd.id, "_buffer", text);
-        self.text_entry.text = dataGetSlice(null, self.text_entry.wd.id, "_buffer", []u8).?;
-        self.text_entry.len = text.len;
-        const sel = self.text_entry.textLayout.selectionGet(text.len);
-        sel.cursor = text.len;
-        focusWidget(self.text_entry.wd.id, null, null);
-    }
-
-    pub fn deinit(self: *SuggestionsWidget) void {
-        if (self.drop != null) {
-            self.drop.?.deinit();
-            self.drop = null;
-        }
-    }
-};
-
 pub fn textEntrySuggestions(src: std.builtin.SourceLocation, suggested_values: []const []const u8, opts: Options) !*TextEntryWidget {
     var text_entry = try currentWindow().arena().create(TextEntryWidget);
     text_entry.* = dvui.TextEntryWidget.init(src, .{}, opts);
     try text_entry.install();
 
     var suggestions_widget = dvui.SuggestionsWidget.init(src, text_entry, .{});
+    try suggestions_widget.install();
     if (suggested_values.len > 0 and try suggestions_widget.dropped()) {
         for (suggested_values) |value| {
             if (try suggestions_widget.addSuggestionLabel(value)) {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5041,57 +5041,13 @@ pub const SuggestionsWidget = struct {
         // move the mouse, the entries are highlighted but not focused
         drop.menu.submenus_activated = true;
 
-        // only want a mouse-up to choose something if the mouse has moved in the dropup
-        var eat_mouse_up = dataGet(null, drop.wd.id, "_eat_mouse_up", bool) orelse true;
-        var drag_scroll = dataGet(null, drop.wd.id, "_drag_scroll", bool) orelse false;
-
-        const drop_rs = drop.data().rectScale();
-        const scroll_rs = drop.scroll.data().contentRectScale();
         const evts = events();
         for (evts) |*e| {
-            if (drag_scroll and e.evt == .mouse and !e.evt.mouse.button.touch() and (e.evt.mouse.action == .motion or e.evt.mouse.action == .position)) {
-                if (e.evt.mouse.p.x >= scroll_rs.r.x and e.evt.mouse.p.x <= scroll_rs.r.x + scroll_rs.r.w and (e.evt.mouse.p.y <= scroll_rs.r.y or e.evt.mouse.p.y >= scroll_rs.r.y + scroll_rs.r.h)) {
-                    if (e.evt.mouse.action == .motion) {
-                        var scrolldrag = Event{ .evt = .{ .scroll_drag = .{
-                            .mouse_pt = e.evt.mouse.p,
-                            .screen_rect = drop.menu.data().rectScale().r,
-                            .capture_id = drop.wd.id,
-                        } } };
-                        drop.scroll.scroll.processEvent(&scrolldrag, true);
-                    } else if (e.evt.mouse.action == .position) {
-                        dvui.currentWindow().inject_motion_event = true;
-                    }
-                }
-            }
-
             if (e.evt == .key and self.text_entry.matchEvent(e)) {
                 if (e.evt.key.action == .down and e.evt.key.matchBind("char_down")) {
                     focusWidget(drop.menu.wd.id, null, null);
                     // Focus next tab item to select the first item in the menu immediately
                     tabIndexNext(e.num);
-                }
-            }
-
-            if (!eventMatch(e, .{ .id = drop.data().id, .r = drop_rs.r }))
-                continue;
-
-            if (e.evt == .mouse) {
-                if (e.evt.mouse.action == .release and e.evt.mouse.button.pointer()) {
-                    if (eat_mouse_up) {
-                        e.handled = true;
-                        eat_mouse_up = false;
-                        dataSet(null, drop.wd.id, "_eat_mouse_up", eat_mouse_up);
-                    }
-                } else if (e.evt.mouse.action == .motion or (e.evt.mouse.action == .press and e.evt.mouse.button.pointer())) {
-                    if (eat_mouse_up) {
-                        eat_mouse_up = false;
-                        dataSet(null, drop.wd.id, "_eat_mouse_up", eat_mouse_up);
-                    }
-
-                    if (!drag_scroll) {
-                        drag_scroll = true;
-                        dataSet(null, drop.wd.id, "_drag_scroll", drag_scroll);
-                    }
                 }
             }
         }

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -4980,6 +4980,7 @@ pub fn textEntrySuggestions(src: std.builtin.SourceLocation, suggested_values: [
     if (suggested_values.len > 0 and try suggestions_widget.dropped()) {
         for (suggested_values) |value| {
             if (try suggestions_widget.addSuggestionLabel(value)) {
+                suggestions_widget.close();
                 suggestions_widget.chooseText(value);
             }
         }
@@ -4987,6 +4988,11 @@ pub fn textEntrySuggestions(src: std.builtin.SourceLocation, suggested_values: [
     suggestions_widget.deinit();
 
     text_entry.processEvents();
+
+    if (text_entry.text_changed) {
+        suggestions_widget.open();
+    }
+
     try text_entry.draw();
     return text_entry;
 }

--- a/src/widgets/SuggestionsWidget.zig
+++ b/src/widgets/SuggestionsWidget.zig
@@ -1,0 +1,203 @@
+const std = @import("std");
+const dvui = @import("../dvui.zig");
+
+const Event = dvui.Event;
+const Options = dvui.Options;
+const Rect = dvui.Rect;
+const RectScale = dvui.RectScale;
+const Size = dvui.Size;
+const Widget = dvui.Widget;
+const WidgetData = dvui.WidgetData;
+
+const SuggestionsWidget = @This();
+
+pub var defaults: Options = .{
+    .corner_radius = Rect.all(5),
+    .padding = Rect.all(6),
+    .name = "Suggestions",
+};
+
+wd: WidgetData = undefined,
+child_rect_union: ?Rect = null,
+
+options: Options = undefined,
+text_entry: *dvui.TextEntryWidget = undefined,
+drop: ?dvui.FloatingMenuWidget = null,
+drop_first_frame: bool = false,
+drop_mi: ?dvui.MenuItemWidget = null,
+drop_mi_index: usize = 0,
+
+pub fn init(src: std.builtin.SourceLocation, text_entry: *dvui.TextEntryWidget, opts: Options) SuggestionsWidget {
+    var self = SuggestionsWidget{};
+    if (text_entry.init_opts.break_lines or text_entry.init_opts.multiline) {
+        dvui.log.err("SuggestionsWidget does not support multiline TextEntryWidgets, initialized at [{s}:{d}:{d}]", .{ src.file, src.line, src.column });
+    }
+
+    const id = dvui.parentGet().extendId(src, opts.idExtra());
+    const rect = dvui.dataGet(null, id, "_rect", Rect);
+    const parent_defaults = Options{ .name = "Virtual Parent", .rect = rect orelse .{} };
+    self.wd = WidgetData.init(src, .{}, parent_defaults.override(opts));
+    self.text_entry = text_entry;
+    self.options = defaults.override(opts);
+    return self;
+}
+
+pub fn install(self: *SuggestionsWidget) !void {
+    dvui.parentSet(self.widget());
+    try self.wd.register();
+}
+
+pub fn dropped(self: *SuggestionsWidget) !bool {
+    if (self.drop != null) {
+        // protect against calling this multiple times
+        return true;
+    }
+
+    const entry_rect = self.text_entry.data().contentRectScale();
+    const start = entry_rect.rectToRectScale(entry_rect.r.justSize()).r.offset(.{ .y = entry_rect.r.h + self.options.marginGet().y });
+    self.drop = .init(@src(), start, self.options.override(.{
+        .min_size_content = .{
+            .w = entry_rect.r
+                .inset(self.options.paddingGet())
+                .inset(self.options.borderGet())
+                .inset(self.options.marginGet()).w,
+        },
+    }));
+    var drop = &self.drop.?;
+    self.drop_first_frame = dvui.firstFrame(drop.wd.id);
+
+    const cw = dvui.currentWindow();
+    if (cw.focused_subwindowId != drop.wd.id and dvui.focusedWidgetId() != self.text_entry.wd.id) {
+        // Hide the suggestions when the textfield and suggestions window doesn't have focus
+        self.drop = null;
+        return false;
+    }
+
+    try drop.install();
+    if (self.drop_first_frame) {
+        // don't take focus away from text_entry when showing the suggestions
+        dvui.focusWidget(self.text_entry.wd.id, null, null);
+    } else {
+        const sw = cw.subwindowCurrent();
+        if (cw.focused_subwindowId != sw.id) {
+            // reset focus of suggestions to always start at the first item
+            sw.focused_widgetId = null;
+        } else if (sw.focused_widgetId == null or sw.focused_widgetId == drop.menu.wd.id) {
+            // Focus text_entry if we have no suggestion focused
+            dvui.focusWidget(self.text_entry.wd.id, null, null);
+        }
+    }
+
+    // without this, if you trigger the dropdown with the keyboard and then
+    // move the mouse, the entries are highlighted but not focused
+    drop.menu.submenus_activated = true;
+
+    const evts = dvui.events();
+    for (evts) |*e| {
+        if (e.evt == .key and self.text_entry.matchEvent(e)) {
+            if (e.evt.key.action == .down and e.evt.key.matchBind("char_down")) {
+                dvui.focusWidget(drop.menu.wd.id, null, null);
+                // Focus next tab item to select the first item in the menu immediately
+                dvui.tabIndexNext(e.num);
+            }
+        }
+    }
+
+    if (self.drop != null) {
+        return true;
+    }
+
+    return false;
+}
+
+pub fn addSuggestionLabel(self: *SuggestionsWidget, label_text: []const u8) !bool {
+    var mi = try self.addSuggestion();
+    defer mi.deinit();
+
+    var opts = self.options.strip();
+    if (mi.show_active) {
+        opts = opts.override(dvui.themeGet().style_accent);
+    }
+
+    try dvui.labelNoFmt(@src(), label_text, opts);
+
+    if (mi.activeRect()) |_| {
+        return true;
+    }
+
+    return false;
+}
+
+pub fn addSuggestion(self: *SuggestionsWidget) !*dvui.MenuItemWidget {
+    self.drop_mi = dvui.MenuItemWidget.init(@src(), .{}, .{ .id_extra = self.drop_mi_index, .expand = .horizontal });
+    try self.drop_mi.?.install();
+    self.drop_mi.?.processEvents();
+    try self.drop_mi.?.drawBackground(.{});
+
+    self.drop_mi_index += 1;
+
+    return &self.drop_mi.?;
+}
+
+// TODO: Add close function to call once a suggestion has been choosen.
+//       Should remain closed until text_entry changes again
+
+pub fn chooseText(self: *SuggestionsWidget, text: []const u8) void {
+    if (text.len == 0) {
+        self.text_entry.len = 0;
+        self.text_entry.addNullTerminator();
+        return;
+    }
+    // Set the TextEntryWidgets text data assuming an internal buffer
+    dvui.dataSetSlice(null, self.text_entry.wd.id, "_buffer", text);
+    self.text_entry.text = dvui.dataGetSlice(null, self.text_entry.wd.id, "_buffer", []u8).?;
+    self.text_entry.len = text.len;
+    const sel = self.text_entry.textLayout.selectionGet(text.len);
+    sel.cursor = text.len;
+    dvui.focusWidget(self.text_entry.wd.id, null, null);
+}
+
+pub fn widget(self: *SuggestionsWidget) Widget {
+    return Widget.init(self, data, rectFor, screenRectScale, minSizeForChild, processEvent);
+}
+
+pub fn data(self: *SuggestionsWidget) *WidgetData {
+    return &self.wd;
+}
+
+pub fn rectFor(self: *SuggestionsWidget, id: u32, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+    const ret = self.wd.parent.rectFor(id, min_size, e, g);
+    if (self.child_rect_union) |u| {
+        self.child_rect_union = u.unionWith(ret);
+    } else {
+        self.child_rect_union = ret;
+    }
+    return ret;
+}
+
+pub fn screenRectScale(self: *SuggestionsWidget, rect: Rect) RectScale {
+    return self.wd.parent.screenRectScale(rect);
+}
+
+pub fn minSizeForChild(self: *SuggestionsWidget, s: Size) void {
+    self.wd.parent.minSizeForChild(s);
+}
+
+pub fn processEvent(self: *SuggestionsWidget, e: *Event, bubbling: bool) void {
+    _ = bubbling;
+    if (e.bubbleable()) {
+        self.wd.parent.processEvent(e, true);
+    }
+}
+
+pub fn deinit(self: *SuggestionsWidget) void {
+    if (self.drop != null) {
+        self.drop.?.deinit();
+        self.drop = null;
+    }
+
+    if (self.child_rect_union) |u| {
+        dvui.dataSet(null, self.wd.id, "_rect", u);
+    }
+    dvui.parentReset(self.wd.id, self.wd.parent);
+}


### PR DESCRIPTION
Related issue: #123

This adds a `SuggestionsWidget` which takes a `TextEntryWidget` and augments it with a dropdown bellow the field with suggested values. See the `textEntrySuggestions` function in dvui.zig for an example of the usage of this widget.

![{DA66B4A2-C4BC-4261-9DAF-1877C3656492}](https://github.com/user-attachments/assets/2994ef78-fb46-4cc6-a05e-49c9ac0da380)


## Notes on behavior and api
- This widget needs to be called between `TextEntryWidget`s `.install()` and `processEvents()`.
- The suggestion doesn't show unless the `TextEntryWidget` or one of the suggestions have focus
- Calling `.close()` on the `SuggestionsWidget` will hide the suggestions until `open()` is called
  - The common case will likely call `.open()` if the text has changed in the input
- If `"char_down"`  keybind is pressed, the suggestions open and the first item, if it exists, will be focused
- Currently the suggestions window is anchored to the bottom left corner of the `TextEntryWidget`
  - A wide suggestion will cause the suggestions window to extend to the right of the `TextEntryWidget`
 