### PR TITLE
Add justify-content for FlexBoxWidget

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -51,6 +51,7 @@ var layout_border: Rect = Rect.all(0);
 var layout_padding: Rect = Rect.all(4);
 var layout_gravity_x: f32 = 0.5;
 var layout_gravity_y: f32 = 0.5;
+var layout_flex_content_justify: dvui.FlexBoxWidget.ContentPosition = .center;
 var layout_expand_horizontal: bool = false;
 var layout_expand_vertical: bool = false;
 var show_dialog: bool = false;
@@ -1512,23 +1513,33 @@ pub fn layout() !void {
         }
     }
 
-    try dvui.label(@src(), "FlexBox", .{}, .{});
     {
-        var fbox = try dvui.flexbox(@src(), .{}, .{ .border = dvui.Rect.all(1), .background = true, .padding = .{ .w = 4, .h = 4 } });
-        defer fbox.deinit();
+        {
+            var hbox2 = try dvui.box(@src(), .horizontal, .{});
+            defer hbox2.deinit();
+            try dvui.label(@src(), "FlexBox", .{}, .{});
+            inline for (std.meta.tags(dvui.FlexBoxWidget.ContentPosition)) |opt| {
+                if (try dvui.radio(@src(), layout_flex_content_justify == opt, @tagName(opt), .{ .id_extra = @intFromEnum(opt) })) {
+                    layout_flex_content_justify = opt;
+                }
+            }
+        }
+        {
+            var fbox = try dvui.flexbox(@src(), .{ .justify_content = layout_flex_content_justify }, .{ .border = dvui.Rect.all(1), .background = true, .padding = .{ .w = 4, .h = 4 } });
+            defer fbox.deinit();
 
-        for (0..10) |i| {
-            var labelbox = try dvui.box(@src(), .vertical, .{ .id_extra = i, .margin = .{ .x = 4, .y = 4 }, .border = dvui.Rect.all(1), .background = true });
-            defer labelbox.deinit();
+            for (0..10) |i| {
+                var labelbox = try dvui.box(@src(), .vertical, .{ .id_extra = i, .margin = .{ .x = 4, .y = 4 }, .border = dvui.Rect.all(1), .background = true });
+                defer labelbox.deinit();
 
-            if (i % 2 == 0) {
-                try dvui.label(@src(), "Box {d}", .{i}, .{ .expand = .both, .gravity_x = 0.5, .gravity_y = 0.5 });
-            } else {
-                try dvui.label(@src(), "Large\nBox {d}", .{i}, .{ .expand = .both, .gravity_x = 0.5, .gravity_y = 0.5 });
+                if (i % 2 == 0) {
+                    try dvui.label(@src(), "Box {d}", .{i}, .{ .expand = .both, .gravity_x = 0.5, .gravity_y = 0.5 });
+                } else {
+                    try dvui.label(@src(), "Large\nBox {d}", .{i}, .{ .expand = .both, .gravity_x = 0.5, .gravity_y = 0.5 });
+                }
             }
         }
     }
-
     try dvui.label(@src(), "Collapsible Pane with Draggable Sash", .{}, .{});
     {
         var paned = try dvui.paned(@src(), .{ .direction = .horizontal, .collapsed_size = paned_collapsed_width }, .{ .expand = .both, .background = false, .min_size_content = .{ .h = 100 } });

--- a/src/widgets/FlexBoxWidget.zig
+++ b/src/widgets/FlexBoxWidget.zig
@@ -10,7 +10,10 @@ const WidgetData = dvui.WidgetData;
 
 const FlexBoxWidget = @This();
 
-pub const InitOptions = struct {};
+pub const InitOptions = struct {
+    /// Imitates `justify-content` in CSS Flexbox
+    justify_content: enum { start, center } = .center,
+};
 
 wd: WidgetData = undefined,
 init_options: InitOptions = undefined,
@@ -80,7 +83,10 @@ pub fn rectFor(self: *FlexBoxWidget, id: u32, min_size: Size, e: Options.Expand,
     }
 
     var ret = Rect.fromPoint(self.insert_pt).toSize(min_size);
-    ret.x += (self.wd.contentRect().w - self.max_row_width_prev) / 2;
+    switch (self.init_options.justify_content) {
+        .start => {},
+        .center => ret.x += (self.wd.contentRect().w - self.max_row_width_prev) / 2,
+    }
 
     self.insert_pt.x += min_size.w;
 

--- a/src/widgets/FlexBoxWidget.zig
+++ b/src/widgets/FlexBoxWidget.zig
@@ -12,8 +12,10 @@ const FlexBoxWidget = @This();
 
 pub const InitOptions = struct {
     /// Imitates `justify-content` in CSS Flexbox
-    justify_content: enum { start, center } = .center,
+    justify_content: ContentPosition = .center,
 };
+
+pub const ContentPosition = enum { start, center };
 
 wd: WidgetData = undefined,
 init_options: InitOptions = undefined,


### PR DESCRIPTION
Previous behaviour was to center all rows based on the widest. The `start` option left aligns all the items, even after adding a new row. This imitates [`justify-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content#try_it) from CSS Flexbox, were the naming is derived from.

The previous default behaviour of `center` has been kept, so no changes are needed for users.

An option for `end` could be added, but would require the row width logic to be reversed, starting from the right. Other options like `space-between` seem very difficult to implement in an immediate mode GUI, but may be possible by saving number/width of children between frames.