### PR TITLE
Add wasm file upload

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -2771,9 +2771,11 @@ pub fn dialogs(demo_win_id: u32) !void {
         var hbox = try dvui.box(@src(), .horizontal, .{});
         defer hbox.deinit();
 
+        const single_file_id = hbox.widget().extendId(@src(), 0);
+
         if (try dvui.button(@src(), "Open File", .{}, .{})) {
             if (dvui.wasm) {
-                dvui.dialogWasmFileOpen(123, .{ .accept = ".png, .jpg" });
+                dvui.dialogWasmFileOpen(single_file_id, .{ .accept = ".png, .jpg" });
             } else {
                 const filename = try dvui.dialogNativeFileOpen(dvui.currentWindow().arena(), .{ .title = "dvui native file open", .filters = &.{ "*.png", "*.jpg" }, .filter_description = "images" });
                 if (filename) |f| {
@@ -2782,13 +2784,15 @@ pub fn dialogs(demo_win_id: u32) !void {
             }
         }
 
-        if (dvui.wasmFileUploaded(123)) |file| {
+        if (dvui.wasmFileUploaded(single_file_id)) |file| {
             try dvui.dialog(@src(), .{ .modal = false, .title = "File Open Result", .ok_label = "Done", .message = file.name });
         }
 
+        const multi_file_id = hbox.widget().extendId(@src(), 0);
+
         if (try dvui.button(@src(), "Open Multiple Files", .{}, .{})) {
             if (dvui.wasm) {
-                dvui.dialogWasmFileOpenMultiple(321, .{ .accept = ".png, .jpg" });
+                dvui.dialogWasmFileOpenMultiple(multi_file_id, .{ .accept = ".png, .jpg" });
             } else {
                 const filenames = try dvui.dialogNativeFileOpenMultiple(dvui.currentWindow().arena(), .{ .title = "dvui native file open multiple", .filter_description = "images" });
                 if (filenames) |fs| {
@@ -2798,7 +2802,7 @@ pub fn dialogs(demo_win_id: u32) !void {
             }
         }
 
-        if (dvui.wasmFileUploadedMultiple(321)) |files| {
+        if (dvui.wasmFileUploadedMultiple(multi_file_id)) |files| {
             var msg = std.ArrayList(u8).init(dvui.currentWindow().arena());
             var writer = msg.writer();
             for (files) |file| {

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -2773,6 +2773,7 @@ pub fn dialogs(demo_win_id: u32) !void {
 
         if (try dvui.button(@src(), "Open File", .{}, .{})) {
             if (dvui.wasm) {
+                try dvui.backend.openFilePicker(123, ".png, .jpg", false);
                 try dvui.toast(@src(), .{ .subwindow_id = demo_win_id, .message = "Not implemented for web" });
             } else {
                 const filename = try dvui.dialogNativeFileOpen(dvui.currentWindow().arena(), .{ .title = "dvui native file open", .filters = &.{ "*.png", "*.jpg" }, .filter_description = "images" });
@@ -2782,8 +2783,13 @@ pub fn dialogs(demo_win_id: u32) !void {
             }
         }
 
+        if (try dvui.backend.getFileName(123, 0)) |name| {
+            dvui.log.debug("File name {s}", .{name});
+        }
+
         if (try dvui.button(@src(), "Open Multiple Files", .{}, .{})) {
             if (dvui.wasm) {
+                try dvui.backend.openFilePicker(321, ".png, .jpg", true);
                 try dvui.toast(@src(), .{ .subwindow_id = demo_win_id, .message = "Not implemented for web" });
             } else {
                 const filenames = try dvui.dialogNativeFileOpenMultiple(dvui.currentWindow().arena(), .{ .title = "dvui native file open multiple", .filter_description = "images" });
@@ -2792,6 +2798,10 @@ pub fn dialogs(demo_win_id: u32) !void {
                     try dvui.dialog(@src(), .{ .modal = false, .title = "File Open Multiple Result", .ok_label = "Done", .message = msg });
                 }
             }
+        }
+
+        if (try dvui.backend.getFileName(321, 0)) |name| {
+            dvui.log.debug("First file name {s}", .{name});
         }
     }
     {

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -2773,7 +2773,7 @@ pub fn dialogs(demo_win_id: u32) !void {
 
         if (try dvui.button(@src(), "Open File", .{}, .{})) {
             if (dvui.wasm) {
-                try dvui.backend.openFilePicker(123, ".png, .jpg", false);
+                try dvui.backend.openFilePicker(123, ".png, .jpg, .txt", false);
                 try dvui.toast(@src(), .{ .subwindow_id = demo_win_id, .message = "Not implemented for web" });
             } else {
                 const filename = try dvui.dialogNativeFileOpen(dvui.currentWindow().arena(), .{ .title = "dvui native file open", .filters = &.{ "*.png", "*.jpg" }, .filter_description = "images" });
@@ -2785,6 +2785,10 @@ pub fn dialogs(demo_win_id: u32) !void {
 
         if (try dvui.backend.getFileName(123, 0)) |name| {
             dvui.log.debug("File name {s}", .{name});
+            if (dvui.backend.getFileSize(123, 0)) |size| {
+                const data = try dvui.currentWindow().arena().alloc(u8, size);
+                dvui.backend.readFileData(123, 0, data.ptr);
+            }
         }
 
         if (try dvui.button(@src(), "Open Multiple Files", .{}, .{})) {

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -2773,7 +2773,7 @@ pub fn dialogs(demo_win_id: u32) !void {
 
         if (try dvui.button(@src(), "Open File", .{}, .{})) {
             if (dvui.wasm) {
-                try dvui.backend.openFilePicker(123, ".png, .jpg, .txt", false);
+                dvui.backend.openFilePicker(123, ".png, .jpg, .txt", false);
                 try dvui.toast(@src(), .{ .subwindow_id = demo_win_id, .message = "Not implemented for web" });
             } else {
                 const filename = try dvui.dialogNativeFileOpen(dvui.currentWindow().arena(), .{ .title = "dvui native file open", .filters = &.{ "*.png", "*.jpg" }, .filter_description = "images" });
@@ -2783,7 +2783,7 @@ pub fn dialogs(demo_win_id: u32) !void {
             }
         }
 
-        if (try dvui.backend.getFileName(123, 0)) |name| {
+        if (dvui.backend.getFileName(123, 0)) |name| {
             dvui.log.debug("File name {s}", .{name});
             if (dvui.backend.getFileSize(123, 0)) |size| {
                 const data = try dvui.currentWindow().arena().alloc(u8, size);
@@ -2793,7 +2793,7 @@ pub fn dialogs(demo_win_id: u32) !void {
 
         if (try dvui.button(@src(), "Open Multiple Files", .{}, .{})) {
             if (dvui.wasm) {
-                try dvui.backend.openFilePicker(321, ".png, .jpg", true);
+                dvui.backend.openFilePicker(321, ".png, .jpg", true);
                 try dvui.toast(@src(), .{ .subwindow_id = demo_win_id, .message = "Not implemented for web" });
             } else {
                 const filenames = try dvui.dialogNativeFileOpenMultiple(dvui.currentWindow().arena(), .{ .title = "dvui native file open multiple", .filter_description = "images" });
@@ -2804,7 +2804,7 @@ pub fn dialogs(demo_win_id: u32) !void {
             }
         }
 
-        if (try dvui.backend.getFileName(321, 0)) |name| {
+        if (dvui.backend.getFileName(321, 0)) |name| {
             dvui.log.debug("First file name {s}", .{name});
         }
     }

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -475,7 +475,6 @@ function dvui(canvasId, wasmFile) {
                 let data = [];
                 for (let i = 0; i < filelist.length; i++) {
                     const file = filelist.item(i);
-                    if (!file) console.error("FILE", i, "NOT FOUND", file)
                     files.push(file);
                     data.push(file.arrayBuffer());
                 }
@@ -506,6 +505,11 @@ function dvui(canvasId, wasmFile) {
             if (!cached || cached.files.length <= file_index) return;
 		    var dest = new Uint8Array(wasmResult.instance.exports.memory.buffer, data_ptr);
             dest.set(new Uint8Array(cached.data[file_index]));
+        },
+        wasm_get_number_of_files_available(id) {
+            const cached = filesCache.get(id);
+            if (!cached) return 0;
+            return cached.files.length;
         },
         wasm_clipboardTextSet: (ptr, len) => {
             if (len == 0) {

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -501,6 +501,12 @@ function dvui(canvasId, wasmFile) {
             dest.set([0], name.length);
             return ptr;
         },
+        wasm_read_file_data(id, file_index, data_ptr) {
+            const cached = filesCache.get(id);
+            if (!cached || cached.files.length <= file_index) return;
+		    var dest = new Uint8Array(wasmResult.instance.exports.memory.buffer, data_ptr);
+            dest.set(new Uint8Array(cached.data[file_index]));
+        },
         wasm_clipboardTextSet: (ptr, len) => {
             if (len == 0) {
                 return;

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -55,8 +55,9 @@ pub const wasm = struct {
     pub extern fn wasm_download_data(name_ptr: [*]const u8, name_len: usize, data_ptr: [*]const u8, data_len: usize) void;
     pub extern fn wasm_clipboardTextSet(ptr: [*]const u8, len: usize) void;
 
-    // NOTE: bool in extern becomes 0 and 1 in js, which is falsy and truthy spectively
+    // NOTE: bool in extern becomes 0 and 1 in js, which is falsy and truthy respectively
     pub extern fn wasm_open_file_picker(id: u32, accept_ptr: [*]const u8, accept_len: usize, multiple: bool) void;
+    pub extern fn wasm_get_number_of_files_available(id: u32) usize;
     pub extern fn wasm_get_file_name(id: u32, file_index: usize) [*:0]u8;
     pub extern fn wasm_get_file_size(id: u32, file_index: usize) isize;
     pub extern fn wasm_read_file_data(id: u32, file_index: usize, data: [*]u8) void;
@@ -693,4 +694,8 @@ pub fn getFileSize(id: u32, file_index: usize) ?usize {
 
 pub fn readFileData(id: u32, file_index: usize, data: [*]u8) void {
     wasm.wasm_read_file_data(id, file_index, data);
+}
+
+pub fn getNumberOfFilesAvailable(id: u32) usize {
+    return wasm.wasm_get_number_of_files_available(id);
 }

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -674,11 +674,11 @@ pub fn setCursor(self: *WebBackend, cursor: dvui.enums.Cursor) void {
     }
 }
 
-pub fn openFilePicker(id: u32, accept: []const u8, multiple: bool) !void {
+pub fn openFilePicker(id: u32, accept: []const u8, multiple: bool) void {
     wasm.wasm_open_file_picker(id, accept.ptr, accept.len, multiple);
 }
 
-pub fn getFileName(id: u32, file_index: usize) !?[:0]const u8 {
+pub fn getFileName(id: u32, file_index: usize) ?[:0]const u8 {
     const ptr = wasm.wasm_get_file_name(id, file_index);
     if (@intFromPtr(ptr) <= 0) return null;
     return std.mem.sliceTo(ptr, 0);

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -56,7 +56,8 @@ pub const wasm = struct {
     pub extern fn wasm_clipboardTextSet(ptr: [*]const u8, len: usize) void;
 
     // NOTE: bool in extern becomes 0 and 1 in js, which is falsy and truthy spectively
-    pub extern fn wasm_open_file_picker(accept_ptr: [*]const u8, accept_len: usize, multiple: bool) void;
+    pub extern fn wasm_open_file_picker(id: u32, accept_ptr: [*]const u8, accept_len: usize, multiple: bool) void;
+    pub extern fn wasm_get_file_name(id: u32, file_index: usize) [*:0]u8;
 
     pub extern fn wasm_add_noto_font() void;
 };
@@ -671,6 +672,12 @@ pub fn setCursor(self: *WebBackend, cursor: dvui.enums.Cursor) void {
     }
 }
 
-pub fn openFilePicker(accept: []const u8, multiple: bool) !void {
-    wasm.wasm_open_file_picker(accept.ptr, accept.len, multiple);
+pub fn openFilePicker(id: u32, accept: []const u8, multiple: bool) !void {
+    wasm.wasm_open_file_picker(id, accept.ptr, accept.len, multiple);
+}
+
+pub fn getFileName(id: u32, file_index: usize) !?[:0]const u8 {
+    const ptr = wasm.wasm_get_file_name(id, file_index);
+    if (@intFromPtr(ptr) <= 0) return null;
+    return std.mem.sliceTo(ptr, 0);
 }

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -55,6 +55,9 @@ pub const wasm = struct {
     pub extern fn wasm_download_data(name_ptr: [*]const u8, name_len: usize, data_ptr: [*]const u8, data_len: usize) void;
     pub extern fn wasm_clipboardTextSet(ptr: [*]const u8, len: usize) void;
 
+    // NOTE: bool in extern becomes 0 and 1 in js, which is falsy and truthy spectively
+    pub extern fn wasm_open_file_picker(accept_ptr: [*]const u8, accept_len: usize, multiple: bool) void;
+
     pub extern fn wasm_add_noto_font() void;
 };
 
@@ -666,4 +669,8 @@ pub fn setCursor(self: *WebBackend, cursor: dvui.enums.Cursor) void {
         };
         wasm.wasm_cursor(name.ptr, name.len);
     }
+}
+
+pub fn openFilePicker(accept: []const u8, multiple: bool) !void {
+    wasm.wasm_open_file_picker(accept.ptr, accept.len, multiple);
 }

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -59,6 +59,7 @@ pub const wasm = struct {
     pub extern fn wasm_open_file_picker(id: u32, accept_ptr: [*]const u8, accept_len: usize, multiple: bool) void;
     pub extern fn wasm_get_file_name(id: u32, file_index: usize) [*:0]u8;
     pub extern fn wasm_get_file_size(id: u32, file_index: usize) isize;
+    pub extern fn wasm_read_file_data(id: u32, file_index: usize, data: [*]u8) void;
 
     pub extern fn wasm_add_noto_font() void;
 };
@@ -687,4 +688,8 @@ pub fn getFileSize(id: u32, file_index: usize) ?usize {
     const size: isize = wasm.wasm_get_file_size(id, file_index);
     if (size <= 0) return null;
     return @intCast(size);
+}
+
+pub fn readFileData(id: u32, file_index: usize, data: [*]u8) void {
+    wasm.wasm_read_file_data(id, file_index, data);
 }

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -58,6 +58,7 @@ pub const wasm = struct {
     // NOTE: bool in extern becomes 0 and 1 in js, which is falsy and truthy spectively
     pub extern fn wasm_open_file_picker(id: u32, accept_ptr: [*]const u8, accept_len: usize, multiple: bool) void;
     pub extern fn wasm_get_file_name(id: u32, file_index: usize) [*:0]u8;
+    pub extern fn wasm_get_file_size(id: u32, file_index: usize) isize;
 
     pub extern fn wasm_add_noto_font() void;
 };
@@ -680,4 +681,10 @@ pub fn getFileName(id: u32, file_index: usize) !?[:0]const u8 {
     const ptr = wasm.wasm_get_file_name(id, file_index);
     if (@intFromPtr(ptr) <= 0) return null;
     return std.mem.sliceTo(ptr, 0);
+}
+
+pub fn getFileSize(id: u32, file_index: usize) ?usize {
+    const size: isize = wasm.wasm_get_file_size(id, file_index);
+    if (size <= 0) return null;
+    return @intCast(size);
 }

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -674,8 +674,9 @@ pub fn setCursor(self: *WebBackend, cursor: dvui.enums.Cursor) void {
     }
 }
 
-pub fn openFilePicker(id: u32, accept: []const u8, multiple: bool) void {
-    wasm.wasm_open_file_picker(id, accept.ptr, accept.len, multiple);
+pub fn openFilePicker(id: u32, accept: ?[]const u8, multiple: bool) void {
+    const accept_final = accept orelse "";
+    wasm.wasm_open_file_picker(id, accept_final.ptr, accept_final.len, multiple);
 }
 
 pub fn getFileName(id: u32, file_index: usize) ?[:0]const u8 {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -4430,6 +4430,98 @@ pub fn dialogDisplay(id: u32) !void {
     scroll.deinit();
 }
 
+pub const DialogWasmFileOptions = struct {
+    /// Filter files shown by setting the [accept](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept) attribute
+    ///
+    /// Example: ".pdf, image/*"
+    accept: ?[]const u8 = null,
+};
+
+const WasmFile = struct {
+    id: u32,
+    index: usize,
+    /// The size of the data in bytes
+    size: usize,
+    /// The filename of the uploaded file. Does not include the path of the file
+    name: [:0]const u8,
+
+    pub fn read_data(self: *WasmFile, allocator: std.mem.Allocator) ![]u8 {
+        std.debug.assert(wasm); // WasmFile shouldn't be used outside wasm builds
+        const data = try allocator.alloc(u8, self.size);
+        dvui.backend.readFileData(self.id, self.index, data.ptr);
+        return data;
+    }
+};
+
+/// Opens a file picker WITHOUT blocking. The file can be accessed by calling wasmFileUploaded(id) with the same id
+///
+/// This function does nothing in non-wasm builds
+pub fn dialogWasmFileOpen(id: u32, opts: DialogWasmFileOptions) void {
+    if (!wasm) return;
+    dvui.backend.openFilePicker(id, opts.accept, false);
+}
+
+/// Will only return a non-null value for a single frame
+///
+/// This function does nothing in non-wasm builds
+pub fn wasmFileUploaded(id: u32) ?WasmFile {
+    if (!wasm) return null;
+    const num_files = dvui.backend.getNumberOfFilesAvailable(id);
+    if (num_files == 0) return null;
+    if (num_files > 1) {
+        log.err("Recived more than one file for id {d}. Did you mean to call wasmFileUploadedMultiple?", .{id});
+    }
+    const name = dvui.backend.getFileName(id, 0);
+    const size = dvui.backend.getFileSize(id, 0);
+    if (name == null or size == null) {
+        log.err("Could not get file metadata. Got size: {?d} and name: {?s}", .{ size, name });
+        return null;
+    }
+    return WasmFile{
+        .id = id,
+        .index = 0,
+        .size = size.?,
+        .name = name.?,
+    };
+}
+
+/// Opens a file picker WITHOUT blocking. The files can be accessed by calling wasmFileUploadedMultiple(id) with the same id
+///
+/// This function does nothing in non-wasm builds
+pub fn dialogWasmFileOpenMultiple(id: u32, opts: DialogWasmFileOptions) void {
+    if (!wasm) return;
+    dvui.backend.openFilePicker(id, opts.accept, true);
+}
+
+/// Will only return a non-null value for a single frame
+///
+/// This function does nothing in non-wasm builds
+pub fn wasmFileUploadedMultiple(id: u32) ?[]WasmFile {
+    if (!wasm) return null;
+    const num_files = dvui.backend.getNumberOfFilesAvailable(id);
+    if (num_files == 0) return null;
+
+    const files = dvui.currentWindow().arena().alloc(WasmFile, num_files) catch |err| {
+        log.err("File upload skipped, failed to allocate space for file handles: {!}", .{err});
+        return null;
+    };
+    for (0.., files) |i, *file| {
+        const name = dvui.backend.getFileName(id, i);
+        const size = dvui.backend.getFileSize(id, i);
+        if (name == null or size == null) {
+            log.err("Could not get file metadata for id {d} file number {d}. Got size: {?d} and name: {?s}", .{ id, i, size, name });
+            return null;
+        }
+        file.* = WasmFile{
+            .id = id,
+            .index = i,
+            .size = size.?,
+            .name = name.?,
+        };
+    }
+    return files;
+}
+
 pub const DialogNativeFileOptions = struct {
     /// Title of the dialog window
     title: ?[]const u8 = null,

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -4445,7 +4445,7 @@ const WasmFile = struct {
     /// The filename of the uploaded file. Does not include the path of the file
     name: [:0]const u8,
 
-    pub fn read_data(self: *WasmFile, allocator: std.mem.Allocator) ![]u8 {
+    pub fn readData(self: *WasmFile, allocator: std.mem.Allocator) ![]u8 {
         std.debug.assert(wasm); // WasmFile shouldn't be used outside wasm builds
         const data = try allocator.alloc(u8, self.size);
         dvui.backend.readFileData(self.id, self.index, data.ptr);


### PR DESCRIPTION
Addresses #218.

This adds file uploads to wasm by a adding separate api that only works for wasm. This is needed to work around the inability to block while awaiting javascript promises.

The files are stored on the javascript side for 2 frames because the async resolve may happen after the check for the file, but before the end of the frame. To make the api simpler the whole file data is loaded eagerly on the javascript side. To access the file data, use `WasmFile.read_data(allocator)` to allocate a slice for the file data with any allocator. The `WasmFile` is only valid for one frame as the name is allocated in the arena.