### PR TITLE
TooltipWidget

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -1664,6 +1664,9 @@ pub fn layoutText() !void {
         const start = "\nNotice that the text in this box is wrapping around the stuff in the corners.\n\n";
         try tl.addText(start, .{ .font_style = .title_4 });
 
+        const col = dvui.Color.average(dvui.themeGet().color_text, dvui.themeGet().color_fill);
+        try tl.addTextTooltip(@src(), "Hover this for a tooltip.\n\n", "This is some tooltip", .{ .color_text = .{ .color = col }, .font = dvui.themeGet().font_body.lineHeightFactor(line_height_factor) });
+
         try tl.addText("Title ", .{ .font_style = .title });
         try tl.addText("Title-1 ", .{ .font_style = .title_1 });
         try tl.addText("Title-2 ", .{ .font_style = .title_2 });

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -2021,7 +2021,7 @@ pub fn reorderListsAdvanced() !void {
 }
 
 pub fn menus() !void {
-    var vbox = try dvui.box(@src(), .vertical, .{ .expand = .both });
+    var vbox = try dvui.box(@src(), .vertical, .{ .expand = .both, .margin = .{ .x = 4 } });
     defer vbox.deinit();
 
     {
@@ -2073,6 +2073,52 @@ pub fn menus() !void {
     }
 
     try dvui.labelNoFmt(@src(), "Right click for a context menu", .{});
+
+    _ = try dvui.spacer(@src(), .{ .h = 20 }, .{});
+
+    {
+        var hbox = try dvui.box(@src(), .horizontal, .{ .border = dvui.Rect.all(1), .min_size_content = .{ .h = 50 }, .max_size_content = .{ .w = 300 } });
+        defer hbox.deinit();
+
+        var tl = try dvui.textLayout(@src(), .{}, .{ .background = false });
+        try tl.addText("This box has a simple tooltip.", .{});
+        tl.deinit();
+
+        try dvui.tooltip(@src(), .{ .active_rect = hbox.data().rectScale().r }, "{s}", .{"Simple Tooltip"}, .{});
+    }
+
+    _ = try dvui.spacer(@src(), .{ .h = 10 }, .{});
+
+    {
+        var hbox = try dvui.box(@src(), .horizontal, .{ .border = dvui.Rect.all(1), .min_size_content = .{ .h = 50 }, .max_size_content = .{ .w = 300 } });
+        defer hbox.deinit();
+
+        var tl = try dvui.textLayout(@src(), .{}, .{ .background = false });
+        try tl.addText("This box has a complex tooltip with a nested tooltip.", .{});
+        tl.deinit();
+
+        var tt: dvui.FloatingTooltipWidget = .init(@src(), .{
+            .active_rect = hbox.data().rectScale().r,
+        }, .{});
+        if (try tt.shown()) {
+            var tl2 = try dvui.textLayout(@src(), .{}, .{ .background = false });
+            try tl2.addText("This is the tooltip text", .{});
+            tl2.deinit();
+
+            _ = try dvui.checkbox(@src(), &checkbox_bool, "Checkbox", .{});
+
+            var tt2: dvui.FloatingTooltipWidget = .init(@src(), .{
+                .active_rect = tt.data().rectScale().r,
+            }, .{});
+            if (try tt2.shown()) {
+                var tl3 = try dvui.textLayout(@src(), .{}, .{ .background = false });
+                try tl3.addText("Text in a nested tooltip", .{});
+                tl3.deinit();
+            }
+            tt2.deinit();
+        }
+        tt.deinit();
+    }
 
     _ = try dvui.spacer(@src(), .{ .h = 20 }, .{});
 

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -32,6 +32,7 @@ pub const ButtonWidget = @import("widgets/ButtonWidget.zig");
 pub const ContextWidget = @import("widgets/ContextWidget.zig");
 pub const FloatingWindowWidget = @import("widgets/FloatingWindowWidget.zig");
 pub const FloatingWidget = @import("widgets/FloatingWidget.zig");
+pub const FloatingTooltipWidget = @import("widgets/FloatingTooltipWidget.zig");
 pub const FloatingMenuWidget = @import("widgets/FloatingMenuWidget.zig");
 pub const IconWidget = @import("widgets/IconWidget.zig");
 pub const ImageWidget = @import("widgets/ImageWidget.zig");
@@ -5588,105 +5589,14 @@ pub fn context(src: std.builtin.SourceLocation, init_opts: ContextWidget.InitOpt
     return ret;
 }
 
-pub const TooltipWidget = struct {
-    pub const InitOptions = struct {
-        /// The triggering rect in screen pixels
-        rect: Rect,
-        /// Animation duration in microseconds
-        animation_duration: i32 = 200_000,
-    };
-
-    pub var defaults: Options = .{
-        .corner_radius = Rect.all(4),
-        .background = true,
-    };
-
-    /// Used to check if a tooltip has already been opened this frame
-    /// to prevent opening tooltips beneath the current one
-    // TODO: Make tooltip-in-tooltip possible
-    var tooltip_opened_frame_time: i32 = 0;
-
-    id: u32 = undefined,
-    is_open: bool = false,
-    options: Options = undefined,
-    init_opts: InitOptions = undefined,
-    float: ?FloatingWidget = null,
-    animate: ?AnimateWidget = null,
-
-    pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) TooltipWidget {
-        var self = TooltipWidget{};
-
-        self.init_opts = init_opts;
-        self.options = opts;
-
-        self.id = parentGet().extendId(src, 1);
-
-        return self;
+pub fn tooltip(src: std.builtin.SourceLocation, init_opts: FloatingTooltipWidget.InitOptions, comptime fmt: []const u8, fmt_args: anytype, opts: Options) !void {
+    var tt: dvui.FloatingTooltipWidget = .init(src, init_opts, opts);
+    if (try tt.shown()) {
+        var tl2 = try dvui.textLayout(@src(), .{}, .{ .background = false });
+        try tl2.format(fmt, fmt_args, .{});
+        tl2.deinit();
     }
-
-    pub fn shown(self: *TooltipWidget) !bool {
-        const cw = currentWindow();
-        const mouse_pt = cw.mouse_pt;
-        const current_frame_time: i32 = @truncate(cw.frame_time_ns);
-
-        const is_open = dataGet(null, self.id, "_is_open", bool) orelse false;
-        const mouse_in_trigger_rect = if (tooltip_opened_frame_time == current_frame_time) false else self.init_opts.rect.contains(mouse_pt);
-
-        if (is_open or mouse_in_trigger_rect) blk: {
-            tooltip_opened_frame_time = current_frame_time;
-            const start_offset = dataGet(null, self.id, "_start_offset", f32);
-            if (start_offset == null) {
-                // wait for the mouse to stop to get the horizontal start offset
-                if (!mouseTotalMotion().nonZero()) {
-                    dataSet(null, self.id, "_start_offset", mouse_pt.x);
-                }
-                refresh(null, @src(), self.id);
-                break :blk;
-            }
-
-            self.float = FloatingWidget.init(@src(), .{
-                .name = "Tooltip",
-                .rect = Rect.fromPoint(self.init_opts.rect.bottomLeft()),
-                .id_extra = self.id,
-            });
-            var rs = self.float.?.wd.rectScale();
-            rs.r.x = start_offset.?;
-            self.float.?.wd.rect = placeOnScreen(windowRect(), self.init_opts.rect, .vertical, rs.r);
-            try self.float.?.install();
-
-            var opts = defaults.override(.{ .color_fill = .{ .color = themeGet().color_fill.transparent(0.8) } });
-
-            self.animate = AnimateWidget.init(@src(), .alpha, self.init_opts.animation_duration, opts.override(self.options));
-            try self.animate.?.install();
-
-            // TODO: handle tooltip in tooltips with another solution (similar to chainFocused in FloatingMenuWidget)
-            if (!mouse_in_trigger_rect and !self.float.?.wd.rect.contains(mouse_pt)) {
-                // don't store is_open if mouse is outside trigger and tooltip which will close it next frame
-                dataRemove(null, self.id, "_is_open");
-                refresh(null, @src(), self.id); // refresh with new hidden state
-            } else {
-                dataSet(null, self.id, "_is_open", true);
-            }
-
-            return true;
-        }
-        return false;
-    }
-
-    pub fn deinit(self: *TooltipWidget) void {
-        if (self.animate != null) {
-            self.animate.?.deinit();
-        }
-        if (self.float != null) {
-            self.float.?.deinit();
-        }
-    }
-};
-
-pub fn tooltip(src: std.builtin.SourceLocation, init_opts: TooltipWidget.InitOptions, opts: Options) !*TooltipWidget {
-    const self = try currentWindow().arena().create(TooltipWidget);
-    self.* = TooltipWidget.init(src, init_opts, opts);
-    return self;
+    tt.deinit();
 }
 
 pub fn virtualParent(src: std.builtin.SourceLocation, opts: Options) !*VirtualParentWidget {

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -62,7 +62,6 @@ scroll: ScrollAreaWidget = undefined,
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) FloatingMenuWidget {
     var self = FloatingMenuWidget{};
-    self.prev_rendering = dvui.renderingSet(false);
 
     // options is really for our embedded ScrollAreaWidget, so save them for the
     // end of install()
@@ -93,6 +92,8 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *FloatingMenuWidget) !void {
+    self.prev_rendering = dvui.renderingSet(false);
+
     dvui.parentSet(self.widget());
 
     self.prev_windowId = dvui.subwindowCurrentSet(self.wd.id, null).id;

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -1,0 +1,218 @@
+const std = @import("std");
+const dvui = @import("../dvui.zig");
+
+const Event = dvui.Event;
+const Options = dvui.Options;
+const Rect = dvui.Rect;
+const RectScale = dvui.RectScale;
+const Size = dvui.Size;
+const Widget = dvui.Widget;
+const WidgetData = dvui.WidgetData;
+
+const FloatingTooltipWidget = @This();
+
+// maintain a chain of all the nested FloatingTooltipWidgets
+var tooltip_current: ?*FloatingTooltipWidget = null;
+
+fn tooltipSet(tt: ?*FloatingTooltipWidget) ?*FloatingTooltipWidget {
+    const ret = tooltip_current;
+    tooltip_current = tt;
+    return ret;
+}
+
+pub var defaults: Options = .{
+    .name = "Tooltip",
+    .corner_radius = Rect.all(5),
+    .border = Rect.all(1),
+    .background = true,
+};
+
+pub const Position = enum {
+    /// Right of active_rect
+    horizontal,
+    /// Below active_rect
+    vertical,
+    /// Starts where mouse is but stays there
+    sticky,
+};
+
+pub const InitOptions = struct {
+    /// Show when mouse enters this rect in screen pixels
+    active_rect: Rect,
+
+    position: Position = .horizontal,
+};
+
+parent_tooltip: ?*FloatingTooltipWidget = null,
+prev_rendering: bool = undefined,
+wd: WidgetData = undefined,
+prev_windowId: u32 = 0,
+prevClip: Rect = Rect{},
+scale_val: f32 = undefined,
+scaler: dvui.ScaleWidget = undefined,
+options: Options = undefined,
+init_options: InitOptions = undefined,
+showing: bool = false,
+installed: bool = false,
+tt_child_shown: bool = false,
+
+/// FloatingTooltipWidget is a subwindow to show temporary floating tooltips,
+/// possibly nested. It doesn't focus itself (as a subwindow).
+///
+/// Will show when the mouse is in the active rect.
+///
+/// Will stop if the mouse is outside the active rect AND outside
+/// FloatingTooltipWidget's rect AND no nested FloatingTooltipWidget is still
+/// showing.
+///
+/// Don't put menus or menuItems in this those depend on focus to work.
+/// FloatingMenu is made for that.
+///
+/// Use FloatingWindowWidget for a floating window that the user can change
+/// size, move around, and adjust stacking.
+pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts_in: Options) FloatingTooltipWidget {
+    var self = FloatingTooltipWidget{};
+
+    // get scale from parent
+    self.scale_val = dvui.parentGet().screenRectScale(Rect{}).s / dvui.windowNaturalScale();
+    self.options = defaults.override(opts_in);
+    if (self.options.min_size_content) |msc| {
+        self.options.min_size_content = msc.scale(self.scale_val);
+    }
+
+    // passing options.rect will stop WidgetData.init from calling
+    // rectFor/minSizeForChild which is important because we are outside
+    // normal layout
+    self.wd = WidgetData.init(src, .{ .subwindow = true }, (Options{ .name = "FloatingTooltip" }).override(.{ .rect = self.options.rect orelse .{} }));
+
+    self.init_options = init_opts;
+    self.showing = dvui.dataGet(null, self.wd.id, "_showing", bool) orelse false;
+
+    return self;
+}
+
+pub fn shown(self: *FloatingTooltipWidget) !bool {
+    // protect against this being called multiple times
+    if (self.installed) {
+        return true;
+    }
+
+    if (!self.showing) {
+        // check if we should show
+        if (self.init_options.active_rect.contains(dvui.currentWindow().mouse_pt)) {
+            self.showing = true;
+        }
+    }
+
+    if (self.showing) {
+        switch (self.init_options.position) {
+            .horizontal, .vertical => |o| {
+                const ar = self.init_options.active_rect.scale(1 / dvui.windowNaturalScale());
+                const r: Rect = dvui.Rect.fromPoint(ar.topLeft()).toSize(self.wd.rect.size());
+                self.wd.rect = dvui.placeOnScreen(dvui.windowRect(), ar, if (o == .horizontal) .horizontal else .vertical, r);
+            },
+            .sticky => {
+                if (dvui.firstFrame(self.wd.id)) {
+                    const mp = dvui.currentWindow().mouse_pt.scale(1 / dvui.windowNaturalScale());
+                    dvui.dataSet(null, self.wd.id, "_sticky_pt", mp);
+                } else {
+                    const mp = dvui.dataGet(null, self.wd.id, "_sticky_pt", dvui.Point) orelse dvui.Point{};
+                    var r: Rect = dvui.Rect.fromPoint(mp).toSize(self.wd.rect.size());
+                    r.x += 10;
+                    r.y -= r.h + 10;
+                    self.wd.rect = dvui.placeOnScreen(dvui.windowRect(), .{}, .none, r);
+                }
+            },
+        }
+        //std.debug.print("rect {}\n", .{self.wd.rect});
+
+        try self.install();
+
+        return true;
+    }
+
+    return false;
+}
+
+pub fn install(self: *FloatingTooltipWidget) !void {
+    self.installed = true;
+    self.prev_rendering = dvui.renderingSet(false);
+
+    dvui.parentSet(self.widget());
+
+    self.prev_windowId = dvui.subwindowCurrentSet(self.wd.id, null).id;
+    self.parent_tooltip = tooltipSet(self);
+
+    const rs = self.wd.rectScale();
+
+    try dvui.subwindowAdd(self.wd.id, self.wd.rect, rs.r, false, self.prev_windowId);
+    dvui.captureMouseMaintain(self.wd.id);
+    try self.wd.register();
+
+    // clip to just our window (using clipSet since we are not inside our parent)
+    self.prevClip = dvui.clipGet();
+    dvui.clipSet(rs.r);
+
+    self.scaler = dvui.ScaleWidget.init(@src(), self.scale_val, self.options.override(.{ .expand = .both }));
+    try self.scaler.install();
+}
+
+pub fn widget(self: *FloatingTooltipWidget) Widget {
+    return Widget.init(self, data, rectFor, screenRectScale, minSizeForChild, processEvent);
+}
+
+pub fn data(self: *FloatingTooltipWidget) *WidgetData {
+    return &self.wd;
+}
+
+pub fn rectFor(self: *FloatingTooltipWidget, id: u32, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+    _ = id;
+    return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
+}
+
+pub fn screenRectScale(self: *FloatingTooltipWidget, rect: Rect) RectScale {
+    return self.wd.contentRectScale().rectToRectScale(rect);
+}
+
+pub fn minSizeForChild(self: *FloatingTooltipWidget, s: Size) void {
+    self.wd.minSizeMax(self.wd.options.padSize(s));
+}
+
+pub fn processEvent(self: *FloatingTooltipWidget, e: *Event, bubbling: bool) void {
+    // no event processing, everything stops
+    _ = self;
+    _ = e;
+    _ = bubbling;
+}
+
+pub fn deinit(self: *FloatingTooltipWidget) void {
+    if (!self.installed) {
+        return;
+    }
+
+    // check if we should still be shown
+    const mp = dvui.currentWindow().mouse_pt;
+    if (self.tt_child_shown or self.init_options.active_rect.contains(mp) or self.wd.rectScale().r.contains(mp)) {
+        dvui.dataSet(null, self.wd.id, "_showing", true);
+        var parent: ?*FloatingTooltipWidget = self.parent_tooltip;
+        while (parent) |p| {
+            p.tt_child_shown = true;
+            parent = p.parent_tooltip;
+        }
+    } else {
+        // don't store showing if mouse is outside trigger and tooltip which will close it next frame
+        dvui.dataRemove(null, self.wd.id, "_showing");
+        dvui.refresh(null, @src(), self.wd.id); // refresh with new hidden state
+    }
+
+    self.scaler.deinit();
+    self.wd.minSizeSetAndRefresh();
+
+    // outside normal layout, don't call minSizeForChild or self.wd.minSizeReportToParent();
+
+    _ = tooltipSet(self.parent_tooltip);
+    dvui.parentReset(self.wd.id, self.wd.parent);
+    _ = dvui.subwindowCurrentSet(self.prev_windowId, null);
+    dvui.clipSet(self.prevClip);
+    _ = dvui.renderingSet(self.prev_rendering);
+}

--- a/src/widgets/FloatingWidget.zig
+++ b/src/widgets/FloatingWidget.zig
@@ -46,12 +46,12 @@ pub fn init(src: std.builtin.SourceLocation, opts_in: Options) FloatingWidget {
     // normal layout
     self.wd = WidgetData.init(src, .{ .subwindow = true }, defaults.override(opts).override(.{ .rect = opts.rect orelse .{} }));
 
-    self.prev_rendering = dvui.renderingSet(false);
-
     return self;
 }
 
 pub fn install(self: *FloatingWidget) !void {
+    self.prev_rendering = dvui.renderingSet(false);
+
     dvui.parentSet(self.widget());
 
     self.prev_windowId = dvui.subwindowCurrentSet(self.wd.id, null).id;

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -84,7 +84,6 @@ drag_part: ?DragPart = null,
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) FloatingWindowWidget {
     var self = FloatingWindowWidget{};
-    self.prev_rendering = dvui.renderingSet(false);
 
     // options is really for our embedded BoxWidget, so save them for the
     // end of install()
@@ -199,6 +198,8 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *FloatingWindowWidget) !void {
+    self.prev_rendering = dvui.renderingSet(false);
+
     if (dvui.firstFrame(self.wd.id)) {
         dvui.focusSubwindow(self.wd.id, null);
 


### PR DESCRIPTION
Addresses #158

Adds a tooltip widget that takes a triggering rect and shows a `FloatingWidget` with the users content. The tooltip waits for the mouse to stop moving to capture a starting horizontal location and from then onwards the tooltip is stationary. This means that the tooltip opens close to the users mouse, but still positioned around the triggering rect. This behavior is inspired by vscodes tooltips.

The user can move the mouse around the triggering rect and into the tooltip window, which can contain most other widgets. Widgets that extend outside the tooltip is currently not supported as the original tooltip would close when the mouse exits. Text, buttons, links and other useful short information should work fine.

An animation is also added by default to mimic the behavior of tooltips in vscode. They can be easily disabled by setting a duration of 0. The `AnimateWidget` is also being used as a container for styling purposes.

The waiting for mouse movements to stop does mean that a user that never stops moving the mouse won't see a popup. This is an unlikely scenario as the widget only requires a frame with no movement. It could be made to wait for a very small amount of movement to be more forgiving. It could also the the mouse position immediately.

There isn't currently an example added as I'm unsure of where it would fit. Will gladly add one with some pointers as to where. 

Usage:

```zig
var label = dvui.LabelWidget.initNoFmt(@src(), "Some hoverable text", .{});
try label.install();
try label.draw();
label.deinit();

var tooltip = try dvui.tooltip(@src(), .{ .rect = label.wd.borderRectScale().r }, .{});
defer tooltip.deinit();
if (try tooltip.shown()) {
    var text = try dvui.textLayout(@src(), .{ .break_lines = true }, .{ .background = false });
    defer text.deinit();
    try text.addText("Some tooltip text shown bellow", .{});
}
```

![{2C4A6DCE-820B-4C31-96B4-16B559BCA49C}](https://github.com/user-attachments/assets/fa45d1df-3a84-40a1-9b0b-9173a57f8b6e)
(Cursor not visible, is roughly bellow the 'e' in Some)
