### PR TITLE
sliderentry text mode touch support

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -824,7 +824,7 @@ pub fn basicWidgets(demo_win_id: u32) !void {
         try dvui.label(@src(), "Slider Entry", .{}, .{ .gravity_y = 0.5 });
         if (!slider_entry_vector) {
             _ = try dvui.sliderEntry(@src(), "val: {d:0.3}", .{ .value = &slider_entry_val, .min = (if (slider_entry_min) 0 else null), .max = (if (slider_entry_max) 1 else null), .interval = (if (slider_entry_interval) 0.1 else null) }, .{ .gravity_y = 0.5 });
-            try dvui.label(@src(), "(enter or ctrl-click)", .{}, .{ .gravity_y = 0.5 });
+            try dvui.label(@src(), "(enter, ctrl-click or touch-tap)", .{}, .{ .gravity_y = 0.5 });
         } else {
             _ = try dvui.sliderVector(@src(), "{d:0.2}", 3, &slider_vector_array, .{ .min = (if (slider_entry_min) 0 else null), .max = (if (slider_entry_max) 1 else null), .interval = (if (slider_entry_interval) 0.1 else null) }, .{});
         }

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -6371,11 +6371,24 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
                             refresh(null, @src(), b.data().id);
                         } else {
                             captureMouse(b.data().id);
-                            p = me.p;
                             dataSet(null, b.data().id, "_start_x", me.p.x);
                             dataSet(null, b.data().id, "_start_v", init_opts.value.*);
+
+                            if (me.button.touch()) {
+                                dvui.dragPreStart(me.p, .{});
+                            } else {
+                                // Only start tracking the position on press if this
+                                // is not a touch to prevent the value from
+                                // "jumping" when entering text mode on a
+                                // touch-tap event
+                                p = me.p;
+                            }
                         }
                     } else if (me.action == .release and me.button.pointer()) {
+                        if (me.button.touch() and dvui.dragging(me.p) == null) {
+                            text_mode = true;
+                            refresh(null, @src(), b.data().id);
+                        }
                         e.handled = true;
                         captureMouse(null);
                         dragEnd();
@@ -6383,7 +6396,13 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
                         dataRemove(null, b.data().id, "_start_v");
                     } else if (me.action == .motion and captured(b.data().id)) {
                         e.handled = true;
-                        p = me.p;
+                        // If this is a touch motion we need to make sure to
+                        // only update the value if we are exceeding the
+                        // drag threshold to prevent the value from jumping while
+                        // entering text mode via a non-drag touch-tap
+                        if (!me.button.touch() or dvui.dragging(me.p) != null) {
+                            p = me.p;
+                        }
                     } else if (me.action == .position) {
                         e.handled = true;
                         hover = true;

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -6368,6 +6368,7 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
                         e.handled = true;
                         if (ctrl_down) {
                             text_mode = true;
+                            refresh(null, @src(), b.data().id);
                         } else {
                             captureMouse(b.data().id);
                             p = me.p;


### PR DESCRIPTION
Tested on android (firefox, vanadium), Firefox linux desktop and sdl-standalone.

----

##   sliderentry: fix not showing text mode when already focused
    
    Explicitly request a refresh after entering text mode via ctrl+click.
    
    Without this fix, entering text mode by ctrl+clicking when the
    sliderentry already has focus and in the absence of other events would
    result in the slider entry not visually transitioning to text input mode
    until the next event/refresh.

##  sliderentry: enter text_mode by touch-tapping
    
    Entering text mode via ctrl+click or the enter key is cumbersome on
    mobile devices, so this adds support for entering text mode by tapping
    on a sliderentry.
    
    Regular pointer (mouse/non-touch) events keep their current behavior
    of jumping the slider to the position of the pointer.
    
    Fixes https://github.com/david-vanderson/dvui/issues/215.