### PR TITLE
Prevent two tooltips chains at once

### DIFF
--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -13,21 +13,11 @@ const FloatingTooltipWidget = @This();
 
 // maintain a chain of all the nested FloatingTooltipWidgets
 var tooltip_current: ?*FloatingTooltipWidget = null;
-// the last frame time a chain was open, only one allowed per frame
-var last_tooltip_set: i32 = 0;
 
 fn tooltipSet(tt: ?*FloatingTooltipWidget) ?*FloatingTooltipWidget {
-    if (tooltip_current == null) {
-        // Set the time of the current frame
-        last_tooltip_set = @truncate(dvui.frameTimeNS());
-    }
     const ret = tooltip_current;
     tooltip_current = tt;
     return ret;
-}
-
-fn tooltipCanOpen() bool {
-    return tooltip_current != null or last_tooltip_set != @as(i32, @truncate(dvui.frameTimeNS()));
 }
 
 pub var defaults: Options = .{
@@ -107,13 +97,10 @@ pub fn shown(self: *FloatingTooltipWidget) !bool {
         return true;
     }
 
-    if (!tooltipCanOpen()) {
-        return false;
-    }
-
     if (!self.showing) {
         // check if we should show
-        if (self.init_options.active_rect.contains(dvui.currentWindow().mouse_pt)) {
+        const cw = dvui.currentWindow();
+        if (cw.windowFor(cw.mouse_pt) == cw.subwindow_currentId and self.init_options.active_rect.contains(cw.mouse_pt)) {
             self.showing = true;
         }
     }

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -100,7 +100,10 @@ pub fn shown(self: *FloatingTooltipWidget) !bool {
     if (!self.showing) {
         // check if we should show
         const cw = dvui.currentWindow();
-        if (cw.windowFor(cw.mouse_pt) == cw.subwindow_currentId and self.init_options.active_rect.contains(cw.mouse_pt)) {
+        if ((cw.captureID == null or cw.captureID == self.wd.id) and
+            cw.windowFor(cw.mouse_pt) == cw.subwindow_currentId and
+            self.init_options.active_rect.contains(cw.mouse_pt))
+        {
             self.showing = true;
         }
     }


### PR DESCRIPTION
This is a minor fix for tooltips. When a tooltip opens over another tooltip trigger area, both were shown at once. The second tooltip should not be shown before first one closes.

To fix this, a check is added to see if this is the first chain in the frame. Otherwise don't show the tooltip.

Before and after (with the mouse over the "Some text" tooltip in both cases)
![{F03B6CD5-C807-4268-9627-12232541FB0F}](https://github.com/user-attachments/assets/6733f601-3e4a-40ed-b8a1-2fc76bcd1447)
![{862EDB1D-3619-4A1A-8E04-A20A1B8100E3}](https://github.com/user-attachments/assets/b45aacc9-1ee1-4356-aa21-865f25718faa)
