### PR TITLE
Make Tooltip interactivity optional

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -2117,6 +2117,7 @@ pub fn menus() !void {
 
         var tt: dvui.FloatingTooltipWidget = .init(@src(), .{
             .active_rect = hbox.data().borderRectScale().r,
+            .interactive = true,
         }, .{});
         if (try tt.shown()) {
             var tl2 = try dvui.textLayout(@src(), .{}, .{ .background = false });

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -216,7 +216,7 @@ pub fn deinit(self: *FloatingTooltipWidget) void {
     }
 
     // check if we should still be shown
-    if (self.mouse_good_this_frame or self.tt_child_shown) {
+    if (self.mouse_good_this_frame or (self.init_options.interactive and self.tt_child_shown)) {
         dvui.dataSet(null, self.wd.id, "_showing", true);
         var parent: ?*FloatingTooltipWidget = self.parent_tooltip;
         while (parent) |p| {

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -41,6 +41,9 @@ pub const InitOptions = struct {
     active_rect: Rect,
 
     position: Position = .horizontal,
+
+    /// Is true if the user should be able to hover the tooltips content without it disappearing
+    interactive: bool = false,
 };
 
 parent_tooltip: ?*FloatingTooltipWidget = null,
@@ -137,14 +140,16 @@ pub fn shown(self: *FloatingTooltipWidget) !bool {
 
         try self.install();
 
-        // check for mouse position in tooltip window rect
-        for (evts) |*e| {
-            if (!dvui.eventMatch(e, .{ .id = self.wd.id, .r = self.wd.borderRectScale().r })) {
-                continue;
-            }
+        if (self.init_options.interactive) {
+            // check for mouse position in tooltip window rect
+            for (evts) |*e| {
+                if (!dvui.eventMatch(e, .{ .id = self.wd.id, .r = self.wd.borderRectScale().r })) {
+                    continue;
+                }
 
-            if (e.evt == .mouse and e.evt.mouse.action == .position) {
-                self.mouse_good_this_frame = true;
+                if (e.evt == .mouse and e.evt.mouse.action == .position) {
+                    self.mouse_good_this_frame = true;
+                }
             }
         }
 


### PR DESCRIPTION
From using the new tooltips, I've realised that I often just want to show contextual information to the user. Having the tooltips always stay open on hover makes this difficult to use in a list were the tooltip covers the next list item. I believe most tooltips are NOT interactive and have set that as the default.

In short most tooltips shouldn't hinder the access to other elements unless is has a reason to.