### PR TITLE
Web refactor for added modularity

### DIFF
--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -985,10 +985,44 @@ class Dvui {
         );
     }
 
+    init() {
+        let app_init_return = 0;
+        let str = utf8encoder.encode(navigator.platform);
+        if (str.length > 0) {
+            const ptr = this.instance.exports.gpa_u8(
+                str.length,
+            );
+            var dest = new Uint8Array(
+                this.instance.exports.memory.buffer,
+                ptr,
+                str.length,
+            );
+            dest.set(str);
+            app_init_return = this.instance.exports.app_init(
+                ptr,
+                str.length,
+            );
+            this.instance.exports.gpa_free(ptr, str.length);
+        } else {
+            app_init_return = this.instance.exports.app_init(
+                0,
+                0,
+            );
+        }
+
+        if (app_init_return != 0) {
+            console.log(
+                "ERROR: app_init returned " + app_init_return,
+            );
+            return;
+        }
+    }
+
     run() {
+        this.init();
+
         let renderRequested = false;
         let renderTimeoutId = 0;
-        let app_initialized = false;
 
         const render = () => {
             renderRequested = false;
@@ -1019,40 +1053,6 @@ class Dvui {
 
             this.gl.clearColor(0.0, 0.0, 0.0, 1.0); // Clear to black, fully opaque
             this.gl.clear(this.gl.COLOR_BUFFER_BIT);
-
-            if (!app_initialized) {
-                app_initialized = true;
-                let app_init_return = 0;
-                let str = utf8encoder.encode(navigator.platform);
-                if (str.length > 0) {
-                    const ptr = this.instance.exports.gpa_u8(
-                        str.length,
-                    );
-                    var dest = new Uint8Array(
-                        this.instance.exports.memory.buffer,
-                        ptr,
-                        str.length,
-                    );
-                    dest.set(str);
-                    app_init_return = this.instance.exports.app_init(
-                        ptr,
-                        str.length,
-                    );
-                    this.instance.exports.gpa_free(ptr, str.length);
-                } else {
-                    app_init_return = this.instance.exports.app_init(
-                        0,
-                        0,
-                    );
-                }
-
-                if (app_init_return != 0) {
-                    console.log(
-                        "ERROR: app_init returned " + app_init_return,
-                    );
-                    return;
-                }
-            }
 
             let millis_to_wait = this.instance.exports.app_update();
             if (!this.filesCacheModified) {

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -1009,10 +1009,7 @@ class Dvui {
         }
 
         if (app_init_return != 0) {
-            console.log(
-                "ERROR: app_init returned " + app_init_return,
-            );
-            return;
+            throw new Error("ERROR: app_init returned " + app_init_return);
         }
     }
 

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -1,7 +1,14 @@
+/**
+ * @param {number} ms Number of milliseconds to sleep
+ */
 async function dvui_sleep(ms) {
     await new Promise((r) => setTimeout(r, ms));
 }
 
+/**
+ * @param {string} url
+ * @returns {Uint8Array}
+ */
 async function dvui_fetch(url) {
     let x = await fetch(url);
     let blob = await x.blob();
@@ -9,6 +16,11 @@ async function dvui_fetch(url) {
     return new Uint8Array(await blob.arrayBuffer());
 }
 
+/**
+ * @param {string} accept Maps to the accept attribute of the file input element
+ * @param {boolean} multiple
+ * @returns {Promise<FileList>}
+ */
 async function dvui_open_file_picker(accept, multiple) {
     return new Promise((res, rej) => {
         const file_input = document.createElement("input");
@@ -117,6 +129,10 @@ const fragmentShaderSource_webgl2 = `# version 300 es
     }
 `;
 
+/**
+ * @param {string} canvasId
+ * @param {string} wasmFile The url to the wasm file, to be used in `fetch`
+ */
 function dvui(canvasId, wasmFile) {
     const dvui = new Dvui();
     fetch(wasmFile)
@@ -134,25 +150,52 @@ const utf8encoder = new TextEncoder();
 
 class Dvui {
     webgl2 = true;
+    /** @type {WebGL2RenderingContext | WebGLRenderingContext} */
     gl;
+    /** @type {WebGLBuffer} */
     indexBuffer;
+    /** @type {WebGLBuffer} */
     vertexBuffer;
+    /** @type {WebGLProgram} */
     shaderProgram;
+    /** @type {{ attribLocations: { vertexPosition: number;
+            vertexColor: number;
+            textureCoord: number;
+        };
+        uniformLocations: {
+            matrix: WebGLUniformLocation | null;
+            uSampler: WebGLUniformLocation | null;
+            useTex: WebGLUniformLocation | null;
+        };
+    }} */
     programInfo;
+    /** @type {Map<number, [WebGLTexture, number, number]>} */
     textures = new Map();
     newTextureId = 1;
     using_fb = false;
+    /** @type {WebGLFramebuffer | null} */
     frame_buffer = null;
+    /** @type {[number, number]} */
     renderTargetSize = [0, 0];
 
+    /** @type {WebAssembly.Instance} */
     instance;
     log_string = "";
+    /** @type {HTMLInputElement} */
     hidden_input;
-    touches = []; // list of tuple (touch identifier, initial index)
-    textInputRect = []; // x y w h of on screen keyboard editing position, or empty if none
+    /**
+     * list of tuple (touch identifier, initial index)
+     * @type {[number, number][]} */
+    touches = [];
+    /**
+     * x y w h of on screen keyboard editing position, or empty if none
+     *
+     * @type {[number, number, number, number] | []} */
+    textInputRect = [];
 
     // Used for file uploads. Only valid for one frame
     filesCacheModified = false;
+    /** @type {Map<number, FileList>} */
     filesCache = new Map();
 
     //let par = document.createElement("p");

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -824,7 +824,7 @@ class Dvui {
                     this.hidden_input.select();
                     document.execCommand("copy");
                     this.hidden_input.value = "";
-                    oskCheck();
+                    this.oskCheck();
                 }
             },
             wasm_add_noto_font: () => {
@@ -1106,7 +1106,7 @@ class Dvui {
         this.gl.canvas.addEventListener("mouseup", (ev) => {
             this.instance.exports.add_event(3, ev.button, 0, 0, 0);
             requestRender();
-            oskCheck();
+            this.oskCheck();
         });
         this.gl.canvas.addEventListener("wheel", (ev) => {
             ev.preventDefault();
@@ -1216,7 +1216,7 @@ class Dvui {
                     (rect.right - rect.left);
                 let y = (touch.clientY - rect.top) /
                     (rect.bottom - rect.top);
-                let tidx = touchIndex(touch.identifier);
+                let tidx = this.touchIndex(touch.identifier);
                 this.instance.exports.add_event(
                     8,
                     this.touches[tidx][1],
@@ -1236,7 +1236,7 @@ class Dvui {
                     (rect.right - rect.left);
                 let y = (touch.clientY - rect.top) /
                     (rect.bottom - rect.top);
-                let tidx = touchIndex(touch.identifier);
+                let tidx = this.touchIndex(touch.identifier);
                 this.instance.exports.add_event(
                     9,
                     this.touches[tidx][1],
@@ -1247,7 +1247,7 @@ class Dvui {
                 this.touches.splice(tidx, 1);
             }
             requestRender();
-            oskCheck();
+            this.oskCheck();
         });
         this.gl.canvas.addEventListener("touchmove", (ev) => {
             ev.preventDefault();
@@ -1258,7 +1258,7 @@ class Dvui {
                     (rect.right - rect.left);
                 let y = (touch.clientY - rect.top) /
                     (rect.bottom - rect.top);
-                let tidx = touchIndex(touch.identifier);
+                let tidx = this.touchIndex(touch.identifier);
                 this.instance.exports.add_event(
                     10,
                     this.touches[tidx][1],

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -1014,6 +1014,16 @@ class Dvui {
     }
 
     run() {
+        if (!this.instance) {
+            throw new Error(
+                "Missing wasm instance, did you forget to call `setInstance`?",
+            );
+        }
+        if (!this.gl) {
+            throw new Error(
+                "Missing rendering context, did you forget to call `setCanvas`?",
+            );
+        }
         this.init();
 
         let renderRequested = false;

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -137,7 +137,7 @@ function dvui(canvasId, wasmFile) {
     const dvui = new Dvui();
     fetch(wasmFile)
         .then((response) => response.arrayBuffer())
-        .then((bytes) => WebAssembly.instantiate(bytes, { env: dvui.imports }))
+        .then((bytes) => WebAssembly.instantiate(bytes, { dvui: dvui.imports }))
         .then((result) => {
             dvui.setInstance(result.instance);
             dvui.setCanvas(canvasId);

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -860,7 +860,7 @@ class Dvui {
                 : document.querySelector(canvasSelectorOrCanvasElement);
 
         if (!canvas) {
-            alert("Could find canvas element.");
+            alert("Could not find canvas element.");
             return;
         }
 

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -149,7 +149,6 @@ const utf8decoder = new TextDecoder();
 const utf8encoder = new TextEncoder();
 
 class Dvui {
-    webgl2 = true;
     /** @type {WebGL2RenderingContext | WebGLRenderingContext} */
     gl;
     /** @type {WebGLBuffer} */
@@ -201,6 +200,10 @@ class Dvui {
     //let par = document.createElement("p");
     //document.body.prepend(par);
 
+    get webgl2() {
+        return this.gl instanceof WebGL2RenderingContext;
+    }
+
     oskCheck() {
         if (this.textInputRect.length == 0) {
             this.gl.canvas.focus();
@@ -229,6 +232,14 @@ class Dvui {
     }
 
     constructor() {
+        this.hidden_input = document.createElement("input");
+        this.hidden_input.style.position = "absolute";
+        this.hidden_input.style.left = 0;
+        this.hidden_input.style.top = 0;
+        this.hidden_input.style.opacity = 0;
+        this.hidden_input.style.zIndex = -1;
+        document.body.prepend(this.hidden_input);
+
         this.imports = {
             wasm_about_webgl2: () => {
                 if (this.webgl2) {
@@ -843,13 +854,20 @@ class Dvui {
         this.instance = instance;
     }
 
-    setCanvas(canvasId) {
-        /** @type {HTMLCanvasElement} */
-        const canvas = document.querySelector(canvasId);
+    setCanvas(canvasSelectorOrCanvasElement) {
+        /** @type {HTMLCanvasElement | null} */
+        const canvas =
+            canvasSelectorOrCanvasElement instanceof HTMLCanvasElement
+                ? canvasSelectorOrCanvasElement
+                : document.querySelector(canvasSelectorOrCanvasElement);
+
+        if (!canvas) {
+            alert("Could find canvas element.");
+            return;
+        }
 
         this.gl = canvas.getContext("webgl2", { alpha: true });
         if (this.gl === null) {
-            this.webgl2 = false;
             this.gl = canvas.getContext("webgl", { alpha: true });
         }
 
@@ -865,17 +883,6 @@ class Dvui {
                 return;
             }
         }
-    }
-
-    run() {
-        this.hidden_input = document.createElement("input");
-        this.hidden_input.style.position = "absolute";
-        this.hidden_input.style.left = 0;
-        this.hidden_input.style.top = 0;
-        this.hidden_input.style.opacity = 0;
-        this.hidden_input.style.zIndex = -1;
-        document.body.prepend(this.hidden_input);
-
         this.frame_buffer = this.gl.createFramebuffer();
 
         const vertexShader = this.gl.createShader(this.gl.VERTEX_SHADER);
@@ -976,7 +983,9 @@ class Dvui {
             this.gl.canvas.clientWidth,
             this.gl.canvas.clientHeight,
         );
+    }
 
+    run() {
         let renderRequested = false;
         let renderTimeoutId = 0;
         let app_initialized = false;

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -135,9 +135,7 @@ const fragmentShaderSource_webgl2 = `# version 300 es
  */
 function dvui(canvasId, wasmFile) {
     const dvui = new Dvui();
-    fetch(wasmFile)
-        .then((response) => response.arrayBuffer())
-        .then((bytes) => WebAssembly.instantiate(bytes, { dvui: dvui.imports }))
+    WebAssembly.instantiateStreaming(fetch(wasmFile), { dvui: dvui.imports })
         .then((result) => {
             dvui.setInstance(result.instance);
             dvui.setCanvas(canvasId);

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -1,6 +1,5 @@
-
 async function dvui_sleep(ms) {
-    await new Promise(r => setTimeout(r, ms));
+    await new Promise((r) => setTimeout(r, ms));
 }
 
 async function dvui_fetch(url) {
@@ -29,17 +28,16 @@ async function dvui_open_file_picker(accept, multiple) {
             }
             if (!multiple && file_input.files.length > 1) {
                 console.error("Picked multiple files in single file picker");
-                rej("Too many files")
+                rej("Too many files");
                 return;
             }
-            res(file_input.files)
+            res(file_input.files);
         };
         file_input.click();
     });
 }
 
 function dvui(canvasId, wasmFile) {
-
     const vertexShaderSource_webgl = `
         precision mediump float;
 
@@ -78,7 +76,6 @@ function dvui(canvasId, wasmFile) {
           vTextureCoord = aTextureCoord;
         }
     `;
-
 
     const fragmentShaderSource_webgl = `
         precision mediump float;
@@ -134,10 +131,10 @@ function dvui(canvasId, wasmFile) {
     let renderTargetSize = [0, 0];
 
     let wasmResult;
-    let log_string = '';
+    let log_string = "";
     let hidden_input;
-    let touches = [];  // list of tuple (touch identifier, initial index)
-    let textInputRect = [];  // x y w h of on screen keyboard editing position, or empty if none
+    let touches = []; // list of tuple (touch identifier, initial index)
+    let textInputRect = []; // x y w h of on screen keyboard editing position, or empty if none
 
     // Used for file uploads. Only valid for one frame
     let filesCacheModified = false;
@@ -150,12 +147,16 @@ function dvui(canvasId, wasmFile) {
         if (textInputRect.length == 0) {
             gl.canvas.focus();
         } else {
-	    hidden_input.style.left = (window.scrollX + gl.canvas.getBoundingClientRect().left + textInputRect[0]) + 'px';
-	    hidden_input.style.top = (window.scrollY + gl.canvas.getBoundingClientRect().top + textInputRect[1]) + 'px';
-	    hidden_input.style.width = textInputRect[2] + 'px';
-	    hidden_input.style.height = textInputRect[3] + 'px';
+            hidden_input.style.left =
+                (window.scrollX + gl.canvas.getBoundingClientRect().left +
+                    textInputRect[0]) + "px";
+            hidden_input.style.top =
+                (window.scrollY + gl.canvas.getBoundingClientRect().top +
+                    textInputRect[1]) + "px";
+            hidden_input.style.width = textInputRect[2] + "px";
+            hidden_input.style.height = textInputRect[3] + "px";
             hidden_input.focus();
-    	    //par.textContent = hidden_input.style.left + " " + hidden_input.style.top + " " + hidden_input.style.width + " " + hidden_input.style.height;
+            //par.textContent = hidden_input.style.left + " " + hidden_input.style.top + " " + hidden_input.style.width + " " + hidden_input.style.height;
         }
     }
 
@@ -174,661 +175,956 @@ function dvui(canvasId, wasmFile) {
 
     const imports = {
         env: {
-        wasm_about_webgl2: () => {
-            if (webgl2) {
-                return 1;
-            } else {
-                return 0;
-            }
-        },
-        wasm_panic: (ptr, len) => {
-            let msg = utf8decoder.decode(new Uint8Array(wasmResult.instance.exports.memory.buffer, ptr, len));
-            alert(msg);
-            throw Error(msg);
-        },
-        wasm_log_write: (ptr, len) => {
-            log_string += utf8decoder.decode(new Uint8Array(wasmResult.instance.exports.memory.buffer, ptr, len));
-        },
-        wasm_log_flush: () => {
-            console.log(log_string);
-            log_string = '';
-        },
-        wasm_now() {
-            return performance.now();
-        },
-        wasm_sleep(ms) {
-            dvui_sleep(ms);
-        },
-        wasm_pixel_width() {
-            return gl.drawingBufferWidth;
-        },
-        wasm_pixel_height() {
-            return gl.drawingBufferHeight;
-        },
-        wasm_frame_buffer() {
-	    if (using_fb)
-		return 1;
-	    else
-		return 0;
-        },
-        wasm_canvas_width() {
-            return gl.canvas.clientWidth;
-        },
-        wasm_canvas_height() {
-            return gl.canvas.clientHeight;
-        },
-        wasm_textureCreate(pixels, width, height, interp) {
-            const pixelData = new Uint8Array(wasmResult.instance.exports.memory.buffer, pixels, width * height * 4);
-
-            const texture = gl.createTexture();
-            const id = newTextureId;
-            //console.log("creating texture " + id);
-            newTextureId += 1;
-            textures.set(id, [texture, width, height]);
-          
-            gl.bindTexture(gl.TEXTURE_2D, texture);
-
-            gl.texImage2D(
-                gl.TEXTURE_2D,
-                0,
-                gl.RGBA,
-                width,
-                height,
-                0,
-                gl.RGBA,
-                gl.UNSIGNED_BYTE,
-                pixelData,
-            );
-
-            if (webgl2) {
-                gl.generateMipmap(gl.TEXTURE_2D);
-	    }
-
-	    if (interp == 0) {
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-	    } else {
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-	    }
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-
-	    gl.bindTexture(gl.TEXTURE_2D, null);
-
-            return id;
-        },
-        wasm_textureCreateTarget(width, height, interp) {
-            const texture = gl.createTexture();
-            const id = newTextureId;
-            //console.log("creating texture " + id);
-            newTextureId += 1;
-            textures.set(id, [texture, width, height]);
-          
-            gl.bindTexture(gl.TEXTURE_2D, texture);
-
-            gl.texImage2D(
-                gl.TEXTURE_2D,
-                0,
-                gl.RGBA,
-                width,
-                height,
-                0,
-                gl.RGBA,
-                gl.UNSIGNED_BYTE,
-                null,
-            );
-
-	    if (interp == 0) {
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-	    } else {
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-	    }
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-
-	    gl.bindTexture(gl.TEXTURE_2D, null);
-
-	    return id;
-	},
-        wasm_textureRead(textureId, pixels_out, width, height) {
-	    //console.log("textureRead " + textureId);
-            const texture = textures.get(textureId)[0];
-
-	    gl.bindFramebuffer(gl.FRAMEBUFFER, frame_buffer);
-	    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
-
-	    var dest = new Uint8Array(wasmResult.instance.exports.memory.buffer, pixels_out, width * height * 4);
-	    gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, dest, 0);
-	
-	    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-	},
-	wasm_renderTarget(id) {
-	    //console.log("renderTarget " + id);
-	    if (id === 0) {
-		using_fb = false;
-	        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-		renderTargetSize = [gl.drawingBufferWidth, gl.drawingBufferHeight];
-		gl.viewport(0, 0, renderTargetSize[0], renderTargetSize[1]);
-		gl.scissor(0, 0, renderTargetSize[0], renderTargetSize[1]);
-	    } else {
-		using_fb = true;
-	        gl.bindFramebuffer(gl.FRAMEBUFFER, frame_buffer);
-		
-		gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, textures.get(id)[0], 0);
-		renderTargetSize = [textures.get(id)[1], textures.get(id)[2]];
-		gl.viewport(0, 0, renderTargetSize[0], renderTargetSize[1]);
-		gl.scissor(0, 0, renderTargetSize[0], renderTargetSize[1]);
-	    }
-	},
-        wasm_textureDestroy(id) {
-            //console.log("deleting texture " + id);
-            const texture = textures.get(id)[0];
-            textures.delete(id);
-
-            gl.deleteTexture(texture);
-        },
-        wasm_renderGeometry(textureId, index_ptr, index_len, vertex_ptr, vertex_len, sizeof_vertex, offset_pos, offset_col, offset_uv, clip, x, y, w, h) {
-            //console.log("drawClippedTriangles " + textureId + " sizeof " + sizeof_vertex + " pos " + offset_pos + " col " + offset_col + " uv " + offset_uv);
-
-	    //let old_scissor;
-	    if (clip === 1) {
-		// just calling getParameter here is quite slow (5-10 ms per frame according to chrome)
-                //old_scissor = gl.getParameter(gl.SCISSOR_BOX);
-                gl.scissor(x, y, w, h);
-            }
-
-            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
-            const indices = new Uint16Array(wasmResult.instance.exports.memory.buffer, index_ptr, index_len / 2);
-            gl.bufferData( gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
-
-            gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
-            const vertexes = new Uint8Array(wasmResult.instance.exports.memory.buffer, vertex_ptr, vertex_len);
-            gl.bufferData( gl.ARRAY_BUFFER, vertexes, gl.STATIC_DRAW);
-
-            let matrix = new Float32Array(16);
-            matrix[0] = 2.0 / renderTargetSize[0];
-            matrix[1] = 0.0;
-            matrix[2] = 0.0;
-            matrix[3] = 0.0;
-            matrix[4] = 0.0;
-	    if (using_fb) {
-		matrix[5] = 2.0 / renderTargetSize[1];
-	    } else {
-		matrix[5] = -2.0 / renderTargetSize[1];
-	    }
-            matrix[6] = 0.0;
-            matrix[7] = 0.0;
-            matrix[8] = 0.0;
-            matrix[9] = 0.0;
-            matrix[10] = 1.0;
-            matrix[11] = 0.0;
-            matrix[12] = -1.0;
-	    if (using_fb) {
-                matrix[13] = -1.0;
-	    } else {
-                matrix[13] = 1.0;
-	    }
-            matrix[14] = 0.0;
-            matrix[15] = 1.0;
-
-            // vertex
-            gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
-            gl.vertexAttribPointer(
-                programInfo.attribLocations.vertexPosition,
-                2,  // num components
-                gl.FLOAT,
-                false,  // don't normalize
-                sizeof_vertex,  // stride
-                offset_pos,  // offset
-            );
-            gl.enableVertexAttribArray(programInfo.attribLocations.vertexPosition);
-
-            // color
-            gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
-            gl.vertexAttribPointer(
-                programInfo.attribLocations.vertexColor,
-                4,  // num components
-                gl.UNSIGNED_BYTE,
-                false,  // don't normalize
-                sizeof_vertex, // stride
-                offset_col,  // offset
-            );
-            gl.enableVertexAttribArray(programInfo.attribLocations.vertexColor);
-
-            // texture
-            gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
-            gl.vertexAttribPointer(
-            programInfo.attribLocations.textureCoord,
-                2,  // num components
-                gl.FLOAT,
-                false,  // don't normalize
-                sizeof_vertex, // stride
-                offset_uv,  // offset
-            );
-            gl.enableVertexAttribArray(programInfo.attribLocations.textureCoord);
-
-            // Tell WebGL to use our program when drawing
-            gl.useProgram(shaderProgram);
-
-            // Set the shader uniforms
-            gl.uniformMatrix4fv(
-            programInfo.uniformLocations.matrix,
-            false,
-            matrix,
-            );
-
-            if (textureId != 0) {
-                gl.activeTexture(gl.TEXTURE0);
-                gl.bindTexture(gl.TEXTURE_2D, textures.get(textureId)[0]);
-                gl.uniform1i(programInfo.uniformLocations.useTex, 1);
-            } else {
-                gl.bindTexture(gl.TEXTURE_2D, null);
-                gl.uniform1i(programInfo.uniformLocations.useTex, 0);
-            }
-
-            gl.uniform1i(programInfo.uniformLocations.uSampler, 0);
-
-            //console.log("drawElements " + textureId);
-            gl.drawElements(gl.TRIANGLES, indices.length, gl.UNSIGNED_SHORT, 0);
-
-	    if (clip === 1) {
-		//gl.scissor(old_scissor[0], old_scissor[1], old_scissor[2], old_scissor[3]);
-		gl.scissor(0, 0, renderTargetSize[0], renderTargetSize[1]);
-	    }
-        },
-        wasm_cursor(name_ptr, name_len) {
-            let cursor_name = utf8decoder.decode(new Uint8Array(wasmResult.instance.exports.memory.buffer, name_ptr, name_len));
-            gl.canvas.style.cursor = cursor_name;
-        },
-        wasm_text_input(x, y, w, h) {
-            if (w > 0 && h > 0) {
-                textInputRect = [x, y, w, h];
-            } else {
-                textInputRect = [];
-            }
-        },
-        wasm_open_url: (ptr, len) => {
-            let url = utf8decoder.decode(new Uint8Array(wasmResult.instance.exports.memory.buffer, ptr, len));
-	    window.open(url);
-        },
-        wasm_download_data: (name_ptr, name_len, data_ptr, data_len) => {
-            const name = utf8decoder.decode(new Uint8Array(wasmResult.instance.exports.memory.buffer, name_ptr, name_len));
-	    const data = new Uint8Array(wasmResult.instance.exports.memory.buffer, data_ptr, data_len);
-	    const blob = new Blob([data], { type: "octet/stream" });
-	    const fileURL = URL.createObjectURL(blob);
-	    const dl = document.createElement('a');
-	    dl.href = fileURL;
-	    dl.download = name;
-	    document.body.appendChild(dl);
-	    dl.click();
-	    document.body.removeChild(dl);
-	    URL.revokeObjectURL(fileURL);
-        },
-        wasm_open_file_picker(id, accept_ptr, accept_len, multiple) {
-            let accept = utf8decoder.decode(new Uint8Array(wasmResult.instance.exports.memory.buffer, accept_ptr, accept_len));
-            // console.log("Open picker", accept_ptr, accept_len, accept, multiple);
-            dvui_open_file_picker(accept, multiple).then(filelist => {
-                let files = [];
-                let data = [];
-                for (let i = 0; i < filelist.length; i++) {
-                    const file = filelist.item(i);
-                    files.push(file);
-                    data.push(file.arrayBuffer());
+            wasm_about_webgl2: () => {
+                if (webgl2) {
+                    return 1;
+                } else {
+                    return 0;
                 }
-                Promise.all(data).then(data => {
-                    filesCacheModified = true;
-                    filesCache.set(id, { files, data })
-                });
-            })
-        },
-        wasm_get_file_size(id, file_index) {
-            const cached = filesCache.get(id);
-            if (!cached || cached.files.length <= file_index) return;
-            const size = cached.files[file_index].size;
-            return size;
-        },
-        wasm_get_file_name(id, file_index) {
-            const cached = filesCache.get(id);
-            if (!cached || cached.files.length <= file_index) return;
-            const name = utf8encoder.encode(cached.files[file_index].name);
-		    const ptr = wasmResult.instance.exports.arena_u8(name.length + 1);
-		    var dest = new Uint8Array(wasmResult.instance.exports.memory.buffer, ptr, name.length + 1);
-            dest.set(name);
-            dest.set([0], name.length);
-            return ptr;
-        },
-        wasm_read_file_data(id, file_index, data_ptr) {
-            const cached = filesCache.get(id);
-            if (!cached || cached.files.length <= file_index) return;
-		    var dest = new Uint8Array(wasmResult.instance.exports.memory.buffer, data_ptr);
-            dest.set(new Uint8Array(cached.data[file_index]));
-        },
-        wasm_get_number_of_files_available(id) {
-            const cached = filesCache.get(id);
-            if (!cached) return 0;
-            return cached.files.length;
-        },
-        wasm_clipboardTextSet: (ptr, len) => {
-            if (len == 0) {
-                return;
-            }
+            },
+            wasm_panic: (ptr, len) => {
+                let msg = utf8decoder.decode(
+                    new Uint8Array(
+                        wasmResult.instance.exports.memory.buffer,
+                        ptr,
+                        len,
+                    ),
+                );
+                alert(msg);
+                throw Error(msg);
+            },
+            wasm_log_write: (ptr, len) => {
+                log_string += utf8decoder.decode(
+                    new Uint8Array(
+                        wasmResult.instance.exports.memory.buffer,
+                        ptr,
+                        len,
+                    ),
+                );
+            },
+            wasm_log_flush: () => {
+                console.log(log_string);
+                log_string = "";
+            },
+            wasm_now() {
+                return performance.now();
+            },
+            wasm_sleep(ms) {
+                dvui_sleep(ms);
+            },
+            wasm_pixel_width() {
+                return gl.drawingBufferWidth;
+            },
+            wasm_pixel_height() {
+                return gl.drawingBufferHeight;
+            },
+            wasm_frame_buffer() {
+                if (using_fb) {
+                    return 1;
+                } else {
+                    return 0;
+                }
+            },
+            wasm_canvas_width() {
+                return gl.canvas.clientWidth;
+            },
+            wasm_canvas_height() {
+                return gl.canvas.clientHeight;
+            },
+            wasm_textureCreate(pixels, width, height, interp) {
+                const pixelData = new Uint8Array(
+                    wasmResult.instance.exports.memory.buffer,
+                    pixels,
+                    width * height * 4,
+                );
 
-            let msg = utf8decoder.decode(new Uint8Array(wasmResult.instance.exports.memory.buffer, ptr, len));
-            if (navigator.clipboard) {
-                navigator.clipboard.writeText(msg);
-            } else {
-                hidden_input.value = msg;
-                hidden_input.focus();
-                hidden_input.select();
-                document.execCommand("copy");
-                hidden_input.value = "";
-                oskCheck();
-            }
+                const texture = gl.createTexture();
+                const id = newTextureId;
+                //console.log("creating texture " + id);
+                newTextureId += 1;
+                textures.set(id, [texture, width, height]);
+
+                gl.bindTexture(gl.TEXTURE_2D, texture);
+
+                gl.texImage2D(
+                    gl.TEXTURE_2D,
+                    0,
+                    gl.RGBA,
+                    width,
+                    height,
+                    0,
+                    gl.RGBA,
+                    gl.UNSIGNED_BYTE,
+                    pixelData,
+                );
+
+                if (webgl2) {
+                    gl.generateMipmap(gl.TEXTURE_2D);
+                }
+
+                if (interp == 0) {
+                    gl.texParameteri(
+                        gl.TEXTURE_2D,
+                        gl.TEXTURE_MIN_FILTER,
+                        gl.NEAREST,
+                    );
+                    gl.texParameteri(
+                        gl.TEXTURE_2D,
+                        gl.TEXTURE_MAG_FILTER,
+                        gl.NEAREST,
+                    );
+                } else {
+                    gl.texParameteri(
+                        gl.TEXTURE_2D,
+                        gl.TEXTURE_MIN_FILTER,
+                        gl.LINEAR,
+                    );
+                    gl.texParameteri(
+                        gl.TEXTURE_2D,
+                        gl.TEXTURE_MAG_FILTER,
+                        gl.LINEAR,
+                    );
+                }
+                gl.texParameteri(
+                    gl.TEXTURE_2D,
+                    gl.TEXTURE_WRAP_S,
+                    gl.CLAMP_TO_EDGE,
+                );
+                gl.texParameteri(
+                    gl.TEXTURE_2D,
+                    gl.TEXTURE_WRAP_T,
+                    gl.CLAMP_TO_EDGE,
+                );
+
+                gl.bindTexture(gl.TEXTURE_2D, null);
+
+                return id;
+            },
+            wasm_textureCreateTarget(width, height, interp) {
+                const texture = gl.createTexture();
+                const id = newTextureId;
+                //console.log("creating texture " + id);
+                newTextureId += 1;
+                textures.set(id, [texture, width, height]);
+
+                gl.bindTexture(gl.TEXTURE_2D, texture);
+
+                gl.texImage2D(
+                    gl.TEXTURE_2D,
+                    0,
+                    gl.RGBA,
+                    width,
+                    height,
+                    0,
+                    gl.RGBA,
+                    gl.UNSIGNED_BYTE,
+                    null,
+                );
+
+                if (interp == 0) {
+                    gl.texParameteri(
+                        gl.TEXTURE_2D,
+                        gl.TEXTURE_MIN_FILTER,
+                        gl.NEAREST,
+                    );
+                    gl.texParameteri(
+                        gl.TEXTURE_2D,
+                        gl.TEXTURE_MAG_FILTER,
+                        gl.NEAREST,
+                    );
+                } else {
+                    gl.texParameteri(
+                        gl.TEXTURE_2D,
+                        gl.TEXTURE_MIN_FILTER,
+                        gl.LINEAR,
+                    );
+                    gl.texParameteri(
+                        gl.TEXTURE_2D,
+                        gl.TEXTURE_MAG_FILTER,
+                        gl.LINEAR,
+                    );
+                }
+                gl.texParameteri(
+                    gl.TEXTURE_2D,
+                    gl.TEXTURE_WRAP_S,
+                    gl.CLAMP_TO_EDGE,
+                );
+                gl.texParameteri(
+                    gl.TEXTURE_2D,
+                    gl.TEXTURE_WRAP_T,
+                    gl.CLAMP_TO_EDGE,
+                );
+
+                gl.bindTexture(gl.TEXTURE_2D, null);
+
+                return id;
+            },
+            wasm_textureRead(textureId, pixels_out, width, height) {
+                //console.log("textureRead " + textureId);
+                const texture = textures.get(textureId)[0];
+
+                gl.bindFramebuffer(gl.FRAMEBUFFER, frame_buffer);
+                gl.framebufferTexture2D(
+                    gl.FRAMEBUFFER,
+                    gl.COLOR_ATTACHMENT0,
+                    gl.TEXTURE_2D,
+                    texture,
+                    0,
+                );
+
+                var dest = new Uint8Array(
+                    wasmResult.instance.exports.memory.buffer,
+                    pixels_out,
+                    width * height * 4,
+                );
+                gl.readPixels(
+                    0,
+                    0,
+                    width,
+                    height,
+                    gl.RGBA,
+                    gl.UNSIGNED_BYTE,
+                    dest,
+                    0,
+                );
+
+                gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+            },
+            wasm_renderTarget(id) {
+                //console.log("renderTarget " + id);
+                if (id === 0) {
+                    using_fb = false;
+                    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+                    renderTargetSize = [
+                        gl.drawingBufferWidth,
+                        gl.drawingBufferHeight,
+                    ];
+                    gl.viewport(0, 0, renderTargetSize[0], renderTargetSize[1]);
+                    gl.scissor(0, 0, renderTargetSize[0], renderTargetSize[1]);
+                } else {
+                    using_fb = true;
+                    gl.bindFramebuffer(gl.FRAMEBUFFER, frame_buffer);
+
+                    gl.framebufferTexture2D(
+                        gl.FRAMEBUFFER,
+                        gl.COLOR_ATTACHMENT0,
+                        gl.TEXTURE_2D,
+                        textures.get(id)[0],
+                        0,
+                    );
+                    renderTargetSize = [
+                        textures.get(id)[1],
+                        textures.get(id)[2],
+                    ];
+                    gl.viewport(0, 0, renderTargetSize[0], renderTargetSize[1]);
+                    gl.scissor(0, 0, renderTargetSize[0], renderTargetSize[1]);
+                }
+            },
+            wasm_textureDestroy(id) {
+                //console.log("deleting texture " + id);
+                const texture = textures.get(id)[0];
+                textures.delete(id);
+
+                gl.deleteTexture(texture);
+            },
+            wasm_renderGeometry(
+                textureId,
+                index_ptr,
+                index_len,
+                vertex_ptr,
+                vertex_len,
+                sizeof_vertex,
+                offset_pos,
+                offset_col,
+                offset_uv,
+                clip,
+                x,
+                y,
+                w,
+                h,
+            ) {
+                //console.log("drawClippedTriangles " + textureId + " sizeof " + sizeof_vertex + " pos " + offset_pos + " col " + offset_col + " uv " + offset_uv);
+
+                //let old_scissor;
+                if (clip === 1) {
+                    // just calling getParameter here is quite slow (5-10 ms per frame according to chrome)
+                    //old_scissor = gl.getParameter(gl.SCISSOR_BOX);
+                    gl.scissor(x, y, w, h);
+                }
+
+                gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+                const indices = new Uint16Array(
+                    wasmResult.instance.exports.memory.buffer,
+                    index_ptr,
+                    index_len / 2,
+                );
+                gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+
+                gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+                const vertexes = new Uint8Array(
+                    wasmResult.instance.exports.memory.buffer,
+                    vertex_ptr,
+                    vertex_len,
+                );
+                gl.bufferData(gl.ARRAY_BUFFER, vertexes, gl.STATIC_DRAW);
+
+                let matrix = new Float32Array(16);
+                matrix[0] = 2.0 / renderTargetSize[0];
+                matrix[1] = 0.0;
+                matrix[2] = 0.0;
+                matrix[3] = 0.0;
+                matrix[4] = 0.0;
+                if (using_fb) {
+                    matrix[5] = 2.0 / renderTargetSize[1];
+                } else {
+                    matrix[5] = -2.0 / renderTargetSize[1];
+                }
+                matrix[6] = 0.0;
+                matrix[7] = 0.0;
+                matrix[8] = 0.0;
+                matrix[9] = 0.0;
+                matrix[10] = 1.0;
+                matrix[11] = 0.0;
+                matrix[12] = -1.0;
+                if (using_fb) {
+                    matrix[13] = -1.0;
+                } else {
+                    matrix[13] = 1.0;
+                }
+                matrix[14] = 0.0;
+                matrix[15] = 1.0;
+
+                // vertex
+                gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+                gl.vertexAttribPointer(
+                    programInfo.attribLocations.vertexPosition,
+                    2, // num components
+                    gl.FLOAT,
+                    false, // don't normalize
+                    sizeof_vertex, // stride
+                    offset_pos, // offset
+                );
+                gl.enableVertexAttribArray(
+                    programInfo.attribLocations.vertexPosition,
+                );
+
+                // color
+                gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+                gl.vertexAttribPointer(
+                    programInfo.attribLocations.vertexColor,
+                    4, // num components
+                    gl.UNSIGNED_BYTE,
+                    false, // don't normalize
+                    sizeof_vertex, // stride
+                    offset_col, // offset
+                );
+                gl.enableVertexAttribArray(
+                    programInfo.attribLocations.vertexColor,
+                );
+
+                // texture
+                gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+                gl.vertexAttribPointer(
+                    programInfo.attribLocations.textureCoord,
+                    2, // num components
+                    gl.FLOAT,
+                    false, // don't normalize
+                    sizeof_vertex, // stride
+                    offset_uv, // offset
+                );
+                gl.enableVertexAttribArray(
+                    programInfo.attribLocations.textureCoord,
+                );
+
+                // Tell WebGL to use our program when drawing
+                gl.useProgram(shaderProgram);
+
+                // Set the shader uniforms
+                gl.uniformMatrix4fv(
+                    programInfo.uniformLocations.matrix,
+                    false,
+                    matrix,
+                );
+
+                if (textureId != 0) {
+                    gl.activeTexture(gl.TEXTURE0);
+                    gl.bindTexture(gl.TEXTURE_2D, textures.get(textureId)[0]);
+                    gl.uniform1i(programInfo.uniformLocations.useTex, 1);
+                } else {
+                    gl.bindTexture(gl.TEXTURE_2D, null);
+                    gl.uniform1i(programInfo.uniformLocations.useTex, 0);
+                }
+
+                gl.uniform1i(programInfo.uniformLocations.uSampler, 0);
+
+                //console.log("drawElements " + textureId);
+                gl.drawElements(
+                    gl.TRIANGLES,
+                    indices.length,
+                    gl.UNSIGNED_SHORT,
+                    0,
+                );
+
+                if (clip === 1) {
+                    //gl.scissor(old_scissor[0], old_scissor[1], old_scissor[2], old_scissor[3]);
+                    gl.scissor(0, 0, renderTargetSize[0], renderTargetSize[1]);
+                }
+            },
+            wasm_cursor(name_ptr, name_len) {
+                let cursor_name = utf8decoder.decode(
+                    new Uint8Array(
+                        wasmResult.instance.exports.memory.buffer,
+                        name_ptr,
+                        name_len,
+                    ),
+                );
+                gl.canvas.style.cursor = cursor_name;
+            },
+            wasm_text_input(x, y, w, h) {
+                if (w > 0 && h > 0) {
+                    textInputRect = [x, y, w, h];
+                } else {
+                    textInputRect = [];
+                }
+            },
+            wasm_open_url: (ptr, len) => {
+                let url = utf8decoder.decode(
+                    new Uint8Array(
+                        wasmResult.instance.exports.memory.buffer,
+                        ptr,
+                        len,
+                    ),
+                );
+                window.open(url);
+            },
+            wasm_download_data: (name_ptr, name_len, data_ptr, data_len) => {
+                const name = utf8decoder.decode(
+                    new Uint8Array(
+                        wasmResult.instance.exports.memory.buffer,
+                        name_ptr,
+                        name_len,
+                    ),
+                );
+                const data = new Uint8Array(
+                    wasmResult.instance.exports.memory.buffer,
+                    data_ptr,
+                    data_len,
+                );
+                const blob = new Blob([data], { type: "octet/stream" });
+                const fileURL = URL.createObjectURL(blob);
+                const dl = document.createElement("a");
+                dl.href = fileURL;
+                dl.download = name;
+                document.body.appendChild(dl);
+                dl.click();
+                document.body.removeChild(dl);
+                URL.revokeObjectURL(fileURL);
+            },
+            wasm_open_file_picker(id, accept_ptr, accept_len, multiple) {
+                let accept = utf8decoder.decode(
+                    new Uint8Array(
+                        wasmResult.instance.exports.memory.buffer,
+                        accept_ptr,
+                        accept_len,
+                    ),
+                );
+                // console.log("Open picker", accept_ptr, accept_len, accept, multiple);
+                dvui_open_file_picker(accept, multiple).then((filelist) => {
+                    let files = [];
+                    let data = [];
+                    for (let i = 0; i < filelist.length; i++) {
+                        const file = filelist.item(i);
+                        files.push(file);
+                        data.push(file.arrayBuffer());
+                    }
+                    Promise.all(data).then((data) => {
+                        filesCacheModified = true;
+                        filesCache.set(id, { files, data });
+                    });
+                });
+            },
+            wasm_get_file_size(id, file_index) {
+                const cached = filesCache.get(id);
+                if (!cached || cached.files.length <= file_index) return;
+                const size = cached.files[file_index].size;
+                return size;
+            },
+            wasm_get_file_name(id, file_index) {
+                const cached = filesCache.get(id);
+                if (!cached || cached.files.length <= file_index) return;
+                const name = utf8encoder.encode(cached.files[file_index].name);
+                const ptr = wasmResult.instance.exports.arena_u8(
+                    name.length + 1,
+                );
+                var dest = new Uint8Array(
+                    wasmResult.instance.exports.memory.buffer,
+                    ptr,
+                    name.length + 1,
+                );
+                dest.set(name);
+                dest.set([0], name.length);
+                return ptr;
+            },
+            wasm_read_file_data(id, file_index, data_ptr) {
+                const cached = filesCache.get(id);
+                if (!cached || cached.files.length <= file_index) return;
+                var dest = new Uint8Array(
+                    wasmResult.instance.exports.memory.buffer,
+                    data_ptr,
+                );
+                dest.set(new Uint8Array(cached.data[file_index]));
+            },
+            wasm_get_number_of_files_available(id) {
+                const cached = filesCache.get(id);
+                if (!cached) return 0;
+                return cached.files.length;
+            },
+            wasm_clipboardTextSet: (ptr, len) => {
+                if (len == 0) {
+                    return;
+                }
+
+                let msg = utf8decoder.decode(
+                    new Uint8Array(
+                        wasmResult.instance.exports.memory.buffer,
+                        ptr,
+                        len,
+                    ),
+                );
+                if (navigator.clipboard) {
+                    navigator.clipboard.writeText(msg);
+                } else {
+                    hidden_input.value = msg;
+                    hidden_input.focus();
+                    hidden_input.select();
+                    document.execCommand("copy");
+                    hidden_input.value = "";
+                    oskCheck();
+                }
+            },
+            wasm_add_noto_font: () => {
+                dvui_fetch("NotoSansKR-Regular.ttf").then((bytes) => {
+                    //console.log("bytes len " + bytes.length);
+                    const ptr = wasmResult.instance.exports.gpa_u8(
+                        bytes.length,
+                    );
+                    var dest = new Uint8Array(
+                        wasmResult.instance.exports.memory.buffer,
+                        ptr,
+                        bytes.length,
+                    );
+                    dest.set(bytes);
+                    wasmResult.instance.exports.new_font(ptr, bytes.length);
+                });
+            },
         },
-	wasm_add_noto_font: () => {
-	    dvui_fetch("NotoSansKR-Regular.ttf").then((bytes) => {
-		    //console.log("bytes len " + bytes.length);
-		    const ptr = wasmResult.instance.exports.gpa_u8(bytes.length);
-		    var dest = new Uint8Array(wasmResult.instance.exports.memory.buffer, ptr, bytes.length);
-		    dest.set(bytes);
-		    wasmResult.instance.exports.new_font(ptr, bytes.length);
-	    });
-        },
-      },
     };
 
     fetch(wasmFile)
-    .then((response) => response.arrayBuffer())
-    .then((bytes) => WebAssembly.instantiate(bytes, imports))
-    .then(result => {
+        .then((response) => response.arrayBuffer())
+        .then((bytes) => WebAssembly.instantiate(bytes, imports))
+        .then((result) => {
+            wasmResult = result;
 
-        wasmResult = result;
+            /** @type {HTMLCanvasElement} */
+            const canvas = document.querySelector(canvasId);
 
-        /** @type {HTMLCanvasElement} */
-        const canvas = document.querySelector(canvasId);
+            hidden_input = document.createElement("input");
+            hidden_input.style.position = "absolute";
+            hidden_input.style.left = 0;
+            hidden_input.style.top = 0;
+            hidden_input.style.opacity = 0;
+            hidden_input.style.zIndex = -1;
+            document.body.prepend(hidden_input);
 
-        hidden_input = document.createElement("input");
-	hidden_input.style.position = "absolute";
-	hidden_input.style.left = 0;
-	hidden_input.style.top = 0;
-        hidden_input.style.opacity = 0;
-        hidden_input.style.zIndex = -1;
-	document.body.prepend(hidden_input);
+            gl = canvas.getContext("webgl2", { alpha: true });
+            if (gl === null) {
+                webgl2 = false;
+                gl = canvas.getContext("webgl", { alpha: true });
+            }
 
-        gl = canvas.getContext("webgl2", { alpha: true });
-        if (gl === null) {
-            webgl2 = false;
-            gl = canvas.getContext("webgl", { alpha: true });
-        }
-
-        if (gl === null) {
-            alert("Unable to initialize WebGL.");
-            return;
-        }
-
-        if (!webgl2) {
-            const ext = gl.getExtension("OES_element_index_uint");
-            if (ext === null) {
-                alert("WebGL doesn't support OES_element_index_uint.");
+            if (gl === null) {
+                alert("Unable to initialize WebGL.");
                 return;
             }
-        }
 
-	frame_buffer = gl.createFramebuffer();
-
-        const vertexShader = gl.createShader(gl.VERTEX_SHADER);
-        if (webgl2) {
-            gl.shaderSource(vertexShader, vertexShaderSource_webgl2);
-        } else {
-            gl.shaderSource(vertexShader, vertexShaderSource_webgl);
-        }
-        gl.compileShader(vertexShader);
-        if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
-            alert(`Error compiling vertex shader: ${gl.getShaderInfoLog(vertexShader)}`);
-            gl.deleteShader(vertexShader);
-            return null;
-        }
-
-        const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
-        if (webgl2) {
-            gl.shaderSource(fragmentShader, fragmentShaderSource_webgl2);
-        } else {
-            gl.shaderSource(fragmentShader, fragmentShaderSource_webgl);
-        }
-        gl.compileShader(fragmentShader);
-        if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
-            alert(`Error compiling fragment shader: ${gl.getShaderInfoLog(fragmentShader)}`);
-            gl.deleteShader(fragmentShader);
-            return null;
-        }
-
-        shaderProgram = gl.createProgram();
-        gl.attachShader(shaderProgram, vertexShader);
-        gl.attachShader(shaderProgram, fragmentShader);
-        gl.linkProgram(shaderProgram);
-
-        if (!gl.getProgramParameter(shaderProgram, gl.LINK_STATUS)) {
-            alert(`Error initializing shader program: ${gl.getProgramInfoLog(shaderProgram)}`);
-            return null;
-        }
-
-        programInfo = {
-            attribLocations: {
-                vertexPosition: gl.getAttribLocation(shaderProgram, "aVertexPosition"),
-                vertexColor: gl.getAttribLocation(shaderProgram, "aVertexColor"),
-                textureCoord: gl.getAttribLocation(shaderProgram, "aTextureCoord"),
-            },
-            uniformLocations: {
-                matrix: gl.getUniformLocation(shaderProgram, "uMatrix"),
-                uSampler: gl.getUniformLocation(shaderProgram, "uSampler"),
-                useTex: gl.getUniformLocation(shaderProgram, "useTex"),
-            },
-        };
-
-        indexBuffer = gl.createBuffer();
-        vertexBuffer = gl.createBuffer();
-
-        gl.enable(gl.BLEND);
-        gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
-        gl.enable(gl.SCISSOR_TEST);
-        gl.scissor(0, 0, gl.canvas.clientWidth, gl.canvas.clientHeight);
-
-        let renderRequested = false;
-        let renderTimeoutId = 0;
-        let app_initialized = false;
-
-        function render() {
-            renderRequested = false;
-
-            // if the canvas changed size, adjust the backing buffer
-            const w = gl.canvas.clientWidth;
-            const h = gl.canvas.clientHeight;
-            const scale = window.devicePixelRatio;
-            //console.log("wxh " + w + "x" + h + " scale " + scale);
-            gl.canvas.width = Math.round(w * scale);
-            gl.canvas.height = Math.round(h * scale);
-	    renderTargetSize = [gl.drawingBufferWidth, gl.drawingBufferHeight];
-            gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-            gl.scissor(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-
-            gl.clearColor(0.0, 0.0, 0.0, 1.0); // Clear to black, fully opaque
-            gl.clear(gl.COLOR_BUFFER_BIT);
-
-            if (!app_initialized) {
-                app_initialized = true;
-	        let app_init_return = 0;
-	        let str = utf8encoder.encode(navigator.platform);
-                if (str.length > 0) {
-                    const ptr = wasmResult.instance.exports.gpa_u8(str.length);
-                    var dest = new Uint8Array(wasmResult.instance.exports.memory.buffer, ptr, str.length);
-                    dest.set(str);
-                    app_init_return = wasmResult.instance.exports.app_init(ptr, str.length);
-		    wasmResult.instance.exports.gpa_free(ptr, str.length);
-		} else {
-                    app_init_return = wasmResult.instance.exports.app_init(0, 0);
-		}
-
-		if (app_init_return != 0) {
-		    console.log("ERROR: app_init returned " + app_init_return);
-		    return;
-		}
+            if (!webgl2) {
+                const ext = gl.getExtension("OES_element_index_uint");
+                if (ext === null) {
+                    alert("WebGL doesn't support OES_element_index_uint.");
+                    return;
+                }
             }
 
-            let millis_to_wait = wasmResult.instance.exports.app_update();
-            if (!filesCacheModified) {
-                // Only clear if we didn't add anything this frame. Async could add items after they were requested 
-                // in the frame, so keep if for two frames 
-                filesCache.clear();
-            }
-            filesCacheModified = false;
-            if (millis_to_wait == 0) {
-                requestRender();
-            } else if (millis_to_wait > 0) {
-                renderTimeoutId = setTimeout(function () { renderTimeoutId = 0; requestRender(); }, millis_to_wait);
-            }
-            // otherwise something went wrong, so stop
+            frame_buffer = gl.createFramebuffer();
 
-            
-        }
-
-        function requestRender() {
-            if (renderTimeoutId > 0) {
-                // we got called before the timeout happened
-                clearTimeout(renderTimeoutId);
-                renderTimeoutId = 0;
+            const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+            if (webgl2) {
+                gl.shaderSource(vertexShader, vertexShaderSource_webgl2);
+            } else {
+                gl.shaderSource(vertexShader, vertexShaderSource_webgl);
+            }
+            gl.compileShader(vertexShader);
+            if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
+                alert(
+                    `Error compiling vertex shader: ${
+                        gl.getShaderInfoLog(vertexShader)
+                    }`,
+                );
+                gl.deleteShader(vertexShader);
+                return null;
             }
 
-            if (!renderRequested) {
-                // multiple events could call requestRender multiple times, and
-                // we only want a single requestAnimationFrame to happen before
-                // each call to app_update
-                renderRequested = true;
-                requestAnimationFrame(render);
+            const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+            if (webgl2) {
+                gl.shaderSource(fragmentShader, fragmentShaderSource_webgl2);
+            } else {
+                gl.shaderSource(fragmentShader, fragmentShaderSource_webgl);
             }
-        }
+            gl.compileShader(fragmentShader);
+            if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
+                alert(
+                    `Error compiling fragment shader: ${
+                        gl.getShaderInfoLog(fragmentShader)
+                    }`,
+                );
+                gl.deleteShader(fragmentShader);
+                return null;
+            }
 
-        // event listeners
-        canvas.addEventListener("contextmenu", (ev) => {
-            ev.preventDefault();
-        });
-        window.addEventListener("resize", (ev) => {
-            requestRender();
-        });
-        canvas.addEventListener("mousemove", (ev) => {
-            let rect = canvas.getBoundingClientRect();
-            let x = (ev.clientX - rect.left) / (rect.right - rect.left) * canvas.clientWidth;
-            let y = (ev.clientY - rect.top) / (rect.bottom - rect.top) * canvas.clientHeight;
-            wasmResult.instance.exports.add_event(1, 0, 0, x, y);
-            requestRender();
-        });
-        canvas.addEventListener("mousedown", (ev) => {
-            wasmResult.instance.exports.add_event(2, ev.button, 0, 0, 0);
-            requestRender();
-        });
-        canvas.addEventListener("mouseup", (ev) => {
-            wasmResult.instance.exports.add_event(3, ev.button, 0, 0, 0);
-            requestRender();
-            oskCheck();
-        });
-        canvas.addEventListener("wheel", (ev) => {
-	    ev.preventDefault();
-            if (ev.deltaX != 0) {
-                wasmResult.instance.exports.add_event(4, 0, 0, -ev.deltaX, 0);
-            }
-            if (ev.deltaY != 0) {
-                wasmResult.instance.exports.add_event(4, 1, 0, ev.deltaY, 0);
-            }
-            requestRender();
-        });
+            shaderProgram = gl.createProgram();
+            gl.attachShader(shaderProgram, vertexShader);
+            gl.attachShader(shaderProgram, fragmentShader);
+            gl.linkProgram(shaderProgram);
 
-        let keydown = function(ev) {
-            if (ev.key == "Tab") {
-                // stop tab from tabbing away from the canvas
+            if (!gl.getProgramParameter(shaderProgram, gl.LINK_STATUS)) {
+                alert(
+                    `Error initializing shader program: ${
+                        gl.getProgramInfoLog(shaderProgram)
+                    }`,
+                );
+                return null;
+            }
+
+            programInfo = {
+                attribLocations: {
+                    vertexPosition: gl.getAttribLocation(
+                        shaderProgram,
+                        "aVertexPosition",
+                    ),
+                    vertexColor: gl.getAttribLocation(
+                        shaderProgram,
+                        "aVertexColor",
+                    ),
+                    textureCoord: gl.getAttribLocation(
+                        shaderProgram,
+                        "aTextureCoord",
+                    ),
+                },
+                uniformLocations: {
+                    matrix: gl.getUniformLocation(shaderProgram, "uMatrix"),
+                    uSampler: gl.getUniformLocation(shaderProgram, "uSampler"),
+                    useTex: gl.getUniformLocation(shaderProgram, "useTex"),
+                },
+            };
+
+            indexBuffer = gl.createBuffer();
+            vertexBuffer = gl.createBuffer();
+
+            gl.enable(gl.BLEND);
+            gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+            gl.enable(gl.SCISSOR_TEST);
+            gl.scissor(0, 0, gl.canvas.clientWidth, gl.canvas.clientHeight);
+
+            let renderRequested = false;
+            let renderTimeoutId = 0;
+            let app_initialized = false;
+
+            function render() {
+                renderRequested = false;
+
+                // if the canvas changed size, adjust the backing buffer
+                const w = gl.canvas.clientWidth;
+                const h = gl.canvas.clientHeight;
+                const scale = window.devicePixelRatio;
+                //console.log("wxh " + w + "x" + h + " scale " + scale);
+                gl.canvas.width = Math.round(w * scale);
+                gl.canvas.height = Math.round(h * scale);
+                renderTargetSize = [
+                    gl.drawingBufferWidth,
+                    gl.drawingBufferHeight,
+                ];
+                gl.viewport(
+                    0,
+                    0,
+                    gl.drawingBufferWidth,
+                    gl.drawingBufferHeight,
+                );
+                gl.scissor(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+
+                gl.clearColor(0.0, 0.0, 0.0, 1.0); // Clear to black, fully opaque
+                gl.clear(gl.COLOR_BUFFER_BIT);
+
+                if (!app_initialized) {
+                    app_initialized = true;
+                    let app_init_return = 0;
+                    let str = utf8encoder.encode(navigator.platform);
+                    if (str.length > 0) {
+                        const ptr = wasmResult.instance.exports.gpa_u8(
+                            str.length,
+                        );
+                        var dest = new Uint8Array(
+                            wasmResult.instance.exports.memory.buffer,
+                            ptr,
+                            str.length,
+                        );
+                        dest.set(str);
+                        app_init_return = wasmResult.instance.exports.app_init(
+                            ptr,
+                            str.length,
+                        );
+                        wasmResult.instance.exports.gpa_free(ptr, str.length);
+                    } else {
+                        app_init_return = wasmResult.instance.exports.app_init(
+                            0,
+                            0,
+                        );
+                    }
+
+                    if (app_init_return != 0) {
+                        console.log(
+                            "ERROR: app_init returned " + app_init_return,
+                        );
+                        return;
+                    }
+                }
+
+                let millis_to_wait = wasmResult.instance.exports.app_update();
+                if (!filesCacheModified) {
+                    // Only clear if we didn't add anything this frame. Async could add items after they were requested
+                    // in the frame, so keep if for two frames
+                    filesCache.clear();
+                }
+                filesCacheModified = false;
+                if (millis_to_wait == 0) {
+                    requestRender();
+                } else if (millis_to_wait > 0) {
+                    renderTimeoutId = setTimeout(function () {
+                        renderTimeoutId = 0;
+                        requestRender();
+                    }, millis_to_wait);
+                }
+                // otherwise something went wrong, so stop
+            }
+
+            function requestRender() {
+                if (renderTimeoutId > 0) {
+                    // we got called before the timeout happened
+                    clearTimeout(renderTimeoutId);
+                    renderTimeoutId = 0;
+                }
+
+                if (!renderRequested) {
+                    // multiple events could call requestRender multiple times, and
+                    // we only want a single requestAnimationFrame to happen before
+                    // each call to app_update
+                    renderRequested = true;
+                    requestAnimationFrame(render);
+                }
+            }
+
+            // event listeners
+            canvas.addEventListener("contextmenu", (ev) => {
                 ev.preventDefault();
-            }
-
-            let str = utf8encoder.encode(ev.key);
-            if (str.length > 0) {
-                const ptr = wasmResult.instance.exports.arena_u8(str.length);
-                var dest = new Uint8Array(wasmResult.instance.exports.memory.buffer, ptr, str.length);
-                dest.set(str);
-                wasmResult.instance.exports.add_event(5, ptr, str.length, ev.repeat, (ev.metaKey << 3) + (ev.altKey << 2) + (ev.ctrlKey << 1) + (ev.shiftKey << 0));
+            });
+            window.addEventListener("resize", (ev) => {
                 requestRender();
-            }
-        };
-        canvas.addEventListener("keydown", keydown);
-        hidden_input.addEventListener("keydown", keydown);
-
-        let keyup = function(ev) {
-            const str = utf8encoder.encode(ev.key);
-            const ptr = wasmResult.instance.exports.arena_u8(str.length);
-            var dest = new Uint8Array(wasmResult.instance.exports.memory.buffer, ptr, str.length);
-            dest.set(str);
-            wasmResult.instance.exports.add_event(6, ptr, str.length, 0, (ev.metaKey << 3) + (ev.altKey << 2) + (ev.ctrlKey << 1) + (ev.shiftKey << 0));
-            requestRender();
-        };
-        canvas.addEventListener("keyup", keyup);
-        hidden_input.addEventListener("keyup", keyup);
-
-        hidden_input.addEventListener("beforeinput", (ev) => {
-            ev.preventDefault();
-            if (ev.data) {
-                const str = utf8encoder.encode(ev.data);
-                const ptr = wasmResult.instance.exports.arena_u8(str.length);
-                var dest = new Uint8Array(wasmResult.instance.exports.memory.buffer, ptr, str.length);
-                dest.set(str);
-                wasmResult.instance.exports.add_event(7, ptr, str.length, 0, 0);
+            });
+            canvas.addEventListener("mousemove", (ev) => {
+                let rect = canvas.getBoundingClientRect();
+                let x = (ev.clientX - rect.left) / (rect.right - rect.left) *
+                    canvas.clientWidth;
+                let y = (ev.clientY - rect.top) / (rect.bottom - rect.top) *
+                    canvas.clientHeight;
+                wasmResult.instance.exports.add_event(1, 0, 0, x, y);
                 requestRender();
-            }
-        });
-        canvas.addEventListener("touchstart", (ev) => {
-            ev.preventDefault();
-            let rect = canvas.getBoundingClientRect();
-            for (let i = 0; i < ev.changedTouches.length; i++) {
-                let touch = ev.changedTouches[i];
-                let x = (touch.clientX - rect.left) / (rect.right - rect.left);
-                let y = (touch.clientY - rect.top) / (rect.bottom - rect.top);
-                let tidx = touchIndex(touch.identifier);
-                wasmResult.instance.exports.add_event(8, touches[tidx][1], 0, x, y);
-            }
-            requestRender();
-        });
-        canvas.addEventListener("touchend", (ev) => {
-            ev.preventDefault();
-            let rect = canvas.getBoundingClientRect();
-            for (let i = 0; i < ev.changedTouches.length; i++) {
-                let touch = ev.changedTouches[i];
-                let x = (touch.clientX - rect.left) / (rect.right - rect.left);
-                let y = (touch.clientY - rect.top) / (rect.bottom - rect.top);
-                let tidx = touchIndex(touch.identifier);
-                wasmResult.instance.exports.add_event(9, touches[tidx][1], 0, x, y);
-                touches.splice(tidx, 1);
-            }
-            requestRender();
-            oskCheck();
-        });
-        canvas.addEventListener("touchmove", (ev) => {
-            ev.preventDefault();
-            let rect = canvas.getBoundingClientRect();
-            for (let i = 0; i < ev.changedTouches.length; i++) {
-                let touch = ev.changedTouches[i];
-                let x = (touch.clientX - rect.left) / (rect.right - rect.left);
-                let y = (touch.clientY - rect.top) / (rect.bottom - rect.top);
-                let tidx = touchIndex(touch.identifier);
-                wasmResult.instance.exports.add_event(10, touches[tidx][1], 0, x, y);
-            }
-            requestRender();
-        });
-        //canvas.addEventListener("touchcancel", (ev) => {
-        //    console.log(ev);
-        //    requestRender();
-        //});
+            });
+            canvas.addEventListener("mousedown", (ev) => {
+                wasmResult.instance.exports.add_event(2, ev.button, 0, 0, 0);
+                requestRender();
+            });
+            canvas.addEventListener("mouseup", (ev) => {
+                wasmResult.instance.exports.add_event(3, ev.button, 0, 0, 0);
+                requestRender();
+                oskCheck();
+            });
+            canvas.addEventListener("wheel", (ev) => {
+                ev.preventDefault();
+                if (ev.deltaX != 0) {
+                    wasmResult.instance.exports.add_event(
+                        4,
+                        0,
+                        0,
+                        -ev.deltaX,
+                        0,
+                    );
+                }
+                if (ev.deltaY != 0) {
+                    wasmResult.instance.exports.add_event(
+                        4,
+                        1,
+                        0,
+                        ev.deltaY,
+                        0,
+                    );
+                }
+                requestRender();
+            });
 
-        // start the first update
-        requestRender();
-    });
+            let keydown = function (ev) {
+                if (ev.key == "Tab") {
+                    // stop tab from tabbing away from the canvas
+                    ev.preventDefault();
+                }
+
+                let str = utf8encoder.encode(ev.key);
+                if (str.length > 0) {
+                    const ptr = wasmResult.instance.exports.arena_u8(
+                        str.length,
+                    );
+                    var dest = new Uint8Array(
+                        wasmResult.instance.exports.memory.buffer,
+                        ptr,
+                        str.length,
+                    );
+                    dest.set(str);
+                    wasmResult.instance.exports.add_event(
+                        5,
+                        ptr,
+                        str.length,
+                        ev.repeat,
+                        (ev.metaKey << 3) + (ev.altKey << 2) +
+                            (ev.ctrlKey << 1) + (ev.shiftKey << 0),
+                    );
+                    requestRender();
+                }
+            };
+            canvas.addEventListener("keydown", keydown);
+            hidden_input.addEventListener("keydown", keydown);
+
+            let keyup = function (ev) {
+                const str = utf8encoder.encode(ev.key);
+                const ptr = wasmResult.instance.exports.arena_u8(str.length);
+                var dest = new Uint8Array(
+                    wasmResult.instance.exports.memory.buffer,
+                    ptr,
+                    str.length,
+                );
+                dest.set(str);
+                wasmResult.instance.exports.add_event(
+                    6,
+                    ptr,
+                    str.length,
+                    0,
+                    (ev.metaKey << 3) + (ev.altKey << 2) + (ev.ctrlKey << 1) +
+                        (ev.shiftKey << 0),
+                );
+                requestRender();
+            };
+            canvas.addEventListener("keyup", keyup);
+            hidden_input.addEventListener("keyup", keyup);
+
+            hidden_input.addEventListener("beforeinput", (ev) => {
+                ev.preventDefault();
+                if (ev.data) {
+                    const str = utf8encoder.encode(ev.data);
+                    const ptr = wasmResult.instance.exports.arena_u8(
+                        str.length,
+                    );
+                    var dest = new Uint8Array(
+                        wasmResult.instance.exports.memory.buffer,
+                        ptr,
+                        str.length,
+                    );
+                    dest.set(str);
+                    wasmResult.instance.exports.add_event(
+                        7,
+                        ptr,
+                        str.length,
+                        0,
+                        0,
+                    );
+                    requestRender();
+                }
+            });
+            canvas.addEventListener("touchstart", (ev) => {
+                ev.preventDefault();
+                let rect = canvas.getBoundingClientRect();
+                for (let i = 0; i < ev.changedTouches.length; i++) {
+                    let touch = ev.changedTouches[i];
+                    let x = (touch.clientX - rect.left) /
+                        (rect.right - rect.left);
+                    let y = (touch.clientY - rect.top) /
+                        (rect.bottom - rect.top);
+                    let tidx = touchIndex(touch.identifier);
+                    wasmResult.instance.exports.add_event(
+                        8,
+                        touches[tidx][1],
+                        0,
+                        x,
+                        y,
+                    );
+                }
+                requestRender();
+            });
+            canvas.addEventListener("touchend", (ev) => {
+                ev.preventDefault();
+                let rect = canvas.getBoundingClientRect();
+                for (let i = 0; i < ev.changedTouches.length; i++) {
+                    let touch = ev.changedTouches[i];
+                    let x = (touch.clientX - rect.left) /
+                        (rect.right - rect.left);
+                    let y = (touch.clientY - rect.top) /
+                        (rect.bottom - rect.top);
+                    let tidx = touchIndex(touch.identifier);
+                    wasmResult.instance.exports.add_event(
+                        9,
+                        touches[tidx][1],
+                        0,
+                        x,
+                        y,
+                    );
+                    touches.splice(tidx, 1);
+                }
+                requestRender();
+                oskCheck();
+            });
+            canvas.addEventListener("touchmove", (ev) => {
+                ev.preventDefault();
+                let rect = canvas.getBoundingClientRect();
+                for (let i = 0; i < ev.changedTouches.length; i++) {
+                    let touch = ev.changedTouches[i];
+                    let x = (touch.clientX - rect.left) /
+                        (rect.right - rect.left);
+                    let y = (touch.clientY - rect.top) /
+                        (rect.bottom - rect.top);
+                    let tidx = touchIndex(touch.identifier);
+                    wasmResult.instance.exports.add_event(
+                        10,
+                        touches[tidx][1],
+                        0,
+                        x,
+                        y,
+                    );
+                }
+                requestRender();
+            });
+            //canvas.addEventListener("touchcancel", (ev) => {
+            //    console.log(ev);
+            //    requestRender();
+            //});
+
+            // start the first update
+            requestRender();
+        });
 }
-

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -27,42 +27,42 @@ const EventTemp = struct {
 pub var event_temps = std.ArrayList(EventTemp).init(gpa);
 
 pub const wasm = struct {
-    pub extern fn wasm_about_webgl2() u8;
+    pub extern "dvui" fn wasm_about_webgl2() u8;
 
-    pub extern fn wasm_panic(ptr: [*]const u8, len: usize) void;
-    pub extern fn wasm_log_write(ptr: [*]const u8, len: usize) void;
-    pub extern fn wasm_log_flush() void;
+    pub extern "dvui" fn wasm_panic(ptr: [*]const u8, len: usize) void;
+    pub extern "dvui" fn wasm_log_write(ptr: [*]const u8, len: usize) void;
+    pub extern "dvui" fn wasm_log_flush() void;
 
-    pub extern fn wasm_now() f64;
-    pub extern fn wasm_sleep(ms: u32) void;
+    pub extern "dvui" fn wasm_now() f64;
+    pub extern "dvui" fn wasm_sleep(ms: u32) void;
 
-    pub extern fn wasm_pixel_width() f32;
-    pub extern fn wasm_pixel_height() f32;
-    pub extern fn wasm_canvas_width() f32;
-    pub extern fn wasm_canvas_height() f32;
+    pub extern "dvui" fn wasm_pixel_width() f32;
+    pub extern "dvui" fn wasm_pixel_height() f32;
+    pub extern "dvui" fn wasm_canvas_width() f32;
+    pub extern "dvui" fn wasm_canvas_height() f32;
 
-    pub extern fn wasm_frame_buffer() u8;
-    pub extern fn wasm_textureCreate(pixels: [*]u8, width: u32, height: u32, interp: u8) u32;
-    pub extern fn wasm_textureCreateTarget(width: u32, height: u32, interp: u8) u32;
-    pub extern fn wasm_textureRead(texture: u32, pixels_out: [*]u8, width: u32, height: u32) void;
-    pub extern fn wasm_renderTarget(u32) void;
-    pub extern fn wasm_textureDestroy(u32) void;
-    pub extern fn wasm_renderGeometry(texture: u32, index_ptr: [*]const u8, index_len: usize, vertex_ptr: [*]const u8, vertex_len: usize, sizeof_vertex: u8, offset_pos: u8, offset_col: u8, offset_uv: u8, clip: u8, x: i32, y: i32, w: i32, h: i32) void;
+    pub extern "dvui" fn wasm_frame_buffer() u8;
+    pub extern "dvui" fn wasm_textureCreate(pixels: [*]u8, width: u32, height: u32, interp: u8) u32;
+    pub extern "dvui" fn wasm_textureCreateTarget(width: u32, height: u32, interp: u8) u32;
+    pub extern "dvui" fn wasm_textureRead(texture: u32, pixels_out: [*]u8, width: u32, height: u32) void;
+    pub extern "dvui" fn wasm_renderTarget(u32) void;
+    pub extern "dvui" fn wasm_textureDestroy(u32) void;
+    pub extern "dvui" fn wasm_renderGeometry(texture: u32, index_ptr: [*]const u8, index_len: usize, vertex_ptr: [*]const u8, vertex_len: usize, sizeof_vertex: u8, offset_pos: u8, offset_col: u8, offset_uv: u8, clip: u8, x: i32, y: i32, w: i32, h: i32) void;
 
-    pub extern fn wasm_cursor(name: [*]const u8, name_len: u32) void;
-    pub extern fn wasm_text_input(x: f32, y: f32, w: f32, h: f32) void;
-    pub extern fn wasm_open_url(ptr: [*]const u8, len: usize) void;
-    pub extern fn wasm_download_data(name_ptr: [*]const u8, name_len: usize, data_ptr: [*]const u8, data_len: usize) void;
-    pub extern fn wasm_clipboardTextSet(ptr: [*]const u8, len: usize) void;
+    pub extern "dvui" fn wasm_cursor(name: [*]const u8, name_len: u32) void;
+    pub extern "dvui" fn wasm_text_input(x: f32, y: f32, w: f32, h: f32) void;
+    pub extern "dvui" fn wasm_open_url(ptr: [*]const u8, len: usize) void;
+    pub extern "dvui" fn wasm_download_data(name_ptr: [*]const u8, name_len: usize, data_ptr: [*]const u8, data_len: usize) void;
+    pub extern "dvui" fn wasm_clipboardTextSet(ptr: [*]const u8, len: usize) void;
 
     // NOTE: bool in extern becomes 0 and 1 in js, which is falsy and truthy respectively
-    pub extern fn wasm_open_file_picker(id: u32, accept_ptr: [*]const u8, accept_len: usize, multiple: bool) void;
-    pub extern fn wasm_get_number_of_files_available(id: u32) usize;
-    pub extern fn wasm_get_file_name(id: u32, file_index: usize) [*:0]u8;
-    pub extern fn wasm_get_file_size(id: u32, file_index: usize) isize;
-    pub extern fn wasm_read_file_data(id: u32, file_index: usize, data: [*]u8) void;
+    pub extern "dvui" fn wasm_open_file_picker(id: u32, accept_ptr: [*]const u8, accept_len: usize, multiple: bool) void;
+    pub extern "dvui" fn wasm_get_number_of_files_available(id: u32) usize;
+    pub extern "dvui" fn wasm_get_file_name(id: u32, file_index: usize) [*:0]u8;
+    pub extern "dvui" fn wasm_get_file_size(id: u32, file_index: usize) isize;
+    pub extern "dvui" fn wasm_read_file_data(id: u32, file_index: usize, data: [*]u8) void;
 
-    pub extern fn wasm_add_noto_font() void;
+    pub extern "dvui" fn wasm_add_noto_font() void;
 };
 
 export fn dvui_c_alloc(size: usize) ?*anyopaque {


### PR DESCRIPTION
Addresses #235

This cleans up the javascript file for the web backend. Moreover all extern functions are now under the namespace "dvui". See the new `dvui` function for an example of how to instantiate the wasm module with the new refactor. Most of the code is now part of the `Dvui` class and most variables and functions have JSDoc strings added for editor integration.

Some remaining questions are:

- Should the `dvui` function remain in web.js? Perhaps this is something that should be a part of `index.html` to be copied by users that want to instantiate it themselves?
- Could/should the `wasm_` prefix be removed from the extern functions? This is purely a cosmetic change, but i believe `wasm.sleep` reads better than `wasm.wasm_sleep` and it fits with the web refactor