### PR TITLE
App runner with dvui provided main functions

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -150,6 +150,7 @@ pub fn build(b: *std.Build) !void {
         linkBackend(dvui_raylib, raylib_mod);
         addExample(b, target, optimize, "raylib-standalone", dvui_raylib, null, null);
         addExample(b, target, optimize, "raylib-ontop", dvui_raylib, null, null);
+        addExample(b, target, optimize, "app", dvui_raylib, raylib_mod, .raylib);
     }
 
     // Dx11

--- a/examples/app.zig
+++ b/examples/app.zig
@@ -1,0 +1,21 @@
+const std = @import("std");
+const dvui = @import("dvui");
+
+pub fn init() !struct { size: dvui.Size, title: [:0]const u8 } {
+    std.debug.print("init\n", .{});
+    return .{
+        .size = .{ .w = 800.0, .h = 600.0 },
+        .title = "MyApp",
+    };
+}
+
+pub fn frame() !void {
+    if (try dvui.button(@src(), "Examples", .{}, .{})) {
+        dvui.Examples.show_demo_window = !dvui.Examples.show_demo_window;
+    }
+    try dvui.Examples.demo();
+}
+
+pub fn deinit() !void {
+    std.debug.print("deinit\n", .{});
+}

--- a/examples/app.zig
+++ b/examples/app.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const dvui = @import("dvui");
 
-pub fn init() !struct { size: dvui.Size, title: [:0]const u8 } {
+pub fn init() !dvui.Runner.InitOptions {
     std.debug.print("init\n", .{});
     return .{
         .size = .{ .w = 800.0, .h = 600.0 },

--- a/src/Runner.zig
+++ b/src/Runner.zig
@@ -1,0 +1,22 @@
+//! Used for applications were dvui provides the main function of the application.
+//! This makes using multiple backends easier as the application code does not
+//! have to change between backends.
+//!
+//! TODO: Explain what functions the applications should provide
+
+const dvui = @import("dvui.zig");
+
+pub const InitOptions = struct {
+    /// The initial size of the application window
+    size: dvui.Size,
+    /// Set the minimum size of the window
+    min_size: ?dvui.Size = null,
+    /// Set the maximum size of the window
+    max_size: ?dvui.Size = null,
+    vsync: bool = true,
+    /// The application title to display
+    title: [:0]const u8,
+    /// content of a PNG image (or any other format stb_image can load)
+    /// tip: use @embedFile
+    icon: ?[:0]const u8 = null,
+};

--- a/src/backends/raylib.zig
+++ b/src/backends/raylib.zig
@@ -802,3 +802,61 @@ pub fn dvuiRectToRaylib(rect: dvui.Rect) c.Rectangle {
     const r = rect.scale(1 / dvui.windowNaturalScale());
     return c.Rectangle{ .x = r.x, .y = r.y, .width = r.w, .height = r.h };
 }
+
+pub fn main() !void {
+    const App = @import("app");
+
+    var gpa_instance = std.heap.GeneralPurposeAllocator(.{}){};
+    const gpa = gpa_instance.allocator();
+    defer _ = gpa_instance.deinit();
+
+    const init_opts: dvui.Runner.InitOptions = try App.init();
+
+    // init Raylib backend (creates OS window)
+    // initWindow() means the backend calls CloseWindow for you in deinit()
+    var b = try RaylibBackend.initWindow(.{
+        .gpa = gpa,
+        .size = init_opts.size,
+        .min_size = init_opts.min_size,
+        .max_size = init_opts.max_size,
+        .vsync = init_opts.vsync,
+        .title = init_opts.title,
+        .icon = init_opts.icon,
+    });
+    defer b.deinit();
+
+    // init dvui Window (maps onto a single OS window)
+    var win = try dvui.Window.init(@src(), gpa, b.backend(), .{});
+    defer win.deinit();
+
+    main_loop: while (true) {
+        c.BeginDrawing();
+
+        // Raylib does not support waiting with event interruption, so dvui
+        // can't do variable framerate.  So can't call win.beginWait() or
+        // win.waitTime().
+        try win.begin(std.time.nanoTimestamp());
+
+        // send all events to dvui for processing
+        const quit = try b.addAllEvents(&win);
+        if (quit) break :main_loop;
+
+        // if dvui widgets might not cover the whole window, then need to clear
+        // the previous frame's render
+        c.ClearBackground(.{});
+
+        try App.frame();
+
+        // marks end of dvui frame, don't call dvui functions after this
+        // - sends all dvui stuff to backend for rendering, must be called before renderPresent()
+        _ = try win.end(.{});
+
+        // cursor management
+        b.setCursor(win.cursorRequested());
+
+        // render frame to OS
+        c.EndDrawing();
+    }
+
+    try App.deinit();
+}

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1010,27 +1010,23 @@ pub fn main() !void {
     const gpa = gpa_instance.allocator();
     defer _ = gpa_instance.deinit();
 
-    const init_opts = try App.init();
+    const init_opts: dvui.Runner.InitOptions = try App.init();
 
-    // init Raylib backend (creates OS window)
-    // initWindow() means the backend calls CloseWindow for you in deinit()
     var b = try SDLBackend.initWindow(.{
         .allocator = gpa,
         .size = init_opts.size,
-        .vsync = true,
+        .min_size = init_opts.min_size,
+        .max_size = init_opts.max_size,
+        .vsync = init_opts.vsync,
         .title = init_opts.title,
-        // .icon = window_icon_png, // can also call setIconFromFileContent()
+        .icon = init_opts.icon,
     });
     defer b.deinit();
-    // b.log_events = true;
 
     // init dvui Window (maps onto a single OS window)
     var win = try dvui.Window.init(@src(), gpa, b.backend(), .{});
     defer win.deinit();
 
-    c.SDL_EnableScreenSaver();
-
-    // Taken from: https://github.com/david-vanderson/dvui/blob/main/examples/sdl-standalone.zig
     main_loop: while (true) {
         // beginWait coordinates with waitTime below to run frames only when needed
         const nstime = win.beginWait(b.hasEvent());
@@ -1047,7 +1043,6 @@ pub fn main() !void {
         _ = c.SDL_SetRenderDrawColor(b.renderer, 0, 0, 0, 255);
         _ = c.SDL_RenderClear(b.renderer);
 
-        // The demos we pass in here show up under "Platform-specific demos"
         try App.frame();
 
         // marks end of dvui frame, don't call dvui functions after this

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -7,6 +7,7 @@ pub const math = std.math;
 pub const fnv = std.hash.Fnv1a_32;
 
 pub const Backend = @import("Backend.zig");
+pub const Runner = @import("Runner.zig");
 pub const Color = @import("Color.zig");
 pub const Examples = @import("Examples.zig");
 pub const Event = @import("Event.zig");


### PR DESCRIPTION
This related to #165.

This adds a proof of concept with `sdl-app` and `raylib-app` examples which reuses the same application code for both backends. The backend defined a main function for use as the applications root and the user code gets imported as `app` with predefined exports.

This can be extended with more optional lifetime functions like `pub fn configure_window(win: *dvui.Window) void {...}` which would only be called if `@hasDecl(App, "configure_window")` is true.