### PR TITLE
Animation easing

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -94,7 +94,7 @@ const AnimatingDialog = struct {
         const winHeight = win.data().rect.h;
 
         if (dvui.animationGet(win.data().id, "rect_percent")) |a| {
-            win.data().rect.h *= a.lerp();
+            win.data().rect.h *= a.value();
 
             // mucking with the window size can screw up the windows auto sizing, so force it
             win.autoSize();
@@ -171,8 +171,8 @@ pub fn animatingWindowRect(src: std.builtin.SourceLocation, rect: *Rect, show_fl
     if (dvui.animationGet(fwin_id, "rect_percent")) |a| {
         if (dvui.dataGet(null, fwin_id, "size", Size)) |ss| {
             var r = rect.*;
-            const dw = ss.w * a.lerp();
-            const dh = ss.h * a.lerp();
+            const dw = ss.w * a.value();
+            const dh = ss.h * a.value();
             r.x = r.x + (r.w / 2) - (dw / 2);
             r.w = dw;
             r.y = r.y + (r.h / 2) - (dh / 2);
@@ -1000,7 +1000,7 @@ pub fn textEntryWidgets(demo_win_id: u32) !void {
 
         if (dvui.animationGet(hbox.data().id, "enter_pressed")) |a| {
             const prev_alpha = dvui.themeGet().alpha;
-            dvui.themeGet().alpha *= a.lerp();
+            dvui.themeGet().alpha *= a.value();
             try dvui.label(@src(), "Enter!", .{}, .{ .gravity_y = 0.5 });
             dvui.themeGet().alpha = prev_alpha;
         }
@@ -1297,7 +1297,7 @@ pub fn textEntryWidgets(demo_win_id: u32) !void {
 
                 if (dvui.animationGet(hbox.data().id, "value_changed")) |a| {
                     const prev_alpha = dvui.themeGet().alpha;
-                    dvui.themeGet().alpha *= a.lerp();
+                    dvui.themeGet().alpha *= a.value();
                     try dvui.label(@src(), "Changed!", .{}, .{ .gravity_y = 0.5 });
                     dvui.themeGet().alpha = prev_alpha;
                 }
@@ -3060,7 +3060,7 @@ pub fn animations() !void {
         defer button_wiggle.deinit();
 
         if (dvui.animationGet(button_wiggle.data().id, "xoffset")) |a| {
-            button_wiggle.data().rect.x += 20 * (1.0 - a.lerp()) * (1.0 - a.lerp()) * @sin(a.lerp() * std.math.pi * 50);
+            button_wiggle.data().rect.x += 20 * (1.0 - a.value()) * (1.0 - a.value()) * @sin(a.value() * std.math.pi * 50);
         }
 
         try button_wiggle.install();

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -3056,7 +3056,7 @@ pub fn animations() !void {
         try dvui.labelNoFmt(@src(), "Alpha", .{ .gravity_y = 0.5 });
 
         {
-            var animator = try dvui.animate(@src(), .alpha, 500_000, .{});
+            var animator = try dvui.animate(@src(), .{ .kind = .alpha, .duration = 500_000 }, .{});
             defer animator.deinit();
 
             var hbox2 = try dvui.box(@src(), .horizontal, .{});
@@ -3079,7 +3079,7 @@ pub fn animations() !void {
         try dvui.labelNoFmt(@src(), "Vertical", .{ .gravity_y = 0.5 });
 
         {
-            var animator = try dvui.animate(@src(), .vertical, 500_000, .{});
+            var animator = try dvui.animate(@src(), .{ .kind = .vertical, .duration = 500_000 }, .{});
             defer animator.deinit();
 
             var hbox2 = try dvui.box(@src(), .horizontal, .{});
@@ -3102,7 +3102,7 @@ pub fn animations() !void {
         try dvui.labelNoFmt(@src(), "Horizontal", .{ .gravity_y = 0.5 });
 
         {
-            var animator = try dvui.animate(@src(), .horizontal, 500_000, .{});
+            var animator = try dvui.animate(@src(), .{ .kind = .horizontal, .duration = 500_000 }, .{});
             defer animator.deinit();
 
             var hbox2 = try dvui.box(@src(), .horizontal, .{});

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -88,7 +88,7 @@ const AnimatingDialog = struct {
         var win = FloatingWindowWidget.init(@src(), .{ .modal = modal }, .{ .id_extra = id, .max_size_content = .{ .w = 300 } });
 
         if (dvui.firstFrame(win.data().id)) {
-            dvui.animation(win.wd.id, "rect_percent", .{ .start_val = 0, .end_val = 1.0, .end_time = 200_000 });
+            dvui.animation(win.wd.id, "rect_percent", .{ .start_val = 0.2, .end_val = 1.0, .end_time = 800_000, .easing = dvui.easing.outElastic });
         }
 
         const winHeight = win.data().rect.h;

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2514,6 +2514,11 @@ pub const Animation = struct {
     start_time: i32 = 0,
     end_time: i32,
 
+    /// Get the interpolated value between `start_val` and `end_val`
+    ///
+    /// For some easing functions, this value can extend above or bellow
+    /// `start_val` and `end_val`. If this is an issue, you can choose
+    /// a different easing function or use `std.math.clamp`
     pub fn value(a: *const Animation) f32 {
         if (a.start_time >= 0) return a.start_val;
         if (a.done()) return a.end_val;

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5038,7 +5038,7 @@ pub fn toastDisplay(id: u32) !void {
         return;
     };
 
-    var animator = try dvui.animate(@src(), .alpha, 500_000, .{ .id_extra = id });
+    var animator = try dvui.animate(@src(), .{ .kind = .alpha, .duration = 500_000 }, .{ .id_extra = id });
     defer animator.deinit();
     try dvui.labelNoFmt(@src(), message, .{ .background = true, .corner_radius = dvui.Rect.all(1000), .padding = Rect.all(8) });
 
@@ -5051,9 +5051,9 @@ pub fn toastDisplay(id: u32) !void {
     }
 }
 
-pub fn animate(src: std.builtin.SourceLocation, kind: AnimateWidget.Kind, duration_micros: i32, opts: Options) !*AnimateWidget {
+pub fn animate(src: std.builtin.SourceLocation, init_opts: AnimateWidget.InitOptions, opts: Options) !*AnimateWidget {
     var ret = try currentWindow().arena().create(AnimateWidget);
-    ret.* = AnimateWidget.init(src, kind, duration_micros, opts);
+    ret.* = AnimateWidget.init(src, init_opts, opts);
     try ret.install();
     return ret;
 }

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5862,9 +5862,9 @@ pub fn spinner(src: std.builtin.SourceLocation, opts: Options) !void {
     const rs = wd.contentRectScale();
     const r = rs.r;
 
-    var angle: f32 = 0;
-    const anim = Animation{ .start_val = 0, .end_val = 2 * math.pi, .end_time = 4_500_000 };
-    if (animationGet(wd.id, "_angle")) |a| {
+    var t: f32 = 0;
+    const anim = Animation{ .end_time = 3_000_000 };
+    if (animationGet(wd.id, "_t")) |a| {
         // existing animation
         var aa = a;
         if (aa.done()) {
@@ -5872,19 +5872,25 @@ pub fn spinner(src: std.builtin.SourceLocation, opts: Options) !void {
             aa = anim;
             aa.start_time = a.end_time;
             aa.end_time += a.end_time;
-            animation(wd.id, "_angle", aa);
+            animation(wd.id, "_t", aa);
         }
-        angle = aa.lerp();
+        t = aa.lerp();
     } else {
         // first frame we are seeing the spinner
-        animation(wd.id, "_angle", anim);
+        animation(wd.id, "_t", anim);
     }
 
     var path: std.ArrayList(dvui.Point) = .init(dvui.currentWindow().arena());
     defer path.deinit();
 
+    const full_circle = 2 * std.math.pi;
+    // start begins fast, speeding away from end
+    const start = full_circle * easing.outSine(t);
+    // end begins slow, catching up to start
+    const end = full_circle * easing.inSine(t);
+
     const center = Point{ .x = r.x + r.w / 2, .y = r.y + r.h / 2 };
-    try pathAddArc(&path, center, @min(r.w, r.h) / 3, angle, 0, false);
+    try pathAddArc(&path, center, @min(r.w, r.h) / 3, start, end, false);
     try pathStroke(path.items, 3.0 * rs.s, options.color(.text), .{});
 }
 

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2508,15 +2508,16 @@ pub fn eventMatch(e: *Event, opts: EventMatchOptions) bool {
 /// how to have a seemless continuous animation.
 pub const Animation = struct {
     used: bool = true,
+    easing: *const easing.EasingFn = easing.linear,
     start_val: f32 = 0,
     end_val: f32 = 1,
     start_time: i32 = 0,
     end_time: i32,
 
     pub fn lerp(a: *const Animation) f32 {
-        var frac = @as(f32, @floatFromInt(-a.start_time)) / @as(f32, @floatFromInt(a.end_time - a.start_time));
-        frac = @max(0, @min(1, frac));
-        return (a.start_val * (1.0 - frac)) + (a.end_val * frac);
+        const frac = @as(f32, @floatFromInt(-a.start_time)) / @as(f32, @floatFromInt(a.end_time - a.start_time));
+        const t = a.easing(std.math.clamp(frac, 0, 1));
+        return (a.start_val * (1.0 - t)) + (a.end_val * t);
     }
 
     // return true on the last frame for this animation

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -56,6 +56,7 @@ pub const structEntryExAlloc = se.structEntryExAlloc;
 pub const StructFieldOptions = se.StructFieldOptions;
 
 pub const enums = @import("enums.zig");
+pub const easing = @import("easing.zig");
 
 pub const wasm = (builtin.target.cpu.arch == .wasm32);
 pub const useFreeType = !wasm;

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2514,7 +2514,7 @@ pub const Animation = struct {
     start_time: i32 = 0,
     end_time: i32,
 
-    pub fn lerp(a: *const Animation) f32 {
+    pub fn value(a: *const Animation) f32 {
         if (a.start_time >= 0) return a.start_val;
         if (a.done()) return a.end_val;
         const frac = @as(f32, @floatFromInt(-a.start_time)) / @as(f32, @floatFromInt(a.end_time - a.start_time));
@@ -5876,7 +5876,7 @@ pub fn spinner(src: std.builtin.SourceLocation, opts: Options) !void {
             aa.end_time += a.end_time;
             animation(wd.id, "_t", aa);
         }
-        t = aa.lerp();
+        t = aa.value();
     } else {
         // first frame we are seeing the spinner
         animation(wd.id, "_t", anim);

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2515,6 +2515,8 @@ pub const Animation = struct {
     end_time: i32,
 
     pub fn lerp(a: *const Animation) f32 {
+        if (a.start_time >= 0) return a.start_val;
+        if (a.done()) return a.end_val;
         const frac = @as(f32, @floatFromInt(-a.start_time)) / @as(f32, @floatFromInt(a.end_time - a.start_time));
         const t = a.easing(std.math.clamp(frac, 0, 1));
         return (a.start_val * (1.0 - t)) + (a.end_val * t);

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2519,7 +2519,7 @@ pub const Animation = struct {
         if (a.done()) return a.end_val;
         const frac = @as(f32, @floatFromInt(-a.start_time)) / @as(f32, @floatFromInt(a.end_time - a.start_time));
         const t = a.easing(std.math.clamp(frac, 0, 1));
-        return (a.start_val * (1.0 - t)) + (a.end_val * t);
+        return std.math.lerp(a.start_val, a.end_val, t);
     }
 
     // return true on the last frame for this animation

--- a/src/easing.zig
+++ b/src/easing.zig
@@ -1,6 +1,9 @@
 //! Easing functions mainly used for animations. Controls the rate of change of a value,
 //! used to turn a linearly changing value into a smooth, styalized change.
 //!
+//! Note that some easing functions can return values outside 0 and 1 for values of t
+//! between 0 and 1.
+//!
 //! See [easings.net](https://easings.net/) for examples and visualizations
 
 // Adapted from https://gist.github.com/Kryzarel/bba64622057f21a1d6d44879f9cd7bd4
@@ -89,25 +92,31 @@ pub fn inOutCirc(t: f32) f32 {
     return 1 - inCirc((1 - t) * 2) / 2;
 }
 
+/// This function extents past 0 and 1 for values of t between 0 and 1
 pub fn inElastic(t: f32) f32 {
     return 1 - outElastic(1 - t);
 }
+/// This function extents past 0 and 1 for values of t between 0 and 1
 pub fn outElastic(t: f32) f32 {
     const p: f32 = 0.3;
     return std.math.pow(f32, 2, -10 * t) * std.math.sin((t - p / 4) * (2 * std.math.pi) / p) + 1;
 }
+/// This function extents past 0 and 1 for values of t between 0 and 1
 pub fn inOutElastic(t: f32) f32 {
     if (t < 0.5) return inElastic(t * 2) / 2;
     return 1 - inElastic((1 - t) * 2) / 2;
 }
 
+/// This function extents past 0 and 1 for values of t between 0 and 1
 pub fn inBack(t: f32) f32 {
     const s: f32 = 1.70158;
     return t * t * ((s + 1) * t - s);
 }
+/// This function extents past 0 and 1 for values of t between 0 and 1
 pub fn outBack(t: f32) f32 {
     return 1 - inBack(1 - t);
 }
+/// This function extents past 0 and 1 for values of t between 0 and 1
 pub fn inOutBack(t: f32) f32 {
     if (t < 0.5) return inBack(t * 2) / 2;
     return 1 - inBack((1 - t) * 2) / 2;

--- a/src/easing.zig
+++ b/src/easing.zig
@@ -1,0 +1,139 @@
+//! Easing functions mainly used for animations. Controls the rate of change of a value,
+//! used to turn a linearly changing value into a smooth, styalized change.
+//!
+//! See [easings.net](https://easings.net/) for examples and visualizations
+
+// Adapted from https://gist.github.com/Kryzarel/bba64622057f21a1d6d44879f9cd7bd4
+
+const std = @import("std");
+
+pub const EasingFn = fn (t: f32) f32;
+
+pub fn linear(t: f32) f32 {
+    return t;
+}
+
+pub fn inQuad(t: f32) f32 {
+    return t * t;
+}
+pub fn outQuad(t: f32) f32 {
+    return 1 - inQuad(1 - t);
+}
+pub fn inOutQuad(t: f32) f32 {
+    if (t < 0.5) return inQuad(t * 2) / 2;
+    return 1 - inQuad((1 - t) * 2) / 2;
+}
+
+pub fn inCubic(t: f32) f32 {
+    return t * t * t;
+}
+pub fn outCubic(t: f32) f32 {
+    return 1 - inCubic(1 - t);
+}
+pub fn inOutCubic(t: f32) f32 {
+    if (t < 0.5) return inCubic(t * 2) / 2;
+    return 1 - inCubic((1 - t) * 2) / 2;
+}
+
+pub fn inQuart(t: f32) f32 {
+    return t * t * t * t;
+}
+pub fn outQuart(t: f32) f32 {
+    return 1 - inQuart(1 - t);
+}
+pub fn inOutQuart(t: f32) f32 {
+    if (t < 0.5) return inQuart(t * 2) / 2;
+    return 1 - inQuart((1 - t) * 2) / 2;
+}
+
+pub fn inQuint(t: f32) f32 {
+    return t * t * t * t * t;
+}
+pub fn outQuint(t: f32) f32 {
+    return 1 - inQuint(1 - t);
+}
+pub fn inOutQuint(t: f32) f32 {
+    if (t < 0.5) return inQuint(t * 2) / 2;
+    return 1 - inQuint((1 - t) * 2) / 2;
+}
+
+pub fn inSine(t: f32) f32 {
+    return 1 - std.math.cos(t * std.math.pi / 2);
+}
+pub fn outSine(t: f32) f32 {
+    return std.math.sin(t * std.math.pi / 2);
+}
+pub fn inOutSine(t: f32) f32 {
+    return (std.math.cos(t * std.math.pi) - 1) / -2;
+}
+
+pub fn inExpo(t: f32) f32 {
+    return std.math.pow(f32, 2, 10 * (t - 1));
+}
+pub fn outExpo(t: f32) f32 {
+    return 1 - inExpo(1 - t);
+}
+pub fn inOutExpo(t: f32) f32 {
+    if (t < 0.5) return inExpo(t * 2) / 2;
+    return 1 - inExpo((1 - t) * 2) / 2;
+}
+
+pub fn inCirc(t: f32) f32 {
+    return -(std.math.sqrt(1 - t * t) - 1);
+}
+pub fn outCirc(t: f32) f32 {
+    return 1 - inCirc(1 - t);
+}
+pub fn inOutCirc(t: f32) f32 {
+    if (t < 0.5) return inCirc(t * 2) / 2;
+    return 1 - inCirc((1 - t) * 2) / 2;
+}
+
+pub fn inElastic(t: f32) f32 {
+    return 1 - outElastic(1 - t);
+}
+pub fn outElastic(t: f32) f32 {
+    const p: f32 = 0.3;
+    return std.math.pow(f32, 2, -10 * t) * std.math.sin((t - p / 4) * (2 * std.math.pi) / p) + 1;
+}
+pub fn inOutElastic(t: f32) f32 {
+    if (t < 0.5) return inElastic(t * 2) / 2;
+    return 1 - inElastic((1 - t) * 2) / 2;
+}
+
+pub fn inBack(t: f32) f32 {
+    const s: f32 = 1.70158;
+    return t * t * ((s + 1) * t - s);
+}
+pub fn outBack(t: f32) f32 {
+    return 1 - inBack(1 - t);
+}
+pub fn inOutBack(t: f32) f32 {
+    if (t < 0.5) return inBack(t * 2) / 2;
+    return 1 - inBack((1 - t) * 2) / 2;
+}
+
+pub fn inBounce(t: f32) f32 {
+    return 1 - outBounce(1 - t);
+}
+pub fn outBounce(t: f32) f32 {
+    const div: f32 = 2.75;
+    const mult: f32 = 7.5625;
+
+    if (t < 1 / div) {
+        return mult * t * t;
+    } else if (t < 2 / div) {
+        t -= 1.5 / div;
+        return mult * t * t + 0.75;
+    } else if (t < 2.5 / div) {
+        t -= 2.25 / div;
+        return mult * t * t + 0.9375;
+    } else {
+        t -= 2.625 / div;
+        return mult * t * t + 0.984375;
+    }
+}
+pub fn inOutBounce(t: f32) f32 {
+    if (t < 0.5) return inBounce(t * 2) / 2;
+    return 1 - inBounce((1 - t) * 2) / 2;
+}

--- a/src/easing.zig
+++ b/src/easing.zig
@@ -123,14 +123,14 @@ pub fn outBounce(t: f32) f32 {
     if (t < 1 / div) {
         return mult * t * t;
     } else if (t < 2 / div) {
-        t -= 1.5 / div;
-        return mult * t * t + 0.75;
+        const x = t - 1.5 / div;
+        return mult * x * x + 0.75;
     } else if (t < 2.5 / div) {
-        t -= 2.25 / div;
-        return mult * t * t + 0.9375;
+        const x = t - 2.25 / div;
+        return mult * x * x + 0.9375;
     } else {
-        t -= 2.625 / div;
-        return mult * t * t + 0.984375;
+        const x = t - 2.625 / div;
+        return mult * x * x + 0.984375;
     }
 }
 pub fn inOutBounce(t: f32) f32 {

--- a/src/widgets/AnimateWidget.zig
+++ b/src/widgets/AnimateWidget.zig
@@ -45,9 +45,9 @@ pub fn install(self: *AnimateWidget) !void {
     }
 
     if (dvui.animationGet(self.wd.id, "_end")) |a| {
-        self.val = a.lerp();
+        self.val = a.value();
     } else if (dvui.animationGet(self.wd.id, "_start")) |a| {
-        self.val = a.lerp();
+        self.val = a.value();
     }
 
     if (self.val) |v| {

--- a/src/widgets/AnimateWidget.zig
+++ b/src/widgets/AnimateWidget.zig
@@ -11,6 +11,13 @@ const WidgetData = dvui.WidgetData;
 
 const AnimateWidget = @This();
 
+pub const InitOptions = struct {
+    kind: Kind,
+    /// Duration in microseconds
+    duration: i32,
+    easing: ?*const dvui.easing.EasingFn = null,
+};
+
 pub const Kind = enum {
     alpha,
     vertical,
@@ -18,15 +25,14 @@ pub const Kind = enum {
 };
 
 wd: WidgetData = undefined,
-kind: Kind = undefined,
-duration: i32 = undefined,
+init_opts: InitOptions = undefined,
 val: ?f32 = null,
 
 prev_alpha: f32 = 1.0,
 
-pub fn init(src: std.builtin.SourceLocation, kind: Kind, duration_micros: i32, opts: Options) AnimateWidget {
+pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) AnimateWidget {
     const defaults = Options{ .name = "Animate" };
-    return AnimateWidget{ .wd = WidgetData.init(src, .{}, defaults.override(opts)), .kind = kind, .duration = duration_micros };
+    return AnimateWidget{ .wd = WidgetData.init(src, .{}, defaults.override(opts)), .init_opts = init_opts };
 }
 
 pub fn install(self: *AnimateWidget) !void {
@@ -45,10 +51,11 @@ pub fn install(self: *AnimateWidget) !void {
     }
 
     if (self.val) |v| {
-        switch (self.kind) {
+        switch (self.init_opts.kind) {
             .alpha => {
                 self.prev_alpha = dvui.themeGet().alpha;
-                dvui.themeGet().alpha *= v;
+                // alpha crashed if v is not between 0 and 1, which some easing functions may output
+                dvui.themeGet().alpha *= std.math.clamp(v, 0, 1);
             },
             .vertical => {},
             .horizontal => {},
@@ -59,11 +66,21 @@ pub fn install(self: *AnimateWidget) !void {
 }
 
 pub fn start(self: *AnimateWidget) void {
-    dvui.animation(self.wd.id, "_start", .{ .start_val = 0.0, .end_val = 1.0, .end_time = self.duration });
+    dvui.animation(self.wd.id, "_start", .{
+        .start_val = 0.0,
+        .end_val = 1.0,
+        .end_time = self.init_opts.duration,
+        .easing = self.init_opts.easing orelse dvui.easing.linear,
+    });
 }
 
 pub fn startEnd(self: *AnimateWidget) void {
-    dvui.animation(self.wd.id, "_end", .{ .start_val = 1.0, .end_val = 0.0, .end_time = self.duration });
+    dvui.animation(self.wd.id, "_end", .{
+        .start_val = 1.0,
+        .end_val = 0.0,
+        .end_time = self.init_opts.duration,
+        .easing = self.init_opts.easing orelse dvui.easing.linear,
+    });
 }
 
 pub fn end(self: *AnimateWidget) bool {
@@ -104,15 +121,17 @@ pub fn processEvent(self: *AnimateWidget, e: *Event, bubbling: bool) void {
 
 pub fn deinit(self: *AnimateWidget) void {
     if (self.val) |v| {
-        switch (self.kind) {
+        switch (self.init_opts.kind) {
             .alpha => {
                 dvui.themeGet().alpha = self.prev_alpha;
             },
             .vertical => {
-                self.wd.min_size.h *= v;
+                // Negative height messes with layout
+                self.wd.min_size.h *= @max(v, 0);
             },
             .horizontal => {
-                self.wd.min_size.w *= v;
+                // Negative width messes with layout
+                self.wd.min_size.w *= @max(v, 0);
             },
         }
     }

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -83,7 +83,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     }
 
     if (dvui.animationGet(self.wd.id, "_split_ratio")) |a| {
-        self.split_ratio = a.lerp();
+        self.split_ratio = a.value();
 
         if (self.collapsing and a.done()) {
             self.collapsing = false;


### PR DESCRIPTION
This adds animation easing, which is a very cheap and simple improvement to the feel of an application. This could be done on the user side before by having `start_val` and `end_val` be 0 and 1 and doing this easing yourself. Having access to premade functions makes the barrier to nicer animation much lower.

`Animation` now has a `easing` field for an `EasingFn`. A linear function is passed as a default so the old behaviour stays the default.

Currently only the spinner is making use if the new easing functions, but it is a significant visual improvement imo.

![chrome-capture-2025-4-5](https://github.com/user-attachments/assets/9f2ad423-8de6-4baf-8731-8ce5f16fd9a7)
