### PR TITLE
App interface panic handlers (for web)

### DIFF
--- a/examples/app.zig
+++ b/examples/app.zig
@@ -20,6 +20,7 @@ pub const dvui_app: dvui.App = .{
     .deinitFn = AppDeinit,
 };
 pub const main = dvui.App.main;
+pub const panic = dvui.App.panic;
 pub const std_options: std.Options = .{
     .logFn = dvui.App.logFn,
 };
@@ -37,14 +38,12 @@ pub fn AppDeinit() void {}
 
 // Run each frame to do normal UI
 pub fn AppFrame() dvui.App.Result {
-    frame() catch |err| {
-        std.log.err("in frame: {!}", .{err});
-        return .close;
+    return frame() catch |err| {
+        std.debug.panic("in frame: {!}", .{err});
     };
-    return .ok;
 }
 
-pub fn frame() !void {
+pub fn frame() !dvui.App.Result {
     var scroll = try dvui.scrollArea(@src(), .{}, .{ .expand = .both, .color_fill = .{ .name = .fill_window } });
     defer scroll.deinit();
 
@@ -81,6 +80,15 @@ pub fn frame() !void {
         dvui.Examples.show_demo_window = !dvui.Examples.show_demo_window;
     }
 
+    if (try dvui.button(@src(), "Panic", .{}, .{})) {
+        std.debug.panic("This is a panic message after {d}s", .{@divTrunc(dvui.currentWindow().frame_time_ns, std.time.ns_per_s)});
+    }
+    if (try dvui.button(@src(), "Close", .{}, .{})) {
+        return .close;
+    }
+
     // look at demo() for examples of dvui widgets, shows in a floating window
     try dvui.Examples.demo();
+
+    return .ok;
 }

--- a/examples/app.zig
+++ b/examples/app.zig
@@ -80,10 +80,10 @@ pub fn frame() !dvui.App.Result {
         dvui.Examples.show_demo_window = !dvui.Examples.show_demo_window;
     }
 
-    if (try dvui.button(@src(), "Panic", .{}, .{})) {
-        std.debug.panic("This is a panic message after {d}s", .{@divTrunc(dvui.currentWindow().frame_time_ns, std.time.ns_per_s)});
-    }
-    if (try dvui.button(@src(), "Close", .{}, .{})) {
+    //if (try dvui.button(@src(), "Panic", .{}, .{})) {
+    //std.debug.panic("This is a panic message after {d}s", .{@divTrunc(dvui.currentWindow().frame_time_ns, std.time.ns_per_s)});
+    //}
+    if (try dvui.button(@src(), if (dvui.wasm) "Stop" else "Close", .{}, .{})) {
         return .close;
     }
 

--- a/src/App.zig
+++ b/src/App.zig
@@ -5,9 +5,10 @@
 //! pub const dvui_app: dvui.App = .{ .initFn = AppInit, ...};
 //! ```
 //!
-//! Also must use the App's main and log functions:
+//! Also must use the App's main, panic and log functions:
 //! ```
 //! pub const main = dvui.App.main;
+//! pub const panic = dvui.App.panic;
 //! pub const std_options: std.Options = .{
 //!     .logFn = dvui.App.logFn,
 //! };
@@ -32,6 +33,13 @@ fn nop_main() !void {}
 /// pub const main = dvui.App.main;
 /// ```
 pub const main: fn () anyerror!void = if (@hasDecl(dvui.backend, "main")) dvui.backend.main else nop_main;
+
+/// The root file needs to expose the App panic function:
+/// ```
+/// pub const panic = dvui.App.panic;
+/// ```
+pub const panic = if (@hasDecl(dvui.backend, "panic")) dvui.backend.panic else std.debug.FullPanic(std.debug.defaultPanic);
+
 /// Some backends, like web, cannot use stdout and has a custom logFn to be used.
 /// Dvui apps should always prefer to use std.log over stdout to work across all backends.
 ///

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -256,9 +256,8 @@ class Dvui {
                         len,
                     ),
                 );
-                // NOTE: Delay alert so Error shows up in the console before
-                setTimeout(() => alert(msg));
-                throw Error(msg);
+                console.error("PANIC:", msg);
+                alert(msg);
             },
             wasm_log_write: (ptr, len) => {
                 this.log_string += utf8decoder.decode(


### PR DESCRIPTION
On the web backend, no panic  information was provided as stderr isn't present and all default handling relies on it. This adds a panic handler to the `App` interface which handles this. I wasn't able to generate stack traces within zig, but the error message shown in 

Additionally, web.js now properly stops when encountering a panic instead of continuing when new events come in.