### PR TITLE
fix: sdl backend broken due to unused return values

### DIFF
--- a/examples/sdl-standalone.zig
+++ b/examples/sdl-standalone.zig
@@ -46,7 +46,7 @@ pub fn main() !void {
     g_backend = backend;
     defer backend.deinit();
 
-    Backend.c.SDL_EnableScreenSaver();
+    _ = Backend.c.SDL_EnableScreenSaver();
 
     // init dvui Window (maps onto a single OS window)
     var win = try dvui.Window.init(@src(), gpa, backend.backend(), .{});

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1048,7 +1048,7 @@ pub fn main() !void {
     });
     defer back.deinit();
 
-    c.SDL_EnableScreenSaver();
+    _ = c.SDL_EnableScreenSaver();
 
     //// init dvui Window (maps onto a single OS window)
     var win = try dvui.Window.init(@src(), gpa, back.backend(), .{});


### PR DESCRIPTION
closes: #253

I looked around at other call of SDL functions and it looked like in the vast majority of cases, the return values are discarded. Let me know if this is appropriate!