### PR TITLE
Triangle abstraction

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -53,6 +53,8 @@ var layout_border: Rect = Rect.all(0);
 var layout_padding: Rect = Rect.all(4);
 var layout_gravity_x: f32 = 0.5;
 var layout_gravity_y: f32 = 0.5;
+var layout_rotation: f32 = 0;
+var layout_corner_radius: Rect = Rect.all(5);
 var layout_flex_content_justify: dvui.FlexBoxWidget.ContentPosition = .center;
 var layout_expand: dvui.Options.Expand = .none;
 var show_dialog: bool = false;
@@ -1362,6 +1364,7 @@ pub fn layout() !void {
         const Static = struct {
             var img: bool = false;
             var shrink: bool = false;
+            var background: bool = false;
             var shrinkE: dvui.Options.Expand = .none;
             var size: Size = .{ .w = 16, .h = 16 };
         };
@@ -1384,6 +1387,7 @@ pub fn layout() !void {
                 _ = try dvui.sliderEntry(@src(), "H: {d:0.0}", .{ .value = &Static.size.h, .min = 1, .max = 280, .interval = 1 }, .{ .gravity_y = 0.5 });
 
                 _ = try dvui.checkbox(@src(), &Static.shrink, "Shrink", .{});
+                _ = try dvui.checkbox(@src(), &Static.background, "Background", .{});
             }
 
             var opts: Options = .{ .border = Rect.all(1), .background = true, .min_size_content = .{ .w = 200, .h = 140 } };
@@ -1393,10 +1397,12 @@ pub fn layout() !void {
 
             var o = try dvui.overlay(@src(), opts);
 
-            const options: Options = .{ .gravity_x = layout_gravity_x, .gravity_y = layout_gravity_y, .expand = layout_expand };
+            const options: Options = .{ .gravity_x = layout_gravity_x, .gravity_y = layout_gravity_y, .expand = layout_expand, .rotation = layout_rotation, .corner_radius = layout_corner_radius };
             if (Static.img) {
                 _ = try dvui.image(@src(), .{ .name = "zig favicon", .bytes = zig_favicon, .shrink = if (Static.shrink) Static.shrinkE else null }, options.override(.{
                     .min_size_content = Static.size,
+                    .background = Static.background,
+                    .color_fill = .{ .color = dvui.themeGet().color_text },
                 }));
             } else {
                 var buf: [128]u8 = undefined;
@@ -1412,6 +1418,12 @@ pub fn layout() !void {
             try dvui.label(@src(), "Gravity", .{}, .{});
             _ = try dvui.sliderEntry(@src(), "X: {d:0.2}", .{ .value = &layout_gravity_x, .min = 0, .max = 1.0, .interval = 0.01 }, .{});
             _ = try dvui.sliderEntry(@src(), "Y: {d:0.2}", .{ .value = &layout_gravity_y, .min = 0, .max = 1.0, .interval = 0.01 }, .{});
+            try dvui.label(@src(), "Rotation", .{}, .{});
+            _ = try dvui.sliderEntry(@src(), "{d:0.2} radians", .{ .value = &layout_rotation, .min = std.math.pi * -2, .max = std.math.pi * 2, .interval = 0.01 }, .{});
+            try dvui.label(@src(), "Corner Radius", .{}, .{});
+            inline for (0.., @typeInfo(dvui.Rect).@"struct".fields) |i, field| {
+                _ = try dvui.sliderEntry(@src(), field.name ++ ": {d:0}", .{ .min = 0, .max = 200, .interval = 1, .value = &@field(layout_corner_radius, field.name) }, .{ .id_extra = i });
+            }
         }
 
         {

--- a/src/Point.zig
+++ b/src/Point.zig
@@ -17,6 +17,14 @@ pub fn diff(a: Point, b: Point) Point {
     return Point{ .x = a.x - b.x, .y = a.y - b.y };
 }
 
+pub fn min(a: Point, b: Point) Point {
+    return Point{ .x = @min(a.x, b.x), .y = @min(a.y, b.y) };
+}
+
+pub fn max(a: Point, b: Point) Point {
+    return Point{ .x = @max(a.x, b.x), .y = @max(a.y, b.y) };
+}
+
 pub fn scale(self: *const Point, s: f32) Point {
     return Point{ .x = self.x * s, .y = self.y * s };
 }

--- a/src/Rect.zig
+++ b/src/Rect.zig
@@ -95,6 +95,10 @@ pub fn bottomRight(self: *const Rect) Point {
     return Point{ .x = self.x + self.w, .y = self.y + self.h };
 }
 
+pub fn center(self: *const Rect) Point {
+    return Point{ .x = self.x + self.w / 2, .y = self.y + self.h / 2 };
+}
+
 pub fn size(self: *const Rect) Size {
     return Size{ .w = self.w, .h = self.h };
 }

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1163,7 +1163,7 @@ pub fn textInputRequested(self: *const Self) ?Rect {
     return self.text_input_rect;
 }
 
-pub fn renderCommands(self: *Self, queue: std.ArrayList(dvui.RenderCommand)) !void {
+pub fn renderCommands(_: *Self, queue: std.ArrayList(dvui.RenderCommand)) !void {
     const oldsnap = dvui.snapToPixels();
     defer _ = dvui.snapToPixelsSet(oldsnap);
 
@@ -1183,16 +1183,8 @@ pub fn renderCommands(self: *Self, queue: std.ArrayList(dvui.RenderCommand)) !vo
             .debug_font_atlases => |t| {
                 try dvui.debugRenderFontAtlases(t.rs, t.color);
             },
-            .texture => |t| {
-                try dvui.renderTexture(t.tex, t.rs, t.opts);
-            },
-            .pathFillConvex => |pf| {
-                try dvui.pathFillConvex(pf.path, pf.color);
-                self.arena().free(pf.path);
-            },
-            .pathStroke => |ps| {
-                try dvui.pathStrokeRaw(ps.path, ps.thickness, ps.color, ps.closed, ps.endcap_style);
-                self.arena().free(ps.path);
+            .render_triangles => |triangles| {
+                try dvui.renderTriangles(triangles);
             },
         }
     }

--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -48,7 +48,7 @@ pub fn matchEvent(self: *IconWidget, e: *dvui.Event) bool {
 
 pub fn draw(self: *IconWidget) !void {
     const rs = self.wd.parent.screenRectScale(self.wd.contentRect());
-    try dvui.renderIcon(self.name, self.tvg_bytes, rs, self.wd.options.rotationGet(), self.wd.options.color(.text));
+    try dvui.renderIcon(self.name, self.tvg_bytes, rs, .{ .rotation = self.wd.options.rotationGet(), .colormod = self.wd.options.color(.text) });
 }
 
 pub fn deinit(self: *IconWidget) void {


### PR DESCRIPTION
Closes #204

This effectively implements the base for https://github.com/david-vanderson/dvui/issues/220#issuecomment-2758640352
This PR could also be expanded to include gradients by creating a gradient triangle function for #221 and "feathered" box shadow triangles for #220.

The layout example for images have been extended to show these new features.

![{69F0EB95-508B-4F8B-AF8B-38836264E992}](https://github.com/user-attachments/assets/6c626cb5-f07d-49e5-955b-b66db13df056)

There is some issue with rounded corners on images combined with shrinking. I've compromised by ratio shrinking not being able to be used without the `Option.expand` being `.ratio` as well.  The previous implementation could also be left as it works for non-rounded corners.

The ratio shrink with rounded corners could be solved by rendering the image to a texture matching the size of the rect leaving some padding, and then rendering that texture with the rounded corner to fix this. There is no good place to inject this extra textures without the `shrink` needing to be passed down to the lower level functions. There is also an issue of caching this temporary texture if possible, otherwise creating multiple textures every frame would be too much.