### PR TITLE
Add check and test build steps

### DIFF
--- a/examples/dx11-standalone.zig
+++ b/examples/dx11-standalone.zig
@@ -22,26 +22,12 @@ const vsync = true;
 
 var show_dialog_outside_frame: bool = false;
 
+const window_class = win32.L("DvuiStandaloneWindow");
+
 /// This example shows how to use the dvui for a normal application:
 /// - dvui renders the whole application
 /// - render frames only when needed
-pub export fn main(
-    _: win32.HINSTANCE,
-    _: ?win32.HINSTANCE,
-    _: ?[*:0]const u16,
-    _: win32.SHOW_WINDOW_CMD,
-) void {
-    return main2() catch |e| {
-        if (@errorReturnTrace()) |trace| {
-            std.debug.dumpStackTrace(trace.*);
-        }
-        std.debug.panic("{s}", .{@errorName(e)});
-    };
-}
-
-const window_class = win32.L("DvuiStandaloneWindow");
-
-fn main2() !void {
+pub fn main() !void {
     defer _ = gpa_instance.deinit();
 
     Backend.RegisterClass(window_class, .{}) catch win32.panicWin32(

--- a/src/App.zig
+++ b/src/App.zig
@@ -14,6 +14,8 @@
 //! };
 //! ```
 
+pub const App = @This();
+
 /// The configuration options for the app, either directly or a function that
 /// is run at startup that returns the options.
 config: AppConfig,
@@ -90,8 +92,12 @@ pub const Result = enum {
     close,
 };
 
-/// Used internally to confirm that the App main function is being used
-pub fn assertIsApp(comptime root: type) void {
+/// Used internally to get the dvui_app if it's defined
+pub fn get() ?App {
+    const root = @import("root");
+    // return error instead of failing compile to allow for reference in tests without dvui_app defined
+    if (!@hasDecl(root, "dvui_app")) return null;
+
     if (!@hasDecl(root, "main") or @field(root, "main") != main) {
         @compileError(
             \\Using the App interface requires using the App main function
@@ -100,6 +106,8 @@ pub fn assertIsApp(comptime root: type) void {
             \\pub const main = dvui.App.main;
         );
     }
+
+    return root.dvui_app;
 }
 
 const std = @import("std");

--- a/src/App.zig
+++ b/src/App.zig
@@ -104,3 +104,7 @@ pub fn assertIsApp(comptime root: type) void {
 
 const std = @import("std");
 const dvui = @import("dvui.zig");
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -190,3 +190,7 @@ pub fn openURL(self: *Backend, url: []const u8) error{OutOfMemory}!void {
 pub fn refresh(self: *Backend) void {
     return self.vtable.refresh(self.ctx);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/Color.zig
+++ b/src/Color.zig
@@ -181,3 +181,7 @@ pub fn fromHex(hex: HexString) !Color {
     };
     return result;
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/Event.zig
+++ b/src/Event.zig
@@ -159,3 +159,7 @@ pub const ScrollPropagate = struct {
     /// at the edge.
     motion: Point,
 };
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -3593,3 +3593,7 @@ pub const StrokeTest = struct {
         dvui.parentReset(self.wd.id, self.wd.parent);
     }
 };
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -143,3 +143,7 @@ pub fn initTTFBytesDatabase(allocator: std.mem.Allocator) !std.StringHashMap(dvu
 
     return result;
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -359,3 +359,7 @@ pub fn padSize(self: *const Options, s: Size) Size {
 //pub fn format(self: *const Options, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
 //    try std.fmt.format(writer, "Options{{ .background = {?}, .color_style = {?} }}", .{ self.background, self.color_style });
 //}
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/Point.zig
+++ b/src/Point.zig
@@ -42,3 +42,7 @@ pub fn normalize(self: *const Point) Point {
 pub fn format(self: *const Point, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
     try std.fmt.format(writer, "Point{{ {d} {d} }}", .{ self.x, self.y });
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/Rect.zig
+++ b/src/Rect.zig
@@ -181,3 +181,7 @@ pub fn outsetAll(self: *const Rect, p: f32) Rect {
 pub fn format(self: *const Rect, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
     try std.fmt.format(writer, "Rect{{ {d} {d} {d} {d} }}", .{ self.x, self.y, self.w, self.h });
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/RectScale.zig
+++ b/src/RectScale.zig
@@ -27,3 +27,7 @@ pub fn pointToScreen(rs: *const RectScale, p: Point) Point {
 pub fn pointFromScreen(rs: *const RectScale, p: Point) Point {
     return Point.diff(p, rs.r.topLeft()).scale(1 / rs.s);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/ScrollInfo.zig
+++ b/src/ScrollInfo.zig
@@ -152,3 +152,7 @@ pub fn scrollPageUp(self: *ScrollInfo, dir: enums.Direction) void {
 pub fn scrollPageDown(self: *ScrollInfo, dir: enums.Direction) void {
     self.scrollPage(dir, false);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/Size.zig
+++ b/src/Size.zig
@@ -43,3 +43,7 @@ pub fn scale(self: *const Size, s: f32) Size {
 pub fn format(self: *const Size, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
     try std.fmt.format(writer, "Size{{ {d} {d} }}", .{ self.w, self.h });
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/Theme.zig
+++ b/src/Theme.zig
@@ -251,3 +251,7 @@ pub const QuickTheme = struct {
         };
     }
 };
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/Vertex.zig
+++ b/src/Vertex.zig
@@ -6,3 +6,7 @@ const Color = dvui.Color;
 pos: Point,
 col: Color,
 uv: @Vector(2, f32),
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/Widget.zig
+++ b/src/Widget.zig
@@ -98,3 +98,7 @@ pub fn minSizeForChild(self: Widget, s: Size) void {
 pub fn processEvent(self: Widget, e: *Event, bubbling: bool) void {
     self.vtable.processEvent(self.ptr, e, bubbling);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -277,3 +277,7 @@ pub fn minSizeReportToParent(self: *const WidgetData) void {
         self.parent.minSizeForChild(self.min_size);
     }
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1762,3 +1762,7 @@ const std = @import("std");
 const math = std.math;
 const builtin = @import("builtin");
 const dvui = @import("dvui.zig");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -1531,3 +1531,7 @@ pub fn main() !void {
         .quit, .close_windows => break,
     };
 }
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -1445,16 +1445,6 @@ fn convertVKeyToDvuiKey(vkey: win32.VIRTUAL_KEY) dvui.enums.Key {
     };
 }
 
-// dvui_app stuff
-const root = @import("root");
-pub const dvui_app: ?dvui.App = if (@hasDecl(root, "dvui_app")) root.dvui_app else null;
-comptime {
-    if (dvui_app != null) {
-        dvui.App.assertIsApp(root);
-        @export(&wWinMain, .{ .name = "wWinMain" });
-    }
-}
-
 // win32 is Windows exclusive so this can be unconditionally defined
 extern "kernel32" fn AttachConsole(dwProcessId: std.os.windows.DWORD) std.os.windows.BOOL;
 
@@ -1474,6 +1464,8 @@ fn wWinMain(
 }
 
 pub fn main() !void {
+    const app = dvui.App.get() orelse return error.DvuiAppNotDefined;
+
     const window_class = win32.L("DvuiWindow");
 
     var gpa_instance = std.heap.GeneralPurposeAllocator(.{}){};
@@ -1485,7 +1477,7 @@ pub fn main() !void {
         win32.GetLastError(),
     );
 
-    const init_opts = dvui_app.?.config.get();
+    const init_opts = app.config.get();
 
     var window_state: WindowState = undefined;
 
@@ -1505,8 +1497,8 @@ pub fn main() !void {
 
     const win = b.getWindow();
 
-    if (dvui_app.?.initFn) |initFn| initFn(win);
-    defer if (dvui_app.?.deinitFn) |deinitFn| deinitFn();
+    if (app.initFn) |initFn| initFn(win);
+    defer if (app.deinitFn) |deinitFn| deinitFn();
 
     while (true) switch (serviceMessageQueue()) {
         .queue_empty => {
@@ -1517,7 +1509,7 @@ pub fn main() !void {
             try win.begin(nstime);
 
             // both dvui and dx11 drawing
-            const res = try dvui_app.?.frameFn();
+            const res = try app.frameFn();
 
             // marks end of dvui frame, don't call dvui functions after this
             // - sends all dvui stuff to backend for rendering, must be called before renderPresent()

--- a/src/backends/raylib.zig
+++ b/src/backends/raylib.zig
@@ -878,3 +878,7 @@ pub fn main() !void {
         if (res != .ok) break :main_loop;
     }
 }
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1096,3 +1096,7 @@ pub fn main() !void {
         back.waitEventTimeout(wait_event_micros);
     }
 }
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -16,7 +16,7 @@ pub const c = blk: {
     });
 };
 
-pub const kind: dvui.enums.Backend = .sdl;
+pub const kind: dvui.enums.Backend = if (sdl3) .sdl3 else .sdl;
 pub fn description() [:0]const u8 {
     return if (sdl3) "SDL3" else "SDL2";
 }

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1014,14 +1014,6 @@ pub fn getSDLVersion() std.SemanticVersion {
     }
 }
 
-// dvui_app stuff
-const root = @import("root");
-pub const dvui_app: ?dvui.App = if (@hasDecl(root, "dvui_app")) root.dvui_app else null;
-comptime {
-    if (dvui_app != null) {
-        dvui.App.assertIsApp(root);
-    }
-}
 // Optional: windows os only
 const winapi = if (builtin.os.tag == .windows) struct {
     extern "kernel32" fn AttachConsole(dwProcessId: std.os.windows.DWORD) std.os.windows.BOOL;
@@ -1029,13 +1021,15 @@ const winapi = if (builtin.os.tag == .windows) struct {
 
 // This must be exposed in the app's root source file.
 pub fn main() !void {
+    const app = dvui.App.get() orelse return error.DvuiAppNotDefined;
+
     if (@import("builtin").os.tag == .windows) { // optional
         // on windows graphical apps have no console, so output goes to nowhere - attach it manually. related: https://github.com/ziglang/zig/issues/4196
         _ = winapi.AttachConsole(0xFFFFFFFF);
     }
     std.log.info("SDL version: {}", .{getSDLVersion()});
 
-    const init_opts = dvui_app.?.config.get();
+    const init_opts = app.config.get();
 
     var gpa_instance = std.heap.GeneralPurposeAllocator(.{}){};
     const gpa = gpa_instance.allocator();
@@ -1061,8 +1055,8 @@ pub fn main() !void {
     var win = try dvui.Window.init(@src(), gpa, back.backend(), .{});
     defer win.deinit();
 
-    if (dvui_app.?.initFn) |initFn| initFn(&win);
-    defer if (dvui_app.?.deinitFn) |deinitFn| deinitFn();
+    if (app.initFn) |initFn| initFn(&win);
+    defer if (app.deinitFn) |deinitFn| deinitFn();
 
     main_loop: while (true) {
 
@@ -1081,7 +1075,7 @@ pub fn main() !void {
         _ = c.SDL_SetRenderDrawColor(back.renderer, 0, 0, 0, 255);
         _ = c.SDL_RenderClear(back.renderer);
 
-        const res = try dvui_app.?.frameFn();
+        const res = try app.frameFn();
 
         const end_micros = try win.end(.{});
 

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -819,3 +819,7 @@ fn update() !i32 {
     const wait_event_micros = win.waitTime(end_micros, null);
     return @intCast(@divTrunc(wait_event_micros, 1000));
 }
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5915,3 +5915,7 @@ pub fn plotXY(src: std.builtin.SourceLocation, plot_opts: PlotWidget.InitOptions
     s1.deinit();
     p.deinit();
 }
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2781,7 +2781,7 @@ pub fn wantTextInput(r: Rect) void {
     cw.text_input_rect = r.scale(1 / cw.natural_scale);
 }
 
-pub const popup = @compileError("popup renamed to floatingMenu");
+pub const popup = if (!builtin.is_test) @compileError("popup renamed to floatingMenu");
 
 pub fn floatingMenu(src: std.builtin.SourceLocation, init_opts: FloatingMenuWidget.InitOptions, opts: Options) !*FloatingMenuWidget {
     var ret = try currentWindow().arena().create(FloatingMenuWidget);

--- a/src/easing.zig
+++ b/src/easing.zig
@@ -146,3 +146,7 @@ pub fn inOutBounce(t: f32) f32 {
     if (t < 0.5) return inBounce(t * 2) / 2;
     return 1 - inBounce((1 - t) * 2) / 2;
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 pub const Backend = enum {
     custom,
     sdl,
+    sdl3,
     raylib,
     dx11,
     web,

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -157,9 +157,10 @@ pub const Mod = enum(u16) {
 
         var found_set = false;
 
-        inline for (@typeInfo(Mod).Enum.fields[0..9]) |field| {
-            if (self.has(@field(Mod, field.name))) {
-                std.debug.print(".{s}, ", .{field.name});
+        const mod_fields = comptime std.meta.fieldNames(Mod);
+        inline for (mod_fields[0..9]) |field_name| {
+            if (self.has(@field(Mod, field_name))) {
+                std.debug.print(".{s}, ", .{field_name});
                 found_set = true;
             }
         }
@@ -324,3 +325,7 @@ pub const Cursor = enum(u8) {
     bad,
     hand,
 };
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/hsluv.zig
+++ b/src/hsluv.zig
@@ -400,3 +400,7 @@ pub fn rgb2hpluv(r: f32, g: f32, b: f32, ph: *f32, ps: *f32, pl: *f32) bool {
 
     return if (0.0 <= tmp.b and tmp.b <= 100.0) true else false;
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/icons/entypo.zig
+++ b/src/icons/entypo.zig
@@ -332,3 +332,7 @@ pub const voicemail = @embedFile("entypo/voicemail.tvg");
 pub const wallet = @embedFile("entypo/wallet.tvg");
 pub const warning = @embedFile("entypo/warning.tvg");
 pub const water = @embedFile("entypo/water.tvg");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/import_widgets.zig
+++ b/src/import_widgets.zig
@@ -37,3 +37,7 @@ pub const VirtualParentWidget = @import("widgets/VirtualParentWidget.zig");
 
 // Needed for autodocs "backlink" to work
 const dvui = @import("dvui");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/structEntry.zig
+++ b/src/structEntry.zig
@@ -964,3 +964,7 @@ pub fn structEntryExAlloc(
 //    return result;
 //}
 //
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -71,7 +71,7 @@ pub const InitOptions = struct {
 };
 
 pub fn init(options: InitOptions) !Self {
-    if (Backend.kind != .sdl) {
+    if (Backend.kind != .sdl or Backend.kind != .sdl3) {
         std.debug.print("dvui.testing can currently only be used with the SDL backend\n", .{});
         return error.SkipZigTest;
     }

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -253,3 +253,7 @@ const dvui = @import("dvui.zig");
 
 const Backend = dvui.backend;
 const Window = dvui.Window;
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -72,7 +72,8 @@ pub const InitOptions = struct {
 
 pub fn init(options: InitOptions) !Self {
     if (Backend.kind != .sdl) {
-        @compileError("dvui.testing can currently only be used with the SDL backend");
+        std.debug.print("dvui.testing can currently only be used with the SDL backend\n", .{});
+        return error.SkipZigTest;
     }
 
     if (should_write_snapshots()) {

--- a/src/tinyvg/builder.zig
+++ b/src/tinyvg/builder.zig
@@ -52,21 +52,21 @@ pub fn Builder(comptime Writer: type) type {
                     const rwidth = mapSizeToType(u8, width) catch return error.OutOfRange;
                     const rheight = mapSizeToType(u8, height) catch return error.OutOfRange;
 
-                    try self.writer.writeIntLittle(u8, rwidth);
-                    try self.writer.writeIntLittle(u8, rheight);
+                    try self.writer.writeInt(u8, rwidth, .little);
+                    try self.writer.writeInt(u8, rheight, .little);
                 },
 
                 .default => {
                     const rwidth = mapSizeToType(u16, width) catch return error.OutOfRange;
                     const rheight = mapSizeToType(u16, height) catch return error.OutOfRange;
 
-                    try self.writer.writeIntLittle(u16, rwidth);
-                    try self.writer.writeIntLittle(u16, rheight);
+                    try self.writer.writeInt(u16, rwidth, .little);
+                    try self.writer.writeInt(u16, rheight, .little);
                 },
 
                 .enhanced => {
-                    try self.writer.writeIntLittle(u32, width);
-                    try self.writer.writeIntLittle(u32, height);
+                    try self.writer.writeInt(u32, width, .little);
+                    try self.writer.writeInt(u32, height, .little);
                 },
             }
 
@@ -93,21 +93,21 @@ pub fn Builder(comptime Writer: type) type {
                         (@as(u16, ((rgb8[1] >> 2) & 0x2F)) << 5) |
                         (@as(u16, ((rgb8[2] >> 3) & 0x1F)) << 11);
 
-                    try self.writer.writeIntLittle(u16, value);
+                    try self.writer.writeInt(u16, value, .little);
                 },
 
                 .u8888 => for (colors) |c| {
                     const rgba = c.toRgba8();
-                    try self.writer.writeIntLittle(u8, rgba[0]);
-                    try self.writer.writeIntLittle(u8, rgba[1]);
-                    try self.writer.writeIntLittle(u8, rgba[2]);
-                    try self.writer.writeIntLittle(u8, rgba[3]);
+                    try self.writer.writeInt(u8, rgba[0], .little);
+                    try self.writer.writeInt(u8, rgba[1], .little);
+                    try self.writer.writeInt(u8, rgba[2], .little);
+                    try self.writer.writeInt(u8, rgba[3], .little);
                 },
                 .f32 => for (colors) |c| {
-                    try self.writer.writeIntLittle(u32, @as(u32, @bitCast(c.r)));
-                    try self.writer.writeIntLittle(u32, @as(u32, @bitCast(c.g)));
-                    try self.writer.writeIntLittle(u32, @as(u32, @bitCast(c.b)));
-                    try self.writer.writeIntLittle(u32, @as(u32, @bitCast(c.a)));
+                    try self.writer.writeInt(u32, @as(u32, @bitCast(c.r)), .little);
+                    try self.writer.writeInt(u32, @as(u32, @bitCast(c.g)), .little);
+                    try self.writer.writeInt(u32, @as(u32, @bitCast(c.b)), .little);
+                    try self.writer.writeInt(u32, @as(u32, @bitCast(c.a)), .little);
                 },
 
                 .custom => return error.UnsupportedColorEncoding,
@@ -357,14 +357,14 @@ pub fn Builder(comptime Writer: type) type {
             switch (self.range) {
                 .reduced => {
                     const reduced_val = std.math.cast(i8, val) orelse return error.OutOfRange;
-                    try self.writer.writeIntLittle(i8, reduced_val);
+                    try self.writer.writeInt(i8, reduced_val, .little);
                 },
                 .default => {
                     const reduced_val = std.math.cast(i16, val) orelse return error.OutOfRange;
-                    try self.writer.writeIntLittle(i16, reduced_val);
+                    try self.writer.writeInt(i16, reduced_val, .little);
                 },
                 .enhanced => {
-                    try self.writer.writeIntLittle(i32, val);
+                    try self.writer.writeInt(i32, val, .little);
                 },
             }
         }

--- a/src/tinyvg/tinyvg.zig
+++ b/src/tinyvg/tinyvg.zig
@@ -376,7 +376,5 @@ pub const Gradient = struct {
 };
 
 test {
-    _ = builder;
-    _ = parsing;
-    _ = rendering;
+    std.testing.refAllDecls(@This());
 }

--- a/src/widgets/AnimateWidget.zig
+++ b/src/widgets/AnimateWidget.zig
@@ -157,3 +157,7 @@ pub fn deinit(self: *AnimateWidget) void {
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/BoxWidget.zig
+++ b/src/widgets/BoxWidget.zig
@@ -221,3 +221,7 @@ pub fn deinit(self: *BoxWidget) void {
 
     dvui.parentReset(self.wd.id, self.wd.parent);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -174,3 +174,7 @@ pub fn deinit(self: *ButtonWidget) void {
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/CacheWidget.zig
+++ b/src/widgets/CacheWidget.zig
@@ -189,3 +189,7 @@ pub fn deinit(self: *CacheWidget) void {
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/ContextWidget.zig
+++ b/src/widgets/ContextWidget.zig
@@ -137,3 +137,7 @@ pub fn deinit(self: *ContextWidget) void {
 
     dvui.parentReset(self.wd.id, self.wd.parent);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -206,3 +206,7 @@ const LabelWidget = dvui.LabelWidget;
 
 const std = @import("std");
 const dvui = @import("../dvui.zig");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/FlexBoxWidget.zig
+++ b/src/widgets/FlexBoxWidget.zig
@@ -120,3 +120,7 @@ pub fn deinit(self: *FlexBoxWidget) void {
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -283,3 +283,7 @@ pub fn deinit(self: *FloatingMenuWidget) void {
     dvui.clipSet(self.prevClip);
     _ = dvui.renderingSet(self.prev_rendering);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -240,3 +240,7 @@ pub fn deinit(self: *FloatingTooltipWidget) void {
     dvui.clipSet(self.prevClip);
     _ = dvui.renderingSet(self.prev_rendering);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/FloatingWidget.zig
+++ b/src/widgets/FloatingWidget.zig
@@ -115,3 +115,7 @@ pub fn deinit(self: *FloatingWidget) void {
     dvui.clipSet(self.prevClip);
     _ = dvui.renderingSet(self.prev_rendering);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -563,3 +563,7 @@ pub fn deinit(self: *FloatingWindowWidget) void {
     dvui.clipSet(self.prevClip);
     _ = dvui.renderingSet(self.prev_rendering);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -55,3 +55,7 @@ pub fn deinit(self: *IconWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -108,3 +108,7 @@ pub fn deinit(self: *LabelWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -263,3 +263,7 @@ pub fn deinit(self: *MenuItemWidget) void {
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -228,3 +228,7 @@ pub fn deinit(self: *MenuWidget) void {
     _ = menuSet(self.parentMenu);
     dvui.parentReset(self.wd.id, self.wd.parent);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/OverlayWidget.zig
+++ b/src/widgets/OverlayWidget.zig
@@ -57,3 +57,7 @@ pub fn deinit(self: *OverlayWidget) void {
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -291,3 +291,7 @@ pub fn deinit(self: *PanedWidget) void {
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/PlotWidget.zig
+++ b/src/widgets/PlotWidget.zig
@@ -306,3 +306,7 @@ const BoxWidget = dvui.BoxWidget;
 
 const std = @import("std");
 const dvui = @import("../dvui.zig");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -399,3 +399,7 @@ pub fn reorderSlice(comptime T: type, slice: []T, removed_idx: ?usize, insert_be
 
     return false;
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/ScaleWidget.zig
+++ b/src/widgets/ScaleWidget.zig
@@ -78,3 +78,7 @@ pub fn deinit(self: *ScaleWidget) void {
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/ScrollAreaWidget.zig
+++ b/src/widgets/ScrollAreaWidget.zig
@@ -161,3 +161,7 @@ pub fn deinit(self: *ScrollAreaWidget) void {
 
     self.hbox.deinit();
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -192,3 +192,7 @@ pub fn deinit(self: *ScrollBarWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -587,3 +587,7 @@ pub fn deinit(self: *ScrollContainerWidget) void {
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/SuggestionWidget.zig
+++ b/src/widgets/SuggestionWidget.zig
@@ -129,3 +129,7 @@ const FloatingMenuWidget = dvui.FloatingMenuWidget;
 
 const std = @import("std");
 const dvui = @import("../dvui.zig");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -169,3 +169,7 @@ const ScrollAreaWidget = dvui.ScrollAreaWidget;
 const std = @import("std");
 const math = std.math;
 const dvui = @import("../dvui.zig");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -883,3 +883,7 @@ pub fn deinit(self: *TextEntryWidget) void {
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -1800,3 +1800,7 @@ pub fn deinit(self: *TextLayoutWidget) void {
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/VirtualParentWidget.zig
+++ b/src/widgets/VirtualParentWidget.zig
@@ -67,3 +67,7 @@ pub fn deinit(self: *VirtualParentWidget) void {
     }
     dvui.parentReset(self.wd.id, self.wd.parent);
 }
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}


### PR DESCRIPTION
Adds a check and test build step that together, currently, semantically checks all declarations in the code base. While adding these steps I also found some bugs in code paths that weren't referenced, see b71d95145b6d463094ac21c1f8e6a00fc1858338.

This is motivated by me creating compilation errors in compile configurations I did not actively test or for functions that weren't referenced. It could also be integrated into CI to verify that everything compiles and run the tests in CI too, which I would be happy to add. Don't know how opening OS windows works in that environment, so maybe not `dvui.testing` tests.

Adding `std.testing.refAllDecls(@This())` to every file does prevent some patterns like `pub const something = @compileError("...")` as that would always fail the test compilation. This has been worked around by checking `builtin.is_test` or by reworking the api, like for `dvui.App` which now has `dvui.App.get()` which returns an optional to prevent a compile error for dereferencing a compile time `null`.

As a part of this the sdl3 backend was separated into its own `enums.Backend` variant, which allows for both of them to be compiled at the same time when not explicitly picking a backend. This would have prevented #253.