### PR TITLE
Dummy backend (for testing)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -48,17 +48,16 @@ pub fn build(b: *std.Build) !void {
         }
     }
 
-    // Dummy, does no rendeing and is intended for tests
-    if (back_to_build == null or back_to_build == .dummy) {
-        const dummy_mod = b.addModule("dummy", .{
-            .root_source_file = b.path("src/backends/dummy.zig"),
+    // Testing
+    if (back_to_build == null or back_to_build == .testing) {
+        const testing_mod = b.addModule("testing", .{
+            .root_source_file = b.path("src/backends/testing.zig"),
             .target = target,
             .optimize = optimize,
-            .link_libc = true,
         });
-        const dvui_dummy = addDvuiModule(dvui_opts, "dvui_dummy", true);
-        linkBackend(dvui_dummy, dummy_mod);
-        addExample(dvui_opts, "app", b.path("examples/app.zig"), dvui_dummy);
+        const dvui_testing = addDvuiModule(dvui_opts, "dvui_testing", true);
+        linkBackend(dvui_testing, testing_mod);
+        addExample(dvui_opts, "testing-app", b.path("examples/app.zig"), dvui_testing);
     }
 
     // SDL2

--- a/build.zig
+++ b/build.zig
@@ -48,6 +48,19 @@ pub fn build(b: *std.Build) !void {
         }
     }
 
+    // Dummy, does no rendeing and is intended for tests
+    if (back_to_build == null or back_to_build == .dummy) {
+        const dummy_mod = b.addModule("dummy", .{
+            .root_source_file = b.path("src/backends/dummy.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        });
+        const dvui_dummy = addDvuiModule(dvui_opts, "dvui_dummy", true);
+        linkBackend(dvui_dummy, dummy_mod);
+        addExample(dvui_opts, "app", b.path("examples/app.zig"), dvui_dummy);
+    }
+
     // SDL2
     if (back_to_build == null or back_to_build == .sdl2) {
         const sdl_mod = b.addModule("sdl2", .{

--- a/src/backends/dummy.zig
+++ b/src/backends/dummy.zig
@@ -84,31 +84,34 @@ pub fn drawClippedTriangles(_: *DummyBackend, _: ?dvui.Texture, _: []const dvui.
 
 /// Create a texture from the given pixels in RGBA.  The returned
 /// pointer is what will later be passed to drawClippedTriangles.
-pub fn textureCreate(self: *DummyBackend, _: [*]u8, width: u32, height: u32, _: dvui.enums.TextureInterpolation) dvui.Texture {
+pub fn textureCreate(self: *DummyBackend, pixels: [*]u8, width: u32, height: u32, _: dvui.enums.TextureInterpolation) dvui.Texture {
+    const new_pixels = self.allocator.dupe(u8, pixels[0 .. width * height * 4]) catch @panic("Couldn't create texture: OOM");
     return .{
         .width = width,
         .height = height,
-        .ptr = self, // arbitrary pointer
+        .ptr = new_pixels.ptr,
     };
 }
 
 /// Create a texture that can be rendered to with renderTarget().  The
 /// returned pointer is what will later be passed to drawClippedTriangles.
-pub fn textureCreateTarget(self: *DummyBackend, width: u32, height: u32, _: dvui.enums.TextureInterpolation) error{ OutOfMemory, TextureCreate }!dvui.Texture {
-    return .{
-        .width = width,
-        .height = height,
-        .ptr = self,
-    };
+pub fn textureCreateTarget(_: *DummyBackend, _: u32, _: u32, _: dvui.enums.TextureInterpolation) error{ OutOfMemory, TextureCreate }!dvui.Texture {
+    return error.TextureCreate;
 }
 
 /// Read pixel data (RGBA) from texture into pixel.
-pub fn textureRead(_: *DummyBackend, _: dvui.Texture, _: [*]u8) error{TextureRead}!void {}
+pub fn textureRead(_: *DummyBackend, texture: dvui.Texture, pixels: [*]u8) error{TextureRead}!void {
+    const ptr: [*]const u8 = @ptrCast(texture.ptr);
+    @memcpy(pixels, ptr[0..(texture.width * texture.height * 4)]);
+}
 
 /// Destroy texture that was previously made with textureCreate() or
 /// textureCreateTarget().  After this call, this texture pointer will not
 /// be used by dvui.
-pub fn textureDestroy(_: *DummyBackend, _: dvui.Texture) void {}
+pub fn textureDestroy(self: *DummyBackend, texture: dvui.Texture) void {
+    const ptr: [*]const u8 = @ptrCast(texture.ptr);
+    self.allocator.free(ptr[0..(texture.width * texture.height * 4)]);
+}
 
 /// Render future drawClippedTriangles() to the passed texture (or screen
 /// if null).

--- a/src/backends/dummy.zig
+++ b/src/backends/dummy.zig
@@ -1,0 +1,148 @@
+//! This is a dummy backend that does no rendering at all intended for no graphicals
+//! logic tests.
+
+size: dvui.Size,
+allocator: std.mem.Allocator,
+
+arena: std.mem.Allocator = undefined,
+
+time: i128 = 0,
+clipboard: ?[]const u8 = null,
+
+pub const kind: dvui.enums.Backend = .dummy;
+pub fn description() [:0]const u8 {
+    return "dummy";
+}
+
+pub const DummyBackend = @This();
+pub const Context = *DummyBackend;
+
+pub const InitOptions = struct {
+    allocator: std.mem.Allocator,
+    size: dvui.Size = .{},
+};
+
+pub fn init(opts: InitOptions) DummyBackend {
+    return .{
+        .allocator = opts.allocator,
+        .size = opts.size,
+    };
+}
+
+pub fn deinit(self: *DummyBackend) void {
+    if (self.clipboard) |text| {
+        self.allocator.free(text);
+    }
+}
+
+/// Get monotonic nanosecond timestamp. Doesn't have to be system time.
+pub fn nanoTime(self: *DummyBackend) i128 {
+    defer self.time += 1 * std.time.ns_per_ms; // arbitrary clock increment
+    return self.time; // maybe should return static value?
+}
+
+/// Sleep for nanoseconds.
+pub fn sleep(_: *DummyBackend, _: u64) void {}
+
+/// Called by dvui during Window.begin(), so prior to any dvui
+/// rendering.  Use to setup anything needed for this frame.  The arena
+/// arg is cleared before begin is called next, useful for any temporary
+/// allocations needed only for this frame.
+pub fn begin(self: *DummyBackend, arena: std.mem.Allocator) void {
+    self.arena = arena;
+}
+
+/// Called by dvui during Window.end(), but currently unused by any
+/// backends.  Probably will be removed.
+pub fn end(_: *DummyBackend) void {}
+
+/// Return size of the window in physical pixels.  For a 300x200 retina
+/// window (so actually 600x400), this should return 600x400.
+pub fn pixelSize(self: *DummyBackend) dvui.Size {
+    return self.size;
+}
+
+/// Return size of the window in logical pixels.  For a 300x200 retina
+/// window (so actually 600x400), this should return 300x200.
+pub fn windowSize(self: *DummyBackend) dvui.Size {
+    return self.size;
+}
+
+/// Return the detected additional scaling.  This represents the user's
+/// additional display scaling (usually set in their window system's
+/// settings).  Currently only called during Window.init(), so currently
+/// this sets the initial content scale.
+pub fn contentScale(_: *DummyBackend) f32 {
+    return 1;
+}
+
+/// Render a triangle list using the idx indexes into the vtx vertexes
+/// clipped to to clipr (if given).  Vertex positions and clipr are in
+/// physical pixels.  If texture is given, the vertexes uv coords are
+/// normalized (0-1).
+pub fn drawClippedTriangles(_: *DummyBackend, _: ?dvui.Texture, _: []const dvui.Vertex, _: []const u16, _: ?dvui.Rect) void {}
+
+/// Create a texture from the given pixels in RGBA.  The returned
+/// pointer is what will later be passed to drawClippedTriangles.
+pub fn textureCreate(self: *DummyBackend, _: [*]u8, width: u32, height: u32, _: dvui.enums.TextureInterpolation) dvui.Texture {
+    return .{
+        .width = width,
+        .height = height,
+        .ptr = self, // arbitrary pointer
+    };
+}
+
+/// Create a texture that can be rendered to with renderTarget().  The
+/// returned pointer is what will later be passed to drawClippedTriangles.
+pub fn textureCreateTarget(self: *DummyBackend, width: u32, height: u32, _: dvui.enums.TextureInterpolation) error{ OutOfMemory, TextureCreate }!dvui.Texture {
+    return .{
+        .width = width,
+        .height = height,
+        .ptr = self,
+    };
+}
+
+/// Read pixel data (RGBA) from texture into pixel.
+pub fn textureRead(_: *DummyBackend, _: dvui.Texture, _: [*]u8) error{TextureRead}!void {}
+
+/// Destroy texture that was previously made with textureCreate() or
+/// textureCreateTarget().  After this call, this texture pointer will not
+/// be used by dvui.
+pub fn textureDestroy(_: *DummyBackend, _: dvui.Texture) void {}
+
+/// Render future drawClippedTriangles() to the passed texture (or screen
+/// if null).
+pub fn renderTarget(_: *DummyBackend, _: ?dvui.Texture) void {}
+
+/// Get clipboard content (text only)
+pub fn clipboardText(self: *DummyBackend) error{OutOfMemory}![]const u8 {
+    if (self.clipboard) |text| {
+        return try self.arena.dupe(u8, text);
+    } else {
+        return "";
+    }
+}
+
+/// Set clipboard content (text only)
+pub fn clipboardTextSet(self: *DummyBackend, text: []const u8) error{OutOfMemory}!void {
+    if (self.clipboard) |prev_text| {
+        self.allocator.free(prev_text);
+    }
+    self.clipboard = try self.allocator.dupe(u8, text);
+}
+
+/// Open URL in system browser
+pub fn openURL(_: *DummyBackend, _: []const u8) error{OutOfMemory}!void {}
+
+/// Called by dvui.refresh() when it is called from a background
+/// thread.  Used to wake up the gui thread.  It only has effect if you
+/// are using waitTime() or some other method of waiting until a new
+/// event comes in.
+pub fn refresh(_: *DummyBackend) void {}
+
+pub fn backend(self: *DummyBackend) dvui.Backend {
+    return dvui.Backend.init(self, DummyBackend);
+}
+
+pub const dvui = @import("dvui");
+pub const std = @import("std");

--- a/src/backends/testing.zig
+++ b/src/backends/testing.zig
@@ -1,5 +1,5 @@
-//! This is a dummy backend that does no rendering at all intended for no graphicals
-//! logic tests.
+//! This is a testing backend that does no rendering at all intended for non graphical
+//! dvui logic tests.
 
 size: dvui.Size,
 allocator: std.mem.Allocator,
@@ -9,62 +9,62 @@ arena: std.mem.Allocator = undefined,
 time: i128 = 0,
 clipboard: ?[]const u8 = null,
 
-pub const kind: dvui.enums.Backend = .dummy;
+pub const kind: dvui.enums.Backend = .testing;
 pub fn description() [:0]const u8 {
-    return "dummy";
+    return "testing";
 }
 
-pub const DummyBackend = @This();
-pub const Context = *DummyBackend;
+pub const TestingBackend = @This();
+pub const Context = *TestingBackend;
 
 pub const InitOptions = struct {
     allocator: std.mem.Allocator,
     size: dvui.Size = .{},
 };
 
-pub fn init(opts: InitOptions) DummyBackend {
+pub fn init(opts: InitOptions) TestingBackend {
     return .{
         .allocator = opts.allocator,
         .size = opts.size,
     };
 }
 
-pub fn deinit(self: *DummyBackend) void {
+pub fn deinit(self: *TestingBackend) void {
     if (self.clipboard) |text| {
         self.allocator.free(text);
     }
 }
 
 /// Get monotonic nanosecond timestamp. Doesn't have to be system time.
-pub fn nanoTime(self: *DummyBackend) i128 {
+pub fn nanoTime(self: *TestingBackend) i128 {
     defer self.time += 1 * std.time.ns_per_ms; // arbitrary clock increment
     return self.time; // maybe should return static value?
 }
 
 /// Sleep for nanoseconds.
-pub fn sleep(_: *DummyBackend, _: u64) void {}
+pub fn sleep(_: *TestingBackend, _: u64) void {}
 
 /// Called by dvui during Window.begin(), so prior to any dvui
 /// rendering.  Use to setup anything needed for this frame.  The arena
 /// arg is cleared before begin is called next, useful for any temporary
 /// allocations needed only for this frame.
-pub fn begin(self: *DummyBackend, arena: std.mem.Allocator) void {
+pub fn begin(self: *TestingBackend, arena: std.mem.Allocator) void {
     self.arena = arena;
 }
 
 /// Called by dvui during Window.end(), but currently unused by any
 /// backends.  Probably will be removed.
-pub fn end(_: *DummyBackend) void {}
+pub fn end(_: *TestingBackend) void {}
 
 /// Return size of the window in physical pixels.  For a 300x200 retina
 /// window (so actually 600x400), this should return 600x400.
-pub fn pixelSize(self: *DummyBackend) dvui.Size {
+pub fn pixelSize(self: *TestingBackend) dvui.Size {
     return self.size;
 }
 
 /// Return size of the window in logical pixels.  For a 300x200 retina
 /// window (so actually 600x400), this should return 300x200.
-pub fn windowSize(self: *DummyBackend) dvui.Size {
+pub fn windowSize(self: *TestingBackend) dvui.Size {
     return self.size;
 }
 
@@ -72,7 +72,7 @@ pub fn windowSize(self: *DummyBackend) dvui.Size {
 /// additional display scaling (usually set in their window system's
 /// settings).  Currently only called during Window.init(), so currently
 /// this sets the initial content scale.
-pub fn contentScale(_: *DummyBackend) f32 {
+pub fn contentScale(_: *TestingBackend) f32 {
     return 1;
 }
 
@@ -80,11 +80,11 @@ pub fn contentScale(_: *DummyBackend) f32 {
 /// clipped to to clipr (if given).  Vertex positions and clipr are in
 /// physical pixels.  If texture is given, the vertexes uv coords are
 /// normalized (0-1).
-pub fn drawClippedTriangles(_: *DummyBackend, _: ?dvui.Texture, _: []const dvui.Vertex, _: []const u16, _: ?dvui.Rect) void {}
+pub fn drawClippedTriangles(_: *TestingBackend, _: ?dvui.Texture, _: []const dvui.Vertex, _: []const u16, _: ?dvui.Rect) void {}
 
 /// Create a texture from the given pixels in RGBA.  The returned
 /// pointer is what will later be passed to drawClippedTriangles.
-pub fn textureCreate(self: *DummyBackend, pixels: [*]u8, width: u32, height: u32, _: dvui.enums.TextureInterpolation) dvui.Texture {
+pub fn textureCreate(self: *TestingBackend, pixels: [*]u8, width: u32, height: u32, _: dvui.enums.TextureInterpolation) dvui.Texture {
     const new_pixels = self.allocator.dupe(u8, pixels[0 .. width * height * 4]) catch @panic("Couldn't create texture: OOM");
     return .{
         .width = width,
@@ -95,12 +95,12 @@ pub fn textureCreate(self: *DummyBackend, pixels: [*]u8, width: u32, height: u32
 
 /// Create a texture that can be rendered to with renderTarget().  The
 /// returned pointer is what will later be passed to drawClippedTriangles.
-pub fn textureCreateTarget(_: *DummyBackend, _: u32, _: u32, _: dvui.enums.TextureInterpolation) error{ OutOfMemory, TextureCreate }!dvui.Texture {
+pub fn textureCreateTarget(_: *TestingBackend, _: u32, _: u32, _: dvui.enums.TextureInterpolation) error{ OutOfMemory, TextureCreate }!dvui.Texture {
     return error.TextureCreate;
 }
 
 /// Read pixel data (RGBA) from texture into pixel.
-pub fn textureRead(_: *DummyBackend, texture: dvui.Texture, pixels: [*]u8) error{TextureRead}!void {
+pub fn textureRead(_: *TestingBackend, texture: dvui.Texture, pixels: [*]u8) error{TextureRead}!void {
     const ptr: [*]const u8 = @ptrCast(texture.ptr);
     @memcpy(pixels, ptr[0..(texture.width * texture.height * 4)]);
 }
@@ -108,17 +108,17 @@ pub fn textureRead(_: *DummyBackend, texture: dvui.Texture, pixels: [*]u8) error
 /// Destroy texture that was previously made with textureCreate() or
 /// textureCreateTarget().  After this call, this texture pointer will not
 /// be used by dvui.
-pub fn textureDestroy(self: *DummyBackend, texture: dvui.Texture) void {
+pub fn textureDestroy(self: *TestingBackend, texture: dvui.Texture) void {
     const ptr: [*]const u8 = @ptrCast(texture.ptr);
     self.allocator.free(ptr[0..(texture.width * texture.height * 4)]);
 }
 
 /// Render future drawClippedTriangles() to the passed texture (or screen
 /// if null).
-pub fn renderTarget(_: *DummyBackend, _: ?dvui.Texture) void {}
+pub fn renderTarget(_: *TestingBackend, _: ?dvui.Texture) void {}
 
 /// Get clipboard content (text only)
-pub fn clipboardText(self: *DummyBackend) error{OutOfMemory}![]const u8 {
+pub fn clipboardText(self: *TestingBackend) error{OutOfMemory}![]const u8 {
     if (self.clipboard) |text| {
         return try self.arena.dupe(u8, text);
     } else {
@@ -127,7 +127,7 @@ pub fn clipboardText(self: *DummyBackend) error{OutOfMemory}![]const u8 {
 }
 
 /// Set clipboard content (text only)
-pub fn clipboardTextSet(self: *DummyBackend, text: []const u8) error{OutOfMemory}!void {
+pub fn clipboardTextSet(self: *TestingBackend, text: []const u8) error{OutOfMemory}!void {
     if (self.clipboard) |prev_text| {
         self.allocator.free(prev_text);
     }
@@ -135,16 +135,16 @@ pub fn clipboardTextSet(self: *DummyBackend, text: []const u8) error{OutOfMemory
 }
 
 /// Open URL in system browser
-pub fn openURL(_: *DummyBackend, _: []const u8) error{OutOfMemory}!void {}
+pub fn openURL(_: *TestingBackend, _: []const u8) error{OutOfMemory}!void {}
 
 /// Called by dvui.refresh() when it is called from a background
 /// thread.  Used to wake up the gui thread.  It only has effect if you
 /// are using waitTime() or some other method of waiting until a new
 /// event comes in.
-pub fn refresh(_: *DummyBackend) void {}
+pub fn refresh(_: *TestingBackend) void {}
 
-pub fn backend(self: *DummyBackend) dvui.Backend {
-    return dvui.Backend.init(self, DummyBackend);
+pub fn backend(self: *TestingBackend) dvui.Backend {
+    return dvui.Backend.init(self, TestingBackend);
 }
 
 pub const dvui = @import("dvui");

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -10,8 +10,8 @@ pub const Backend = enum {
     raylib,
     dx11,
     web,
-    /// Only intended for testing were no graphics are needed
-    dummy,
+    /// Does no rendering!
+    testing,
 };
 
 pub const TextureInterpolation = enum {

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -10,6 +10,8 @@ pub const Backend = enum {
     raylib,
     dx11,
     web,
+    /// Only intended for testing were no graphics are needed
+    dummy,
 };
 
 pub const TextureInterpolation = enum {

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -82,7 +82,7 @@ pub fn init(options: InitOptions) !Self {
             .title = "",
             .hidden = true,
         }),
-        .dummy => Backend.init(.{
+        .testing => Backend.init(.{
             .allocator = options.allocator,
             .size = options.window_size,
         }),
@@ -246,7 +246,7 @@ fn hash_png(png_reader: std.io.AnyReader) !u32 {
 }
 
 fn should_ignore_snapshots() bool {
-    return Backend.kind == .dummy or std.process.hasEnvVarConstant("DVUI_SNAPSHOT_IGNORE");
+    return Backend.kind == .testing or std.process.hasEnvVarConstant("DVUI_SNAPSHOT_IGNORE");
 }
 
 fn should_write_snapshots() bool {


### PR DESCRIPTION
This PR adds a dummy, or no-op, backend that does no rendering or OS interaction. It is intended to be used for tests were OS windows and rendering isn't needed, which is almost all test except `dvui.testing.snapshot`. If you are not using snapshots this backend will be much faster as it does not need to do any rendering but still tests all dvui logic like focus and visibility. 

The name could be changed to `NoOpBackend` or `TestingBackend` if dummy is a poor choice of word. If more testing functionality was going to be added, like verifying that triangles sent to the backend are correct, could also be added and in that case `TestingBackend` would be more fitting.

Additionally this changes the cache widget to prevent endless calls to `dvui.refresh` which stops the window from settling. If it cannot get a renderTarget on the second attempt, it doesn't call refresh and makes a new attempt during the next frame, stopping the endless loop.