### PR TITLE
Backend logging scopes

### DIFF
--- a/src/backends/raylib.zig
+++ b/src/backends/raylib.zig
@@ -17,6 +17,8 @@ pub fn description() [:0]const u8 {
 pub const RaylibBackend = @This();
 pub const Context = *RaylibBackend;
 
+const log = std.log.scoped(.RaylibBackend);
+
 gpa: std.mem.Allocator = undefined,
 we_own_window: bool = false,
 shader: c.Shader = undefined,
@@ -312,7 +314,7 @@ pub fn textureCreate(_: *RaylibBackend, pixels: [*]u8, width: u32, height: u32, 
 pub fn textureCreateTarget(self: *RaylibBackend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.Texture {
     const id = c.rlLoadFramebuffer(); // Load an empty framebuffer
     if (id == 0) {
-        dvui.log.debug("Raylib textureCreateTarget: rlLoadFramebuffer() failed\n", .{});
+        log.debug("textureCreateTarget: rlLoadFramebuffer() failed\n", .{});
         return error.TextureCreate;
     }
 
@@ -339,7 +341,7 @@ pub fn textureCreateTarget(self: *RaylibBackend, width: u32, height: u32, interp
 
     // Check if fbo is complete with attachments (valid)
     if (!c.rlFramebufferComplete(id)) {
-        dvui.log.debug("Raylib textureCreateTarget: rlFramebufferComplete() false\n", .{});
+        log.debug("textureCreateTarget: rlFramebufferComplete() false\n", .{});
         return error.TextureCreate;
     }
 
@@ -616,7 +618,7 @@ pub fn raylibMouseButtonToDvui(button: c_int) dvui.enums.Button {
         c.MOUSE_BUTTON_MIDDLE => .middle,
         c.MOUSE_BUTTON_RIGHT => .right,
         else => blk: {
-            dvui.log.debug("Raylib unknown button {}\n", .{button});
+            log.debug("unknown button {}\n", .{button});
             break :blk .six;
         },
     };
@@ -752,7 +754,7 @@ pub fn raylibKeyToDvui(key: c_int) dvui.enums.Key {
         c.KEY_BACK => .grave, //not sure if this is correct
 
         else => blk: {
-            dvui.log.debug("raylibKeymodToDvui unknown key{}\n", .{key});
+            log.debug("raylibKeymodToDvui unknown key{}\n", .{key});
             break :blk .unknown;
         },
     };

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -713,7 +713,7 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
             const code = SDL_keysym_to_dvui(@intCast(sdl_key));
             const mod = SDL_keymod_to_dvui(if (sdl3) @intCast(event.key.mod) else event.key.keysym.mod);
             if (self.log_events) {
-                std.debug.print("sdl event KEYDOWN {} {s} {} {}\n", .{ sdl_key, @tagName(code), mod, event.key.repeat });
+                log.debug("event KEYDOWN {} {s} {} {}\n", .{ sdl_key, @tagName(code), mod, event.key.repeat });
             }
 
             return try win.addEventKey(.{
@@ -727,7 +727,7 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
             const code = SDL_keysym_to_dvui(@intCast(sdl_key));
             const mod = SDL_keymod_to_dvui(if (sdl3) @intCast(event.key.mod) else event.key.keysym.mod);
             if (self.log_events) {
-                std.debug.print("sdl event KEYUP {} {s} {}\n", .{ sdl_key, @tagName(code), mod });
+                log.debug("event KEYUP {} {s} {}\n", .{ sdl_key, @tagName(code), mod });
             }
 
             return try win.addEventKey(.{
@@ -739,7 +739,7 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
         if (sdl3) c.SDL_EVENT_TEXT_INPUT else c.SDL_TEXTINPUT => {
             const txt = std.mem.sliceTo(if (sdl3) event.text.text else &event.text.text, 0);
             if (self.log_events) {
-                std.debug.print("sdl event TEXTINPUT {s}\n", .{txt});
+                log.debug("event TEXTINPUT {s}\n", .{txt});
             }
 
             return try win.addEventText(txt);
@@ -747,7 +747,7 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
         if (sdl3) c.SDL_EVENT_TEXT_EDITING else c.SDL_TEXTEDITING => {
             const strlen: u8 = @intCast(c.SDL_strlen(if (sdl3) event.edit.text else &event.edit.text));
             if (self.log_events) {
-                std.debug.print("sdl event TEXTEDITING {s} start {d} len {d} strlen {d}\n", .{ event.edit.text, event.edit.start, event.edit.length, strlen });
+                log.debug("event TEXTEDITING {s} start {d} len {d} strlen {d}\n", .{ event.edit.text, event.edit.start, event.edit.length, strlen });
             }
             return try win.addEventTextEx(event.edit.text[0..strlen], true);
         },
@@ -757,7 +757,7 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
                 var touch_str: []const u8 = " ";
                 if (touch) touch_str = " touch ";
                 if (touch and !self.touch_mouse_events) touch_str = " touch ignored ";
-                std.debug.print("sdl event{s}MOUSEMOTION {d} {d}\n", .{ touch_str, event.motion.x, event.motion.y });
+                log.debug("event{s}MOUSEMOTION {d} {d}\n", .{ touch_str, event.motion.x, event.motion.y });
             }
 
             if (touch and !self.touch_mouse_events) {
@@ -776,7 +776,7 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
                 var touch_str: []const u8 = " ";
                 if (touch) touch_str = " touch ";
                 if (touch and !self.touch_mouse_events) touch_str = " touch ignored ";
-                std.debug.print("sdl event{s}MOUSEBUTTONDOWN {d}\n", .{ touch_str, event.button.button });
+                log.debug("event{s}MOUSEBUTTONDOWN {d}\n", .{ touch_str, event.button.button });
             }
 
             if (touch and !self.touch_mouse_events) {
@@ -791,7 +791,7 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
                 var touch_str: []const u8 = " ";
                 if (touch) touch_str = " touch ";
                 if (touch and !self.touch_mouse_events) touch_str = " touch ignored ";
-                std.debug.print("sdl event{s}MOUSEBUTTONUP {d}\n", .{ touch_str, event.button.button });
+                log.debug("event{s}MOUSEBUTTONUP {d}\n", .{ touch_str, event.button.button });
             }
 
             if (touch and !self.touch_mouse_events) {
@@ -802,7 +802,7 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
         },
         if (sdl3) c.SDL_EVENT_MOUSE_WHEEL else c.SDL_MOUSEWHEEL => {
             if (self.log_events) {
-                std.debug.print("sdl event MOUSEWHEEL {d} {d} {d}\n", .{ event.wheel.x, event.wheel.y, event.wheel.which });
+                log.debug("event MOUSEWHEEL {d} {d} {d}\n", .{ event.wheel.x, event.wheel.y, event.wheel.which });
             }
 
             const ticks_x = if (sdl3) event.wheel.x else @as(f32, @floatFromInt(event.wheel.x));
@@ -821,28 +821,28 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
         },
         if (sdl3) c.SDL_EVENT_FINGER_DOWN else c.SDL_FINGERDOWN => {
             if (self.log_events) {
-                std.debug.print("sdl event FINGERDOWN {d} {d} {d}\n", .{ if (sdl3) event.tfinger.fingerID else event.tfinger.fingerId, event.tfinger.x, event.tfinger.y });
+                log.debug("event FINGERDOWN {d} {d} {d}\n", .{ if (sdl3) event.tfinger.fingerID else event.tfinger.fingerId, event.tfinger.x, event.tfinger.y });
             }
 
             return try win.addEventPointer(.touch0, .press, .{ .x = event.tfinger.x, .y = event.tfinger.y });
         },
         if (sdl3) c.SDL_EVENT_FINGER_UP else c.SDL_FINGERUP => {
             if (self.log_events) {
-                std.debug.print("sdl event FINGERUP {d} {d} {d}\n", .{ if (sdl3) event.tfinger.fingerID else event.tfinger.fingerId, event.tfinger.x, event.tfinger.y });
+                log.debug("event FINGERUP {d} {d} {d}\n", .{ if (sdl3) event.tfinger.fingerID else event.tfinger.fingerId, event.tfinger.x, event.tfinger.y });
             }
 
             return try win.addEventPointer(.touch0, .release, .{ .x = event.tfinger.x, .y = event.tfinger.y });
         },
         if (sdl3) c.SDL_EVENT_FINGER_MOTION else c.SDL_FINGERMOTION => {
             if (self.log_events) {
-                std.debug.print("sdl event FINGERMOTION {d} {d} {d} {d} {d}\n", .{ if (sdl3) event.tfinger.fingerID else event.tfinger.fingerId, event.tfinger.x, event.tfinger.y, event.tfinger.dx, event.tfinger.dy });
+                log.debug("event FINGERMOTION {d} {d} {d} {d} {d}\n", .{ if (sdl3) event.tfinger.fingerID else event.tfinger.fingerId, event.tfinger.x, event.tfinger.y, event.tfinger.dx, event.tfinger.dy });
             }
 
             return try win.addEventTouchMotion(.touch0, event.tfinger.x, event.tfinger.y, event.tfinger.dx, event.tfinger.dy);
         },
         else => {
             if (self.log_events) {
-                std.debug.print("unhandled SDL event type {}\n", .{event.type});
+                log.debug("unhandled SDL event type {}\n", .{event.type});
             }
             return false;
         },

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -24,6 +24,8 @@ pub fn description() [:0]const u8 {
 pub const SDLBackend = @This();
 pub const Context = *SDLBackend;
 
+const log = std.log.scoped(.SDLBackend);
+
 window: *c.SDL_Window,
 renderer: *c.SDL_Renderer,
 we_own_window: bool = false,
@@ -64,7 +66,7 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
     _ = c.SDL_SetHint("SDL_HINT_WINDOWS_DPI_SCALING", "1");
 
     if (c.SDL_Init(c.SDL_INIT_VIDEO) != if (sdl3) true else 0) {
-        dvui.log.err("SDL: Couldn't initialize SDL: {s}", .{c.SDL_GetError()});
+        log.err("Couldn't initialize SDL: {s}", .{c.SDL_GetError()});
         return error.BackendError;
     }
 
@@ -72,12 +74,12 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
     var window: *c.SDL_Window = undefined;
     if (sdl3) {
         window = c.SDL_CreateWindow(options.title, @as(c_int, @intFromFloat(options.size.w)), @as(c_int, @intFromFloat(options.size.h)), @intCast(c.SDL_WINDOW_HIGH_PIXEL_DENSITY | c.SDL_WINDOW_RESIZABLE | hidden_flag)) orelse {
-            dvui.log.err("SDL: Failed to open window: {s}", .{c.SDL_GetError()});
+            log.err("Failed to open window: {s}", .{c.SDL_GetError()});
             return error.BackendError;
         };
     } else {
         window = c.SDL_CreateWindow(options.title, c.SDL_WINDOWPOS_UNDEFINED, c.SDL_WINDOWPOS_UNDEFINED, @as(c_int, @intFromFloat(options.size.w)), @as(c_int, @intFromFloat(options.size.h)), @intCast(c.SDL_WINDOW_ALLOW_HIGHDPI | c.SDL_WINDOW_RESIZABLE | hidden_flag)) orelse {
-            dvui.log.err("SDL: Failed to open window: {s}", .{c.SDL_GetError()});
+            log.err("Failed to open window: {s}", .{c.SDL_GetError()});
             return error.BackendError;
         };
     }
@@ -94,12 +96,12 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
         }
 
         renderer = c.SDL_CreateRendererWithProperties(props) orelse {
-            dvui.log.err("SDL: Failed to create renderer: {s}", .{c.SDL_GetError()});
+            log.err("Failed to create renderer: {s}", .{c.SDL_GetError()});
             return error.BackendError;
         };
     } else {
         renderer = c.SDL_CreateRenderer(window, -1, @intCast(c.SDL_RENDERER_TARGETTEXTURE | (if (options.vsync) c.SDL_RENDERER_PRESENTVSYNC else 0))) orelse {
-            dvui.log.err("SDL: Failed to create renderer: {s}", .{c.SDL_GetError()});
+            log.err("Failed to create renderer: {s}", .{c.SDL_GetError()});
             return error.BackendError;
         };
     }
@@ -115,7 +117,7 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
 
     if (sdl3) {
         back.initial_scale = c.SDL_GetDisplayContentScale(c.SDL_GetDisplayForWindow(window));
-        dvui.log.info("SDL3 backend scale {d}", .{back.initial_scale});
+        log.info("SDL3 backend scale {d}", .{back.initial_scale});
     } else {
         const winSize = back.windowSize();
         const pxSize = back.pixelSize();
@@ -131,7 +133,7 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
                 };
                 defer if (qt_auto_str) |str| options.allocator.free(str);
                 if (qt_auto_str != null and std.mem.eql(u8, qt_auto_str.?, "0")) {
-                    dvui.log.info("QT_AUTO_SCREEN_SCALE_FACTOR is 0, disabling content scale guessing", .{});
+                    log.info("QT_AUTO_SCREEN_SCALE_FACTOR is 0, disabling content scale guessing", .{});
                     guess_from_dpi = false;
                 }
                 const qt_str: ?[]u8 = std.process.getEnvVarOwned(options.allocator, "QT_SCALE_FACTOR") catch |err| switch (err) {
@@ -147,12 +149,12 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
 
                 if (qt_str) |str| {
                     const qt_scale = std.fmt.parseFloat(f32, str) catch 1.0;
-                    dvui.log.info("QT_SCALE_FACTOR is {d}, using that for initial content scale", .{qt_scale});
+                    log.info("QT_SCALE_FACTOR is {d}, using that for initial content scale", .{qt_scale});
                     back.initial_scale = qt_scale;
                     guess_from_dpi = false;
                 } else if (gdk_str) |str| {
                     const gdk_scale = std.fmt.parseFloat(f32, str) catch 1.0;
-                    dvui.log.info("GDK_SCALE is {d}, using that for initial content scale", .{gdk_scale});
+                    log.info("GDK_SCALE is {d}, using that for initial content scale", .{gdk_scale});
                     back.initial_scale = gdk_scale;
                     guess_from_dpi = false;
                 }
@@ -187,7 +189,7 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
                         }
 
                         if (mdpi) |dpi| {
-                            dvui.log.info("dpi {d} from xrdb -get Xft.dpi", .{dpi});
+                            log.info("dpi {d} from xrdb -get Xft.dpi", .{dpi});
                         }
                     }
                 }
@@ -201,7 +203,7 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
                     var vdpi: f32 = undefined;
                     _ = c.SDL_GetDisplayDPI(display_num, null, &hdpi, &vdpi);
                     mdpi = @max(hdpi, vdpi);
-                    std.debug.print("SDLBackend dpi {d} from SDL_GetDisplayDPI\n", .{mdpi.?});
+                    log.info("dpi {d} from SDL_GetDisplayDPI\n", .{mdpi.?});
                 }
 
                 if (mdpi) |dpi| {
@@ -220,7 +222,7 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
                         }
                     }
 
-                    dvui.log.info("SDL2 guessing initial backend scale {d} from dpi {d}", .{ back.initial_scale, dpi });
+                    log.info("guessing initial backend scale {d} from dpi {d}", .{ back.initial_scale, dpi });
                 }
             }
 
@@ -255,7 +257,7 @@ pub fn setIconFromFileContent(self: *SDLBackend, file_content: []const u8) void 
     var channels_in_file: c_int = undefined;
     const data = dvui.c.stbi_load_from_memory(file_content.ptr, @as(c_int, @intCast(file_content.len)), &icon_w, &icon_h, &channels_in_file, 4);
     if (data == null) {
-        dvui.log.warn("when setting icon, stbi_load error: {s}", .{dvui.c.stbi_failure_reason()});
+        log.warn("when setting icon, stbi_load error: {s}", .{dvui.c.stbi_failure_reason()});
         return;
     }
     defer dvui.c.stbi_image_free(data);
@@ -356,7 +358,7 @@ pub fn setCursor(self: *SDLBackend, cursor: dvui.enums.Cursor) void {
                 c.SDL_SetCursor(cur);
             }
         } else {
-            dvui.log.err("SDL_CreateSystemCursor \"{s}\" failed", .{@tagName(cursor)});
+            log.err("SDL_CreateSystemCursor \"{s}\" failed", .{@tagName(cursor)});
         }
     }
 }
@@ -855,7 +857,7 @@ pub fn SDL_mouse_button_to_dvui(button: u8) dvui.enums.Button {
         c.SDL_BUTTON_X1 => .four,
         c.SDL_BUTTON_X2 => .five,
         else => blk: {
-            dvui.log.debug("SDL_mouse_button_to_dvui.unknown button {d}", .{button});
+            log.debug("SDL_mouse_button_to_dvui.unknown button {d}", .{button});
             break :blk .six;
         },
     };
@@ -989,7 +991,7 @@ pub fn SDL_keysym_to_dvui(keysym: i32) dvui.enums.Key {
         if (sdl3) c.SDLK_GRAVE else c.SDLK_BACKQUOTE => .grave,
 
         else => blk: {
-            dvui.log.debug("SDL_keysym_to_dvui unknown keysym {d}", .{keysym});
+            log.debug("SDL_keysym_to_dvui unknown keysym {d}", .{keysym});
             break :blk .unknown;
         },
     };
@@ -1027,7 +1029,7 @@ pub fn main() !void {
         // on windows graphical apps have no console, so output goes to nowhere - attach it manually. related: https://github.com/ziglang/zig/issues/4196
         _ = winapi.AttachConsole(0xFFFFFFFF);
     }
-    std.log.info("SDL version: {}", .{getSDLVersion()});
+    log.info("version: {}", .{getSDLVersion()});
 
     const init_opts = app.config.get();
 


### PR DESCRIPTION
Previously only the Dx11 backend had it's own `std.log.scope` which this PR implements for all backends. There was also some printing that happened through `std.debug.print` which has now also been changed to use the log api.