### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the $default-branch branch
+  push:
+    branches: [$default-branch]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Build and test
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+      # uses .minimum_zig_version from build.zig.zon
+      - uses: mlugg/setup-zig@v1
+
+      - name: Build and check
+        run: zig build check # build all backends
+
+      - name: Run tests
+        run: zig build test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           sudo apt-get install mesa-common-dev libgl-dev libglx-dev libegl-dev libpulse-dev libxext-dev libxfixes-dev libxrender-dev libasound2-dev libx11-dev libxrandr-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev libxcursor-dev libxinerama-dev libwayland-dev libxkbcommon-dev
 
       - name: Build and check
-        run: zig build check # build all backends
+        run: zig build check -Duse-lld=false # build all backends
 
       - name: Run tests
-        run: zig build test -Dbackend=testing
+        run: zig build test -Dbackend=testing -Duse-lld=false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,4 @@ jobs:
         run: zig build check # build all backends
 
       - name: Run tests
-        run: zig build test
+        run: zig build test -Dbackend=testing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,11 @@ jobs:
       # uses .minimum_zig_version from build.zig.zon
       - uses: mlugg/setup-zig@v1
 
+      - name: Install libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install mesa-common-dev libgl-dev libglx-dev libegl-dev libpulse-dev libxext-dev libxfixes-dev libxrender-dev libasound2-dev libx11-dev libxrandr-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev libxcursor-dev libxinerama-dev libwayland-dev libxkbcommon-dev
+
       - name: Build and check
         run: zig build check # build all backends
 

--- a/build.zig
+++ b/build.zig
@@ -429,9 +429,9 @@ fn addExample(
     });
     mod.addImport("dvui", dvui_mod);
 
-    const exe = b.addExecutable(.{ .name = name, .root_module = mod });
+    const exe = b.addExecutable(.{ .name = name, .root_module = mod, .use_lld = false });
 
-    const exe_check = b.addExecutable(.{ .name = name, .root_module = mod });
+    const exe_check = b.addExecutable(.{ .name = name, .root_module = mod, .use_lld = false });
     if (opts.check_step) |step| step.dependOn(&exe_check.step);
 
     if (opts.target.result.os.tag == .windows) {

--- a/build.zig
+++ b/build.zig
@@ -19,12 +19,16 @@ pub fn build(b: *std.Build) !void {
     const test_step = b.step("test", "Test the dvui codebase");
     const check_step = b.step("check", "Check that the dvui codebase compiles");
 
+    // Setting this to false may fix linking errors: https://github.com/david-vanderson/dvui/issues/269
+    const use_lld = b.option(bool, "use-lld", "The value of the use_lld executable option");
+
     const dvui_opts = DvuiModuleOptions{
         .b = b,
         .target = target,
         .optimize = optimize,
         .test_step = test_step,
         .check_step = check_step,
+        .use_lld = use_lld,
     };
 
     if (back_to_build == .custom) {
@@ -351,6 +355,7 @@ const DvuiModuleOptions = struct {
     check_step: ?*std.Build.Step = null,
     test_step: ?*std.Build.Step = null,
     add_stb_image: bool = true,
+    use_lld: ?bool = null,
 };
 
 fn addDvuiModule(
@@ -429,9 +434,9 @@ fn addExample(
     });
     mod.addImport("dvui", dvui_mod);
 
-    const exe = b.addExecutable(.{ .name = name, .root_module = mod, .use_lld = false });
+    const exe = b.addExecutable(.{ .name = name, .root_module = mod, .use_lld = opts.use_lld });
 
-    const exe_check = b.addExecutable(.{ .name = name, .root_module = mod, .use_lld = false });
+    const exe_check = b.addExecutable(.{ .name = name, .root_module = mod, .use_lld = opts.use_lld });
     if (opts.check_step) |step| step.dependOn(&exe_check.step);
 
     if (opts.target.result.os.tag == .windows) {


### PR DESCRIPTION
This runs the new `check` and `test` step in CI. This would have prevented me from merging many small issues that breaks builds on some backends.

It currently only builds and runs on `ubuntu-latest`, but to test dx11 we might want to expand that to windows as well. We could also run it on MacOS or just cross compile with zig (which I believe wouldn't work for dx11 because of the win32 dependency).

There was additionally an issue with linking raylib with zig, also observed in https://github.com/Not-Nik/raylib-zig/issues/219. I followed their recommendation of disabling lld but I'm not sure if there are other consequences for that. 