### PR TITLE
Fix failing tests

### DIFF
--- a/docs/readme-docs.md
+++ b/docs/readme-docs.md
@@ -13,6 +13,19 @@ I also add success temporarily adding in the `<head>` section of `docs/index.htm
 ` <script type="text/javascript" src="http://livejs.com/live.js"></script>`  
 For a full auto reload experience. Cool enough to be mentioned.
 
+# About Images
+
+Images/screenshots are integrated in the docs. It works by : 
+
+- Declaring a `test` block whose name ends with `.png`
+- Said test block should use `dvui.testing.saveDocImage` function
+- It relies on `docs/image_gen_test_runner.zig` test runner to provide a path.
+- To use the image, use the markdown image syntax with the test name.
+
+e.g. :
+- `test "my-image.png" { // declare gui element and call dvui.testing.saveDocImage }`
+- `/// ![image description](my-image.png)`
+
 
 # About Customization
 

--- a/src/Rect.zig
+++ b/src/Rect.zig
@@ -355,15 +355,8 @@ test "Rect-unionWith.png" {
 test inset {
     const rect = Rect{ .x = 50, .y = 50, .w = 150, .h = 150 };
     const res = rect.inset(.{ .x = 50, .y = 50, .w = 25, .h = 25 });
-    try std.testing.expectEqualDeep(Rect{ .x = 100, .y = 100, .w = 50, .h = 50 }, res);
+    try std.testing.expectEqualDeep(Rect{ .x = 100, .y = 100, .w = 75, .h = 75 }, res);
 }
-
-test insetAll {
-    const rect = Rect{ .x = 50, .y = 50, .w = 150, .h = 150 };
-    const res = rect.insetAll(50);
-    try std.testing.expectEqualDeep(Rect{ .x = 100, .y = 100, .w = 50, .h = 50 }, res);
-}
-
 test "Rect-inset.png" {
     var t = try dvui.testing.init(.{ .window_size = .all(250) });
     defer t.deinit();
@@ -386,18 +379,17 @@ test "Rect-inset.png" {
     try t.saveDocImage(@src(), .{}, frame);
 }
 
+test insetAll {
+    const rect = Rect{ .x = 50, .y = 50, .w = 150, .h = 150 };
+    const res = rect.insetAll(50);
+    try std.testing.expectEqualDeep(Rect{ .x = 100, .y = 100, .w = 50, .h = 50 }, res);
+}
+
 test outset {
     const rect = Rect{ .x = 100, .y = 100, .w = 50, .h = 50 };
     const res = rect.outset(.{ .x = 50, .y = 50, .w = 25, .h = 25 });
     try std.testing.expectEqualDeep(Rect{ .x = 50, .y = 50, .w = 125, .h = 125 }, res);
 }
-
-test outsetAll {
-    const rect = Rect{ .x = 100, .y = 100, .w = 50, .h = 50 };
-    const res = rect.outsetAll(50);
-    try std.testing.expectEqualDeep(Rect{ .x = 50, .y = 50, .w = 100, .h = 100 }, res);
-}
-
 test "Rect-outset.png" {
     var t = try dvui.testing.init(.{ .window_size = .all(250) });
     defer t.deinit();
@@ -418,4 +410,10 @@ test "Rect-outset.png" {
     }.frame;
 
     try t.saveDocImage(@src(), .{}, frame);
+}
+
+test outsetAll {
+    const rect = Rect{ .x = 100, .y = 100, .w = 50, .h = 50 };
+    const res = rect.outsetAll(50);
+    try std.testing.expectEqualDeep(Rect{ .x = 50, .y = 50, .w = 150, .h = 150 }, res);
 }

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -298,19 +298,14 @@ pub fn saveDocImage(self: *Self, comptime src: std.builtin.SourceLocation, compt
         .sub_path = filename,
         // set exclusive flag to error if two test generate an image with the same name
         .flags = .{ .exclusive = true },
-    }) catch |err|
-        {
-            if (err == std.fs.File.OpenError.PathAlreadyExists) {
-                fatal("Error generating doc image : duplicated test name ('{s}')", .{src.fn_name});
-            } else {
-                return err;
-            }
-        };
-}
-
-fn fatal(comptime format: []const u8, args: anytype) noreturn {
-    std.debug.print(format, args);
-    std.process.exit(1);
+    }) catch |err| {
+        if (err == std.fs.File.OpenError.PathAlreadyExists) {
+            std.debug.print("Error generating doc image: duplicated test name '{s}'\n", .{filename});
+            return error.DuplicateDocImageName;
+        } else {
+            return err;
+        }
+    };
 }
 
 /// Used internally for documentation generation


### PR DESCRIPTION
While playing with the new stuff for doc and tests, I noticed a couple of typo in `Rect.zig` that were failing tests.

I also made the `saveDocImage` output something a bit more explicit in case of duplicate image name.

@david-vanderson let me know if you would prefer this kind of small stuff to be pushed directly to main instead of going through a PR. 
I prefer the PR way, but don't want to create annoying noise either. 