### PR TITLE
options: max_size_content is type MaxSize

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -89,7 +89,7 @@ const AnimatingDialog = struct {
         // once we record a response, refresh it until we close
         _ = dvui.dataGet(null, id, "response", enums.DialogResponse);
 
-        var win = FloatingWindowWidget.init(@src(), .{ .modal = modal }, .{ .id_extra = id, .max_size_content = .{ .w = 300 } });
+        var win = FloatingWindowWidget.init(@src(), .{ .modal = modal }, .{ .id_extra = id, .max_size_content = .width(300) });
 
         if (dvui.firstFrame(win.data().id)) {
             dvui.animation(win.wd.id, "rect_percent", .{ .start_val = 0.0, .end_val = 1.0, .end_time = duration, .easing = easing });
@@ -368,7 +368,7 @@ pub fn demo() !void {
         return;
     }
 
-    var float = try dvui.floatingWindow(@src(), .{ .open_flag = &show_demo_window }, .{ .min_size_content = .{ .w = 600, .h = 400 }, .max_size_content = .{ .w = 600 }, .tag = demo_window_tag });
+    var float = try dvui.floatingWindow(@src(), .{ .open_flag = &show_demo_window }, .{ .min_size_content = .{ .w = 600, .h = 400 }, .max_size_content = .width(600), .tag = demo_window_tag });
     defer float.deinit();
 
     // pad the fps label so that it doesn't trigger refresh when the number
@@ -435,7 +435,7 @@ pub fn demo() !void {
 
         inline for (0..@typeInfo(demoKind).@"enum".fields.len) |i| {
             const e = @as(demoKind, @enumFromInt(i));
-            var bw = dvui.ButtonWidget.init(@src(), .{}, .{ .id_extra = i, .border = Rect.all(1), .background = true, .min_size_content = dvui.Size.all(120), .max_size_content = dvui.Size.all(120), .margin = Rect.all(5), .color_fill = .{ .name = .fill }, .tag = "demo_button_" ++ @tagName(e) });
+            var bw = dvui.ButtonWidget.init(@src(), .{}, .{ .id_extra = i, .border = Rect.all(1), .background = true, .min_size_content = dvui.Size.all(120), .max_size_content = .size(dvui.Size.all(120)), .margin = Rect.all(5), .color_fill = .{ .name = .fill }, .tag = "demo_button_" ++ @tagName(e) });
             try bw.install();
             bw.processEvents();
             try bw.drawBackground();
@@ -900,7 +900,7 @@ pub fn textEntryWidgets(demo_win_id: u32) !void {
 
         try left_alignment.spacer(@src(), 0);
 
-        var te = try dvui.textEntry(@src(), .{ .text = .{ .buffer = &text_entry_buf } }, .{ .max_size_content = dvui.Options.sizeM(20, 0) });
+        var te = try dvui.textEntry(@src(), .{ .text = .{ .buffer = &text_entry_buf } }, .{ .max_size_content = .size(dvui.Options.sizeM(20, 1)) });
         enter_pressed = te.enter_pressed;
         te.deinit();
 
@@ -1147,7 +1147,7 @@ pub fn textEntryWidgets(demo_win_id: u32) !void {
 
         try left_alignment.spacer(@src(), 0);
 
-        var te = dvui.TextEntryWidget.init(@src(), .{}, .{ .max_size_content = dvui.Options.sizeM(20, 0) });
+        var te = dvui.TextEntryWidget.init(@src(), .{}, .{ .max_size_content = .size(dvui.Options.sizeM(20, 1)) });
         try te.install();
 
         var sug = try dvui.suggestion(&te, .{ .open_on_text_change = true });
@@ -1395,7 +1395,7 @@ pub fn layout() !void {
 
             var opts: Options = .{ .border = Rect.all(1), .background = true, .min_size_content = .{ .w = 200, .h = 140 } };
             if (Static.shrink) {
-                opts.max_size_content = opts.min_size_contentGet();
+                opts.max_size_content = .size(opts.min_size_contentGet());
             }
 
             var o = try dvui.overlay(@src(), opts);
@@ -1616,7 +1616,7 @@ pub fn layoutText() !void {
         }
         cbox.deinit();
 
-        cbox = try dvui.box(@src(), .vertical, .{ .margin = Rect.all(4), .padding = Rect.all(4), .gravity_x = 1.0, .background = true, .color_fill = .{ .name = .fill_window }, .min_size_content = .{ .w = 160 }, .max_size_content = .{ .w = 160 } });
+        cbox = try dvui.box(@src(), .vertical, .{ .margin = Rect.all(4), .padding = Rect.all(4), .gravity_x = 1.0, .background = true, .color_fill = .{ .name = .fill_window }, .min_size_content = .{ .w = 160 }, .max_size_content = .width(160) });
         try dvui.icon(@src(), "aircraft", entypo.aircraft, .{ .min_size_content = .{ .h = 30 }, .gravity_x = 0.5 });
         try dvui.label(@src(), "Caption Heading", .{}, .{ .font_style = .caption_heading, .gravity_x = 0.5 });
         var tl_caption = try dvui.textLayout(@src(), .{}, .{ .expand = .horizontal, .background = false });
@@ -2067,7 +2067,7 @@ pub fn menus() !void {
     _ = try dvui.spacer(@src(), .{ .h = 20 }, .{});
 
     {
-        var hbox = try dvui.box(@src(), .horizontal, .{ .border = dvui.Rect.all(1), .min_size_content = .{ .h = 50 }, .max_size_content = .{ .w = 300 } });
+        var hbox = try dvui.box(@src(), .horizontal, .{ .border = dvui.Rect.all(1), .min_size_content = .{ .h = 50 }, .max_size_content = .width(300) });
         defer hbox.deinit();
 
         var tl = try dvui.textLayout(@src(), .{}, .{ .background = false });
@@ -2080,7 +2080,7 @@ pub fn menus() !void {
     _ = try dvui.spacer(@src(), .{ .h = 10 }, .{});
 
     {
-        var hbox = try dvui.box(@src(), .horizontal, .{ .border = dvui.Rect.all(1), .min_size_content = .{ .h = 50 }, .max_size_content = .{ .w = 300 } });
+        var hbox = try dvui.box(@src(), .horizontal, .{ .border = dvui.Rect.all(1), .min_size_content = .{ .h = 50 }, .max_size_content = .width(300) });
         defer hbox.deinit();
 
         var tl = try dvui.textLayout(@src(), .{}, .{ .background = false });
@@ -2411,7 +2411,7 @@ pub fn scrolling(comptime data: u8) !void {
         }
     }
     {
-        var vbox = try dvui.box(@src(), .vertical, .{ .expand = .horizontal, .max_size_content = .{ .h = 300 } });
+        var vbox = try dvui.box(@src(), .vertical, .{ .expand = .horizontal, .max_size_content = .height(300) });
         defer vbox.deinit();
 
         try dvui.label(@src(), "{d:0>4.2}% visible, offset {d} frac {d:0>4.2}", .{ Data.scroll_info.visibleFraction(.vertical) * 100.0, Data.scroll_info.viewport.y, Data.scroll_info.offsetFraction(.vertical) }, .{});
@@ -3339,7 +3339,7 @@ pub fn dialogDirect() !void {
     const data = struct {
         var extra_stuff: bool = false;
     };
-    var dialog_win = try dvui.floatingWindow(@src(), .{ .modal = false, .open_flag = &show_dialog }, .{ .max_size_content = .{ .w = 500 } });
+    var dialog_win = try dvui.floatingWindow(@src(), .{ .modal = false, .open_flag = &show_dialog }, .{ .max_size_content = .width(500) });
     defer dialog_win.deinit();
 
     try dvui.windowHeader("Dialog", "", &show_dialog);

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -45,6 +45,25 @@ pub const FontStyle = enum {
     title_4,
 };
 
+pub const MaxSize = struct {
+    w: f32,
+    h: f32,
+
+    pub const zero: MaxSize = .{ .w = 0, .h = 0 };
+
+    pub fn width(w: f32) MaxSize {
+        return .{ .w = w, .h = 1_000_000 };
+    }
+
+    pub fn height(h: f32) MaxSize {
+        return .{ .w = 1_000_000, .h = h };
+    }
+
+    pub fn size(s: Size) MaxSize {
+        return .{ .w = s.w, .h = s.h };
+    }
+};
+
 // used to adjust widget id when @src() is not enough (like in a loop)
 id_extra: ?usize = null,
 
@@ -110,7 +129,7 @@ min_size_content: ?Size = null,
 /// Use when a child textLayout or scrollArea is making the parent too big.
 ///
 /// padding/border/margin will be added to this.
-max_size_content: ?Size = null,
+max_size_content: ?MaxSize = null,
 
 // whether to fill the background
 background: ?bool = null,
@@ -251,7 +270,11 @@ pub fn max_sizeGet(self: *const Options) Size {
 }
 
 pub fn max_size_contentGet(self: *const Options) Size {
-    return self.max_size_content orelse Size{};
+    if (self.max_size_content) |msc| {
+        return .{ .w = msc.w, .h = msc.h };
+    } else {
+        return Size.all(1_000_000.0);
+    }
 }
 
 pub fn rotationGet(self: *const Options) f32 {

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -52,11 +52,11 @@ pub const MaxSize = struct {
     pub const zero: MaxSize = .{ .w = 0, .h = 0 };
 
     pub fn width(w: f32) MaxSize {
-        return .{ .w = w, .h = 1_000_000 };
+        return .{ .w = w, .h = dvui.max_float_safe };
     }
 
     pub fn height(h: f32) MaxSize {
-        return .{ .w = 1_000_000, .h = h };
+        return .{ .w = dvui.max_float_safe, .h = h };
     }
 
     pub fn size(s: Size) MaxSize {
@@ -273,7 +273,7 @@ pub fn max_size_contentGet(self: *const Options) Size {
     if (self.max_size_content) |msc| {
         return .{ .w = msc.w, .h = msc.h };
     } else {
-        return Size.all(1_000_000.0);
+        return Size.all(dvui.max_float_safe);
     }
 }
 

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -235,8 +235,8 @@ pub fn minSizeMax(self: *WidgetData, s: Size) void {
 pub fn minSizeSetAndRefresh(self: *WidgetData) void {
     const msContent = self.options.max_size_contentGet();
     const max_size = self.options.padSize(msContent);
-    if (msContent.w != 0) self.min_size.w = @min(self.min_size.w, max_size.w);
-    if (msContent.h != 0) self.min_size.h = @min(self.min_size.h, max_size.h);
+    self.min_size.w = @min(self.min_size.w, max_size.w);
+    self.min_size.h = @min(self.min_size.h, max_size.h);
 
     if (dvui.minSizeGet(self.id)) |ms| {
         // If the size we got was exactly our previous min size then our min size

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -632,7 +632,7 @@ pub const FontCacheEntry = struct {
 
     // doesn't scale the font or max_width, always stops at newlines
     pub fn textSizeRaw(fce: *FontCacheEntry, font_name: []const u8, text: []const u8, max_width: ?f32, end_idx: ?*usize, end_metric: Font.EndMetric) !Size {
-        const mwidth = max_width orelse 1000000.0;
+        const mwidth = max_width orelse 1_000_000;
 
         var x: f32 = 0;
         var minx: f32 = 0;
@@ -2911,7 +2911,7 @@ pub const DialogOptions = struct {
     message: []const u8,
     ok_label: []const u8 = "Ok",
     cancel_label: ?[]const u8 = null,
-    max_size: ?Size = null,
+    max_size: ?Options.MaxSize = null,
     displayFn: DialogDisplayFn = dialogDisplay,
     callafterFn: ?DialogCallAfterFn = null,
 };
@@ -2985,7 +2985,7 @@ pub fn dialogDisplay(id: u32) !void {
 
     const callafter = dvui.dataGet(null, id, "_callafter", DialogCallAfterFn);
 
-    const maxSize = dvui.dataGet(null, id, "_max_size", Size);
+    const maxSize = dvui.dataGet(null, id, "_max_size", Options.MaxSize);
 
     var win = try floatingWindow(@src(), .{ .modal = modal, .center_on = center_on, .window_avoid = .nudge }, .{ .id_extra = id, .max_size_content = maxSize });
     defer win.deinit();

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -94,6 +94,19 @@ pub const testing = @import("testing.zig");
 pub const wasm = (builtin.target.cpu.arch == .wasm32 or builtin.target.cpu.arch == .wasm64);
 pub const useFreeType = !wasm;
 
+/// Used as a default maximum in various places:
+/// * Options.max_size_content
+/// * Font.textSizeEx max_width
+///
+/// This is a compromise between desires:
+/// * gives a decent range
+/// * is a normal number (not nan/inf) that works in normal math
+/// * can still have some extra added to it (like padding)
+/// * float precision in this range (0.125) is small enough so integer stuff still works
+///
+/// If positions/sizes are getting into this range, then likely something is going wrong.
+pub const max_float_safe: f32 = 1_000_000; // 1000000 and 1e6 for searchability
+
 pub const c = @cImport({
     // musl fails to compile saying missing "bits/setjmp.h", and nobody should
     // be using setjmp anyway
@@ -632,7 +645,7 @@ pub const FontCacheEntry = struct {
 
     // doesn't scale the font or max_width, always stops at newlines
     pub fn textSizeRaw(fce: *FontCacheEntry, font_name: []const u8, text: []const u8, max_width: ?f32, end_idx: ?*usize, end_metric: Font.EndMetric) !Size {
-        const mwidth = max_width orelse 1_000_000;
+        const mwidth = max_width orelse max_float_safe;
 
         var x: f32 = 0;
         var minx: f32 = 0;

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -93,8 +93,8 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
         // max size not given, so default to the same as min size for direction
         // we can scroll in
         const ms = options.min_size_contentGet();
-        const maxw = if (self.scroll_init_opts.horizontal == .auto) ms.w else 1_000_000;
-        const maxh = if (self.scroll_init_opts.vertical == .auto) ms.h else 1_000_000;
+        const maxw = if (self.scroll_init_opts.horizontal == .auto) ms.w else dvui.max_float_safe;
+        const maxh = if (self.scroll_init_opts.vertical == .auto) ms.h else dvui.max_float_safe;
         options = options.override(.{ .max_size_content = .{ .w = maxw, .h = maxh } });
     }
 

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -93,8 +93,8 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
         // max size not given, so default to the same as min size for direction
         // we can scroll in
         const ms = options.min_size_contentGet();
-        const maxw = if (self.scroll_init_opts.horizontal == .auto) ms.w else 0;
-        const maxh = if (self.scroll_init_opts.vertical == .auto) ms.h else 0;
+        const maxw = if (self.scroll_init_opts.horizontal == .auto) ms.w else 1_000_000;
+        const maxh = if (self.scroll_init_opts.vertical == .auto) ms.h else 1_000_000;
         options = options.override(.{ .max_size_content = .{ .w = maxw, .h = maxh } });
     }
 
@@ -105,12 +105,8 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     options.padding = null;
     options.min_size_content.?.w += self.padding.x + self.padding.w;
     options.min_size_content.?.h += self.padding.y + self.padding.h;
-    if (options.max_size_content.?.w != 0) {
-        options.max_size_content.?.w += self.padding.x + self.padding.w;
-    }
-    if (options.max_size_content.?.h != 0) {
-        options.max_size_content.?.h += self.padding.y + self.padding.h;
-    }
+    options.max_size_content.?.w += self.padding.x + self.padding.w;
+    options.max_size_content.?.h += self.padding.y + self.padding.h;
 
     self.wd = WidgetData.init(src, .{}, options);
     self.scroll_init_opts.focus_id = self.wd.id;


### PR DESCRIPTION
When setting .max_size_content for Options, we don't want the default behavior of Size where unspecified means 0.

So this attempts to solve it by using a new type, MaxSize.  It doesn't have defaults so the user must specify both the width/height or use a decl literal.

The idea is to prevent confusion when trying to do .max_size_content = .{} - does that mean zeros or large numbers?