### PR TITLE
Update `last_focused_id_this_frame` when widget take focus outside `WidgetData.register()`

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -2325,7 +2325,7 @@ pub fn focus() !void {
 
         // firstFrame must be called before te.deinit()
         if (dvui.firstFrame(te.data().id)) {
-            dvui.focusWidget(te.data().id, null, null);
+            dvui.focusWidgetSelf(te.data().id, null);
         }
 
         te.deinit();

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1052,6 +1052,19 @@ pub fn focusWidget(id: ?u32, subwindow_id: ?u32, event_num: ?u16) void {
     }
 }
 
+/// Focuses the given widget id and sets `Window.last_focused_id_this_frame`.
+/// This should only be used by widgets that focuses themselves. If you are
+/// focusing another widget, use `focusWidget`
+///
+/// If you are doing this in response to an `Event`, you can pass that `Event`'s
+/// num to change the focus of any further `Event`s in the list.
+///
+/// Only valid between `Window.begin`and `Window.end`.
+pub fn focusWidgetSelf(id: u32, event_num: ?u16) void {
+    currentWindow().last_focused_id_this_frame = id;
+    focusWidget(id, null, event_num);
+}
+
 /// Id of the focused widget (if any) in the focused subwindow.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
@@ -3644,7 +3657,7 @@ pub fn suggestion(te: *TextEntryWidget, init_opts: SuggestionInitOptions) !*Sugg
     if (init_opts.button) {
         if (try dvui.buttonIcon(@src(), "combobox_triangle", entypo.chevron_small_down, .{}, .{ .expand = .ratio, .margin = dvui.Rect.all(2), .gravity_x = 1.0, .tab_index = 0 })) {
             open_sug = true;
-            dvui.focusWidget(te.data().id, null, null);
+            dvui.focusWidgetSelf(te.data().id, null);
         }
     }
 
@@ -4095,7 +4108,7 @@ pub fn labelClick(src: std.builtin.SourceLocation, comptime fmt: []const u8, arg
                     e.handled = true;
 
                     // focus this widget for events after this one (starting with e.num)
-                    dvui.focusWidget(lwid, null, e.num);
+                    dvui.focusWidgetSelf(lwid, e.num);
                 } else if (me.action == .press and me.button.pointer()) {
                     e.handled = true;
                     dvui.captureMouse(lw.data());
@@ -4423,7 +4436,7 @@ pub fn slider(src: std.builtin.SourceLocation, dir: enums.Direction, fraction: *
                 var p: ?Point = null;
                 if (me.action == .focus) {
                     e.handled = true;
-                    focusWidget(b.data().id, null, e.num);
+                    focusWidgetSelf(b.data().id, e.num);
                 } else if (me.action == .press and me.button.pointer()) {
                     // capture
                     captureMouse(b.data());
@@ -4655,7 +4668,7 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
             // don't want TextEntry to get focus
             if (e.evt == .mouse and e.evt.mouse.action == .focus) {
                 e.handled = true;
-                focusWidget(b.data().id, null, e.num);
+                focusWidgetSelf(b.data().id, e.num);
             }
 
             if (!e.handled) {
@@ -4706,7 +4719,7 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
                     var p: ?Point = null;
                     if (me.action == .focus) {
                         e.handled = true;
-                        focusWidget(b.data().id, null, e.num);
+                        focusWidgetSelf(b.data().id, e.num);
                     } else if (me.action == .press and me.button.pointer()) {
                         e.handled = true;
                         if (ctrl_down) {

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -122,7 +122,7 @@ pub fn processEvent(self: *ButtonWidget, e: *Event, bubbling: bool) void {
         .mouse => |me| {
             if (me.action == .focus) {
                 e.handled = true;
-                dvui.focusWidget(self.wd.id, null, e.num);
+                dvui.focusWidgetSelf(self.wd.id, e.num);
             } else if (me.action == .press and me.button.pointer()) {
                 e.handled = true;
                 dvui.captureMouse(self.data());

--- a/src/widgets/ContextWidget.zig
+++ b/src/widgets/ContextWidget.zig
@@ -102,7 +102,7 @@ pub fn processEvent(self: *ContextWidget, e: *Event, bubbling: bool) void {
             } else if (me.action == .press and me.button == .right) {
                 e.handled = true;
 
-                dvui.focusWidget(self.wd.id, null, e.num);
+                dvui.focusWidgetSelf(self.wd.id, e.num);
                 self.focused = true;
 
                 // scale the point back to natural so we can use it in Popup

--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -176,7 +176,7 @@ pub fn addChoice(self: *DropdownWidget) !*MenuItemWidget {
     if (self.drop_first_frame) {
         if (self.init_options.selected_index) |si| {
             if (si == self.drop_mi_index) {
-                dvui.focusWidget(self.drop_mi.?.wd.id, null, null);
+                dvui.focusWidgetSelf(self.drop_mi.?.wd.id, null);
                 dvui.dataSet(null, self.menu.wd.id, "_drop_adjust", self.drop_height);
             }
         }

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -149,7 +149,7 @@ pub fn install(self: *FloatingMenuWidget) !void {
 
     // if no widget in this popup has focus, make the menu have focus to handle keyboard events
     if (dvui.focusedWidgetIdInCurrentSubwindow() == null) {
-        dvui.focusWidget(self.menu.wd.id, null, null);
+        dvui.focusWidgetSelf(self.menu.wd.id, null);
     }
 }
 

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -159,7 +159,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event, bubbling: bool) void {
             if (me.action == .focus) {
                 dvui.MenuWidget.current().?.mouse_mode = true;
                 e.handled = true;
-                dvui.focusWidget(self.wd.id, null, e.num);
+                dvui.focusWidgetSelf(self.wd.id, e.num);
             } else if (me.action == .press and me.button.pointer()) {
                 // This works differently than normal (like buttons) where we
                 // captureMouse on press, to support the mouse
@@ -217,7 +217,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event, bubbling: bool) void {
                     // we shouldn't have gotten this event if the motion
                     // was towards a submenu (caught in MenuWidget)
                     dvui.focusSubwindow(null, null); // focuses the window we are in
-                    dvui.focusWidget(self.wd.id, null, null);
+                    dvui.focusWidgetSelf(self.wd.id, null);
 
                     if (self.init_opts.submenu) {
                         dvui.MenuWidget.current().?.submenus_in_child = true;
@@ -266,4 +266,41 @@ pub fn deinit(self: *MenuItemWidget) void {
 
 test {
     @import("std").testing.refAllDecls(@This());
+}
+
+test "test mouse event setting last_focused_id_this_frame" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const fns = struct {
+        var test_focus_change = false;
+
+        fn frame() !dvui.App.Result {
+            var m = try dvui.menu(@src(), .vertical, .{ .padding = .all(10) });
+            defer m.deinit();
+            const last_focused = dvui.lastFocusedIdInFrame();
+            try std.testing.expectEqual(0, last_focused);
+
+            _ = try dvui.menuItemLabel(@src(), "item 1", .{}, .{ .tag = "item 1" });
+            _ = try dvui.menuItemLabel(@src(), "item 2", .{}, .{ .tag = "item 2" });
+
+            if (test_focus_change) {
+                // After first frame, events should have been added to make item 2 take focus
+                const new_focused = dvui.lastFocusedIdInFrame();
+                try std.testing.expect(last_focused != new_focused);
+
+                const item2 = dvui.tagGet("item 2") orelse unreachable;
+                try std.testing.expectEqual(new_focused, item2.id);
+            }
+
+            return .ok;
+        }
+    };
+
+    try dvui.testing.settle(fns.frame);
+    try dvui.testing.moveTo("item 2");
+    try dvui.testing.click(.left);
+    fns.test_focus_change = true;
+    _ = try dvui.testing.step(fns.frame);
+    try dvui.testing.expectFocused("item 2");
 }

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -90,7 +90,7 @@ pub fn processEvents(self: *ScrollBarWidget, grabrs: Rect) void {
                     .focus => {
                         if (self.focus_id) |fid| {
                             e.handled = true;
-                            dvui.focusWidget(fid, null, e.num);
+                            dvui.focusWidgetSelf(fid, e.num);
                         }
                     },
                     .press => {

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -479,7 +479,7 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
                 if (me.action == .focus) {
                     e.handled = true;
                     // focus so that we can receive keyboard input
-                    dvui.focusWidget(self.wd.id, null, e.num);
+                    dvui.focusWidgetSelf(self.wd.id, e.num);
                 } else if (me.action == .wheel_x) {
                     if (self.si.scrollMax(.horizontal) > 0) {
                         if ((me.action.wheel_x < 0 and self.si.viewport.x <= 0) or (me.action.wheel_x > 0 and self.si.viewport.x >= self.si.scrollMax(.horizontal))) {

--- a/src/widgets/SuggestionWidget.zig
+++ b/src/widgets/SuggestionWidget.zig
@@ -58,7 +58,7 @@ pub fn dropped(self: *SuggestionWidget) !bool {
         self.drop = try dvui.floatingMenu(@src(), .{ .from = self.init_options.rs.r.scale(1 / dvui.windowNaturalScale()) }, self.options);
         if (dvui.firstFrame(self.drop.?.data().id)) {
             // don't take focus away from text_entry when showing the suggestions
-            dvui.focusWidget(self.init_options.text_entry_id, null, null);
+            dvui.focusWidgetSelf(self.init_options.text_entry_id, null);
         }
     }
 

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -780,7 +780,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
         .mouse => |me| {
             if (me.action == .focus) {
                 e.handled = true;
-                dvui.focusWidget(self.wd.id, null, e.num);
+                dvui.focusWidgetSelf(self.wd.id, e.num);
             }
         },
         else => {},

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -1524,7 +1524,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event, bubbling: bool) void {
             if (me.action == .focus) {
                 e.handled = true;
                 // focus so that we can receive keyboard input
-                dvui.focusWidget(self.wd.id, null, e.num);
+                dvui.focusWidgetSelf(self.wd.id, e.num);
             } else if (me.action == .press and me.button.pointer()) {
                 e.handled = true;
                 // capture and start drag


### PR DESCRIPTION
Closes: #283

This adds a new function `dvui.focusWidgetSelf` which should only be used by widgets to focus themselves. This is use cases like `dvui.firstFrame` or the `.focus` event.

The test added fails without this change.