### PR TITLE
Datagrid first cut

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,23 @@
+### Todos
+- [ ] Get rid of the padding for the sortable header. It isn't const the size of the symbol is dependent on the font size?
+- [ ] Handle padding when header column width is smaller than the heading button width. Currently doesn't show the separator.
+- [ ] Draws over vertical scroll bar when horizontal scrolling. Need to change the clip or reserve space for the scrollbar.
+- [ ] Need some defalt padding, so the first column isn;t hard against the edge of the grid.
+- [ ] Fix checkbox padding or size? It's not shown the speparator.
+
+### Issues
+- [ ] Is there a better name than window size for the scroller? It's not really a window size. It's a number of extra rows to render above and below the visible rows.
+        - Windows size > 1 doesn't seem to make any difference really.
+- [ ] Grid header widget assumes vertical scroll bar width is 10 and that it will always be displayed. 
+- [ ] Example needs to be added to Example.zig, rather than a stand-alone.
+- [ ] Issue with grid headers moving while virtual scrolling. Header is set to scroll_info.vieport.y, but this is not always at the top of the viewport (due to floating point precision?)
+- [ ] Gravity is applied incorrectly when virtual scrolling? i..e things will only center when scrolling stops.
+        - It doesn't happen with non-virtual scrolling, so something is not expanding correctly?
+        - Actually, I don't think it is gravity, it is some cells being drawn too wide while scrolling and then corrected when the scrolling stops.
+        - Also note in the demo there is an "Expand" column for Description. That's not really compatible with virtual scrolling.
+        - Need to investigate further.
+
+### Future
+* Some better visual indication that columns are sortable.
+* Resize columns via dragging
+* Filtering headers

--- a/build.zig
+++ b/build.zig
@@ -149,6 +149,7 @@ pub fn build(b: *std.Build) !void {
 
         linkBackend(dvui_sdl, sdl_mod);
         addExample("sdl2-standalone", b.path("examples/sdl-standalone.zig"), dvui_sdl, true, dvui_opts);
+        addExample("sdl2-datagrid", b.path("examples/data_grid_example.zig"), dvui_sdl, true, dvui_opts);
         addExample("sdl2-ontop", b.path("examples/sdl-ontop.zig"), dvui_sdl, true, dvui_opts);
         addExample("sdl2-app", b.path("examples/app.zig"), dvui_sdl, test_dvui_and_app, dvui_opts);
     }

--- a/examples/data_grid_example.zig
+++ b/examples/data_grid_example.zig
@@ -1,0 +1,588 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const dvui = @import("dvui");
+const Backend = dvui.backend;
+comptime {
+    std.debug.assert(@hasDecl(Backend, "SDLBackend"));
+}
+
+const window_icon_png = @embedFile("zig-favicon.png");
+
+var gpa_instance = std.heap.GeneralPurposeAllocator(.{}){};
+const gpa = gpa_instance.allocator();
+
+const vsync = true;
+var scale_val: f32 = 1.0;
+
+var g_backend: ?Backend = null;
+var g_win: ?*dvui.Window = null;
+var filter_grid = false;
+var frame_count: usize = 0;
+/// This example shows how to use the dvui for a normal application:
+/// - dvui renders the whole application
+/// - render frames only when needed
+///
+pub fn main() !void {
+    if (@import("builtin").os.tag == .windows) { // optional
+        // on windows graphical apps have no console, so output goes to nowhere - attach it manually. related: https://github.com/ziglang/zig/issues/4196
+        _ = winapi.AttachConsole(0xFFFFFFFF);
+    }
+    std.log.info("SDL version: {}", .{Backend.getSDLVersion()});
+
+    defer if (gpa_instance.deinit() != .ok) @panic("Memory leak on exit!");
+
+    // init SDL backend (creates and owns OS window)
+    var backend = try Backend.initWindow(.{
+        .allocator = gpa,
+        .size = .{ .w = 800.0, .h = 600.0 },
+        .min_size = .{ .w = 250.0, .h = 350.0 },
+        .vsync = vsync,
+        .title = "DVUI SDL Standalone Example",
+        .icon = window_icon_png, // can also call setIconFromFileContent()
+    });
+    g_backend = backend;
+    defer backend.deinit();
+
+    _ = Backend.c.SDL_EnableScreenSaver();
+
+    // init dvui Window (maps onto a single OS window)
+    var win = try dvui.Window.init(@src(), gpa, backend.backend(), .{});
+    defer win.deinit();
+    filtered_cars = try filterCars(gpa, cars[0..], filterLongModels);
+    defer gpa.free(filtered_cars);
+
+    main_loop: while (true) {
+
+        // beginWait coordinates with waitTime below to run frames only when needed
+        const nstime = win.beginWait(backend.hasEvent());
+
+        // marks the beginning of a frame for dvui, can call dvui functions after this
+        try win.begin(nstime);
+
+        // send all SDL events to dvui for processing
+        const quit = try backend.addAllEvents(&win);
+        if (quit) break :main_loop;
+
+        // if dvui widgets might not cover the whole window, then need to clear
+        // the previous frame's render
+        _ = Backend.c.SDL_SetRenderDrawColor(backend.renderer, 0, 0, 0, 255);
+        _ = Backend.c.SDL_RenderClear(backend.renderer);
+
+        // The demos we pass in here show up under "Platform-specific demos"
+        try gui_frame();
+
+        // marks end of dvui frame, don't call dvui functions after this
+        // - sends all dvui stuff to backend for rendering, must be called before renderPresent()
+        const end_micros = try win.end(.{});
+
+        // cursor management
+        backend.setCursor(win.cursorRequested());
+        backend.textInputRect(win.textInputRequested());
+
+        // render frame to OS
+        backend.renderPresent();
+
+        // waitTime and beginWait combine to achieve variable framerates
+        const wait_event_micros = win.waitTime(end_micros, null);
+        backend.waitEventTimeout(wait_event_micros);
+    }
+}
+
+const num_cars = 500_000;
+pub const testing = false;
+pub var scroll_info: dvui.ScrollInfo = .{ .horizontal = .auto, .vertical = .given };
+var virtual_scrolling = true;
+var horizontal_scrolling = false;
+var sortable = true;
+var header_height: f32 = 0;
+var row_height: f32 = 0;
+var selectable = false;
+const ColumnSizing = enum {
+    equal_width,
+    proportional,
+    col_info,
+    col_width,
+    expand,
+};
+var column_sizing: ColumnSizing = .equal_width;
+const prev_height: f32 = 0;
+var resize_rows: bool = false;
+
+const fixed_width_w: f32 = 50;
+pub fn headerCheckboxOptions() dvui.Options {
+    if (header_height == 0) {
+        return .{
+            .min_size_content = .{ .w = 40 },
+            .max_size_content = .width(40),
+        };
+    } else {
+        return .{
+            .min_size_content = .{ .w = 40, .h = header_height },
+            .max_size_content = .width(40),
+        };
+    }
+}
+
+//pub fn rowCheckboxOptions() dvui.Options {
+//    return headerCheckboxOptions();
+//}
+
+const col_widths_default: [7]f32 = .{ 50, 20, 30, 40, 50, 60, 70 };
+const col_widths_proportional: [7]f32 = .{ 50, -20, -30, -40, -20, -60, -70 };
+var col_widths: [col_widths_default.len]f32 = col_widths_default;
+
+fn colOptions(opts: dvui.GridWidget.ColOptions) dvui.GridWidget.ColOptions {
+    if (column_sizing == .col_width) {
+        var result = opts;
+        result.width = 200;
+        return result;
+    }
+    return opts;
+}
+
+fn headerCellOpts(opts: dvui.GridWidget.CellOptions) dvui.GridWidget.CellOptions {
+    if (header_height > 0) {
+        var result = opts;
+        result.height = header_height;
+        return result;
+    }
+    return opts;
+}
+
+fn bodyCellOpts(opts: dvui.GridWidget.CellOptions) dvui.CellOptionsOrCallback {
+    if (row_height > 0) {
+        var result = opts;
+        result.height = row_height;
+        return .{ .options = result };
+    }
+    return .{ .options = opts };
+}
+
+// both dvui and SDL drawing
+fn gui_frame() !void {
+    //std.debug.print("frame: {d}\n", .{frame_count});
+    defer frame_count += 1;
+    const backend = g_backend orelse return;
+    _ = backend;
+    {
+        var m = try dvui.menu(@src(), .horizontal, .{ .background = true, .expand = .horizontal });
+        defer m.deinit();
+
+        if (try dvui.menuItemLabel(@src(), "File", .{ .submenu = true }, .{ .expand = .none })) |r| {
+            var fw = try dvui.floatingMenu(@src(), .{ .from = r }, .{});
+            defer fw.deinit();
+        }
+    }
+    var main_hbox = try dvui.box(@src(), .horizontal, .{ .expand = .both, .background = true });
+    defer main_hbox.deinit();
+    if (testing) {
+        const use_text_layout = true;
+        const count = 6_000;
+        var box = try dvui.box(@src(), .vertical, .{ .expand = .both });
+        defer box.deinit();
+        for (0..count) |i| {
+            if (!use_text_layout) {
+                try dvui.labelNoFmt(@src(), "Test", .{ .id_extra = i });
+            } else {
+                var text = try dvui.textLayout(@src(), .{}, .{ .id_extra = i });
+                defer text.deinit();
+                // Note: Passing id_extra = i here sometimes changes the behaviour.
+                //try text.addText("Test", .{ .id_extra = i });
+                //
+                //
+                try text.addText("Test", .{});
+            }
+        }
+        return;
+    }
+    {
+        scroll_info.horizontal = if (horizontal_scrolling) .auto else .none;
+        const start_idx: usize = if (selectable) 0 else 1;
+
+        var grid = try dvui.grid(
+            @src(),
+            .{ .scroll_opts = .{
+                .scroll_info = if (virtual_scrolling) &scroll_info else null,
+                .horizontal = if (!virtual_scrolling) .auto else null,
+            }, .col_widths = switch (column_sizing) {
+                .expand, .col_width => null,
+                .col_info, .equal_width, .proportional => col_widths[start_idx..],
+            }, .resize_rows = resize_rows },
+            .{
+                .expand = .both,
+                .background = true,
+                .max_size_content = .width(main_hbox.data().contentRect().w - 250),
+                // TODO: Why is this 250 and not 200? I think the control panel should only be 200 wide.
+                // But if I make this 200, the grid walks it's way from -250 to -200 on startup
+            },
+        );
+        defer grid.deinit();
+        resize_rows = false;
+        const content_w: ?f32 = if (horizontal_scrolling) grid.data().contentRect().w + 1024 else null;
+        switch (column_sizing) {
+            .equal_width => {
+                // Make all columns equal width, except for checbox which stays a fixed width.
+                col_widths = @splat(-1);
+                col_widths[0] = col_widths_default[0];
+            },
+            .proportional => {
+                @memcpy(&col_widths, &col_widths_proportional);
+            },
+            .col_info => @memcpy(&col_widths, &col_widths_default),
+            .col_width, .expand => {},
+        }
+        dvui.columnLayoutProportional(grid, col_widths[start_idx..], content_w);
+        {
+            const first: usize, const last: usize = range: {
+                if (virtual_scrolling) {
+                    var scroller = dvui.GridWidget.GridVirtualScroller.init(grid, .{ .scroll_info = &scroll_info, .total_rows = cars.len, .window_size = 1 });
+                    break :range .{ scroller.rowFirstRendered(), scroller.rowLastRendered() };
+                } else {
+                    break :range .{ 0, cars.len };
+                }
+            };
+            first_row = first;
+            var selection: dvui.GridColumnSelectAllState = undefined;
+            var sort_dir: dvui.GridWidget.SortDirection = undefined;
+            if (selectable) {
+                var col = try grid.column(@src(), colOptions(.{}));
+                defer col.deinit();
+
+                if (try dvui.gridHeadingCheckbox(@src(), grid, &selection, .{}, headerCheckboxOptions())) {
+                    for (cars[0..]) |*car| {
+                        switch (selection) {
+                            .select_all => car.selected = true,
+                            .select_none => car.selected = false,
+                            .unchanged => {},
+                        }
+                    }
+                }
+
+                const changed = try dvui.gridColumnCheckbox(
+                    @src(),
+                    grid,
+                    Car,
+                    cars[first..last],
+                    "selected",
+                    .{ .border = dvui.Rect.all(1) },
+                    .{},
+                );
+                if (changed) std.debug.print("selection changed\n", .{});
+            }
+
+            {
+                var col = try grid.column(@src(), colOptions(.{}));
+                defer col.deinit();
+                if (sortable) {
+                    if (try dvui.gridHeadingSortable(@src(), grid, "Make", &sort_dir, headerCellOpts(.{ .border = dvui.Rect.all(0) }), .{})) {
+                        sort("Make", sort_dir);
+                    }
+                } else {
+                    try dvui.gridHeading(@src(), grid, "Make", headerCellOpts(.{}), .{});
+                }
+                try dvui.gridColumnFromSlice(@src(), grid, Car, cars[first..last], "make", "{s}", .{ .callback = bandedRows }, .none);
+            }
+            {
+                var col = try grid.column(@src(), colOptions(.{}));
+                defer col.deinit();
+                if (try dvui.gridHeadingSortable(@src(), grid, "Model", &sort_dir, .{}, .{})) {
+                    sort("Model", sort_dir);
+                }
+                try dvui.gridColumnFromSlice(@src(), grid, Car, cars[first..last], "model", "{s}", .none, .none);
+            }
+            {
+                var col = try grid.column(@src(), colOptions(.{}));
+                defer col.deinit();
+                if (try dvui.gridHeadingSortable(@src(), grid, "Year", &sort_dir, .{}, .{})) {
+                    sort("Year", sort_dir);
+                }
+                try customColumn(@src(), grid, cars[first..last], .{});
+            }
+            {
+                var col = try grid.column(@src(), colOptions(.{}));
+                defer col.deinit();
+
+                if (try dvui.gridHeadingSortable(@src(), grid, "Mileage", &sort_dir, .{}, .{})) {
+                    sort("Mileage", sort_dir);
+                }
+                try dvui.gridColumnFromSlice(@src(), grid, Car, cars[first..last], "mileage", "{d}", bodyCellOpts(.{}), .{ .options = .{ .gravity_x = 1.0 } });
+            }
+            {
+                var col = try grid.column(@src(), colOptions(.{}));
+                defer col.deinit();
+
+                if (try dvui.gridHeadingSortable(@src(), grid, "Condition", &sort_dir, .{}, .{})) {
+                    sort("Condition", sort_dir);
+                }
+                try dvui.gridColumnFromSlice(@src(), grid, Car, cars[first..last], "condition", "{s}", bodyCellOpts(.{}), .{ .options = .{ .gravity_x = 0.5 } });
+            }
+            {
+                var col = try grid.column(@src(), .{});
+                defer col.deinit();
+                if (try dvui.gridHeadingSortable(@src(), grid, "Description", &sort_dir, .{ .border = dvui.Rect.all(0) }, .{ .font_style = .title })) {
+                    sort("Description", sort_dir);
+                }
+                try textAreaColumn(@src(), grid, cars[first..last]);
+                //                    try dvui.gridColumnFromSlice(@src(), grid, Car, cars[0..], "description", "{s}", .{}, .{});
+            }
+        }
+    }
+    {
+        // Control panel
+        var vbox = try dvui.box(@src(), .vertical, .{ .expand = .vertical, .min_size_content = .{ .w = 250 }, .max_size_content = .width(250) });
+        defer vbox.deinit();
+        try dvui.labelNoFmt(@src(), "Control Panel", .{ .font_style = .title_2 });
+        _ = try dvui.checkbox(@src(), &sortable, "sortable", .{});
+        _ = try dvui.checkbox(@src(), &virtual_scrolling, "virtual scrolling", .{});
+        if (try dvui.expander(@src(), "Column Layout", .{ .default_expanded = true }, .{ .expand = .horizontal })) {
+            var inner_vbox = try dvui.box(@src(), .vertical, .{ .margin = .{ .x = 10 } });
+            defer inner_vbox.deinit();
+
+            if (try dvui.radio(@src(), column_sizing == .equal_width, "Equal Spacing", .{})) {
+                column_sizing = .equal_width;
+                resize_rows = true;
+            }
+            if (try dvui.radio(@src(), column_sizing == .proportional, "Proportional", .{})) {
+                column_sizing = .proportional;
+                resize_rows = true;
+            }
+            if (try dvui.radio(@src(), column_sizing == .col_info, "col_info", .{})) {
+                column_sizing = .col_info;
+                resize_rows = true;
+            }
+            if (try dvui.radio(@src(), column_sizing == .col_width, "col_width", .{})) {
+                column_sizing = .col_width;
+                resize_rows = true;
+            }
+            if (try dvui.radio(@src(), column_sizing == .expand, ".expand", .{})) {
+                column_sizing = .expand;
+                resize_rows = true;
+            }
+        }
+        _ = try dvui.checkbox(@src(), &horizontal_scrolling, "Horizontal scrolling", .{});
+        _ = try dvui.checkbox(@src(), &selectable, "Selection", .{});
+        {
+            var hbox = try dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
+            defer hbox.deinit();
+            try dvui.labelNoFmt(@src(), "Header Height: ", .{});
+            const result = try dvui.textEntryNumber(@src(), f32, .{ .value = if (header_height == 0) null else &header_height }, .{});
+            if (result.enter_pressed and result.value == .Valid) {
+                header_height = result.value.Valid;
+            }
+        }
+        {
+            var hbox = try dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
+            defer hbox.deinit();
+            try dvui.labelNoFmt(@src(), "Row Height: ", .{});
+            const result = try dvui.textEntryNumber(@src(), f32, .{ .value = if (row_height == 0) null else &row_height }, .{});
+            if (result.enter_pressed and result.value == .Valid) {
+                row_height = result.value.Valid;
+            }
+        }
+        {
+            if (try dvui.expander(@src(), "Populate From", .{ .default_expanded = true }, .{ .expand = .horizontal })) {
+                if (try dvui.checkbox(@src(), &filter_grid, "Filter", .{})) {
+                    gpa.free(filtered_cars);
+                    filtered_cars = try filterCars(gpa, cars[0..], filterLongModels);
+                }
+            }
+        }
+    }
+}
+
+fn customColumn(src: std.builtin.SourceLocation, g: *dvui.GridWidget, data: []Car, opts: dvui.GridWidget.CellOptions) !void {
+    var cell_opts = opts;
+    for (data, 0..) |*item, i| {
+        cell_opts.color_fill = if (item.year % 2 == 0) .{ .name = .fill_press } else null;
+        cell_opts.background = true;
+        var cell = try g.bodyCell(
+            src,
+            i,
+            cell_opts,
+        );
+
+        defer cell.deinit();
+        try dvui.label(@src(), "{d}", .{item.year}, .{
+            .id_extra = i,
+            .gravity_x = if (item.year % 2 == 0) 0.0 else 1.0,
+            .gravity_y = 0.5,
+        });
+    }
+}
+
+fn textAreaColumn(src: std.builtin.SourceLocation, g: *dvui.GridWidget, data: []Car) !void {
+    for (data, 0..) |*item, i| {
+        var cell = try g.bodyCell(
+            src,
+            i,
+            .{},
+        );
+        defer cell.deinit();
+        var text = try dvui.textLayout(@src(), .{ .break_lines = true }, .{ .expand = .both });
+        defer text.deinit();
+        try text.addText(item.description, .{ .expand = .both });
+    }
+}
+
+// TODO: Is it worth providing in-built support for iterator population?
+// the grid is laid out by column, so iterator would need to:
+// 1) Implement a count if virtual scrolling.
+// 2) Implement a reset of use multiple iterators to lay out each column
+// Currently filtering uses a slice of pointers instead of iterators, due to the
+// awkward interface.
+// At least for large array-based data sets, user can store values in a MultiArrayList
+// so that it is optimised for iterating through each colunm.
+const CarsIterator = struct {
+    const FilterFN = *const fn (car: *const Car) bool;
+    filter_fn: FilterFN = undefined,
+    index: usize,
+    cars: []Car,
+
+    pub fn init(_cars: []Car, filter_fn: ?FilterFN) CarsIterator {
+        return .{
+            .index = 0,
+            .cars = _cars,
+            .filter_fn = filter_fn orelse filterNone,
+        };
+    }
+
+    pub fn next(self: *CarsIterator) ?*Car {
+        while (self.index < self.cars.len) : (self.index += 1) {
+            if (self.filter_fn(&cars[self.index])) {
+                self.index += 1;
+                return &cars[self.index - 1];
+            }
+        }
+        return null;
+    }
+
+    pub fn reset(self: *CarsIterator) void {
+        self.index = 0;
+    }
+
+    pub fn count(self: *CarsIterator) usize {
+        var result_count: usize = 0;
+        var count_itr: CarsIterator = .init(self.cars, self.filter_fn);
+        while (count_itr.next() != null) {
+            result_count += 1;
+        }
+        return result_count;
+    }
+
+    fn filterNone(_: *const Car) bool {
+        return true;
+    }
+};
+
+var filtered_cars: []*Car = undefined;
+
+/// Filter the cars data based on the filter function: const fn (*const Car) bool
+/// caller is responsible for freeing the returned slice.
+fn filterCars(allocator: std.mem.Allocator, src: []Car, filter_fn: fn (*Car) bool) ![]*Car {
+    var result: std.ArrayListUnmanaged(*Car) = try .initCapacity(allocator, src.len);
+    for (src) |*car| {
+        if (filter_fn(car)) { // TODO: FIX
+            result.appendAssumeCapacity(car);
+        }
+    }
+    return result.toOwnedSlice(allocator);
+}
+
+fn filterLongModels(car: *const Car) bool {
+    return (car.model.len < 10);
+}
+
+fn sort(key: []const u8, direction: dvui.GridWidget.SortDirection) void {
+    switch (direction) {
+        .descending,
+        => std.mem.sort(Car, &cars, key, sortDesc),
+        .ascending,
+        .unsorted,
+        => std.mem.sort(Car, &cars, key, sortAsc),
+    }
+}
+
+fn sortAsc(key: []const u8, lhs: Car, rhs: Car) bool {
+    if (std.mem.eql(u8, key, "Model")) return std.mem.lessThan(u8, lhs.model, rhs.model);
+    if (std.mem.eql(u8, key, "Year")) return lhs.year < rhs.year;
+    if (std.mem.eql(u8, key, "Mileage")) return lhs.mileage < rhs.mileage;
+    if (std.mem.eql(u8, key, "Condition")) return @intFromEnum(lhs.condition) < @intFromEnum(rhs.condition);
+    if (std.mem.eql(u8, key, "Description")) return std.mem.lessThan(u8, lhs.description, rhs.description);
+    // default sort on Make
+    return std.mem.lessThan(u8, lhs.make, rhs.make);
+}
+
+fn sortDesc(key: []const u8, lhs: Car, rhs: Car) bool {
+    if (std.mem.eql(u8, key, "Model")) return std.mem.lessThan(u8, rhs.model, lhs.model);
+    if (std.mem.eql(u8, key, "Year")) return rhs.year < lhs.year;
+    if (std.mem.eql(u8, key, "Mileage")) return rhs.mileage < lhs.mileage;
+    if (std.mem.eql(u8, key, "Condition")) return @intFromEnum(rhs.condition) < @intFromEnum(lhs.condition);
+    if (std.mem.eql(u8, key, "Description")) return std.mem.lessThan(u8, rhs.description, lhs.description);
+
+    // default sort on Make
+    return std.mem.lessThan(u8, rhs.make, lhs.make);
+}
+
+const Car = struct {
+    selected: bool = false,
+    model: []const u8,
+    make: []const u8,
+    year: u32,
+    mileage: u32,
+    condition: Condition,
+    description: []const u8,
+
+    const Condition = enum(u32) { New, Excellent, Good, Fair, Poor };
+};
+
+var cars = initCars();
+fn initCars() [num_cars]Car {
+    comptime var result: [num_cars]Car = undefined;
+    comptime {
+        @setEvalBranchQuota(num_cars + 1);
+
+        for (0..num_cars) |i| {
+            result[i] = some_cars[i % some_cars.len];
+            result[i].year = i;
+        }
+    }
+    return result;
+}
+
+const some_cars = [_]Car{
+    .{ .model = "Civic", .make = "Honda", .year = 2022, .mileage = 8500, .condition = .New, .description = "Still smells like optimism and plastic wrap." },
+    .{ .model = "Model 3", .make = "Tesla", .year = 2021, .mileage = 15000, .condition = .Excellent, .description = "Drives itself better than I drive myself." },
+    .{ .model = "Camry", .make = "Toyota", .year = 2018, .mileage = 43000, .condition = .Good, .description = "Reliable enough to make your toaster jealous." },
+    .{ .model = "F-150", .make = "Ford", .year = 2015, .mileage = 78000, .condition = .Fair, .description = "Hauls stuff, occasionally emotions." },
+    .{ .model = "Altima", .make = "Nissan", .year = 2010, .mileage = 129000, .condition = .Poor, .description = "Drives like it’s got beef with the road." },
+    .{ .model = "Accord", .make = "Honda", .year = 2019, .mileage = 78000, .condition = .Excellent, .description = "Sensible and smooth, like your friend with a Costco card." },
+    .{ .model = "Impreza", .make = "Subaru", .year = 2016, .mileage = 78000, .condition = .Good, .description = "All-wheel drive and all-weather vibes." },
+    .{ .model = "Charger", .make = "Dodge", .year = 2014, .mileage = 97000, .condition = .Fair, .description = "Goes fast, stops… usually." },
+    .{ .model = "Beetle", .make = "Volkswagen", .year = 2006, .mileage = 142000, .condition = .Poor, .description = "Quirky, creaky, and still kinda cute." },
+    .{ .model = "Mustang", .make = "Ford", .year = 2020, .mileage = 24000, .condition = .Good, .description = "Makes you feel 20% cooler just sitting in it." },
+    .{ .model = "CX-5", .make = "Mazda", .year = 2019, .mileage = 32000, .condition = .Excellent, .description = "Zoom zoom, but responsibly." },
+    .{ .model = "Outback", .make = "Subaru", .year = 2017, .mileage = 61000, .condition = .Good, .description = "Always looks ready for a camping trip, even when it's not." },
+    .{ .model = "Civic", .make = "Honda", .year = 2022, .mileage = 8500, .condition = .New, .description = "Still smells like optimism and plastic wrap." },
+    .{ .model = "Model 3", .make = "Tesla", .year = 2021, .mileage = 15000, .condition = .Excellent, .description = "Drives itself better than I drive myself." },
+    .{ .model = "Camry", .make = "Toyota", .year = 2018, .mileage = 43000, .condition = .Good, .description = "Reliable enough to make your toaster jealous." },
+    .{ .model = "F-150", .make = "Ford", .year = 2015, .mileage = 78000, .condition = .Fair, .description = "Hauls stuff, occasionally emotions." },
+    .{ .model = "Altima", .make = "Nissan", .year = 2010, .mileage = 129000, .condition = .Poor, .description = "Drives like it’s got beef with the road." },
+    .{ .model = "Accord", .make = "Honda", .year = 2019, .mileage = 78000, .condition = .Excellent, .description = "Sensible and smooth, like your friend with a Costco card." },
+    .{ .model = "Impreza", .make = "Subaru", .year = 2016, .mileage = 78000, .condition = .Good, .description = "All-wheel drive and all-weather vibes." },
+    .{ .model = "Charger", .make = "Dodge", .year = 2014, .mileage = 97000, .condition = .Fair, .description = "Goes fast, stops… usually." },
+    .{ .model = "Beetle", .make = "Volkswagen", .year = 2006, .mileage = 142000, .condition = .Poor, .description = "Quirky, creaky, and still kinda cute." },
+    .{ .model = "Mustang with a really long name", .make = "Ford", .year = 2020, .mileage = 24000, .condition = .Good, .description = "Makes you feel 20% cooler just sitting in it." },
+};
+var first_row: usize = 0;
+fn bandedRows(_: usize, row_num: usize) dvui.GridWidget.CellOptions {
+    const result: dvui.GridWidget.CellOptions = .{
+        .color_fill = if ((first_row + row_num) % 2 == 0) .{ .name = .fill_press } else null,
+        .background = true,
+    };
+    return result;
+}
+
+// Optional: windows os only
+const winapi = if (builtin.os.tag == .windows) struct {
+    extern "kernel32" fn AttachConsole(dwProcessId: std.os.windows.DWORD) std.os.windows.BOOL;
+} else struct {};

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -80,7 +80,7 @@ pub const TabsWidget = widgets.TabsWidget;
 pub const TextEntryWidget = widgets.TextEntryWidget;
 pub const TextLayoutWidget = widgets.TextLayoutWidget;
 pub const VirtualParentWidget = widgets.VirtualParentWidget;
-
+pub const GridWidget = widgets.GridWidget;
 const se = @import("structEntry.zig");
 pub const structEntry = se.structEntry;
 pub const structEntryEx = se.structEntryEx;
@@ -4052,6 +4052,312 @@ pub fn scrollArea(src: std.builtin.SourceLocation, init_opts: ScrollAreaWidget.I
     return ret;
 }
 
+pub fn grid(src: std.builtin.SourceLocation, init_opts: GridWidget.InitOpts, opts: Options) !*GridWidget {
+    const ret = try currentWindow().arena().create(GridWidget);
+    ret.* = try GridWidget.init(src, init_opts, opts);
+    try ret.install();
+    return ret;
+}
+
+// TODO: Add col num to the styling callbacks. // TODO
+/// Create a heading with a static label
+///
+/// opts controls the styling for the label.
+pub fn gridHeading(src: std.builtin.SourceLocation, g: *GridWidget, heading: []const u8, cell_opts: dvui.GridWidget.CellOptions, opts: dvui.Options) !void {
+    const label_defaults: Options = .{
+        .corner_radius = Rect.all(0),
+        .expand = .horizontal,
+        .gravity_x = 0.5,
+        .gravity_y = 0.5,
+        .color_fill = .{ .name = .fill_control },
+        .background = true,
+    };
+    const label_options = label_defaults.override(opts);
+    var cell = try g.headerCell(src, cell_opts);
+    defer cell.deinit();
+
+    try labelNoFmt(@src(), heading, label_options);
+    try separator(@src(), .{ .expand = .vertical });
+}
+
+/// Create a heading and allow the column to be sorted.
+///
+/// Returns true if the sort direction has changed.
+/// sort_dir is an out parameter containing the current sort direction.
+/// opts controls the styling for the button label used for the heading.
+pub fn gridHeadingSortable(
+    src: std.builtin.SourceLocation,
+    g: *GridWidget,
+    heading: []const u8,
+    dir: *GridWidget.SortDirection,
+    cell_opts: GridWidget.CellOptions,
+    opts: dvui.Options,
+) !bool {
+    const icon_ascending = @embedFile("icons/entypo/chevron-small-down.tvg");
+    const icon_descending = @embedFile("icons/entypo/chevron-small-up.tvg");
+    const icon_width = 27.5; // TODO: This is not const.
+    const padding = ButtonWidget.defaults.padding orelse Rect.all(6);
+
+    // Pad buttons with extra space if there is no sort indicator.
+    const padding_opts: Options = .{ .padding = .{ .x = icon_width / 2.0, .w = icon_width / 2.0, .y = padding.y, .h = padding.h } };
+    const heading_defaults: Options = .{
+        .expand = .horizontal,
+        .corner_radius = Rect.all(0),
+    };
+    const heading_opts = heading_defaults.override(opts);
+
+    var cell = try g.headerCell(src, cell_opts);
+    defer cell.deinit();
+
+    const sort_changed = switch (g.colSortOrder()) {
+        .unsorted => try button(@src(), heading, .{ .draw_focus = false }, padding_opts.override(heading_opts)),
+        .ascending => try buttonLabelAndIcon(@src(), heading, icon_ascending, .{ .draw_focus = false }, heading_opts),
+        .descending => try buttonLabelAndIcon(@src(), heading, icon_descending, .{ .draw_focus = false }, heading_opts),
+    };
+
+    if (sort_changed) {
+        g.sortChanged();
+    }
+    try separator(@src(), .{ .expand = .vertical, .gravity_x = 1.0 });
+    dir.* = g.sort_direction;
+    return sort_changed;
+}
+
+pub const CellOptionsOrCallback = union(enum) {
+    options: GridWidget.CellOptions,
+    callback: *const fn (col_num: usize, row_num: usize) GridWidget.CellOptions,
+
+    pub const none: CellOptionsOrCallback = .{ .options = .{} };
+};
+
+pub const OptionsOrCallback = union(enum) {
+    options: Options,
+    callback: *const fn (col_num: usize, row_num: usize) Options,
+
+    pub const none: OptionsOrCallback = .{ .options = .{} };
+};
+
+/// Create a column from a slice
+///
+/// If data is a slice of struct field_name must be supplied
+/// Enums are displayed as their @tagName and fmt must be "{s}"
+/// Bools are displayed as Y or N and fmt must be "{s}"
+/// Other types are formatted using the supplied fmt string.
+/// cell_opts styles the cell's hbox
+/// opts styles the label
+/// // TODO: Cleanup variable names around options.
+pub fn gridColumnFromSlice(
+    src: std.builtin.SourceLocation,
+    g: *GridWidget,
+    comptime T: type,
+    data: []const T,
+    comptime field_name: ?[]const u8,
+    comptime fmt: []const u8,
+    cell_opts: CellOptionsOrCallback,
+    opts: OptionsOrCallback,
+) !void {
+    // TODO: Support pointer to direct value.
+    comptime var TypeToValidate = T;
+    comptime validate: switch (@typeInfo(T)) {
+        .pointer => |ptr| {
+            if (ptr.size != .one) @compileError("T cannot be an array, slice or vector");
+            const child_type = @typeInfo(ptr.child);
+            if (child_type == .pointer) @compileError("T cannot be a pointer to a pointer");
+            if (child_type == .@"struct") {
+                // If pointer to struct then validate the child struct.
+                TypeToValidate = ptr.child;
+                continue :validate child_type;
+            }
+        },
+        .@"struct" => {
+            if (field_name) |_field_name| {
+                if (!@hasField(TypeToValidate, _field_name)) {
+                    @compileError(std.fmt.comptimePrint("{s} does not contain field {s}.", .{ @typeName(T), _field_name }));
+                }
+            } else @compileError("field_name must be supplied when T is a struct or pointer to a struct");
+        },
+        else => {},
+    };
+
+    const label_defaults: Options = .{
+        .expand = .horizontal,
+    };
+    // If options are supplied create the default options.
+    const label_opts: Options = switch (opts) {
+        .options => |o| label_defaults.override(o),
+        .callback => label_defaults,
+    };
+    const default_cell_opts: GridWidget.CellOptions = switch (cell_opts) {
+        .options => |o| o,
+        .callback => .{},
+    };
+    for (data, 0..) |item, row_num| {
+        // TODO: This copies both sets of options for each row.
+        const this_cell_opts: GridWidget.CellOptions = switch (cell_opts) {
+            .options => default_cell_opts,
+            .callback => |cb| cb(g.col_num, row_num),
+        };
+        const this_label_opts = switch (opts) {
+            .options => label_opts,
+            .callback => |cb| cb(g.col_num, row_num),
+        };
+        var cell = try g.bodyCell(src, row_num, this_cell_opts);
+        defer cell.deinit();
+        const cell_value = value: {
+            if (field_name) |_field_name| {
+                // populate value from struct field.
+                break :value switch (@typeInfo(@TypeOf(@field(item, _field_name)))) {
+                    .@"enum" => @tagName(@field(item, _field_name)),
+                    .bool => if (@field(item, _field_name)) "Y" else "N",
+                    else => @field(item, _field_name),
+                };
+            } else {
+                // populate value directly from slice
+                break :value switch (@typeInfo(T)) {
+                    .@"enum" => @tagName(item),
+                    .bool => if (item) "Y" else "N",
+                    else => item,
+                };
+            }
+        };
+        try label(
+            @src(),
+            fmt,
+            .{cell_value},
+            this_label_opts,
+        );
+    }
+}
+
+pub const GridColumnSelectAllState = enum {
+    select_all,
+    select_none,
+    unchanged,
+};
+
+/// A grid heading with a checkbox for select-all and select-none
+///
+/// Returns true if the selection state has changed.
+/// selection - out parameter containing the current selection state.
+pub fn gridHeadingCheckbox(src: std.builtin.SourceLocation, g: *GridWidget, selection: *GridColumnSelectAllState, cell_opts: GridWidget.CellOptions, opts: Options) !bool {
+    const header_defaults: Options = .{
+        .background = true,
+        .color_fill = .{ .name = .fill_control },
+        .margin = ButtonWidget.defaults.margin,
+        .expand = .vertical,
+        .gravity_y = 0.5,
+    };
+    const header_options = header_defaults.override(opts);
+    var cell = try g.headerCell(src, cell_opts);
+    defer cell.deinit();
+
+    var clicked = false;
+    var selected = false;
+    {
+        var hbox = try dvui.box(@src(), .horizontal, header_options);
+        defer hbox.deinit();
+        selected = dvui.dataGet(null, hbox.data().id, "_selected", bool) orelse false;
+        clicked = try dvui.checkbox(@src(), &selected, null, .{ .gravity_y = 0.5, .gravity_x = 0.5 });
+        dvui.dataSet(null, hbox.data().id, "_selected", selected);
+    }
+    try dvui.separator(@src(), .{ .expand = .vertical });
+
+    if (clicked) {
+        selection.* = if (selected) .select_all else .select_none;
+    } else {
+        selection.* = .unchanged;
+    }
+    return clicked;
+}
+
+/// A checkbox column that allows selection of boolean items.
+///
+/// Returns true if any selections have changed.
+/// If field_name is null, T must be a bool.
+/// Otherwise field_name must refer to a bool field within a struct.
+/// opts is used to style the checkbox.
+pub fn gridColumnCheckbox(
+    src: std.builtin.SourceLocation,
+    g: *dvui.GridWidget,
+    comptime T: type,
+    data: []T,
+    comptime field_name: ?[]const u8,
+    cell_opts: GridWidget.CellOptions,
+    opts: dvui.Options,
+) !bool {
+    if (T != bool) {
+        if (field_name) |_field_name| {
+            if (!@hasField(T, _field_name)) {
+                @compileError(std.fmt.comptimePrint("'{s}' does has no member named {s}.", .{ @typeName(T), _field_name }));
+            } else if (@FieldType(T, _field_name) != bool) {
+                @compileError(std.fmt.comptimePrint("{s}.{s} must be of type bool.", .{ @typeName(T), _field_name }));
+            }
+        } else {
+            @compileError("data must be of type []bool when field_name is null.");
+        }
+    }
+    const cell_defaults: Options = .{
+        .gravity_x = 0.5,
+        .gravity_y = 0.5,
+    };
+
+    var selection_changed = false;
+    for (data, 0..) |*item, i| {
+        var cell = try g.bodyCell(src, i, cell_opts);
+        defer cell.deinit();
+        const is_selected: *bool = if (T == bool) item else &@field(item, field_name.?);
+        const was_selected = is_selected.*;
+        _ = try dvui.checkbox(@src(), is_selected, null, cell_defaults.override(opts));
+        selection_changed = selection_changed or was_selected != is_selected.*;
+    }
+    return selection_changed;
+}
+
+/// Size columns widths using ratios.
+///
+/// Positive widths are treated as fixed widths and are not modified.
+/// Negative widths are treated as ratios and are replaced by a calculated width.
+/// Results are returned in ratio_widths, which will contain calculated column widths.
+/// If content_width is null, the columns will be sized to the grid's visible portion.
+/// If content_w is supplied, all columns will be sized to content_w. If content_w is larger than the visible area,
+/// horizontal scrolling should be enabled via the grid's init_opts.
+///
+/// Examples:
+/// To lay out three columns with equal widths, use the same negative ratio for each column:
+///     { -1, -1, -1 } or { -0.33, -0.33, -0.33 }
+/// To make the second column with twice the width of the first, use a negative ratio twice as large.
+///     {-1, -2 } or { -50, -100 }
+/// To lay out a fixed column width with all other columns sharing the remaining, use a positive width for the fixed column and
+/// the same negative ratio for the variable columns.
+///     { -1, 50, -1 }.
+pub fn columnLayoutProportional(g: *dvui.GridWidget, ratio_widths: []f32, content_width: ?f32) void {
+    const scroll_bar_w: f32 = 10; // TODO: Don't necessarily know if SB is showing? There needs ot be a grid function to work this out.
+    const content_w: f32 = content_width orelse g.data().contentRect().w;
+
+    // Count all of the positive widths as reserved widths.
+    // Total all of the negative widths.
+    const reserved_w, const ratio_w: f32 = blk: {
+        var res_width: f32 = 0;
+        var total_ratio_w: f32 = 0;
+        for (ratio_widths) |w| {
+            if (w <= 0) {
+                total_ratio_w += -w;
+            } else {
+                res_width += w;
+            }
+        }
+        break :blk .{ res_width, total_ratio_w };
+    };
+    const available_w = content_w - reserved_w - scroll_bar_w;
+
+    // For each negative width, replace it width a positive calculated width.
+    for (ratio_widths) |*w| {
+        if (w.* <= 0) {
+            w.* = -w.* / ratio_w * available_w;
+        }
+    }
+}
+
 pub fn separator(src: std.builtin.SourceLocation, opts: Options) !void {
     const defaults: Options = .{
         .name = "Separator",
@@ -4508,6 +4814,36 @@ pub fn buttonIcon(src: std.builtin.SourceLocation, name: []const u8, tvg_bytes: 
 
     const click = bw.clicked();
     try bw.drawFocus();
+    bw.deinit();
+    return click;
+}
+
+pub fn buttonLabelAndIcon(src: std.builtin.SourceLocation, label_str: []const u8, tvg_bytes: []const u8, init_opts: ButtonWidget.InitOptions, opts: Options) !bool {
+    // initialize widget and get rectangle from parent
+    var bw = ButtonWidget.init(src, init_opts, opts);
+
+    // make ourselves the new parent
+    try bw.install();
+
+    // process events (mouse and keyboard)
+    bw.processEvents();
+    var options = opts.strip().override(.{ .gravity_x = 0.5, .gravity_y = 0.5 });
+    if (bw.pressed()) options = options.override(.{ .color_text = .{ .color = opts.color(.text_press) } });
+
+    // draw background/border
+    try bw.drawBackground();
+    {
+        var hbox = try box(src, .horizontal, .{ .expand = .horizontal });
+        defer hbox.deinit();
+
+        try labelNoFmt(@src(), label_str, options.override(.{ .expand = .horizontal }));
+        try icon(@src(), label_str, tvg_bytes, opts.strip().override(.{ .gravity_y = 0.5 }));
+    }
+
+    const click = bw.clicked();
+
+    try bw.drawFocus();
+
     bw.deinit();
     return click;
 }

--- a/src/import_widgets.zig
+++ b/src/import_widgets.zig
@@ -35,7 +35,7 @@ pub const TabsWidget = @import("widgets/TabsWidget.zig");
 pub const TextEntryWidget = @import("widgets/TextEntryWidget.zig");
 pub const TextLayoutWidget = @import("widgets/TextLayoutWidget.zig");
 pub const VirtualParentWidget = @import("widgets/VirtualParentWidget.zig");
-
+pub const GridWidget = @import("widgets/GridWidget.zig");
 // Needed for autodocs "backlink" to work
 const dvui = @import("dvui");
 

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -1,0 +1,395 @@
+const std = @import("std");
+const dvui = @import("../dvui.zig");
+
+const Options = dvui.Options;
+const ColorOrName = dvui.Options.ColorOrName;
+const Rect = dvui.Rect;
+const Size = dvui.Size;
+const MaxSize = Options.MaxSize;
+const ScrollInfo = dvui.ScrollInfo;
+const WidgetData = dvui.WidgetData;
+const BoxWidget = dvui.BoxWidget;
+const ScrollAreaWidget = dvui.ScrollAreaWidget;
+const GridWidget = @This();
+
+pub const CellOptions = struct {
+    height: ?f32 = null,
+    margin: ?Rect = null,
+    border: ?Rect = null,
+    padding: ?Rect = null,
+    background: ?bool = null,
+    color_fill: ?ColorOrName = null,
+    color_fill_hover: ?ColorOrName = null,
+    color_border: ?ColorOrName = null,
+
+    // TODO: provide override???
+    pub fn toOptions(self: *const CellOptions) Options {
+        return .{
+            // height is not converted as cell height is set via rect.
+            .margin = self.margin,
+            .border = self.border,
+            .padding = self.padding,
+            .background = self.background,
+            .color_fill = self.color_fill,
+            .color_fill_hover = self.color_fill_hover,
+            .color_border = self.color_border,
+        };
+    }
+};
+
+pub const ColOptions = struct {
+    width: ?f32 = null,
+    border: ?Rect = null,
+    background: ?bool = null,
+    color_fill: ?ColorOrName = null,
+    color_fill_hover: ?ColorOrName = null, // TODO: Not currently supported.
+    color_border: ?ColorOrName = null,
+
+    // TODO: provide override???
+    pub fn toOptions(self: *const ColOptions) Options {
+        return .{
+            // height is not converted as cell height is set via rect.
+            .border = self.border,
+            .background = self.background,
+            .color_fill = self.color_fill,
+            .color_fill_hover = self.color_fill_hover, // TODO: Not currently supported.
+            .color_border = self.color_border,
+        };
+    }
+};
+
+pub var defaults: Options = .{
+    .name = "GridWidget",
+    .background = true,
+    .corner_radius = Rect{ .x = 0, .y = 0, .w = 5, .h = 5 },
+};
+
+pub const SortDirection = enum {
+    unsorted,
+    ascending,
+    descending,
+};
+
+pub const InitOpts = struct {
+    scroll_opts: ?ScrollAreaWidget.InitOpts = null,
+    col_widths: ?[]f32 = null,
+    // Recalculate row heights. Only set this when row heights might have changed, .e.g on column resize.
+    resize_rows: bool = false,
+};
+pub const default_col_width: f32 = 100;
+
+vbox: BoxWidget = undefined, // Outer container
+scroll: ScrollAreaWidget = undefined,
+hbox: BoxWidget = undefined, // Horizontal box for column layout
+init_opts: InitOpts = undefined,
+num_cols: f32 = undefined,
+current_col: ?*BoxWidget = null,
+next_row_y: f32 = 0,
+last_height: f32 = 0,
+header_height: f32 = 0,
+row_height: f32 = 0,
+last_row_height: f32 = 0,
+col_num: usize = std.math.maxInt(usize),
+sort_col_number: usize = 0,
+sort_direction: SortDirection = .unsorted,
+prev_clip_rect: ?Rect.Physical = null,
+resizing: bool = false,
+y_offset: f32 = 0,
+
+pub fn init(src: std.builtin.SourceLocation, init_opts: InitOpts, opts: Options) !GridWidget {
+    var self = GridWidget{};
+    self.init_opts = init_opts;
+    const options = defaults.override(opts);
+    self.vbox = BoxWidget.init(src, .vertical, false, options);
+    if (dvui.dataGet(null, self.data().id, "_last_height", f32)) |last_height| {
+        self.last_height = last_height;
+    }
+    if (dvui.dataGet(null, self.data().id, "_resizing", bool)) |resizing| {
+        self.resizing = resizing;
+    }
+    if (dvui.dataGet(null, self.data().id, "_header_height", f32)) |header_height| {
+        self.header_height = header_height;
+    }
+    if (dvui.dataGet(null, self.data().id, "_row_height", f32)) |row_height| {
+        self.last_row_height = row_height;
+        self.row_height = row_height;
+    }
+    if (dvui.dataGet(null, self.data().id, "_sort_col", usize)) |sort_col| {
+        self.sort_col_number = sort_col;
+    }
+    if (dvui.dataGet(null, self.data().id, "_sort_direction", SortDirection)) |sort_direction| {
+        self.sort_direction = sort_direction;
+    }
+    // Ensure resize on first initialization.
+    if (self.last_height == 0) {
+        self.resizing = true;
+    }
+    if (init_opts.resize_rows or self.resizing) {
+        self.row_height = 0;
+        dvui.refresh(null, @src(), self.data().id);
+    }
+
+    return self;
+}
+
+pub fn install(self: *GridWidget) !void {
+    try self.vbox.install();
+    try self.vbox.drawBackground();
+
+    self.scroll = ScrollAreaWidget.init(@src(), self.init_opts.scroll_opts orelse .{}, .{ .expand = .both });
+    try self.scroll.install();
+
+    // Lay out columns horizontally.
+    self.hbox = BoxWidget.init(@src(), .horizontal, false, .{
+        .expand = .both,
+    });
+    try self.hbox.install();
+    try self.hbox.drawBackground();
+}
+
+pub fn data(self: *GridWidget) *WidgetData {
+    return &self.vbox.wd;
+}
+
+pub fn deinit(self: *GridWidget) void {
+    self.clipReset();
+
+    // resizing if row heights changed or a resize was requested via init options.
+    self.resizing =
+        self.init_opts.resize_rows or
+        !std.math.approxEqAbs(f32, self.row_height, self.last_row_height, 0.01);
+
+    dvui.dataSet(null, self.data().id, "_last_height", self.next_row_y);
+    dvui.dataSet(null, self.data().id, "_header_height", self.header_height);
+    dvui.dataSet(null, self.data().id, "_resizing", self.resizing);
+    dvui.dataSet(null, self.data().id, "_row_height", self.row_height);
+    dvui.dataSet(null, self.data().id, "_sort_col", self.sort_col_number);
+    dvui.dataSet(null, self.data().id, "_sort_direction", self.sort_direction);
+
+    self.hbox.deinit();
+    self.scroll.deinit();
+    self.vbox.deinit();
+}
+
+/// Set the starting y value to begin rendering rows.
+/// Used for setting the y location of the first row when virtual scrolling.
+pub fn offsetRowsBy(self: *GridWidget, offset: f32) void {
+    self.y_offset = offset;
+}
+
+/// Start a new grid column.
+/// Returns a vbox.
+/// Ensure deinit() is called on the returned vbox before creating a new column.
+/// Column width is determined from:
+/// 1) init_opts.col_width if supplied
+/// 2) opts.width if supplied
+/// 3) If not width is provided it will expand to the available space.
+/// It is highly recommended that widths are provided for all columns.
+pub fn column(self: *GridWidget, src: std.builtin.SourceLocation, opts: ColOptions) !*BoxWidget {
+    self.clipReset();
+    self.current_col = null;
+    if (self.col_num == std.math.maxInt(usize)) {
+        self.col_num = 0;
+    } else {
+        self.col_num += 1;
+    }
+    self.next_row_y = self.y_offset;
+
+    const w: f32, const expand: ?Options.Expand = width: {
+        // Take width from col_opts if it is set.
+        if (self.init_opts.col_widths) |col_info| {
+            if (self.col_num < col_info.len) {
+                break :width .{ col_info[self.col_num], null };
+            } else {
+                dvui.log.debug("GridWidget {x} has more columns than set in init_opts.col_widths. Using default column width of {d}\n", .{ self.data().id, default_col_width });
+                break :width .{ default_col_width, null };
+            }
+        } else {
+            if (opts.width) |w| {
+                if (w > 0) {
+                    break :width .{ w, null };
+                } else {
+                    dvui.log.debug("GridWidget {x} invalid opts.width provided to column(). Using default column width of {d}\n", .{ self.data().id, default_col_width });
+                    break :width .{ default_col_width, null };
+                }
+            } else {
+                // If there is no width specified either in col_info or col_opts,
+                // just expand to fill available width.
+                break :width .{ 0, .horizontal };
+            }
+        }
+    };
+    var col_opts = opts.toOptions();
+    col_opts.expand = expand;
+    col_opts.min_size_content = .{ .w = w, .h = self.last_height };
+    col_opts.max_size_content = if (w > 0) .width(w) else null;
+
+    var col = try dvui.currentWindow().arena().create(BoxWidget);
+    col.* = BoxWidget.init(src, .vertical, false, col_opts);
+    try col.install();
+    try col.drawBackground();
+    self.current_col = col;
+    return col;
+}
+
+/// Restore saved clip region.
+fn clipReset(self: *GridWidget) void {
+    if (self.prev_clip_rect) |cr| {
+        dvui.clipSet(cr);
+        self.prev_clip_rect = null;
+    }
+}
+
+/// Create a new header cell within a column
+/// Returns a hbox, deinit() must be called on this hbox before creating a new cell.
+/// Only one header cell is allowed per column.
+/// Height is taken from opts.height if provided, otherwise height is automatically determined.
+pub fn headerCell(self: *GridWidget, src: std.builtin.SourceLocation, opts: CellOptions) !*BoxWidget {
+    const y: f32 = self.scroll.si.viewport.y;
+    const parent_rect = self.current_col.?.data().contentRect();
+
+    const header_height: f32 = height: {
+        if (opts.height) |height| {
+            break :height height;
+        } else {
+            break :height if (self.resizing) 0 else self.header_height;
+        }
+    };
+    var cell_opts = opts.toOptions();
+    cell_opts.rect = .{ .x = 0, .y = y, .w = parent_rect.w, .h = header_height };
+
+    // Create the cell and install as parent.
+    var cell = try dvui.currentWindow().arena().create(BoxWidget);
+    cell.* = BoxWidget.init(src, .horizontal, false, cell_opts);
+    try cell.install();
+    try cell.drawBackground();
+
+    // Determine heights for next frame.
+    if (cell.data().contentRect().h > 0) {
+        const height = cell.data().rect.h;
+        self.header_height = @max(self.header_height, height);
+    }
+    self.next_row_y += self.header_height;
+    return cell;
+}
+
+/// Create a new body cell within a column
+/// Returns a hbox, deinit() must be called on this hbox before creating a new cell.
+/// Height is taken from opts.height if provided, otherwise height is automatically determined.
+pub fn bodyCell(self: *GridWidget, src: std.builtin.SourceLocation, row_num: usize, opts: CellOptions) !*BoxWidget {
+    const parent_rect = self.current_col.?.data().contentRect();
+
+    const cell_height: f32 = height: {
+        if (opts.height) |height| {
+            break :height height;
+        } else {
+            break :height if (self.resizing) 0 else self.row_height;
+        }
+    };
+
+    // Prevent the header for being overwritten when scrolling.
+    if (self.prev_clip_rect == null) {
+        const rect_scale = self.vbox.data().rectScale();
+        const header_height_scaled = self.header_height * rect_scale.s;
+
+        var clip_rect = rect_scale.r;
+        clip_rect.y += header_height_scaled;
+        clip_rect.h = self.scroll.si.viewport.h * rect_scale.s - header_height_scaled;
+
+        self.prev_clip_rect = dvui.clipGet();
+        dvui.clipSet(clip_rect);
+    }
+
+    var cell_opts = opts.toOptions();
+    cell_opts.rect = .{ .x = 0, .y = self.next_row_y, .w = parent_rect.w, .h = cell_height };
+    cell_opts.id_extra = row_num;
+
+    var cell = try dvui.currentWindow().arena().create(BoxWidget);
+    cell.* = BoxWidget.init(src, .horizontal, false, cell_opts);
+    try cell.install();
+    try cell.drawBackground();
+
+    if (cell.data().contentRect().h > 0) {
+        const measured_cell_height = cell.data().rect.h;
+        self.row_height = @max(self.row_height, measured_cell_height);
+    }
+    self.next_row_y += self.row_height; // TODO: Does row_height or last_row_height look better when resizing?
+
+    return cell;
+}
+
+/// Must be called whenever the sort order for any column has changed.
+pub fn sortChanged(self: *GridWidget) void {
+    // If sorting on a new column, change current sort column to unsorted.
+    if (self.col_num != self.sort_col_number) {
+        self.sort_direction = .unsorted;
+        self.sort_col_number = self.col_num;
+    }
+    // If new sort column, then ascending, otherwise opposite of current sort.
+    self.sort_direction = if (self.sort_direction != .ascending) .ascending else .descending;
+}
+
+/// Returns the sort order for the current column.
+pub fn colSortOrder(self: *const GridWidget) SortDirection {
+    if (self.col_num == self.sort_col_number) {
+        return self.sort_direction;
+    } else {
+        return .unsorted;
+    }
+}
+
+/// Provides vitrual scrolling for a grid so that only the visibile rows are rendered.
+/// GridVirtualScroller requires that a scroll_info has been passed as an init_option
+/// to the GridBodyWidget.
+pub const GridVirtualScroller = struct {
+    pub const InitOpts = struct {
+        // Total rows in the columns displayed
+        total_rows: usize,
+        // The number of rows to render before and after the visible scroll area.
+        // Larger windows can result in smoother scrolling but will take longer to render each frame.
+        window_size: usize = 1,
+        scroll_info: *ScrollInfo,
+    };
+    grid: *GridWidget,
+    si: *ScrollInfo,
+    total_rows: usize,
+    window_size: usize,
+    pub fn init(grid: *GridWidget, init_opts: GridVirtualScroller.InitOpts) GridVirtualScroller {
+        const si = init_opts.scroll_info;
+        const total_rows_f: f32 = @floatFromInt(init_opts.total_rows);
+        si.virtual_size.h = @max(total_rows_f * grid.row_height + 10, si.viewport.h); // TODO: 10 = scrollbar padding
+        const first_row: f32 = @floatFromInt(_rowFirstRendered(grid, si, init_opts.total_rows, init_opts.window_size));
+        grid.offsetRowsBy(first_row * grid.row_height); // TODO: does last_row_height make a difference?
+        return .{
+            .grid = grid,
+            .si = si,
+            .total_rows = init_opts.total_rows,
+            .window_size = init_opts.window_size,
+        };
+    }
+
+    fn _rowFirstRendered(grid: *GridWidget, si: *ScrollInfo, total_rows: usize, window_size: usize) usize {
+        if (grid.row_height < 1) {
+            return 0;
+        }
+        const first_row_in_viewport: usize = @intFromFloat(@round(si.viewport.y / grid.row_height));
+        if (first_row_in_viewport < window_size) {
+            return 0;
+        }
+        return @min(first_row_in_viewport - window_size, total_rows);
+    }
+    /// Return the first row within the visible scroll area, minus window_size
+    pub fn rowFirstRendered(self: *const GridVirtualScroller) usize {
+        return _rowFirstRendered(self.grid, self.si, self.total_rows, self.window_size);
+    }
+
+    /// Return the last row within the visible scroll area, plus the window size.
+    /// TODO: This doesn't return the last row. It returns the last row + 1? Or at least it needs to for first..last to work.
+    pub fn rowLastRendered(self: *const GridVirtualScroller) usize {
+        if (self.grid.row_height < 1) {
+            return 1;
+        }
+        const last_row_in_viewport: usize = @intFromFloat(@round((self.si.viewport.y + self.si.viewport.h) / self.grid.row_height));
+        return @min(last_row_in_viewport + self.window_size, self.total_rows);
+    }
+};


### PR DESCRIPTION
## This comment is out of date.

I don't intend for this to be merged yet, rather it is for review of the approach and code so far.

Something has happened recently with the smoothness of the virtual scrolling which I need to investigate further.

I've come to the view that the GridWidget probably needs to do all of the layout itself, rather than relying on boxes. I've not really looked into how difficult that would be yet, but it would bring several advantages:
1) Smoother scrolling where header and body have to scroll together.
2) More control over virtual scrolling
3) Maybe easier to keep header and body sizes in sync as can layout the header and body at the same time.
4) Likely easier to implement draggable columns.

There are probably a few instances where the widgets are a bit too intimate with each other, such as setting the "invisible_height" in the body widget. It depends how much you want to de-couple the widgets.

A copy of TODO.MD is below:
### Issues
- [ ] Virtual scrolling is sometimes smooth and sometimes flickers by 1 row. 
    - Likely some floating point rounding issue.
    - Is less apparent when vsync = false
    - Possibly resolved by not forcing the grid to scroll on full rows.
- [ ] Virtual scrolling with large row heights doesn't work well because of the way it snaps to the next visible row.
- [ ] scrolling header and body simultaneously is not a smooth as I'd like.
- [ ] Columns flash when sorting. Only the separator is shown and appears that label is not rendered or rendered with no label text.
- [ ] Is there a better name than window size for the scroller? It's not really a window size. It's a number of extra rows to render above and below the visible rows.
- [ ] Checkbox doesn't expand to the full height of the header.
- [ ] Remove the need to pass the same (or sometimes different) styling to the header vs the body.
- [ ] Make column headers respect column width "ownership" so that .expand can be used on the body columns. 
- [ ] Grid header widget assumes vertical scroll bar width is 10 and that it will always be displayed. 
- [ ] Example needs to be added to Example.zig, rather than a stand-alone.

### Future
* Some better visual indication that columns are sortable.
* Make the GridWidget do the layout calculations, rather than relying on hbox / vbox layouts. 
    - Then each column have a style of fixed, expanding, size_to_content etc.
    - The grid Widget can then take into account the available space and size each column accordingy.
    - Potentially it would allows layout out data by row rather than just by col.
    - Would likely fix the issue of the header and body not being 100% in sync while scrolling.
* Resize columns via dragging
* Filtering headers

