### PR TITLE
Fix check step not performing comptime checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install mesa-common-dev libgl-dev libglx-dev libegl-dev libpulse-dev libxext-dev libxfixes-dev libxrender-dev libasound2-dev libx11-dev libxrandr-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev libxcursor-dev libxinerama-dev libwayland-dev libxkbcommon-dev
 
-      - name: Build and check
-        run: zig build check -Duse-lld=false # build all backends
+      - name: Compile
+        run: zig build compile -Duse-lld=false # compile all backends
 
       - name: Run tests
         run: zig build test -Dbackend=testing -Duse-lld=false
@@ -42,8 +42,8 @@ jobs:
       # uses .minimum_zig_version from build.zig.zon
       - uses: mlugg/setup-zig@v1
 
-      - name: Build and check Dx11
-        run: zig build check -Dbackend=dx11
+      - name: Compile Dx11
+        run: zig build compile -Dbackend=dx11
 
       - name: Run tests
         run: zig build test -Dbackend=testing

--- a/build.zig
+++ b/build.zig
@@ -18,6 +18,7 @@ pub fn build(b: *std.Build) !void {
 
     const test_step = b.step("test", "Test the dvui codebase");
     const check_step = b.step("check", "Check that the dvui codebase compiles");
+    const syntax_step = b.step("syntax", "Check that the dvui codebase parses");
 
     // Setting this to false may fix linking errors: https://github.com/david-vanderson/dvui/issues/269
     const use_lld = b.option(bool, "use-lld", "The value of the use_lld executable option");
@@ -33,6 +34,7 @@ pub fn build(b: *std.Build) !void {
         .test_step = test_step,
         .test_filters = test_filters,
         .check_step = check_step,
+        .syntax_step = syntax_step,
         .use_lld = use_lld,
         .build_options = build_options,
     };
@@ -41,8 +43,8 @@ pub fn build(b: *std.Build) !void {
         // For export to users who are bringing their own backend.  Use in your build.zig:
         // const dvui_mod = dvui_dep.module("dvui");
         // @import("dvui").linkBackend(dvui_mod, your_backend_module);
-        const dvui_mod = addDvuiModule("dvui", dvui_opts);
-        dvui_opts.addChecksAndTests(dvui_mod, "dvui");
+        _ = addDvuiModule("dvui", dvui_opts);
+        // does not need to be tested as only dependent would hit this path and test themselves
     }
 
     // Deprecated modules
@@ -70,11 +72,13 @@ pub fn build(b: *std.Build) !void {
             .target = target,
             .optimize = optimize,
         });
-        dvui_opts.addChecksAndTests(testing_mod, "testing-backend");
+        dvui_opts.addChecks(testing_mod, "testing-backend");
+        dvui_opts.addTests(testing_mod, "testing-backend");
 
         const dvui_testing = addDvuiModule("dvui_testing", dvui_opts);
+        dvui_opts.addChecks(dvui_testing, "dvui_testing");
         if (test_dvui_and_app) {
-            dvui_opts.addChecksAndTests(dvui_testing, "dvui_testing");
+            dvui_opts.addTests(dvui_testing, "dvui_testing");
         }
 
         linkBackend(dvui_testing, testing_mod);
@@ -91,7 +95,8 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
             .link_libc = true,
         });
-        dvui_opts.addChecksAndTests(sdl_mod, "sdl2-backend");
+        dvui_opts.addChecks(sdl_mod, "sdl2-backend");
+        dvui_opts.addTests(sdl_mod, "sdl2-backend");
 
         var sdl_options = b.addOptions();
 
@@ -125,8 +130,9 @@ pub fn build(b: *std.Build) !void {
         sdl_mod.addOptions("sdl_options", sdl_options);
 
         const dvui_sdl = addDvuiModule("dvui_sdl2", dvui_opts);
+        dvui_opts.addChecks(dvui_sdl, "dvui_sdl2");
         if (test_dvui_and_app) {
-            dvui_opts.addChecksAndTests(dvui_sdl, "dvui_sdl2");
+            dvui_opts.addTests(dvui_sdl, "dvui_sdl2");
         }
 
         linkBackend(dvui_sdl, sdl_mod);
@@ -146,7 +152,8 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
             .link_libc = true,
         });
-        dvui_opts.addChecksAndTests(sdl_mod, "sdl3-backend");
+        dvui_opts.addChecks(sdl_mod, "sdl3-backend");
+        dvui_opts.addTests(sdl_mod, "sdl3-backend");
 
         var sdl_options = b.addOptions();
 
@@ -167,8 +174,9 @@ pub fn build(b: *std.Build) !void {
         sdl_mod.addOptions("sdl_options", sdl_options);
 
         const dvui_sdl = addDvuiModule("dvui_sdl3", dvui_opts);
+        dvui_opts.addChecks(dvui_sdl, "dvui_sdl3");
         if (test_dvui_and_app) {
-            dvui_opts.addChecksAndTests(dvui_sdl, "dvui_sdl3");
+            dvui_opts.addTests(dvui_sdl, "dvui_sdl3");
         }
 
         linkBackend(dvui_sdl, sdl_mod);
@@ -201,7 +209,8 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
             .link_libc = true,
         });
-        dvui_opts.addChecksAndTests(raylib_mod, "raylib-backend");
+        dvui_opts.addChecks(raylib_mod, "raylib-backend");
+        dvui_opts.addTests(raylib_mod, "raylib-backend");
 
         const maybe_ray = b.lazyDependency(
             "raylib",
@@ -238,8 +247,9 @@ pub fn build(b: *std.Build) !void {
         var dvui_opts_raylib = dvui_opts;
         dvui_opts_raylib.add_stb_image = false;
         const dvui_raylib = addDvuiModule("dvui_raylib", dvui_opts_raylib);
+        dvui_opts.addChecks(dvui_raylib, "dvui_raylib");
         if (test_dvui_and_app) {
-            dvui_opts_raylib.addChecksAndTests(dvui_raylib, "dvui_raylib");
+            dvui_opts.addTests(dvui_raylib, "dvui_raylib");
         }
 
         linkBackend(dvui_raylib, raylib_mod);
@@ -259,15 +269,17 @@ pub fn build(b: *std.Build) !void {
                 .optimize = optimize,
                 .link_libc = true,
             });
-            dvui_opts.addChecksAndTests(dx11_mod, "dx11-backend");
+            dvui_opts.addChecks(dx11_mod, "dx11-backend");
+            dvui_opts.addTests(dx11_mod, "dx11-backend");
 
             if (b.lazyDependency("win32", .{})) |zigwin32| {
                 dx11_mod.addImport("win32", zigwin32.module("win32"));
             }
 
             const dvui_dx11 = addDvuiModule("dvui_dx11", dvui_opts);
+            dvui_opts.addChecks(dvui_dx11, "dvui_dx11");
             if (test_dvui_and_app) {
-                dvui_opts.addChecksAndTests(dvui_dx11, "dvui_dx11");
+                dvui_opts.addTests(dvui_dx11, "dvui_dx11");
             }
 
             linkBackend(dvui_dx11, dx11_mod);
@@ -298,11 +310,15 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
         });
         web_mod.export_symbol_names = export_symbol_names;
-        dvui_opts.addChecksAndTests(web_mod, "web-backend");
+        dvui_opts.addChecks(web_mod, "web-backend");
+        dvui_opts.addTests(web_mod, "web-backend");
 
         // NOTE: exported module uses the standard target so it can be overridden by users
         const dvui_web = addDvuiModule("dvui_web", dvui_opts);
-        // don't add tests here, we test the web backend below in dvui_web_wasm
+        dvui_opts.addChecks(web_mod, "dvui_web");
+        if (test_dvui_and_app) {
+            dvui_opts.addTests(web_mod, "dvui_web");
+        }
 
         linkBackend(dvui_web, web_mod);
 
@@ -315,9 +331,9 @@ pub fn build(b: *std.Build) !void {
                     .os_tag = .freestanding,
                 }),
                 .optimize = optimize,
-                .check_step = check_step,
                 .build_options = build_options,
                 .test_filters = test_filters,
+                // no tests or checks needed, they are check above in native build
             };
 
             const web_mod_wasm = b.createModule(.{
@@ -326,9 +342,6 @@ pub fn build(b: *std.Build) !void {
             web_mod_wasm.export_symbol_names = export_symbol_names;
 
             const dvui_web_wasm = addDvuiModule("dvui_web_wasm", wasm_dvui_opts);
-            if (test_dvui_and_app) {
-                wasm_dvui_opts.addChecksAndTests(dvui_web_wasm, "dvui_web_wasm");
-            }
             linkBackend(dvui_web_wasm, web_mod_wasm);
             addWebExample("web-test", b.path("examples/web-test.zig"), dvui_web_wasm, wasm_dvui_opts);
             addWebExample("web-app", b.path("examples/app.zig"), dvui_web_wasm, wasm_dvui_opts);
@@ -381,16 +394,24 @@ const DvuiModuleOptions = struct {
     optimize: std.builtin.OptimizeMode,
     check_step: ?*std.Build.Step = null,
     test_step: ?*std.Build.Step = null,
+    syntax_step: ?*std.Build.Step = null,
     test_filters: []const []const u8,
     add_stb_image: bool = true,
     use_lld: ?bool = null,
     build_options: *std.Build.Step.Options,
 
-    fn addChecksAndTests(self: *const @This(), mod: *std.Build.Module, name: []const u8) void {
-        if (self.check_step) |step| {
+    fn addChecks(self: *const @This(), mod: *std.Build.Module, name: []const u8) void {
+        if (self.check_step != null or self.syntax_step != null) {
             const tests = self.b.addTest(.{ .root_module = mod, .name = name, .filters = self.test_filters });
-            step.dependOn(&tests.step);
+            if (self.syntax_step) |step| {
+                step.dependOn(&tests.step);
+            }
+            if (self.check_step) |step| {
+                step.dependOn(&self.b.addInstallArtifact(tests, .{}).step);
+            }
         }
+    }
+    fn addTests(self: *const @This(), mod: *std.Build.Module, name: []const u8) void {
         if (self.test_step) |step| {
             const tests = self.b.addTest(.{ .root_module = mod, .name = name, .filters = self.test_filters });
             step.dependOn(&self.b.addRunArtifact(tests).step);
@@ -476,9 +497,11 @@ fn addExample(
 
     const exe = b.addExecutable(.{ .name = name, .root_module = mod, .use_lld = opts.use_lld });
 
+    if (opts.syntax_step) |step| {
+        step.dependOn(&exe.step);
+    }
     if (opts.check_step) |step| {
-        const exe_check = b.addExecutable(.{ .name = name, .root_module = mod, .use_lld = opts.use_lld });
-        step.dependOn(&exe_check.step);
+        step.dependOn(&b.addInstallArtifact(exe, .{}).step);
     }
 
     if (opts.target.result.os.tag == .windows) {
@@ -491,17 +514,11 @@ fn addExample(
     }
 
     if (add_tests) {
-        if (opts.check_step) |step| {
-            const tests = b.addTest(.{ .root_module = mod, .name = name, .filters = opts.test_filters });
-            step.dependOn(&tests.step);
-        }
-        if (opts.test_step) |step| {
-            const tests = b.addTest(.{ .root_module = mod, .name = name, .filters = opts.test_filters });
-            const test_cmd = b.addRunArtifact(tests);
-            const example_test_step = b.step("test-" ++ name, "Test " ++ name);
-            example_test_step.dependOn(&test_cmd.step);
-            step.dependOn(&test_cmd.step);
-        }
+        opts.addChecks(mod, name);
+        opts.addTests(mod, name);
+        var test_step_opts = opts;
+        test_step_opts.test_step = b.step("test-" ++ name, "Test " ++ name);
+        test_step_opts.addTests(mod, name);
     }
 
     const compile_step = b.step("compile-" ++ name, "Compile " ++ name);


### PR DESCRIPTION
I appears that depending on Step.Compile only parses the zig files and doesn't do semantic analysis and comptime evaluation. This became apparent in #287 where the ci did not catch issues in backends not having updated their types.

To force this, the check step now has to install the compiled tests and thus also run llvm. This is much slower but the binaries can at least be reused for running the tests later.

The check step also needs check all backends and their dvui import, otherwise changes to the Backend api wouldn't be caught.