### PR TITLE
Doc image generation changes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -380,7 +380,7 @@ pub fn build(b: *std.Build) !void {
                 const image_tests = b.addTest(.{
                     .name = "generate-images",
                     .root_module = dvui,
-                    .filters = &.{".png"},
+                    .filters = &.{"DOCIMG"},
                     .test_runner = .{ .mode = .simple, .path = b.path("docs/image_gen_test_runner.zig") },
                 });
                 docs_step.dependOn(&b.addRunArtifact(image_tests).step);

--- a/docs/image_gen_test_runner.zig
+++ b/docs/image_gen_test_runner.zig
@@ -5,19 +5,9 @@ pub const std_options = std.Options{
     .log_level = .warn,
 };
 
-/// A global handle to the output directory.
-///
-/// The presence of this declaration signals that the image_gen is currently running
-pub var dvui_image_doc_gen_dir: std.fs.Dir = undefined;
+pub const DvuiDocGenRunner = @This();
 
 pub fn main() !void {
-    var args_iter = try std.process.argsWithAllocator(std.testing.allocator);
-    defer args_iter.deinit();
-    _ = args_iter.skip(); // first arg is the executable
-    const out_path = args_iter.next() orelse @panic("Missing out directory argument");
-    dvui_image_doc_gen_dir = try std.fs.cwd().openDir(out_path, .{});
-    defer dvui_image_doc_gen_dir.close();
-
     const test_fn_list: []const std.builtin.TestFn = builtin.test_functions;
     for (test_fn_list) |test_fn| {
         try test_fn.func();

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -3752,7 +3752,7 @@ test {
     std.testing.refAllDecls(@This());
 }
 
-test "Examples-{s}.png" {
+test "DOCIMG demo" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -3783,7 +3783,7 @@ test "Examples-{s}.png" {
     //}
 }
 
-test "Examples-basic_widgets.png" {
+test "DOCIMG basic_widgets" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 500, .h = 500 } });
     defer t.deinit();
 
@@ -3800,7 +3800,7 @@ test "Examples-basic_widgets.png" {
     try t.saveImage(frame, null, "Examples-basic_widgets.png");
 }
 
-test "Examples-calculator.png" {
+test "DOCIMG calculator" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 250, .h = 250 } });
     defer t.deinit();
 
@@ -3817,7 +3817,7 @@ test "Examples-calculator.png" {
     try t.saveImage(frame, null, "Examples-calculator.png");
 }
 
-test "Examples-text_entry.png" {
+test "DOCIMG text_entry" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 500, .h = 500 } });
     defer t.deinit();
 
@@ -3834,7 +3834,7 @@ test "Examples-text_entry.png" {
     try t.saveImage(frame, null, "Examples-text_entry.png");
 }
 
-test "Examples-styling.png" {
+test "DOCIMG styling" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 500, .h = 300 } });
     defer t.deinit();
 
@@ -3851,7 +3851,7 @@ test "Examples-styling.png" {
     try t.saveImage(frame, null, "Examples-styling.png");
 }
 
-test "Examples-layout.png" {
+test "DOCIMG layout" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 500, .h = 800 } });
     defer t.deinit();
 
@@ -3868,7 +3868,7 @@ test "Examples-layout.png" {
     try t.saveImage(frame, null, "Examples-layout.png");
 }
 
-test "Examples-text_layout.png" {
+test "DOCIMG text_layout" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 500, .h = 500 } });
     defer t.deinit();
 
@@ -3885,7 +3885,7 @@ test "Examples-text_layout.png" {
     try t.saveImage(frame, null, "Examples-text_layout.png");
 }
 
-test "Examples-plots.png" {
+test "DOCIMG plots" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 500, .h = 300 } });
     defer t.deinit();
 
@@ -3902,7 +3902,7 @@ test "Examples-plots.png" {
     try t.saveImage(frame, null, "Examples-plots.png");
 }
 
-test "Examples-reorderable.png" {
+test "DOCIMG reorderable" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 400, .h = 500 } });
     defer t.deinit();
 
@@ -3919,7 +3919,7 @@ test "Examples-reorderable.png" {
     try t.saveImage(frame, null, "Examples-reorderable.png");
 }
 
-test "Examples-menus.png" {
+test "DOCIMG menus" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 300, .h = 500 } });
     defer t.deinit();
 
@@ -3936,7 +3936,7 @@ test "Examples-menus.png" {
     try t.saveImage(frame, null, "Examples-menus.png");
 }
 
-test "Examples-focus.png" {
+test "DOCIMG focus" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 500, .h = 300 } });
     defer t.deinit();
 
@@ -3953,7 +3953,7 @@ test "Examples-focus.png" {
     try t.saveImage(frame, null, "Examples-focus.png");
 }
 
-test "Examples-scrolling.png" {
+test "DOCIMG scrolling" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 500, .h = 400 } });
     defer t.deinit();
 
@@ -3970,7 +3970,7 @@ test "Examples-scrolling.png" {
     try t.saveImage(frame, null, "Examples-scrolling.png");
 }
 
-test "Examples-scroll_canvas.png" {
+test "DOCIMG scroll_canvas" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 300, .h = 400 } });
     defer t.deinit();
 
@@ -3987,7 +3987,7 @@ test "Examples-scroll_canvas.png" {
     try t.saveImage(frame, null, "Examples-scroll_canvas.png");
 }
 
-test "Examples-dialogs.png" {
+test "DOCIMG dialogs" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 400, .h = 300 } });
     defer t.deinit();
 
@@ -4013,7 +4013,7 @@ test "Examples-dialogs.png" {
     try t.saveImage(frame, null, "Examples-dialogs.png");
 }
 
-test "Examples-animations.png" {
+test "DOCIMG animations" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 500, .h = 400 } });
     defer t.deinit();
 
@@ -4046,7 +4046,7 @@ test "Examples-animations.png" {
     try t.saveImage(frame, null, "Examples-animations.png");
 }
 
-test "Examples-struct_ui.png" {
+test "DOCIMG struct_ui" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 400, .h = 700 } });
     defer t.deinit();
 
@@ -4063,7 +4063,7 @@ test "Examples-struct_ui.png" {
     try t.saveImage(frame, null, "Examples-struct_ui.png");
 }
 
-test "Examples-debugging.png" {
+test "DOCIMG debugging" {
     // This tests intentionally logs errors, which fails with the normal test runner.
     // We skip this test instead of downgrading all log.err to log.warn as we usually
     // want to fail if dvui logs errors (for duplicate id's or similar)
@@ -4095,7 +4095,7 @@ test "Examples-debugging.png" {
     try t.saveImage(frame, null, "Examples-debugging.png");
 }
 
-test "Examples-icon_browser.png" {
+test "DOCIMG icon_browser" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 400, .h = 500 } });
     defer t.deinit();
 
@@ -4112,7 +4112,7 @@ test "Examples-icon_browser.png" {
     try t.saveImage(frame, null, "Examples-icon_browser.png");
 }
 
-test "Examples-themeEditor.png" {
+test "DOCIMG themeEditor" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 400, .h = 500 } });
     defer t.deinit();
 

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -3766,8 +3766,7 @@ test "Examples-{s}.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, dvui.tagGet(demo_window_tag).?.rect, .{"demo"});
-
+    try t.saveImage(frame, dvui.tagGet(demo_window_tag).?.rect, "Examples-demo.png");
     // this works, but unsure it's what we want, so disable for now
     //inline for (0..@typeInfo(demoKind).@"enum".fields.len) |i| {
     //    const e = @as(demoKind, @enumFromInt(i));
@@ -3776,7 +3775,7 @@ test "Examples-{s}.png" {
     //    try dvui.testing.click(.left);
     //    try dvui.testing.settle(frame);
 
-    //    try t.saveDocImage(@src(), frame, dvui.tagGet(demo_window_tag).?.rect, .{@tagName(e)});
+    //    try t.saveImage(frame, dvui.tagGet(demo_window_tag).?.rect, "Examples-" ++ @tagName(e) ++ ".png");
 
     //    try dvui.testing.moveTo("dvui_demo_window_back");
     //    try dvui.testing.click(.left);
@@ -3798,7 +3797,7 @@ test "Examples-basic_widgets.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-basic_widgets.png");
 }
 
 test "Examples-calculator.png" {
@@ -3815,7 +3814,7 @@ test "Examples-calculator.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-calculator.png");
 }
 
 test "Examples-text_entry.png" {
@@ -3832,7 +3831,7 @@ test "Examples-text_entry.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-text_entry.png");
 }
 
 test "Examples-styling.png" {
@@ -3849,7 +3848,7 @@ test "Examples-styling.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-styling.png");
 }
 
 test "Examples-layout.png" {
@@ -3866,7 +3865,7 @@ test "Examples-layout.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-layout.png");
 }
 
 test "Examples-text_layout.png" {
@@ -3883,7 +3882,7 @@ test "Examples-text_layout.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-text_layout.png");
 }
 
 test "Examples-plots.png" {
@@ -3900,7 +3899,7 @@ test "Examples-plots.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-plots.png");
 }
 
 test "Examples-reorderable.png" {
@@ -3917,7 +3916,7 @@ test "Examples-reorderable.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-reorderable.png");
 }
 
 test "Examples-menus.png" {
@@ -3934,7 +3933,7 @@ test "Examples-menus.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-menus.png");
 }
 
 test "Examples-focus.png" {
@@ -3951,7 +3950,7 @@ test "Examples-focus.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-focus.png");
 }
 
 test "Examples-scrolling.png" {
@@ -3968,7 +3967,7 @@ test "Examples-scrolling.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-scrolling.png");
 }
 
 test "Examples-scroll_canvas.png" {
@@ -3985,7 +3984,7 @@ test "Examples-scroll_canvas.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-scroll_canvas.png");
 }
 
 test "Examples-dialogs.png" {
@@ -4011,7 +4010,7 @@ test "Examples-dialogs.png" {
     try dvui.testing.pressKey(.enter, .none);
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-dialogs.png");
 }
 
 test "Examples-animations.png" {
@@ -4044,7 +4043,7 @@ test "Examples-animations.png" {
     for (0..10) |_| {
         _ = try dvui.testing.step(frame); // animation will never settle so run a fixed amount of frames
     }
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-animations.png");
 }
 
 test "Examples-struct_ui.png" {
@@ -4061,14 +4060,14 @@ test "Examples-struct_ui.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-struct_ui.png");
 }
 
 test "Examples-debugging.png" {
     // This tests intentionally logs errors, which fails with the normal test runner.
     // We skip this test instead of downgrading all log.err to log.warn as we usually
     // want to fail if dvui logs errors (for duplicate id's or similar)
-    if (!dvui.testing.is_dvui_doc_gen) return error.SkipZigTest;
+    if (!dvui.testing.is_dvui_doc_gen_runner) return error.SkipZigTest;
 
     std.debug.print("IGNORE ERROR LOGS FOR THIS TEST, IT IS EXPECTED\n", .{});
 
@@ -4093,7 +4092,7 @@ test "Examples-debugging.png" {
     _ = try dvui.testing.step(frame);
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-debugging.png");
 }
 
 test "Examples-icon_browser.png" {
@@ -4110,7 +4109,7 @@ test "Examples-icon_browser.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-icon_browser.png");
 }
 
 test "Examples-themeEditor.png" {
@@ -4140,5 +4139,5 @@ test "Examples-themeEditor.png" {
     try dvui.testing.pressKey(.enter, .none);
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), frame, null, .{});
+    try t.saveImage(frame, null, "Examples-themeEditor.png");
 }

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -3752,7 +3752,7 @@ test {
     std.testing.refAllDecls(@This());
 }
 
-test "Doc Images" {
+test "Examples-{s}.png" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -3766,7 +3766,7 @@ test "Doc Images" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveImage(frame, dvui.tagGet(demo_window_tag).?.rect, "Examples-demo.png", .{});
+    try t.saveDocImage(@src(), frame, dvui.tagGet(demo_window_tag).?.rect, .{"demo"});
 
     // this works, but unsure it's what we want, so disable for now
     //inline for (0..@typeInfo(demoKind).@"enum".fields.len) |i| {
@@ -3776,7 +3776,7 @@ test "Doc Images" {
     //    try dvui.testing.click(.left);
     //    try dvui.testing.settle(frame);
 
-    //    try t.saveImage(frame, dvui.tagGet(demo_window_tag).?.rect, "Examples-" ++ @tagName(e) ++ ".png", .{});
+    //    try t.saveDocImage(@src(), frame, dvui.tagGet(demo_window_tag).?.rect, .{@tagName(e)});
 
     //    try dvui.testing.moveTo("dvui_demo_window_back");
     //    try dvui.testing.click(.left);
@@ -3798,7 +3798,7 @@ test "Examples-basic_widgets.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-calculator.png" {
@@ -3815,7 +3815,7 @@ test "Examples-calculator.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-text_entry.png" {
@@ -3832,7 +3832,7 @@ test "Examples-text_entry.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-styling.png" {
@@ -3849,7 +3849,7 @@ test "Examples-styling.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-layout.png" {
@@ -3866,7 +3866,7 @@ test "Examples-layout.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-text_layout.png" {
@@ -3883,7 +3883,7 @@ test "Examples-text_layout.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-plots.png" {
@@ -3900,7 +3900,7 @@ test "Examples-plots.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-reorderable.png" {
@@ -3917,7 +3917,7 @@ test "Examples-reorderable.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-menus.png" {
@@ -3934,7 +3934,7 @@ test "Examples-menus.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-focus.png" {
@@ -3951,7 +3951,7 @@ test "Examples-focus.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-scrolling.png" {
@@ -3968,7 +3968,7 @@ test "Examples-scrolling.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-scroll_canvas.png" {
@@ -3985,7 +3985,7 @@ test "Examples-scroll_canvas.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-dialogs.png" {
@@ -4011,7 +4011,7 @@ test "Examples-dialogs.png" {
     try dvui.testing.pressKey(.enter, .none);
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-animations.png" {
@@ -4044,7 +4044,7 @@ test "Examples-animations.png" {
     for (0..10) |_| {
         _ = try dvui.testing.step(frame); // animation will never settle so run a fixed amount of frames
     }
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-struct_ui.png" {
@@ -4061,7 +4061,7 @@ test "Examples-struct_ui.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-debugging.png" {
@@ -4069,6 +4069,8 @@ test "Examples-debugging.png" {
     // We skip this test instead of downgrading all log.err to log.warn as we usually
     // want to fail if dvui logs errors (for duplicate id's or similar)
     if (!dvui.testing.is_dvui_doc_gen) return error.SkipZigTest;
+
+    std.debug.print("IGNORE ERROR LOGS FOR THIS TEST, IT IS EXPECTED\n", .{});
 
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 500, .h = 500 } });
     defer t.deinit();
@@ -4091,7 +4093,7 @@ test "Examples-debugging.png" {
     _ = try dvui.testing.step(frame);
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-icon_browser.png" {
@@ -4108,7 +4110,7 @@ test "Examples-icon_browser.png" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }
 
 test "Examples-themeEditor.png" {
@@ -4138,5 +4140,5 @@ test "Examples-themeEditor.png" {
     try dvui.testing.pressKey(.enter, .none);
 
     try dvui.testing.settle(frame);
-    try t.saveDocImage(@src(), .{}, frame);
+    try t.saveDocImage(@src(), frame, null, .{});
 }

--- a/src/Rect.zig
+++ b/src/Rect.zig
@@ -259,7 +259,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
                 }
             }.frame;
 
-            try t.saveDocImage(@src(), frame, null, .{});
+            try t.saveImage(frame, null, "Rect-scale.png");
         }
 
         test offset {
@@ -288,7 +288,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
                 }
             }.frame;
 
-            try t.saveDocImage(@src(), frame, null, .{});
+            try t.saveImage(frame, null, "Rect-offset.png");
         }
 
         test offsetNeg {
@@ -323,7 +323,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
                 }
             }.frame;
 
-            try t.saveDocImage(@src(), frame, null, .{});
+            try t.saveImage(frame, null, "Rect-offsetNegPoint.png");
         }
 
         test intersect {
@@ -357,7 +357,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
                 }
             }.frame;
 
-            try t.saveDocImage(@src(), frame, null, .{});
+            try t.saveImage(frame, null, "Rect-intersect.png");
         }
 
         test unionWith {
@@ -391,7 +391,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
                 }
             }.frame;
 
-            try t.saveDocImage(@src(), frame, null, .{});
+            try t.saveImage(frame, null, "Rect-unionWith.png");
         }
 
         test inset {
@@ -419,7 +419,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
                 }
             }.frame;
 
-            try t.saveDocImage(@src(), frame, null, .{});
+            try t.saveImage(frame, null, "Rect-inset.png");
         }
 
         test insetAll {
@@ -453,7 +453,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
                 }
             }.frame;
 
-            try t.saveDocImage(@src(), frame, null, .{});
+            try t.saveImage(frame, null, "Rect-outset.png");
         }
 
         test outsetAll {

--- a/src/Rect.zig
+++ b/src/Rect.zig
@@ -259,7 +259,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
                 }
             }.frame;
 
-            try t.saveDocImage(@src(), .{}, frame);
+            try t.saveDocImage(@src(), frame, null, .{});
         }
 
         test offset {
@@ -288,7 +288,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
                 }
             }.frame;
 
-            try t.saveDocImage(@src(), .{}, frame);
+            try t.saveDocImage(@src(), frame, null, .{});
         }
 
         test offsetNeg {
@@ -323,7 +323,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
                 }
             }.frame;
 
-            try t.saveDocImage(@src(), .{}, frame);
+            try t.saveDocImage(@src(), frame, null, .{});
         }
 
         test intersect {
@@ -357,7 +357,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
                 }
             }.frame;
 
-            try t.saveDocImage(@src(), .{}, frame);
+            try t.saveDocImage(@src(), frame, null, .{});
         }
 
         test unionWith {
@@ -391,7 +391,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
                 }
             }.frame;
 
-            try t.saveDocImage(@src(), .{}, frame);
+            try t.saveDocImage(@src(), frame, null, .{});
         }
 
         test inset {
@@ -419,7 +419,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
                 }
             }.frame;
 
-            try t.saveDocImage(@src(), .{}, frame);
+            try t.saveDocImage(@src(), frame, null, .{});
         }
 
         test insetAll {
@@ -453,7 +453,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
                 }
             }.frame;
 
-            try t.saveDocImage(@src(), .{}, frame);
+            try t.saveDocImage(@src(), frame, null, .{});
         }
 
         test outsetAll {

--- a/src/Rect.zig
+++ b/src/Rect.zig
@@ -239,7 +239,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
             try std.testing.expectEqualDeep(Rect{ .x = 25, .y = 25, .w = 75, .h = 75 }, res);
         }
 
-        test "Rect-scale.png" {
+        test "DOCIMG scale" {
             if (units != .none) return;
             var t = try dvui.testing.init(.{ .window_size = .all(250) });
             defer t.deinit();
@@ -268,7 +268,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
             try std.testing.expectEqualDeep(Rect{ .x = 100, .y = 100, .w = 100, .h = 100 }, res);
         }
 
-        test "Rect-offset.png" {
+        test "DOCIMG offset" {
             if (units != .none) return;
             var t = try dvui.testing.init(.{ .window_size = .all(250) });
             defer t.deinit();
@@ -303,7 +303,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
             try std.testing.expectEqualDeep(Rect{ .x = 50, .y = 50, .w = 100, .h = 100 }, res);
         }
 
-        test "Rect-offsetNegPoint.png" {
+        test "DOCIMG offsetNegPoint" {
             if (units != .none) return;
             var t = try dvui.testing.init(.{ .window_size = .all(250) });
             defer t.deinit();
@@ -334,7 +334,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
             try std.testing.expectEqualDeep(Rect{ .x = 100, .y = 100, .w = 50, .h = 50 }, ab);
         }
 
-        test "Rect-intersect.png" {
+        test "DOCIMG intersect" {
             if (units != .none) return;
             var t = try dvui.testing.init(.{ .window_size = .all(250) });
             defer t.deinit();
@@ -368,7 +368,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
             try std.testing.expectEqualDeep(Rect{ .x = 50, .y = 50, .w = 150, .h = 150 }, ab);
         }
 
-        test "Rect-unionWith.png" {
+        test "DOCIMG unionWith" {
             if (units != .none) return;
             var t = try dvui.testing.init(.{ .window_size = .all(250) });
             defer t.deinit();
@@ -399,7 +399,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
             const res = rect.inset(.{ .x = 50, .y = 50, .w = 25, .h = 25 });
             try std.testing.expectEqualDeep(Rect{ .x = 100, .y = 100, .w = 75, .h = 75 }, res);
         }
-        test "Rect-inset.png" {
+        test "DOCIMG inset" {
             if (units != .none) return;
             var t = try dvui.testing.init(.{ .window_size = .all(250) });
             defer t.deinit();
@@ -433,7 +433,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
             const res = rect.outset(.{ .x = 50, .y = 50, .w = 25, .h = 25 });
             try std.testing.expectEqualDeep(Rect{ .x = 50, .y = 50, .w = 125, .h = 125 }, res);
         }
-        test "Rect-outset.png" {
+        test "DOCIMG outset" {
             if (units != .none) return;
             var t = try dvui.testing.init(.{ .window_size = .all(250) });
             defer t.deinit();

--- a/src/easing.zig
+++ b/src/easing.zig
@@ -189,7 +189,7 @@ test {
     @import("std").testing.refAllDecls(@This());
 }
 
-test "easing-plot-{s}.png" {
+test "DOCIMG easing plots" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 300, .h = 400 } });
     defer t.deinit();
 

--- a/src/easing.zig
+++ b/src/easing.zig
@@ -229,12 +229,12 @@ test "easing-plot-{s}.png" {
     };
 
     try dvui.testing.settle(plot.frame);
-    try t.saveDocImage(@src(), .{"linear"}, plot.frame);
+    try t.saveDocImage(@src(), plot.frame, null, .{"linear"});
 
     inline for (@typeInfo(@This()).@"struct".decls) |decl| {
         if (comptime std.mem.startsWith(u8, decl.name, "in") or std.mem.startsWith(u8, decl.name, "out")) {
             plot.easing = @field(@This(), decl.name);
-            try t.saveDocImage(@src(), .{decl.name}, plot.frame);
+            try t.saveDocImage(@src(), plot.frame, null, .{decl.name});
         }
     }
 }

--- a/src/easing.zig
+++ b/src/easing.zig
@@ -229,12 +229,12 @@ test "easing-plot-{s}.png" {
     };
 
     try dvui.testing.settle(plot.frame);
-    try t.saveDocImage(@src(), plot.frame, null, .{"linear"});
+    try t.saveImage(plot.frame, null, "easing-plot-linear.png");
 
     inline for (@typeInfo(@This()).@"struct".decls) |decl| {
         if (comptime std.mem.startsWith(u8, decl.name, "in") or std.mem.startsWith(u8, decl.name, "out")) {
             plot.easing = @field(@This(), decl.name);
-            try t.saveDocImage(@src(), plot.frame, null, .{decl.name});
+            try t.saveImage(plot.frame, null, "easing-plot-" ++ decl.name ++ ".png");
         }
     }
 }

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -193,7 +193,8 @@ const png_extension = ".png";
 ///
 /// IMPORTANT: Snapshots are unstable and both backend and platform dependent. Changing any of these might fail the test.
 ///
-/// All snapshot tests can be ignored (without skipping the whole test) by setting the environment variable `DVUI_SNAPSHOT_IGNORE`
+/// All snapshot tests can be ignored (without skipping the whole test) by setting the environment variable `DVUI_SNAPSHOT_IGNORE`.
+/// This function will always run exactly one frame.
 ///
 /// Set the environment variable `DVUI_SNAPSHOT_WRITE` to create/overwrite the snapshot files
 ///
@@ -202,7 +203,10 @@ const png_extension = ".png";
 /// 2. Delete the snapshot directory
 /// 3. Run all snapshot tests with `DVUI_SNAPSHOT_WRITE` set to recreate only the used files
 pub fn snapshot(self: *Self, src: std.builtin.SourceLocation, frame: dvui.App.frameFunction) !void {
-    if (should_ignore_snapshots()) return;
+    if (should_ignore_snapshots()) {
+        _ = try step(frame);
+        return;
+    }
 
     defer self.snapshot_index += 1;
     const filename = try std.fmt.allocPrint(self.allocator, "{s}-{s}-{d}" ++ png_extension, .{ src.file, src.fn_name, self.snapshot_index });


### PR DESCRIPTION
There were some painpoints about the existing solution. Running `zig build test -Dbackend=sdl2 -Ddoc-image-dir=zig-out/docs -Dtest-filter=".png"` will still run the steps for other example files, which makes it take longer. It is also very inconvenient to type out all of these arguments when they will be the same every time you want to generate doc images.

Now running `zig build docs -Dgenerate-images` will run only the dvui modules test with the `.png` filter. It will also use the `docs/image_gen_test_runner.zig` which is needed for:
- Providing the output directory
  - It can get a cached directory by the build system, which allows for testing that no two tests generate an image with the same name.
- Ignoring error logs
  - Running the `Example-debbuging.png` test without this causes the test step to fail, failing the full build step.
- Making the doc testing comptime known, allowing for smaller/quicker test when not generating images.

It also didn't make much sense to me to have a `saveImage` function in `dvui.testing` and a runtime known directory. The `capturePng` function allows for the same functionality for users of dvui and a comptime known `saveDocImage` function is more explicit and more efficient.

Additionally, the `saveDocImage` function now always runs one frame. Before it didn't actually test the frame and could cause tests to have different outputs when not generating images because the frame count would change. This became apparent in the Rect tests where the new types didn't fail the tests when not generating images.

There also seems to be an issue with `Picture` and passing a rect to it. On my computer the `Example-demo.png` looks very wrong. I haven't been able to figure out why.
![Examples-demo](https://github.com/user-attachments/assets/a93cc385-1e0f-4882-8f9b-4068b567ceaf)
