### PR TITLE
`Color.fromHex` improvements

### DIFF
--- a/src/Color.zig
+++ b/src/Color.zig
@@ -172,10 +172,18 @@ pub fn alphaAverage(self: Color, other: Color) Color {
 
 pub const HexString = [7]u8;
 
+/// Returns a hex color string in the format "#rrggbb"
 pub fn toHexString(self: Color) !HexString {
-    var result: [7]u8 = .{0} ** 7;
+    var result: HexString = undefined;
     _ = try std.fmt.bufPrint(&result, "#{x:0>2}{x:0>2}{x:0>2}", .{ self.r, self.g, self.b });
     return result;
+}
+
+test toHexString {
+    try std.testing.expectEqual((Color{ .r = 0x1, .g = 0x2, .b = 0x3, .a = 0xFF }).toHexString(), "#010203".*);
+    try std.testing.expectEqual((Color{ .r = 0x1, .g = 0x2, .b = 0x3, .a = 0x4 }).toHexString(), "#010203".*);
+    try std.testing.expectEqual((Color{ .r = 0xa1, .g = 0xa2, .b = 0xa3, .a = 0xFF }).toHexString(), "#a1a2a3".*);
+    try std.testing.expectEqual((Color{ .r = 0xa1, .g = 0xa2, .b = 0xa3, .a = 0xa4 }).toHexString(), "#a1a2a3".*);
 }
 
 /// Converts hex color string to `Color`
@@ -210,6 +218,21 @@ pub fn fromHex(hex_color: []const u8) !Color {
         .b = @intCast((num >> step * (0 + offset)) & mask),
         .a = if (has_alpha) @intCast(num & mask) else 0xFF,
     };
+}
+
+test fromHex {
+    try std.testing.expectEqual(Color{ .r = 0x1, .g = 0x2, .b = 0x3, .a = 0xFF }, Color.fromHex("123"));
+    try std.testing.expectEqual(Color{ .r = 0x1, .g = 0x2, .b = 0x3, .a = 0xFF }, Color.fromHex("#123"));
+    try std.testing.expectEqual(Color{ .r = 0x1, .g = 0x2, .b = 0x3, .a = 0x4 }, Color.fromHex("1234"));
+    try std.testing.expectEqual(Color{ .r = 0x1, .g = 0x2, .b = 0x3, .a = 0x4 }, Color.fromHex("#1234"));
+    try std.testing.expectEqual(Color{ .r = 0xa1, .g = 0xa2, .b = 0xa3, .a = 0xFF }, Color.fromHex("a1a2a3"));
+    try std.testing.expectEqual(Color{ .r = 0xa1, .g = 0xa2, .b = 0xa3, .a = 0xFF }, Color.fromHex("#a1a2a3"));
+    try std.testing.expectEqual(Color{ .r = 0xa1, .g = 0xa2, .b = 0xa3, .a = 0xa4 }, Color.fromHex("a1a2a3a4"));
+    try std.testing.expectEqual(Color{ .r = 0xa1, .g = 0xa2, .b = 0xa3, .a = 0xa4 }, Color.fromHex("#a1a2a3a4"));
+    try std.testing.expectEqual(Color{ .r = 0xa1, .g = 0xa2, .b = 0xa3, .a = 0xFF }, Color.fromHex("A1A2A3"));
+    try std.testing.expectEqual(Color{ .r = 0xa1, .g = 0xa2, .b = 0xa3, .a = 0xFF }, Color.fromHex("#A1A2A3"));
+    try std.testing.expectEqual(Color{ .r = 0xa1, .g = 0xa2, .b = 0xa3, .a = 0xa4 }, Color.fromHex("A1A2A3A4"));
+    try std.testing.expectEqual(Color{ .r = 0xa1, .g = 0xa2, .b = 0xa3, .a = 0xa4 }, Color.fromHex("#A1A2A3A4"));
 }
 
 test {

--- a/src/Color.zig
+++ b/src/Color.zig
@@ -190,8 +190,9 @@ test toHexString {
 /// Converts hex color string to `Color`
 ///
 /// If `hex_color` is invalid, an error is logged and a default color is returned.
-///
 /// In comptime an invalid `hex_color` will cause a compile error.
+///
+/// See `tryFromHex` for a version that returns an error.
 ///
 /// Supports the following formats:
 /// - `#RGB`

--- a/src/Theme.zig
+++ b/src/Theme.zig
@@ -148,27 +148,27 @@ pub const QuickTheme = struct {
     font_name_title: []u8,
 
     // used for focus
-    color_focus: [7]u8 = "#638465".*,
+    color_focus: []const u8 = "#638465",
 
     // text/foreground color
-    color_text: [7]u8 = "$82a29f".*,
+    color_text: []const u8 = "#82a29f",
 
     // text/foreground color when widget is pressed
-    color_text_press: [7]u8 = "#971f81".*,
+    color_text_press: []const u8 = "#971f81",
 
     // background color for displaying lots of text
-    color_fill_text: [7]u8 = "#2c3332".*,
+    color_fill_text: []const u8 = "#2c3332",
 
     // background color for containers that have other widgets inside
-    color_fill_container: [7]u8 = "#2b3a3a".*,
+    color_fill_container: []const u8 = "#2b3a3a",
 
     // background color for controls like buttons
-    color_fill_control: [7]u8 = "#2c3334".*,
+    color_fill_control: []const u8 = "#2c3334",
 
-    color_fill_hover: [7]u8 = "#333e57".*,
-    color_fill_press: [7]u8 = "#3b6357".*,
+    color_fill_hover: []const u8 = "#333e57",
+    color_fill_press: []const u8 = "#3b6357",
 
-    color_border: [7]u8 = "#60827d".*,
+    color_border: []const u8 = "#60827d",
 
     pub const colorFieldNames = &.{
         "color_focus",
@@ -196,7 +196,7 @@ pub const QuickTheme = struct {
 
     pub fn toTheme(self: @This(), gpa: std.mem.Allocator) !Theme {
         const color_accent = try Color.fromHex(self.color_focus);
-        const color_err = try Color.fromHex("#ffaaaa".*);
+        const color_err = try Color.fromHex("#ffaaaa");
         const color_text = try Color.fromHex(self.color_text);
         const color_text_press = try Color.fromHex(self.color_text_press);
         const color_fill = try Color.fromHex(self.color_fill_text);

--- a/src/Theme.zig
+++ b/src/Theme.zig
@@ -195,16 +195,16 @@ pub const QuickTheme = struct {
     }
 
     pub fn toTheme(self: @This(), gpa: std.mem.Allocator) !Theme {
-        const color_accent = try Color.fromHex(self.color_focus);
-        const color_err = try Color.fromHex("#ffaaaa");
-        const color_text = try Color.fromHex(self.color_text);
-        const color_text_press = try Color.fromHex(self.color_text_press);
-        const color_fill = try Color.fromHex(self.color_fill_text);
-        const color_fill_window = try Color.fromHex(self.color_fill_container);
-        const color_fill_control = try Color.fromHex(self.color_fill_control);
-        const color_fill_hover = try Color.fromHex(self.color_fill_hover);
-        const color_fill_press = try Color.fromHex(self.color_fill_press);
-        const color_border = try Color.fromHex(self.color_border);
+        const color_accent = try Color.tryFromHex(self.color_focus);
+        const color_err = try Color.tryFromHex("#ffaaaa");
+        const color_text = try Color.tryFromHex(self.color_text);
+        const color_text_press = try Color.tryFromHex(self.color_text_press);
+        const color_fill = try Color.tryFromHex(self.color_fill_text);
+        const color_fill_window = try Color.tryFromHex(self.color_fill_container);
+        const color_fill_control = try Color.tryFromHex(self.color_fill_control);
+        const color_fill_hover = try Color.tryFromHex(self.color_fill_hover);
+        const color_fill_press = try Color.tryFromHex(self.color_fill_press);
+        const color_border = try Color.tryFromHex(self.color_border);
 
         return Theme{
             .name = try gpa.dupe(u8, self.name),


### PR DESCRIPTION
Relevant for #297

Makes the `Color.fromHex` accept more formats of hex colors and makes the function infallible. A `tryFromHex` function has been added for when you want to know if the string is invalid.

Magenta was used a the fallback color to indicate the error and `@inComptime()` used to give a compile error for invalid strings when possible, as suggested [here](https://github.com/david-vanderson/dvui/pull/297#issuecomment-2864320259).