### PR TITLE
Demo icon browser search bar

### DIFF
--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -48,6 +48,8 @@ pub const InitOptions = struct {
 
     /// If null, same as .internal = .{}
     text: ?TextOption = null,
+    /// Faded text shown when the textEntry is empty
+    placeholder: ?[]const u8 = null,
 
     break_lines: bool = false,
     scroll_vertical: ?bool = null, // default is value of multiline
@@ -145,6 +147,17 @@ pub fn install(self: *TextEntryWidget) !void {
     self.textLayout = TextLayoutWidget.init(@src(), .{ .break_lines = self.init_opts.break_lines, .touch_edit_just_focused = false }, self.wd.options.strip().override(.{ .expand = .both, .padding = self.padding }));
     try self.textLayout.install(.{ .focused = self.wd.id == dvui.focusedWidgetId(), .show_touch_draggables = (self.len > 0) });
     self.textClip = dvui.clipGet();
+
+    if (self.len == 0) {
+        if (self.init_opts.placeholder) |placeholder| {
+            try dvui.renderText(.{
+                .font = self.textLayout.wd.options.fontGet(),
+                .color = self.textLayout.wd.options.color(.text).transparent(0.75),
+                .rs = self.textLayout.wd.contentRectScale(),
+                .text = placeholder,
+            });
+        }
+    }
 
     if (try self.textLayout.touchEditing()) |floating_widget| {
         defer floating_widget.deinit();


### PR DESCRIPTION
This adds a search bar to the icon browser, making it easier to find what's available.

Additionally this PR adds placeholders to TestEntryWidget with an init option. This mimics the web `<input placeholder="...">` api. 

![{185FE77C-C3A3-4A2E-BA3F-A039B5AEB2B1}](https://github.com/user-attachments/assets/77526197-16c9-4c02-ba69-b7818b04ecd5)
![{34032E81-923A-4A3F-9C9B-4B4B04CEA79A}](https://github.com/user-attachments/assets/e88274ab-71ab-4ced-b364-69a97593369d)
