### PR TITLE
Named Colors

### DIFF
--- a/src/Color.zig
+++ b/src/Color.zig
@@ -10,9 +10,31 @@ g: u8 = 0xff,
 b: u8 = 0xff,
 a: u8 = 0xff,
 
-pub const white = Color{ .r = 0xff, .g = 0xff, .b = 0xff };
+// Basic web colors
+// https://en.wikipedia.org/wiki/Web_colors#Basic_colors
+pub const white = Color{ .r = 0xFF, .g = 0xFF, .b = 0xFF };
+pub const silver = Color{ .r = 0xC0, .g = 0xC0, .b = 0xC0 };
+pub const gray = Color{ .r = 0x80, .g = 0x80, .b = 0x80 };
 pub const black = Color{ .r = 0x00, .g = 0x00, .b = 0x00 };
-pub const magenta = Color{ .r = 0xFD, .g = 0x3D, .b = 0xB5 };
+pub const red = Color{ .r = 0xFF, .g = 0x00, .b = 0x00 };
+pub const maroon = Color{ .r = 0x80, .g = 0x00, .b = 0x00 };
+pub const yellow = Color{ .r = 0xFF, .g = 0xFF, .b = 0x00 };
+pub const olive = Color{ .r = 0x80, .g = 0x80, .b = 0x00 };
+pub const lime = Color{ .r = 0x00, .g = 0xFF, .b = 0x00 };
+pub const green = Color{ .r = 0x00, .g = 0x80, .b = 0x00 };
+pub const aqua = Color{ .r = 0x00, .g = 0xFF, .b = 0xFF };
+pub const teal = Color{ .r = 0x00, .g = 0x80, .b = 0x80 };
+pub const blue = Color{ .r = 0x00, .g = 0x00, .b = 0xFF };
+pub const navy = Color{ .r = 0x00, .g = 0x00, .b = 0x80 };
+pub const fuchsia = Color{ .r = 0xFF, .g = 0x00, .b = 0xFF };
+pub const purple = Color{ .r = 0x80, .g = 0x00, .b = 0x80 };
+
+// Aliases for basic colors that are already defined
+// https://en.wikipedia.org/wiki/Web_colors#Extended_colors
+pub const cyan = aqua;
+pub const magenta = fuchsia;
+pub const darl_cyan = teal;
+pub const dark_magenta = purple;
 
 /// Convert normal color to premultiplied alpha.
 pub fn alphaMultiply(self: @This()) @This() {
@@ -35,11 +57,11 @@ pub fn alphaMultiplyPixels(pixels: []u8) void {
 
 /// Returns brightness of the color as a value between 0 and 1
 pub fn brightness(self: @This()) f32 {
-    const red: f32 = @as(f32, @floatFromInt(self.r)) / 255.0;
-    const green: f32 = @as(f32, @floatFromInt(self.g)) / 255.0;
-    const blue: f32 = @as(f32, @floatFromInt(self.b)) / 255.0;
+    const r: f32 = @as(f32, @floatFromInt(self.r)) / 255.0;
+    const g: f32 = @as(f32, @floatFromInt(self.g)) / 255.0;
+    const b: f32 = @as(f32, @floatFromInt(self.b)) / 255.0;
 
-    return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
 
 /// Hue Saturation Lightness

--- a/src/Rect.zig
+++ b/src/Rect.zig
@@ -255,8 +255,8 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
 
                     var box = try dvui.box(@src(), .horizontal, .{ .background = true, .color_fill = .{ .name = .fill_window }, .expand = .both });
                     defer box.deinit();
-                    try Rect.Physical.cast(rect).stroke(.{}, 1, dvui.Color.black.transparent(0.5), .{ .closed = true });
-                    try Rect.Physical.cast(res).stroke(.{}, 1, .{ .r = 0xff, .g = 0, .b = 0 }, .{ .closed = true });
+                    try Rect.Physical.cast(rect).stroke(.{}, 1, .gray, .{ .closed = true });
+                    try Rect.Physical.cast(res).stroke(.{}, 1, .red, .{ .closed = true });
                     return .ok;
                 }
             }.frame;
@@ -284,8 +284,8 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
 
                     var box = try dvui.box(@src(), .horizontal, .{ .background = true, .color_fill = .{ .name = .fill_window }, .expand = .both });
                     defer box.deinit();
-                    try Rect.Physical.cast(rect).stroke(.{}, 1, dvui.Color.black.transparent(0.5), .{ .closed = true });
-                    try Rect.Physical.cast(res).stroke(.{}, 1, .{ .r = 0xff, .g = 0, .b = 0 }, .{ .closed = true });
+                    try Rect.Physical.cast(rect).stroke(.{}, 1, .gray, .{ .closed = true });
+                    try Rect.Physical.cast(res).stroke(.{}, 1, .red, .{ .closed = true });
                     return .ok;
                 }
             }.frame;
@@ -319,8 +319,8 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
 
                     var box = try dvui.box(@src(), .horizontal, .{ .background = true, .color_fill = .{ .name = .fill_window }, .expand = .both });
                     defer box.deinit();
-                    try Rect.Physical.cast(rect).stroke(.{}, 1, dvui.Color.black.transparent(0.5), .{ .closed = true });
-                    try Rect.Physical.cast(res).stroke(.{}, 1, .{ .r = 0xff, .g = 0, .b = 0 }, .{ .closed = true });
+                    try Rect.Physical.cast(rect).stroke(.{}, 1, .gray, .{ .closed = true });
+                    try Rect.Physical.cast(res).stroke(.{}, 1, .red, .{ .closed = true });
                     return .ok;
                 }
             }.frame;
@@ -352,9 +352,9 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
 
                     var box = try dvui.box(@src(), .horizontal, .{ .background = true, .color_fill = .{ .name = .fill_window }, .expand = .both });
                     defer box.deinit();
-                    try Rect.Physical.cast(a).stroke(.{}, 1, dvui.Color.black.transparent(0.5), .{ .closed = true });
-                    try Rect.Physical.cast(b).stroke(.{}, 1, dvui.Color.black.transparent(0.5), .{ .closed = true });
-                    try Rect.Physical.cast(ab).stroke(.{}, 1, .{ .r = 0xff, .g = 0, .b = 0 }, .{ .closed = true });
+                    try Rect.Physical.cast(a).stroke(.{}, 1, .gray, .{ .closed = true });
+                    try Rect.Physical.cast(b).stroke(.{}, 1, .gray, .{ .closed = true });
+                    try Rect.Physical.cast(ab).stroke(.{}, 1, .red, .{ .closed = true });
                     return .ok;
                 }
             }.frame;
@@ -386,9 +386,9 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
 
                     var box = try dvui.box(@src(), .horizontal, .{ .background = true, .color_fill = .{ .name = .fill_window }, .expand = .both });
                     defer box.deinit();
-                    try Rect.Physical.cast(a).stroke(.{}, 1, dvui.Color.black.transparent(0.5), .{ .closed = true });
-                    try Rect.Physical.cast(b).stroke(.{}, 1, dvui.Color.black.transparent(0.5), .{ .closed = true });
-                    try Rect.Physical.cast(ab).stroke(.{}, 1, .{ .r = 0xff, .g = 0, .b = 0 }, .{ .closed = true });
+                    try Rect.Physical.cast(a).stroke(.{}, 1, .gray, .{ .closed = true });
+                    try Rect.Physical.cast(b).stroke(.{}, 1, .gray, .{ .closed = true });
+                    try Rect.Physical.cast(ab).stroke(.{}, 1, .red, .{ .closed = true });
                     return .ok;
                 }
             }.frame;
@@ -415,8 +415,8 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
 
                     var box = try dvui.box(@src(), .horizontal, .{ .background = true, .color_fill = .{ .name = .fill_window }, .expand = .both });
                     defer box.deinit();
-                    try Rect.Physical.cast(rect).stroke(.{}, 1, dvui.Color.black.transparent(0.5), .{ .closed = true });
-                    try Rect.Physical.cast(res).stroke(.{}, 1, .{ .r = 0xff, .g = 0, .b = 0 }, .{ .closed = true });
+                    try Rect.Physical.cast(rect).stroke(.{}, 1, .gray, .{ .closed = true });
+                    try Rect.Physical.cast(res).stroke(.{}, 1, .red, .{ .closed = true });
                     return .ok;
                 }
             }.frame;
@@ -449,8 +449,8 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
 
                     var box = try dvui.box(@src(), .horizontal, .{ .background = true, .color_fill = .{ .name = .fill_window }, .expand = .both });
                     defer box.deinit();
-                    try Rect.Physical.cast(rect).stroke(.{}, 1, dvui.Color.black.transparent(0.5), .{ .closed = true });
-                    try Rect.Physical.cast(res).stroke(.{}, 1, .{ .r = 0xff, .g = 0, .b = 0 }, .{ .closed = true });
+                    try Rect.Physical.cast(rect).stroke(.{}, 1, .gray, .{ .closed = true });
+                    try Rect.Physical.cast(res).stroke(.{}, 1, .red, .{ .closed = true });
                     return .ok;
                 }
             }.frame;


### PR DESCRIPTION
This adds more named colors, finishing up #297.

As suggested by @kcbanner on the zig discord the [web basic colors](https://en.wikipedia.org/wiki/Web_colors#Basic_colors) was was used. In addition I added some aliases from the extended colors that are more commonly used, like "magenta" instead of "fuchsia".

These are mostly just intended for debugging or styling during development. Most application will want to use the theme colors and if needed create their own theme.