### PR TITLE
Event logging

### DIFF
--- a/src/Event.zig
+++ b/src/Event.zig
@@ -1,4 +1,5 @@
 const dvui = @import("dvui.zig");
+const std = @import("std");
 
 const enums = dvui.enums;
 
@@ -27,6 +28,17 @@ evt: union(enum) {
 // this helper at the end of processEvent().
 pub fn bubbleable(self: *const Event) bool {
     return (!self.handled and (self.evt != .mouse));
+}
+
+/// Mark the event as handled
+///
+/// In general, the `dvui.WidgetData` passed here should be the same one that
+/// matched this event, using `dvui.matchEvent` or similar.
+/// This makes it possible to see which widget handled the event.
+pub fn handle(self: *Event, src: std.builtin.SourceLocation, wd: *const dvui.WidgetData) void {
+    //dvui.log.debug("{s}:{d} {s} event (num {d}) handled by {s} ({x})", .{ src.file, src.line, @tagName(self.evt), self.num, wd.options.name orelse "???", wd.id });
+    _ = src;
+    self.handled_by = wd.id;
 }
 
 pub const Text = struct {

--- a/src/Event.zig
+++ b/src/Event.zig
@@ -5,6 +5,7 @@ const enums = dvui.enums;
 
 const Event = @This();
 
+/// Should not be set directly, use the `handle` method
 handled: bool = false,
 focus_windowId: ?u32 = null,
 focus_widgetId: ?u32 = null,
@@ -36,9 +37,10 @@ pub fn bubbleable(self: *const Event) bool {
 /// matched this event, using `dvui.matchEvent` or similar.
 /// This makes it possible to see which widget handled the event.
 pub fn handle(self: *Event, src: std.builtin.SourceLocation, wd: *const dvui.WidgetData) void {
-    //dvui.log.debug("{s}:{d} {s} event (num {d}) handled by {s} ({x})", .{ src.file, src.line, @tagName(self.evt), self.num, wd.options.name orelse "???", wd.id });
-    _ = src;
-    self.handled_by = wd.id;
+    if (dvui.currentWindow().debug_handled_event) {
+        dvui.log.debug("{s}:{d} {s} event (num {d}) handled by {s} ({x})", .{ src.file, src.line, @tagName(self.evt), self.num, wd.options.name orelse "???", wd.id });
+    }
+    self.handled = true;
 }
 
 pub const Text = struct {

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -2712,7 +2712,7 @@ pub fn scrollCanvas(comptime data: u8) !void {
                 switch (e.evt) {
                     .mouse => |me| {
                         if (me.action == .release and me.button.pointer()) {
-                            e.handled = true;
+                            e.handle(@src(), dragBox.data());
                             dvui.dragEnd();
                             dvui.refresh(null, @src(), dragBox.data().id);
 
@@ -2770,12 +2770,12 @@ pub fn scrollCanvas(comptime data: u8) !void {
                     switch (e.evt) {
                         .mouse => |me| {
                             if (me.action == .press and me.button.pointer()) {
-                                e.handled = true;
+                                e.handle(@src(), dragBox.data());
                                 dvui.captureMouse(dbox.data());
                                 dvui.dragPreStart(me.p, .{ .name = "box_transfer" });
                             } else if (me.action == .motion) {
                                 if (dvui.captured(dbox.data().id)) {
-                                    e.handled = true;
+                                    e.handle(@src(), dragBox.data());
                                     if (dvui.dragging(me.p)) |_| {
                                         // started the drag
                                         Data.drag_box_window = i;
@@ -2804,13 +2804,13 @@ pub fn scrollCanvas(comptime data: u8) !void {
             switch (e.evt) {
                 .mouse => |me| {
                     if (me.action == .press and me.button.pointer()) {
-                        e.handled = true;
+                        e.handle(@src(), dragBox.data());
                         dvui.captureMouse(dragBox.data());
                         const offset = me.p.diff(dragBox.data().rectScale().r.topLeft()); // pixel offset from dragBox corner
                         dvui.dragPreStart(me.p, .{ .offset = offset });
                     } else if (me.action == .release and me.button.pointer()) {
                         if (dvui.captured(dragBox.data().id)) {
-                            e.handled = true;
+                            e.handle(@src(), dragBox.data());
                             dvui.captureMouse(null);
                             dvui.dragEnd();
                         }
@@ -2855,23 +2855,23 @@ pub fn scrollCanvas(comptime data: u8) !void {
         switch (e.evt) {
             .mouse => |me| {
                 if (me.action == .press and me.button.pointer()) {
-                    e.handled = true;
+                    e.handle(@src(), scroll.scroll.data());
                     dvui.captureMouse(scroll.scroll.data());
                     dvui.dragPreStart(me.p, .{});
                 } else if (me.action == .release and me.button.pointer()) {
                     if (dvui.captured(scroll.scroll.data().id)) {
-                        e.handled = true;
+                        e.handle(@src(), scroll.scroll.data());
                         dvui.captureMouse(null);
                         dvui.dragEnd();
                     }
                 } else if (me.action == .motion) {
                     if (me.button.touch() and dragging_box) {
                         // eat touch motion events so they don't scroll
-                        e.handled = true;
+                        e.handle(@src(), scroll.scroll.data());
                     }
                     if (dvui.captured(scroll.scroll.data().id)) {
                         if (dvui.dragging(me.p)) |dps| {
-                            e.handled = true;
+                            e.handle(@src(), scroll.scroll.data());
                             const rs = scrollRectScale;
                             Data.scroll_info.viewport.x -= dps.x / rs.s;
                             Data.scroll_info.viewport.y -= dps.y / rs.s;
@@ -2879,7 +2879,7 @@ pub fn scrollCanvas(comptime data: u8) !void {
                         }
                     }
                 } else if (me.action == .wheel_y and ctrl_down) {
-                    e.handled = true;
+                    e.handle(@src(), scroll.scroll.data());
                     const base: f32 = 1.01;
                     const zs = @exp(@log(base) * me.action.wheel_y);
                     if (zs != 1.0) {
@@ -3771,7 +3771,7 @@ pub const StrokeTest = struct {
                 switch (me.action) {
                     .press => {
                         if (me.button == .left) {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             dragi = null;
 
                             for (points, 0..) |p, i| {
@@ -3796,13 +3796,13 @@ pub const StrokeTest = struct {
                     },
                     .release => {
                         if (me.button == .left) {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             dvui.captureMouse(null);
                             dvui.dragEnd();
                         }
                     },
                     .motion => {
-                        e.handled = true;
+                        e.handle(@src(), self.data());
                         if (dvui.dragging(me.p)) |dps| {
                             const dp = dps.scale(1 / rs.s, Point);
                             points[dragi.?].x += dp.x;
@@ -3811,7 +3811,7 @@ pub const StrokeTest = struct {
                         }
                     },
                     .wheel_y => |ticks| {
-                        e.handled = true;
+                        e.handle(@src(), self.data());
                         const base: f32 = 1.02;
                         const zs = @exp(@log(base) * ticks);
                         if (zs != 1.0) {

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1622,12 +1622,12 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
             }
         } else if (e.evt == .key) {
             if (e.evt.key.action == .down and e.evt.key.matchBind("next_widget")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 dvui.tabIndexNext(e.num);
             }
 
             if (e.evt.key.action == .down and e.evt.key.matchBind("prev_widget")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 dvui.tabIndexPrev(e.num);
             }
         }
@@ -1733,7 +1733,7 @@ pub fn processEvent(self: *Self, e: *Event, bubbling: bool) void {
     // window does cleanup events, but not normal events
     switch (e.evt) {
         .close_popup => |cp| {
-            e.handled = true;
+            e.handle(@src(), self.data());
             if (cp.intentional) {
                 // when a popup is closed due to a menu item being chosen,
                 // the window that spawned it (which had focus previously)

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -119,8 +119,10 @@ debug_under_mouse_esc_needed: bool = false,
 debug_under_mouse_quitting: bool = false,
 debug_under_mouse_info: []u8 = "",
 
-debug_refresh_mutex: std.Thread.Mutex,
+debug_toggle_mutex: std.Thread.Mutex,
 debug_refresh: bool = false,
+debug_handled_event: bool = false,
+debug_unhandled_events: bool = false,
 
 /// when true, left mouse button works like a finger
 debug_touch_simulate_events: bool = false,
@@ -203,7 +205,7 @@ pub fn init(
         .dialogs = std.ArrayList(Dialog).init(gpa),
         .toasts = std.ArrayList(Toast).init(gpa),
         .keybinds = std.StringHashMap(dvui.enums.Keybind).init(gpa),
-        .debug_refresh_mutex = std.Thread.Mutex{},
+        .debug_toggle_mutex = std.Thread.Mutex{},
         .wd = WidgetData{ .src = src, .id = hashval, .init_options = .{ .subwindow = true }, .options = .{ .name = "Window" } },
         .backend = backend_ctx,
         .font_bytes = try dvui.Font.initTTFBytesDatabase(gpa),
@@ -438,9 +440,35 @@ pub fn arena(self: *Self) std.mem.Allocator {
 }
 
 /// called from any thread
+pub fn debugHandleEvents(self: *Self, val: ?bool) bool {
+    self.debug_toggle_mutex.lock();
+    defer self.debug_toggle_mutex.unlock();
+
+    const previous = self.debug_handled_event;
+    if (val) |v| {
+        self.debug_handled_event = v;
+    }
+
+    return previous;
+}
+
+/// called from any thread
+pub fn debugUnhandledEvents(self: *Self, val: ?bool) bool {
+    self.debug_toggle_mutex.lock();
+    defer self.debug_toggle_mutex.unlock();
+
+    const previous = self.debug_unhandled_events;
+    if (val) |v| {
+        self.debug_unhandled_events = v;
+    }
+
+    return previous;
+}
+
+/// called from any thread
 pub fn debugRefresh(self: *Self, val: ?bool) bool {
-    self.debug_refresh_mutex.lock();
-    defer self.debug_refresh_mutex.unlock();
+    self.debug_toggle_mutex.lock();
+    defer self.debug_toggle_mutex.unlock();
 
     const previous = self.debug_refresh;
     if (val) |v| {
@@ -1528,9 +1556,17 @@ fn debugWindowShow(self: *Self) !void {
         duf = !duf;
     }
 
-    const logit = self.debugRefresh(null);
-    if (try dvui.button(@src(), if (logit) "Stop Refresh Logging" else "Start Refresh Logging", .{}, .{})) {
-        _ = self.debugRefresh(!logit);
+    const log_refresh = self.debugRefresh(null);
+    if (try dvui.button(@src(), if (log_refresh) "Stop Refresh Logging" else "Start Refresh Logging", .{}, .{})) {
+        _ = self.debugRefresh(!log_refresh);
+    }
+    const log_event_handled = self.debugHandleEvents(null);
+    if (try dvui.button(@src(), if (log_event_handled) "Stop Event Handled Logging" else "Start Event Handled Logging", .{}, .{})) {
+        _ = self.debugHandleEvents(!log_event_handled);
+    }
+    const log_event_unhandled = self.debugUnhandledEvents(null);
+    if (try dvui.button(@src(), if (log_event_unhandled) "Stop Unhandled Event Logging" else "Start Unhandled Event Logging", .{}, .{})) {
+        _ = self.debugUnhandledEvents(!log_event_unhandled);
     }
 
     var scroll = try dvui.scrollArea(@src(), .{}, .{ .expand = .both, .background = false });
@@ -1630,6 +1666,13 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
                 e.handle(@src(), self.data());
                 dvui.tabIndexPrev(e.num);
             }
+        }
+    }
+
+    if (self.debug_unhandled_events) {
+        for (evts) |*e| {
+            if (e.handled) continue;
+            log.debug("Unhandled {s} event (num {d})", .{ @tagName(e.evt), e.num });
         }
     }
 

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -121,17 +121,17 @@ pub fn processEvent(self: *ButtonWidget, e: *Event, bubbling: bool) void {
     switch (e.evt) {
         .mouse => |me| {
             if (me.action == .focus) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 dvui.focusWidget(self.wd.id, null, e.num);
             } else if (me.action == .press and me.button.pointer()) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 dvui.captureMouse(self.data());
 
                 // drag prestart is just for touch events
                 dvui.dragPreStart(me.p, .{});
             } else if (me.action == .release and me.button.pointer()) {
                 if (dvui.captured(self.wd.id)) {
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     dvui.captureMouse(null);
                     dvui.dragEnd();
                     if (self.data().borderRectScale().r.contains(me.p)) {
@@ -156,7 +156,7 @@ pub fn processEvent(self: *ButtonWidget, e: *Event, bubbling: bool) void {
         },
         .key => |ke| {
             if (ke.action == .down and ke.matchBind("activate")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 self.click = true;
                 dvui.refresh(null, @src(), self.wd.id);
             }

--- a/src/widgets/ContextWidget.zig
+++ b/src/widgets/ContextWidget.zig
@@ -98,9 +98,9 @@ pub fn processEvent(self: *ContextWidget, e: *Event, bubbling: bool) void {
                 // caught by the containing window cleanup and cause us
                 // to lose the focus we are about to get from the right
                 // press below
-                e.handled = true;
+                e.handle(@src(), self.data());
             } else if (me.action == .press and me.button == .right) {
-                e.handled = true;
+                e.handle(@src(), self.data());
 
                 dvui.focusWidget(self.wd.id, null, e.num);
                 self.focused = true;

--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -117,7 +117,7 @@ pub fn dropped(self: *DropdownWidget) !bool {
             if (e.evt == .mouse) {
                 if (e.evt.mouse.action == .release and e.evt.mouse.button.pointer()) {
                     if (eat_mouse_up) {
-                        e.handled = true;
+                        e.handle(@src(), drop.data());
                         eat_mouse_up = false;
                         dvui.dataSet(null, drop.wd.id, "_eat_mouse_up", eat_mouse_up);
                     }

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -233,18 +233,18 @@ pub fn deinit(self: *FloatingMenuWidget) void {
         if (e.evt == .mouse) {
             if (e.evt.mouse.action == .focus) {
                 // unhandled click, clear focus
-                e.handled = true;
+                e.handle(@src(), self.data());
                 dvui.focusWidget(null, null, null);
             }
         } else if (e.evt == .key) {
             // catch any tabs that weren't handled by widgets
             if (e.evt.key.action == .down and e.evt.key.matchBind("next_widget")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 dvui.tabIndexNext(e.num);
             }
 
             if (e.evt.key.action == .down and e.evt.key.matchBind("prev_widget")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 dvui.tabIndexPrev(e.num);
             }
         }

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -362,7 +362,7 @@ pub fn processEventsBefore(self: *FloatingWindowWidget) void {
                     const p = me.p.plus(dvui.dragOffset()).toNatural();
                     self.dragAdjust(p, dps.toNatural(), self.drag_part.?);
                     // don't need refresh() because we're before drawing
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     continue;
                 }
             }
@@ -370,7 +370,7 @@ pub fn processEventsBefore(self: *FloatingWindowWidget) void {
             if (me.action == .release and me.button.pointer() and dvui.captured(self.wd.id)) {
                 dvui.captureMouse(null); // stop drag and capture
                 dvui.dragEnd();
-                e.handled = true;
+                e.handle(@src(), self.data());
                 continue;
             }
 
@@ -380,14 +380,14 @@ pub fn processEventsBefore(self: *FloatingWindowWidget) void {
                     dvui.captureMouse(self.data());
                     self.drag_part = .bottom_right;
                     dvui.dragStart(me.p, .{ .cursor = .arrow_nw_se, .offset = .diff(rs.r.bottomRight(), me.p) });
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     continue;
                 }
             }
 
             if (me.action == .position) {
                 if (dragPart(me, rs) == .bottom_right) {
-                    e.handled = true; // don't want any widgets under this to see a hover
+                    e.handle(@src(), self.data()); // don't want any widgets under this to see a hover
                     dvui.cursorSet(.arrow_nw_se);
                     continue;
                 }
@@ -412,13 +412,13 @@ pub fn processEventsAfter(self: *FloatingWindowWidget) void {
             .mouse => |me| {
                 switch (me.action) {
                     .focus => {
-                        e.handled = true;
+                        e.handle(@src(), self.data());
                         // unhandled focus (clicked on nothing)
                         dvui.focusWidget(null, null, null);
                     },
                     .press => {
                         if (me.button.pointer()) {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             // capture and start drag
                             dvui.captureMouse(self.data());
                             self.drag_part = dragPart(me, rs);
@@ -427,7 +427,7 @@ pub fn processEventsAfter(self: *FloatingWindowWidget) void {
                     },
                     .release => {
                         if (me.button.pointer() and dvui.captured(self.wd.id)) {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             dvui.captureMouse(null); // stop drag and capture
                             dvui.dragEnd();
                         }
@@ -439,7 +439,7 @@ pub fn processEventsAfter(self: *FloatingWindowWidget) void {
                                 const p = me.p.plus(dvui.dragOffset()).toNatural();
                                 self.dragAdjust(p, dps.toNatural(), self.drag_part.?);
 
-                                e.handled = true;
+                                e.handle(@src(), self.data());
                                 dvui.refresh(null, @src(), self.wd.id);
                             }
                         }
@@ -453,12 +453,12 @@ pub fn processEventsAfter(self: *FloatingWindowWidget) void {
             .key => |ke| {
                 // catch any tabs that weren't handled by widgets
                 if (ke.action == .down and ke.matchBind("next_widget")) {
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     dvui.tabIndexNext(e.num);
                 }
 
                 if (ke.action == .down and ke.matchBind("prev_widget")) {
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     dvui.tabIndexPrev(e.num);
                 }
             },
@@ -510,7 +510,7 @@ pub fn processEvent(self: *FloatingWindowWidget, e: *Event, bubbling: bool) void
     // floating window doesn't process events normally
     switch (e.evt) {
         .close_popup => |cp| {
-            e.handled = true;
+            e.handle(@src(), self.data());
             if (cp.intentional) {
                 // when a popup is closed because the user chose to, the
                 // window that spawned it (which had focus previously)

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -157,7 +157,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event, bubbling: bool) void {
         .mouse => |me| {
             if (me.action == .focus) {
                 dvui.MenuWidget.current().?.mouse_mode = true;
-                e.handled = true;
+                e.handle(@src(), self.data());
                 dvui.focusWidget(self.wd.id, null, e.num);
             } else if (me.action == .press and me.button.pointer()) {
                 // This works differently than normal (like buttons) where we
@@ -167,7 +167,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event, bubbling: bool) void {
                 // pattern for touch.
                 //
                 // This is how dropdowns are triggered.
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (self.init_opts.submenu) {
                     dvui.MenuWidget.current().?.submenus_activated = true;
                     dvui.MenuWidget.current().?.submenus_in_child = true;
@@ -181,7 +181,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event, bubbling: bool) void {
                 }
             } else if (me.action == .release) {
                 dvui.MenuWidget.current().?.mouse_mode = true;
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (!self.init_opts.submenu and (self.wd.id == dvui.focusedWidgetIdInCurrentSubwindow())) {
                     self.activated = true;
                     dvui.refresh(null, @src(), self.wd.id);
@@ -227,7 +227,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event, bubbling: bool) void {
         .key => |ke| {
             if (ke.action == .down and ke.matchBind("activate")) {
                 dvui.MenuWidget.current().?.mouse_mode = false;
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (self.init_opts.submenu) {
                     dvui.MenuWidget.current().?.submenus_activated = true;
                 } else {
@@ -237,13 +237,13 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event, bubbling: bool) void {
             } else if (ke.code == .right and ke.action == .down) {
                 if (self.init_opts.submenu and dvui.MenuWidget.current().?.init_opts.dir == .vertical) {
                     dvui.MenuWidget.current().?.mouse_mode = false;
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     dvui.MenuWidget.current().?.submenus_activated = true;
                 }
             } else if (ke.code == .down and ke.action == .down) {
                 if (self.init_opts.submenu and dvui.MenuWidget.current().?.init_opts.dir == .horizontal) {
                     dvui.MenuWidget.current().?.mouse_mode = false;
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     dvui.MenuWidget.current().?.submenus_activated = true;
                 }
             }

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -142,7 +142,7 @@ pub fn processEvent(self: *MenuWidget, e: *Event, bubbling: bool) void {
                             // there is an existing submenu and motion is
                             // towards the popup, so eat this event to
                             // prevent any menu items from focusing
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                         }
                     }
 
@@ -157,14 +157,14 @@ pub fn processEvent(self: *MenuWidget, e: *Event, bubbling: bool) void {
                 switch (ke.code) {
                     .escape => {
                         self.mouse_mode = false;
-                        e.handled = true;
+                        e.handle(@src(), self.data());
                         var closeE = Event{ .evt = .{ .close_popup = .{} } };
                         self.processEvent(&closeE, true);
                     },
                     .up => {
                         self.mouse_mode = false;
                         if (self.init_opts.dir == .vertical) {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             // TODO: don't do this if focus would move outside the menu
                             dvui.tabIndexPrev(e.num);
                         }
@@ -172,7 +172,7 @@ pub fn processEvent(self: *MenuWidget, e: *Event, bubbling: bool) void {
                     .down => {
                         self.mouse_mode = false;
                         if (self.init_opts.dir == .vertical) {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             // TODO: don't do this if focus would move outside the menu
                             dvui.tabIndexNext(e.num);
                         }
@@ -180,7 +180,7 @@ pub fn processEvent(self: *MenuWidget, e: *Event, bubbling: bool) void {
                     .left => {
                         self.mouse_mode = false;
                         if (self.init_opts.dir == .vertical) {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             if (self.parentMenu) |pm| {
                                 pm.submenus_activated = false;
                                 if (self.parentSubwindowId) |sid| {
@@ -188,7 +188,7 @@ pub fn processEvent(self: *MenuWidget, e: *Event, bubbling: bool) void {
                                 }
                             }
                         } else {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             // TODO: don't do this if focus would move outside the menu
                             dvui.tabIndexPrev(e.num);
                         }
@@ -196,7 +196,7 @@ pub fn processEvent(self: *MenuWidget, e: *Event, bubbling: bool) void {
                     .right => {
                         self.mouse_mode = false;
                         if (self.init_opts.dir == .horizontal) {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             // TODO: don't do this if focus would move outside the menu
                             dvui.tabIndexNext(e.num);
                         }

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -259,17 +259,17 @@ pub fn processEvent(self: *PanedWidget, e: *Event, bubbling: bool) void {
         if (dvui.captured(self.wd.id) or @abs(mouse - target) < (5 * rs.s)) {
             self.hovered = true;
             if (e.evt.mouse.action == .press and e.evt.mouse.button.pointer()) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 // capture and start drag
                 dvui.captureMouse(self.data());
                 dvui.dragPreStart(e.evt.mouse.p, .{ .cursor = cursor });
             } else if (e.evt.mouse.action == .release and e.evt.mouse.button.pointer()) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 // stop possible drag and capture
                 dvui.captureMouse(null);
                 dvui.dragEnd();
             } else if (e.evt.mouse.action == .motion and dvui.captured(self.wd.id)) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 // move if dragging
                 if (dvui.dragging(e.evt.mouse.p)) |dps| {
                     _ = dps;

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -166,14 +166,14 @@ pub fn draggable(src: std.builtin.SourceLocation, init_opts: draggableInitOption
         switch (e.evt) {
             .mouse => |me| {
                 if (me.action == .press and me.button.pointer()) {
-                    e.handled = true;
+                    e.handle(@src(), iw.data());
                     dvui.captureMouse(iw.data());
                     const reo_top_left: ?dvui.Point.Physical = if (init_opts.reorderable) |reo| reo.wd.rectScale().r.topLeft() else null;
                     const top_left: ?dvui.Point.Physical = init_opts.top_left orelse reo_top_left;
                     dvui.dragPreStart(me.p, .{ .offset = (top_left orelse iw.wd.rectScale().r.topLeft()).diff(me.p) });
                 } else if (me.action == .motion) {
                     if (dvui.captured(iw.wd.id)) {
-                        e.handled = true;
+                        e.handle(@src(), iw.data());
                         if (dvui.dragging(me.p)) |_| {
                             ret = me.p;
                             if (init_opts.reorderable) |reo| {

--- a/src/widgets/ScaleWidget.zig
+++ b/src/widgets/ScaleWidget.zig
@@ -89,7 +89,7 @@ pub fn processEvent(self: *ScaleWidget, e: *Event, bubbling: bool) void {
                 self.touchPoints[idx] = e.evt.mouse.p;
                 if (self.touchPoints[1 - idx] != null) {
                     // both fingers down, grab capture
-                    e.handled = true;
+                    e.handle(@src(), self.data());
 
                     // end any drag that might have been happening
                     dvui.dragEnd();
@@ -99,13 +99,13 @@ pub fn processEvent(self: *ScaleWidget, e: *Event, bubbling: bool) void {
             .release => {
                 self.touchPoints[idx] = null;
                 if (dvui.captured(self.wd.id)) {
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     dvui.captureMouse(null);
                 }
             },
             .motion => {
                 if (self.touchPoints[0] != null and self.touchPoints[1] != null) {
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     var dx: f32 = undefined;
                     var dy: f32 = undefined;
 

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -89,13 +89,13 @@ pub fn processEvents(self: *ScrollBarWidget, grabrs: Rect.Physical) void {
                 switch (me.action) {
                     .focus => {
                         if (self.focus_id) |fid| {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             dvui.focusWidget(fid, null, e.num);
                         }
                     },
                     .press => {
                         if (me.button.pointer()) {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             if (grabrs.contains(me.p)) {
                                 // capture and start drag
                                 dvui.captureMouse(self.data());
@@ -118,7 +118,7 @@ pub fn processEvents(self: *ScrollBarWidget, grabrs: Rect.Physical) void {
                     },
                     .release => {
                         if (me.button.pointer()) {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             // stop possible drag and capture
                             dvui.captureMouse(null);
                             dvui.dragEnd();
@@ -126,7 +126,7 @@ pub fn processEvents(self: *ScrollBarWidget, grabrs: Rect.Physical) void {
                     },
                     .motion => {
                         if (dvui.captured(self.data().id)) {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             // move if dragging
                             if (dvui.dragging(me.p)) |dps| {
                                 _ = dps;
@@ -157,7 +157,7 @@ pub fn processEvents(self: *ScrollBarWidget, grabrs: Rect.Physical) void {
                     },
                     .wheel_x => |ticks| {
                         if (self.dir == .horizontal) {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             self.si.scrollByOffset(self.dir, ticks);
                             dvui.refresh(null, @src(), self.wd.id);
                         }
@@ -165,7 +165,7 @@ pub fn processEvents(self: *ScrollBarWidget, grabrs: Rect.Physical) void {
                     .wheel_y => |ticks| {
                         // Don't care about the direction, because "normal" wheel on
                         // horizontal scrollBar seems still natural to be scrolled
-                        e.handled = true;
+                        e.handle(@src(), self.data());
                         self.si.scrollByOffset(self.dir, -ticks);
                         dvui.refresh(null, @src(), self.wd.id);
                     },

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -281,7 +281,7 @@ pub fn processEvent(self: *ScrollContainerWidget, e: *Event, bubbling: bool) voi
                 if (self.si.velocity.x != 0 or self.si.velocity.y != 0) {
                     // if we were scrolling, then eat the finger press so it
                     // doesn't do anything other than stop the scroll
-                    e.handled = true;
+                    e.handle(@src(), self.data());
 
                     self.si.velocity.x = 0;
                     self.si.velocity.y = 0;
@@ -291,42 +291,42 @@ pub fn processEvent(self: *ScrollContainerWidget, e: *Event, bubbling: bool) voi
         .key => |ke| {
             if (bubbling or (self.wd.id == dvui.focusedWidgetId())) {
                 if (ke.code == .up and (ke.action == .down or ke.action == .repeat)) {
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     if (self.si.vertical != .none) {
                         self.si.scrollByOffset(.vertical, -10);
                     }
                     dvui.refresh(null, @src(), self.wd.id);
                 } else if (ke.code == .down and (ke.action == .down or ke.action == .repeat)) {
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     if (self.si.vertical != .none) {
                         self.si.scrollByOffset(.vertical, 10);
                     }
                     dvui.refresh(null, @src(), self.wd.id);
                 } else if (ke.code == .left and (ke.action == .down or ke.action == .repeat)) {
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     if (self.si.horizontal != .none) {
                         self.si.scrollByOffset(.horizontal, -10);
                     }
                     dvui.refresh(null, @src(), self.wd.id);
                 } else if (ke.code == .right and (ke.action == .down or ke.action == .repeat)) {
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     if (self.si.horizontal != .none) {
                         self.si.scrollByOffset(.horizontal, 10);
                     }
                     dvui.refresh(null, @src(), self.wd.id);
                 } else if (ke.code == .page_up and (ke.action == .down or ke.action == .repeat)) {
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     self.si.scrollPageUp(.vertical);
                     dvui.refresh(null, @src(), self.wd.id);
                 } else if (ke.code == .page_down and (ke.action == .down or ke.action == .repeat)) {
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     self.si.scrollPageDown(.vertical);
                     dvui.refresh(null, @src(), self.wd.id);
                 }
             }
         },
         .scroll_drag => |sd| {
-            e.handled = true;
+            e.handle(@src(), self.data());
             const rs = self.wd.contentRectScale();
             var scrolly: f32 = 0;
             if (sd.mouse_pt.y <= rs.r.y and // want to scroll up
@@ -376,7 +376,7 @@ pub fn processEvent(self: *ScrollContainerWidget, e: *Event, bubbling: bool) voi
             self.seen_scroll_drag = true;
         },
         .scroll_to => |st| {
-            e.handled = true;
+            e.handle(@src(), self.data());
             const rs = self.wd.contentRectScale();
 
             if (self.si.vertical != .none) {
@@ -431,7 +431,7 @@ pub fn processEvent(self: *ScrollContainerWidget, e: *Event, bubbling: bool) voi
 }
 
 pub fn processMotionScrollEvent(self: *ScrollContainerWidget, e: *dvui.Event, motion: dvui.Point.Physical) void {
-    e.handled = true;
+    e.handle(@src(), self.data());
 
     const rs = self.wd.borderRectScale();
 
@@ -477,7 +477,7 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
         switch (e.evt) {
             .mouse => |me| {
                 if (me.action == .focus) {
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     // focus so that we can receive keyboard input
                     dvui.focusWidget(self.wd.id, null, e.num);
                 } else if (me.action == .wheel_x) {
@@ -485,7 +485,7 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
                         if ((me.action.wheel_x < 0 and self.si.viewport.x <= 0) or (me.action.wheel_x > 0 and self.si.viewport.x >= self.si.scrollMax(.horizontal))) {
                             // propagate the scroll event because we are already maxxed out
                         } else {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             self.si.scrollByOffset(.horizontal, me.action.wheel_x);
                             dvui.refresh(null, @src(), self.wd.id);
                         }
@@ -500,7 +500,7 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
                         if ((me.action.wheel_y > 0 and self.si.viewport.y <= 0) or (me.action.wheel_y < 0 and self.si.viewport.y >= self.si.scrollMax(.vertical))) {
                             // try horizontal or propagate the scroll event because we are already maxxed out
                         } else {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             self.si.scrollByOffset(.vertical, -me.action.wheel_y);
                             dvui.refresh(null, @src(), self.wd.id);
                         }
@@ -508,7 +508,7 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
                         if ((me.action.wheel_y > 0 and self.si.viewport.x <= 0) or (me.action.wheel_y < 0 and self.si.viewport.x >= self.si.scrollMax(.horizontal))) {
                             // propagate the scroll event because we are already maxxed out
                         } else {
-                            e.handled = true;
+                            e.handle(@src(), self.data());
                             self.si.scrollByOffset(.horizontal, -me.action.wheel_y);
                             dvui.refresh(null, @src(), self.wd.id);
                         }
@@ -516,10 +516,10 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
                 } else if (me.action == .press and me.button.touch()) {
                     // don't let this event go through to floating window
                     // which would capture the mouse preventing scrolling
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     dvui.captureMouse(self.data());
                 } else if (me.action == .release and dvui.captured(self.wd.id)) {
-                    e.handled = true;
+                    e.handle(@src(), self.data());
                     dvui.captureMouse(null);
                     dvui.dragEnd();
                 } else if (me.action == .motion and me.button.touch()) {

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -510,45 +510,45 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
     switch (e.evt) {
         .key => |ke| blk: {
             if (ke.action == .down and ke.matchBind("next_widget")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 dvui.tabIndexNext(e.num);
                 break :blk;
             }
 
             if (ke.action == .down and ke.matchBind("prev_widget")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 dvui.tabIndexPrev(e.num);
                 break :blk;
             }
 
             if (ke.action == .down and ke.matchBind("paste")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 self.paste();
                 break :blk;
             }
 
             if (ke.action == .down and ke.matchBind("cut")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 self.cut();
                 break :blk;
             }
 
             if (ke.action == .down and ke.matchBind("text_start")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 self.textLayout.selection.moveCursor(0, false);
                 self.textLayout.scroll_to_cursor = true;
                 break :blk;
             }
 
             if (ke.action == .down and ke.matchBind("text_end")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 self.textLayout.selection.moveCursor(std.math.maxInt(usize), false);
                 self.textLayout.scroll_to_cursor = true;
                 break :blk;
             }
 
             if (ke.action == .down and ke.matchBind("line_start")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (self.textLayout.sel_move == .none) {
                     self.textLayout.sel_move = .{ .expand_pt = .{ .select = false, .which = .home } };
                 }
@@ -556,7 +556,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
             }
 
             if (ke.action == .down and ke.matchBind("line_end")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (self.textLayout.sel_move == .none) {
                     self.textLayout.sel_move = .{ .expand_pt = .{ .select = false, .which = .end } };
                 }
@@ -564,7 +564,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
             }
 
             if ((ke.action == .down or ke.action == .repeat) and ke.matchBind("word_left")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (!self.textLayout.selection.empty()) {
                     self.textLayout.selection.moveCursor(self.textLayout.selection.start, false);
                 } else {
@@ -579,7 +579,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
             }
 
             if ((ke.action == .down or ke.action == .repeat) and ke.matchBind("word_right")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (!self.textLayout.selection.empty()) {
                     self.textLayout.selection.moveCursor(self.textLayout.selection.end, false);
                     self.textLayout.selection.affinity = .before;
@@ -595,7 +595,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
             }
 
             if ((ke.action == .down or ke.action == .repeat) and ke.matchBind("char_left")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (!self.textLayout.selection.empty()) {
                     self.textLayout.selection.moveCursor(self.textLayout.selection.start, false);
                 } else {
@@ -610,7 +610,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
             }
 
             if ((ke.action == .down or ke.action == .repeat) and ke.matchBind("char_right")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (!self.textLayout.selection.empty()) {
                     self.textLayout.selection.moveCursor(self.textLayout.selection.end, false);
                     self.textLayout.selection.affinity = .before;
@@ -626,7 +626,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
             }
 
             if ((ke.action == .down or ke.action == .repeat) and ke.matchBind("char_up")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (self.textLayout.sel_move == .none) {
                     self.textLayout.sel_move = .{ .cursor_updown = .{ .select = false } };
                 }
@@ -637,7 +637,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
             }
 
             if ((ke.action == .down or ke.action == .repeat) and ke.matchBind("char_down")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (self.textLayout.sel_move == .none) {
                     self.textLayout.sel_move = .{ .cursor_updown = .{ .select = false } };
                 }
@@ -650,7 +650,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
             switch (ke.code) {
                 .backspace => {
                     if (ke.action == .down or ke.action == .repeat) {
-                        e.handled = true;
+                        e.handle(@src(), self.data());
                         var sel = self.textLayout.selectionGet(self.len);
                         if (!sel.empty()) {
                             // just delete selection
@@ -707,7 +707,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
                 },
                 .delete => {
                     if (ke.action == .down or ke.action == .repeat) {
-                        e.handled = true;
+                        e.handle(@src(), self.data());
                         var sel = self.textLayout.selectionGet(self.len);
                         if (!sel.empty()) {
                             // just delete selection
@@ -760,7 +760,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
                 },
                 .enter => {
                     if (ke.action == .down or ke.action == .repeat) {
-                        e.handled = true;
+                        e.handle(@src(), self.data());
                         if (self.init_opts.multiline) {
                             self.textTyped("\n", false);
                         } else {
@@ -773,7 +773,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
             }
         },
         .text => |te| {
-            e.handled = true;
+            e.handle(@src(), self.data());
             var new = std.mem.sliceTo(te.txt, 0);
             if (self.init_opts.multiline) {
                 self.textTyped(new, te.selected);
@@ -792,7 +792,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event, bubbling: bool) void {
         },
         .mouse => |me| {
             if (me.action == .focus) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 dvui.focusWidget(self.wd.id, null, e.num);
             }
         },

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -1521,11 +1521,11 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event, bubbling: bool) void {
     switch (e.evt) {
         .mouse => |me| {
             if (me.action == .focus) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 // focus so that we can receive keyboard input
                 dvui.focusWidget(self.wd.id, null, e.num);
             } else if (me.action == .press and me.button.pointer()) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 // capture and start drag
                 dvui.captureMouse(self.data());
                 dvui.dragPreStart(me.p, .{ .cursor = .ibeam });
@@ -1553,7 +1553,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event, bubbling: bool) void {
                     }
                 }
             } else if (me.action == .release and me.button.pointer()) {
-                e.handled = true;
+                e.handle(@src(), self.data());
 
                 if (dvui.captured(self.wd.id)) {
                     if (!self.touch_editing and dvui.dragging(me.p) == null) {
@@ -1603,7 +1603,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event, bubbling: bool) void {
                 if (dvui.dragging(me.p)) |_| {
                     self.click_num = 0;
                     if (!me.button.touch()) {
-                        e.handled = true;
+                        e.handle(@src(), self.data());
                         if (self.sel_move == .mouse) {
                             self.sel_move.mouse.drag_pt = self.wd.contentRectScale().pointFromPhysical(me.p);
                         } else if (self.sel_move == .expand_pt) {
@@ -1631,21 +1631,21 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event, bubbling: bool) void {
         },
         .key => |ke| blk: {
             if (ke.action == .down and ke.matchBind("text_start_select")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 self.selection.moveCursor(0, true);
                 self.scroll_to_cursor = true;
                 break :blk;
             }
 
             if (ke.action == .down and ke.matchBind("text_end_select")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 self.selection.moveCursor(std.math.maxInt(usize), true);
                 self.scroll_to_cursor = true;
                 break :blk;
             }
 
             if (ke.action == .down and ke.matchBind("line_start_select")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (self.sel_move == .none) {
                     self.sel_move = .{ .expand_pt = .{ .which = .home } };
                 }
@@ -1653,7 +1653,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event, bubbling: bool) void {
             }
 
             if (ke.action == .down and ke.matchBind("line_end_select")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (self.sel_move == .none) {
                     self.sel_move = .{ .expand_pt = .{ .which = .end } };
                 }
@@ -1661,7 +1661,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event, bubbling: bool) void {
             }
 
             if ((ke.action == .down or ke.action == .repeat) and ke.matchBind("word_left_select")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (self.sel_move == .none) {
                     self.sel_move = .{ .word_left_right = .{} };
                 }
@@ -1672,7 +1672,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event, bubbling: bool) void {
             }
 
             if ((ke.action == .down or ke.action == .repeat) and ke.matchBind("word_right_select")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (self.sel_move == .none) {
                     self.sel_move = .{ .word_left_right = .{} };
                 }
@@ -1683,7 +1683,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event, bubbling: bool) void {
             }
 
             if ((ke.action == .down or ke.action == .repeat) and ke.matchBind("char_left_select")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (self.sel_move == .none) {
                     self.sel_move = .{ .char_left_right = .{} };
                 }
@@ -1694,7 +1694,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event, bubbling: bool) void {
             }
 
             if ((ke.action == .down or ke.action == .repeat) and ke.matchBind("char_right_select")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (self.sel_move == .none) {
                     self.sel_move = .{ .char_left_right = .{} };
                 }
@@ -1705,7 +1705,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event, bubbling: bool) void {
             }
 
             if ((ke.action == .down or ke.action == .repeat) and ke.matchBind("char_up_select")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (self.sel_move == .none) {
                     self.sel_move = .{ .cursor_updown = .{} };
                 }
@@ -1716,7 +1716,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event, bubbling: bool) void {
             }
 
             if ((ke.action == .down or ke.action == .repeat) and ke.matchBind("char_down_select")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 if (self.sel_move == .none) {
                     self.sel_move = .{ .cursor_updown = .{} };
                 }
@@ -1727,13 +1727,13 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event, bubbling: bool) void {
             }
 
             if (ke.action == .down and ke.matchBind("copy")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 self.copy();
                 break :blk;
             }
 
             if (ke.action == .down and ke.matchBind("select_all")) {
-                e.handled = true;
+                e.handle(@src(), self.data());
                 self.selection.selectAll();
                 break :blk;
             }


### PR DESCRIPTION
Closes #201

This does not change `Event.handled` to `handled_by: ?u32` as suggested. Instead the method `handle` was added, which takes a source location like `dvui.refresh`. It also takes a `WidgetData` to log the name and id of the widget that handled the event.

The logging added enables most of the insights that would be available through storing the id on the event. This means that no users are required to change any existing code, but can choose to refactor to it.

Maybe there is a use case for knowing the id of the event handler during the frame, but I couldn't think of one.

<details>

<summary>Sample log output</summary>

```bash
debug(dvui): widgets\FloatingWindowWidget.zig:365 mouse event (num 1) handled by FloatingWindow (de234b64)
debug(dvui): widgets\FloatingWindowWidget.zig:365 mouse event (num 1) handled by FloatingWindow (de234b64)
debug(dvui): widgets\FloatingWindowWidget.zig:365 mouse event (num 1) handled by FloatingWindow (de234b64)
debug(dvui): widgets\FloatingWindowWidget.zig:373 mouse event (num 2) handled by FloatingWindow (de234b64)
debug(dvui): widgets\ButtonWidget.zig:124 mouse event (num 1) handled by Button (5de52e53)
debug(dvui): widgets\ButtonWidget.zig:127 mouse event (num 2) handled by Button (5de52e53)
debug(dvui): widgets\ButtonWidget.zig:134 mouse event (num 1) handled by Button (5de52e53)
debug(dvui): widgets\ScrollContainerWidget.zig:379 scroll_to event (num 0) handled by ScrollContainer (c781ec6b)
debug(dvui): widgets\ButtonWidget.zig:124 mouse event (num 1) handled by Radio (6cdadda3)
debug(dvui): widgets\ButtonWidget.zig:127 mouse event (num 2) handled by Radio (6cdadda3)
debug(dvui): widgets\ButtonWidget.zig:134 mouse event (num 1) handled by Radio (6cdadda3)
debug(dvui): widgets\ButtonWidget.zig:124 mouse event (num 1) handled by Radio (f797e82)
debug(dvui): widgets\ButtonWidget.zig:127 mouse event (num 2) handled by Radio (f797e82)
debug(dvui): widgets\ButtonWidget.zig:134 mouse event (num 1) handled by Radio (f797e82)
debug(dvui): widgets\ButtonWidget.zig:124 mouse event (num 1) handled by Button (dcf9facf)
debug(dvui): widgets\ButtonWidget.zig:127 mouse event (num 2) handled by Button (dcf9facf)
debug(dvui): widgets\ButtonWidget.zig:134 mouse event (num 1) handled by Button (dcf9facf)
```

</details>