### PR TITLE
Color picker

### DIFF
--- a/src/Color.zig
+++ b/src/Color.zig
@@ -387,6 +387,7 @@ pub const FromHexError = std.fmt.ParseIntError || error{
 /// - `RRGGBB`
 /// - `RRGGBBAA`
 pub fn tryFromHex(hex_color: []const u8) FromHexError!Color {
+    if (hex_color.len == 0) return error.InvalidHexStringLength;
     const hex = if (hex_color[0] == '#') hex_color[1..] else hex_color;
 
     const is_nibble_size, const has_alpha = switch (hex.len) {

--- a/src/Color.zig
+++ b/src/Color.zig
@@ -402,22 +402,23 @@ pub fn tryFromHex(hex_color: []const u8) FromHexError!Color {
         std.fmt.ParseIntError.InvalidCharacter => |e| return e,
     };
 
+    const mult: u32 = if (is_nibble_size) 0x10 else 1;
     const mask: u32 = if (is_nibble_size) 0xf else 0xff;
     const step: u5 = if (is_nibble_size) 4 else 8;
     const offset: u5 = @intFromBool(has_alpha);
     return .{
-        .r = @intCast((num >> step * (2 + offset)) & mask),
-        .g = @intCast((num >> step * (1 + offset)) & mask),
-        .b = @intCast((num >> step * (0 + offset)) & mask),
-        .a = if (has_alpha) @intCast(num & mask) else 0xff,
+        .r = @intCast(mult * ((num >> step * (2 + offset)) & mask)),
+        .g = @intCast(mult * ((num >> step * (1 + offset)) & mask)),
+        .b = @intCast(mult * ((num >> step * (0 + offset)) & mask)),
+        .a = if (has_alpha) @intCast(mult * (num & mask)) else 0xff,
     };
 }
 
 test tryFromHex {
-    try std.testing.expectEqual(Color{ .r = 0x1, .g = 0x2, .b = 0x3, .a = 0xff }, Color.tryFromHex("123"));
-    try std.testing.expectEqual(Color{ .r = 0x1, .g = 0x2, .b = 0x3, .a = 0xff }, Color.tryFromHex("#123"));
-    try std.testing.expectEqual(Color{ .r = 0x1, .g = 0x2, .b = 0x3, .a = 0x4 }, Color.tryFromHex("1234"));
-    try std.testing.expectEqual(Color{ .r = 0x1, .g = 0x2, .b = 0x3, .a = 0x4 }, Color.tryFromHex("#1234"));
+    try std.testing.expectEqual(Color{ .r = 0x10, .g = 0x20, .b = 0x30, .a = 0xff }, Color.tryFromHex("123"));
+    try std.testing.expectEqual(Color{ .r = 0x10, .g = 0x20, .b = 0x30, .a = 0xff }, Color.tryFromHex("#123"));
+    try std.testing.expectEqual(Color{ .r = 0x10, .g = 0x20, .b = 0x30, .a = 0x40 }, Color.tryFromHex("1234"));
+    try std.testing.expectEqual(Color{ .r = 0x10, .g = 0x20, .b = 0x30, .a = 0x40 }, Color.tryFromHex("#1234"));
     try std.testing.expectEqual(Color{ .r = 0xa1, .g = 0xa2, .b = 0xa3, .a = 0xff }, Color.tryFromHex("a1a2a3"));
     try std.testing.expectEqual(Color{ .r = 0xa1, .g = 0xa2, .b = 0xa3, .a = 0xff }, Color.tryFromHex("#a1a2a3"));
     try std.testing.expectEqual(Color{ .r = 0xa1, .g = 0xa2, .b = 0xa3, .a = 0xa4 }, Color.tryFromHex("a1a2a3a4"));

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -1467,7 +1467,9 @@ pub fn styling() !void {
 
 // Let's wrap the sliderEntry widget so we have 3 that represent a Color
 pub fn rgbSliders(src: std.builtin.SourceLocation, color: *dvui.Color, opts: Options) !bool {
-    var hbox = try dvui.box(src, .horizontal, opts);
+    var hbox = dvui.BoxWidget.init(src, .horizontal, true, opts);
+    try hbox.install();
+    try hbox.drawBackground();
     defer hbox.deinit();
 
     var red: f32 = @floatFromInt(color.r);
@@ -1494,7 +1496,9 @@ pub fn rgbSliders(src: std.builtin.SourceLocation, color: *dvui.Color, opts: Opt
 
 // Let's wrap the sliderEntry widget so we have 3 that represent a HSLuv Color
 pub fn hsluvSliders(src: std.builtin.SourceLocation, hsluv: *dvui.Color.HSLuv, opts: Options) !bool {
-    var hbox = try dvui.box(src, .horizontal, opts);
+    var hbox = dvui.BoxWidget.init(src, .horizontal, true, opts);
+    try hbox.install();
+    try hbox.drawBackground();
     defer hbox.deinit();
 
     var changed = false;

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -1345,10 +1345,15 @@ pub fn styling() !void {
 
     try dvui.label(@src(), "directly set colors", .{}, .{});
     {
-        var hbox = try dvui.box(@src(), .horizontal, .{});
-        defer hbox.deinit();
+        var picker = dvui.ColorPickerWidget.init(@src(), .{ .hsv = &hsv_color, .dir = .horizontal }, .{ .corner_radius = .all(30) });
+        try picker.install();
+        defer picker.deinit();
+        if (picker.color_changed) {
+            backbox_color = hsv_color.toColor();
+            hsluv_hsl = .fromColor(backbox_color);
+        }
 
-        var backbox = try dvui.box(@src(), .horizontal, .{ .min_size_content = .{ .w = 60, .h = 40 }, .background = true, .color_fill = .{ .color = backbox_color }, .gravity_y = 0.5 });
+        var backbox = try dvui.box(@src(), .horizontal, .{ .min_size_content = .{ .w = 40, .h = 40 }, .corner_radius = .all(200), .background = true, .color_fill = .{ .color = backbox_color } });
         backbox.deinit();
 
         var vbox = try dvui.box(@src(), .vertical, .{});
@@ -1369,16 +1374,6 @@ pub fn styling() !void {
                 backbox_color = hsluv_hsl.color();
                 hsv_color = .fromColor(backbox_color);
             }
-        }
-    }
-
-    if (try dvui.expander(@src(), "Color picker", .{}, .{ .expand = .horizontal })) {
-        var picker = dvui.ColorPickerWidget.init(@src(), .{ .hsv = &hsv_color }, .{});
-        try picker.install();
-        defer picker.deinit();
-        if (picker.color_changed) {
-            backbox_color = hsv_color.toColor();
-            hsluv_hsl = .fromColor(backbox_color);
         }
     }
 

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -1345,7 +1345,7 @@ pub fn styling() !void {
 
     try dvui.label(@src(), "directly set colors", .{}, .{});
     {
-        var picker = dvui.ColorPickerWidget.init(@src(), .{ .hsv = &hsv_color, .dir = .horizontal }, .{ .corner_radius = .all(30) });
+        var picker = dvui.ColorPickerWidget.init(@src(), .{ .hsv = &hsv_color, .dir = .horizontal }, .{ .expand = .horizontal });
         try picker.install();
         defer picker.deinit();
         if (picker.color_changed) {
@@ -1353,33 +1353,36 @@ pub fn styling() !void {
             hsluv_hsl = .fromColor(backbox_color);
         }
 
-        var backbox = try dvui.box(@src(), .horizontal, .{ .min_size_content = .{ .w = 40, .h = 40 }, .corner_radius = .all(200), .background = true, .color_fill = .{ .color = backbox_color } });
-        backbox.deinit();
-
-        var vbox = try dvui.box(@src(), .vertical, .{});
-        defer vbox.deinit();
-
         {
-            var hbox2 = try dvui.box(@src(), .horizontal, .{});
-            defer hbox2.deinit();
-            if (try rgbSliders(@src(), &backbox_color, .{ .gravity_y = 0.5 })) {
+            var vbox = try dvui.box(@src(), .vertical, .{ .min_size_content = .width(130), .max_size_content = .width(130) });
+            defer vbox.deinit();
+
+            var backbox = try dvui.box(@src(), .horizontal, .{ .min_size_content = .{ .h = 40 }, .expand = .horizontal, .background = true, .color_fill = .{ .color = backbox_color } });
+            backbox.deinit();
+
+            if (try dvui.sliderEntry(@src(), "A: {d:0.2}", .{ .value = &hsv_color.a, .min = 0, .max = 1, .interval = 0.01 }, .{ .expand = .horizontal })) {
+                backbox_color = hsv_color.toColor();
+                hsluv_hsl = .fromColor(backbox_color);
+            }
+
+            const res = try dvui.textEntryColor(@src(), .{ .value = &backbox_color }, .{ .expand = .horizontal });
+            if (res.changed) {
                 hsluv_hsl = .fromColor(backbox_color);
                 hsv_color = .fromColor(backbox_color);
             }
         }
         {
-            var hbox2 = try dvui.box(@src(), .horizontal, .{});
-            defer hbox2.deinit();
+            var vbox = try dvui.box(@src(), .vertical, .{});
+            defer vbox.deinit();
+
+            if (try rgbSliders(@src(), &backbox_color, .{ .gravity_y = 0.5 })) {
+                hsluv_hsl = .fromColor(backbox_color);
+                hsv_color = .fromColor(backbox_color);
+            }
             if (try hsluvSliders(@src(), &hsluv_hsl, .{ .gravity_y = 0.5 })) {
                 backbox_color = hsluv_hsl.color();
                 hsv_color = .fromColor(backbox_color);
             }
-        }
-
-        const res = try dvui.textEntryColor(@src(), .{ .value = &backbox_color }, .{});
-        if (res.changed) {
-            hsluv_hsl = .fromColor(backbox_color);
-            hsv_color = .fromColor(backbox_color);
         }
     }
 

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -1470,9 +1470,7 @@ pub fn styling() !void {
 
 // Let's wrap the sliderEntry widget so we have 3 that represent a Color
 pub fn rgbSliders(src: std.builtin.SourceLocation, color: *dvui.Color, opts: Options) !bool {
-    var hbox = dvui.BoxWidget.init(src, .horizontal, true, opts);
-    try hbox.install();
-    try hbox.drawBackground();
+    var hbox = try dvui.boxEqual(src, .horizontal, opts);
     defer hbox.deinit();
 
     var red: f32 = @floatFromInt(color.r);
@@ -1499,9 +1497,7 @@ pub fn rgbSliders(src: std.builtin.SourceLocation, color: *dvui.Color, opts: Opt
 
 // Let's wrap the sliderEntry widget so we have 3 that represent a HSLuv Color
 pub fn hsluvSliders(src: std.builtin.SourceLocation, hsluv: *dvui.Color.HSLuv, opts: Options) !bool {
-    var hbox = dvui.BoxWidget.init(src, .horizontal, true, opts);
-    try hbox.install();
-    try hbox.drawBackground();
+    var hbox = try dvui.boxEqual(src, .horizontal, opts);
     defer hbox.deinit();
 
     var changed = false;

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -64,7 +64,8 @@ var show_dialog: bool = false;
 var scale_val: f32 = 1.0;
 var line_height_factor: f32 = 1.2;
 var backbox_color: dvui.Color = .black;
-var hsluv_hsl: dvui.Color.HSLuv = .{ .l = 50 };
+var hsluv_hsl: dvui.Color.HSLuv = .fromColor(.black);
+var hsv_color: dvui.Color.HSV = .fromColor(.black);
 var animating_window_show: bool = false;
 var animating_window_closing: bool = false;
 var animating_window_rect = Rect{ .x = 100, .y = 100, .w = 300, .h = 200 };
@@ -1358,6 +1359,7 @@ pub fn styling() !void {
             defer hbox2.deinit();
             if (try rgbSliders(@src(), &backbox_color, .{ .gravity_y = 0.5 })) {
                 hsluv_hsl = .fromColor(backbox_color);
+                hsv_color = .fromColor(backbox_color);
             }
         }
         {
@@ -1365,17 +1367,18 @@ pub fn styling() !void {
             defer hbox2.deinit();
             if (try hsluvSliders(@src(), &hsluv_hsl, .{ .gravity_y = 0.5 })) {
                 backbox_color = hsluv_hsl.color();
+                hsv_color = .fromColor(backbox_color);
             }
         }
     }
 
     if (try dvui.expander(@src(), "Color picker", .{}, .{ .expand = .horizontal })) {
-        var hsv = dvui.Color.HSV.fromColor(backbox_color);
-        var picker = dvui.ColorPickerWidget.init(@src(), .{ .hsv = &hsv }, .{});
+        var picker = dvui.ColorPickerWidget.init(@src(), .{ .hsv = &hsv_color }, .{});
         try picker.install();
         defer picker.deinit();
         if (picker.color_changed) {
-            backbox_color = hsv.toColor();
+            backbox_color = hsv_color.toColor();
+            hsluv_hsl = .fromColor(backbox_color);
         }
     }
 

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -1375,6 +1375,12 @@ pub fn styling() !void {
                 hsv_color = .fromColor(backbox_color);
             }
         }
+
+        const res = try dvui.textEntryColor(@src(), .{ .value = &backbox_color }, .{});
+        if (res.changed) {
+            hsluv_hsl = .fromColor(backbox_color);
+            hsv_color = .fromColor(backbox_color);
+        }
     }
 
     {

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -1369,6 +1369,16 @@ pub fn styling() !void {
         }
     }
 
+    if (try dvui.expander(@src(), "Color picker", .{}, .{ .expand = .horizontal })) {
+        var hsv = dvui.Color.HSV.fromColor(backbox_color);
+        var picker = dvui.ColorPickerWidget.init(@src(), .{ .hsv = &hsv }, .{});
+        try picker.install();
+        defer picker.deinit();
+        if (picker.color_changed) {
+            backbox_color = hsv.toColor();
+        }
+    }
+
     {
         var hbox = try dvui.box(@src(), .horizontal, .{});
         defer hbox.deinit();

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -106,6 +106,13 @@ pub const Expand = enum {
     pub fn isVertical(self: Expand) bool {
         return (self == .vertical or self == .both);
     }
+
+    pub fn fromDirection(dir: dvui.enums.Direction) Expand {
+        return switch (dir) {
+            .horizontal => .horizontal,
+            .vertical => .vertical,
+        };
+    }
 };
 
 pub const Gravity = struct {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -53,6 +53,7 @@ pub const widgets = @import("import_widgets.zig");
 pub const AnimateWidget = widgets.AnimateWidget;
 pub const BoxWidget = widgets.BoxWidget;
 pub const CacheWidget = widgets.CacheWidget;
+pub const ColorPickerWidget = widgets.ColorPickerWidget;
 pub const FlexBoxWidget = widgets.FlexBoxWidget;
 pub const ReorderWidget = widgets.ReorderWidget;
 pub const Reorderable = ReorderWidget.Reorderable;

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -321,6 +321,13 @@ pub const Key = enum {
 pub const Direction = enum {
     horizontal,
     vertical,
+
+    pub fn invert(self: Direction) Direction {
+        return switch (self) {
+            .horizontal => .vertical,
+            .vertical => .horizontal,
+        };
+    }
 };
 
 pub const DialogResponse = enum(u8) {

--- a/src/import_widgets.zig
+++ b/src/import_widgets.zig
@@ -10,6 +10,7 @@ pub const AnimateWidget = @import("widgets/AnimateWidget.zig");
 pub const BoxWidget = @import("widgets/BoxWidget.zig");
 pub const ButtonWidget = @import("widgets/ButtonWidget.zig");
 pub const CacheWidget = @import("widgets/CacheWidget.zig");
+pub const ColorPickerWidget = @import("widgets/ColorPickerWidget.zig");
 pub const ContextWidget = @import("widgets/ContextWidget.zig");
 pub const DropdownWidget = @import("widgets/DropdownWidget.zig");
 pub const FlexBoxWidget = @import("widgets/FlexBoxWidget.zig");

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -66,7 +66,6 @@ pub fn valueSaturationBox(src: std.builtin.SourceLocation, hsv: *Color.HSV, opts
     }
 
     const rs = b.data().contentRectScale();
-    const size = rs.r.size();
 
     try dvui.renderTexture(try getValueSaturationTexture(hsv.h), rs, .{
         .corner_radius = options.corner_radiusGet(),
@@ -104,9 +103,8 @@ pub fn valueSaturationBox(src: std.builtin.SourceLocation, hsv: *Color.HSV, opts
                 }
 
                 if (p) |pp| {
-                    const relative = pp.diff(rs.r.topLeft());
-                    hsv.s = std.math.clamp(relative.x / size.w, 0, 1);
-                    hsv.v = std.math.clamp(1 - relative.y / size.h, 0, 1);
+                    hsv.s = std.math.clamp((pp.x - rs.r.x) / rs.r.w, 0, 1);
+                    hsv.v = std.math.clamp(1 - (pp.y - rs.r.y) / rs.r.h, 0, 1);
                     changed = true;
                 }
             },
@@ -143,7 +141,8 @@ pub fn valueSaturationBox(src: std.builtin.SourceLocation, hsv: *Color.HSV, opts
         }
     }
 
-    const current_point: dvui.Point = .{ .x = size.w * hsv.s, .y = size.h * (1 - hsv.v) };
+    const br = b.data().contentRect();
+    const current_point: dvui.Point = .{ .x = br.w * hsv.s, .y = br.h * (1 - hsv.v) };
 
     var indicator = dvui.BoxWidget.init(@src(), .horizontal, false, .{
         .rect = dvui.Rect.fromPoint(current_point).toSize(.all(10)).offsetNeg(.all(5)),

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -1,0 +1,118 @@
+pub const ColorPickerWidget = @This();
+
+id: u32,
+opts: dvui.Options,
+init_opts: InitOptions,
+color_changed: bool = false,
+
+pub const InitOptions = struct {
+    hsv: *Color.HSV,
+};
+
+pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) ColorPickerWidget {
+    const defaults = Options{
+        .name = "ColorPicker",
+    };
+    const self = ColorPickerWidget{
+        .id = dvui.parentGet().extendId(src, opts.idExtra()),
+        .opts = defaults.override(opts),
+        .init_opts = init_opts,
+    };
+    return self;
+}
+
+pub fn install(self: *ColorPickerWidget) !void {
+    var box = try dvui.box(@src(), .horizontal, self.opts);
+    defer box.deinit();
+
+    if (try valueSaturationBox(@src(), self.init_opts.hsv, .{})) {
+        self.color_changed = true;
+    }
+}
+
+pub fn deinit(_: *ColorPickerWidget) void {}
+
+/// Returns true if the color was changed
+pub fn valueSaturationBox(src: std.builtin.SourceLocation, hsv: *Color.HSV, opts: Options) !bool {
+    const defaults = Options{
+        .name = "ValueSaturationBox",
+        .expand = .ratio,
+        .min_size_content = .all(100),
+        .border = .all(1),
+        .padding = .all(5),
+    };
+
+    var box = try dvui.box(src, .horizontal, defaults.override(opts));
+    defer box.deinit();
+
+    const rs = box.data().contentRectScale();
+    const size = rs.r.size();
+
+    var vertexes = [_]dvui.Vertex{
+        .{ .pos = rs.r.topLeft(), .col = .white, .uv = .{ 0.25, 0.25 } },
+        .{ .pos = rs.r.bottomLeft(), .col = .white, .uv = .{ 0.25, 0.75 } },
+        .{ .pos = rs.r.bottomRight(), .col = .white, .uv = .{ 0.75, 0.75 } },
+        .{ .pos = rs.r.topRight(), .col = .white, .uv = .{ 0.75, 0.25 } },
+    };
+    var indices = [_]u16{ 0, 1, 2, 2, 3, 0 };
+
+    const triangles = dvui.Triangles{
+        .vertexes = vertexes[0..],
+        .indices = indices[0..],
+        .bounds = rs.r,
+    };
+
+    var pixels = Color.white.toRGBA() ** 2 ++ Color.black.toRGBA() ** 2;
+    comptime std.debug.assert(pixels.len == 2 * 2 * 4);
+    // set top right corner to the max value of that hue
+    @memcpy(pixels[4..8], &Color.HSV.toColor(.{ .h = hsv.h }).toRGBA());
+
+    const tex = dvui.textureCreate(&pixels, 2, 2, .linear);
+    // FIXME: Cache texture until hue changes, potentially modify existing texture
+    dvui.textureDestroyLater(tex);
+
+    try dvui.renderTriangles(triangles, tex);
+
+    var changed = false;
+    for (dvui.events()) |*e| {
+        if (!dvui.eventMatchSimple(e, box.data())) {
+            continue;
+        }
+
+        if (e.evt == .mouse) {
+            switch (e.evt.mouse.action) {
+                .press => {
+                    e.handle(@src(), box.data());
+                    const relative = e.evt.mouse.p.diff(rs.r.topLeft());
+                    hsv.s = std.math.clamp(relative.x / size.w, 0, 1);
+                    hsv.v = std.math.clamp(1 - relative.y / size.h, 0, 1);
+                    changed = true;
+                },
+                else => {},
+            }
+        }
+    }
+
+    const current_point: dvui.Point = .{ .x = size.w * hsv.s, .y = size.h * (1 - hsv.v) };
+
+    var indicator = dvui.BoxWidget.init(@src(), .horizontal, false, .{
+        .rect = dvui.Rect.fromPoint(current_point).toSize(.all(10)).offsetNeg(.all(5)),
+        .padding = .{},
+        .margin = .{},
+        .background = true,
+        .border = .all(1),
+        .corner_radius = .all(100),
+        .color_fill = .fromColor(hsv.toColor()),
+    });
+    try indicator.install();
+    try indicator.drawBackground();
+    indicator.deinit();
+
+    return changed;
+}
+
+const Options = dvui.Options;
+const Color = dvui.Color;
+
+const std = @import("std");
+const dvui = @import("../dvui.zig");

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -352,7 +352,7 @@ test {
 }
 
 test "DOCIMG ColorPickerWidget" {
-    var t = try dvui.testing.init(.{ .window_size = .{ .w = 250, .h = 200 } });
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 300, .h = 130 } });
     defer t.deinit();
 
     const frame = struct {
@@ -361,9 +361,7 @@ test "DOCIMG ColorPickerWidget" {
             defer box.deinit();
 
             var hsv: dvui.Color.HSV = .{ .h = 120, .s = 0.8, .v = 0.9 };
-            var picker = ColorPickerWidget.init(@src(), .{ .hsv = &hsv }, .{ .expand = .vertical, .gravity_x = 0.5 });
-            try picker.install();
-            defer picker.deinit();
+            _ = try dvui.colorPicker(@src(), .{ .hsv = &hsv }, .{ .gravity_x = 0.5, .gravity_y = 0.5 });
             return .ok;
         }
     }.frame;

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -38,7 +38,7 @@ pub fn install(self: *ColorPickerWidget) !void {
         self.color_changed = true;
     }
 
-    if (try hue_slider(@src(), self.init_opts.dir.invert(), &self.init_opts.hsv.h, .{ .expand = .fromDirection(self.init_opts.dir.invert()) })) {
+    if (try hueSlider(@src(), self.init_opts.dir.invert(), &self.init_opts.hsv.h, .{ .expand = .fromDirection(self.init_opts.dir.invert()) })) {
         self.color_changed = true;
     }
 }
@@ -68,7 +68,7 @@ pub fn valueSaturationBox(src: std.builtin.SourceLocation, hsv: *Color.HSV, opts
     const rs = b.data().contentRectScale();
     const size = rs.r.size();
 
-    try dvui.renderTexture(try get_value_saturation_texture(hsv.h), rs, .{
+    try dvui.renderTexture(try getValueSaturationTexture(hsv.h), rs, .{
         .corner_radius = options.corner_radiusGet(),
         .uv = .{ .x = 0.25, .y = 0.25, .w = 0.75, .h = 0.75 },
     });
@@ -173,7 +173,7 @@ pub var hue_slider_defaults: Options = .{
 /// Returns true if the hue was changed
 ///
 /// `hue` >= 0 and `hue` < 360
-pub fn hue_slider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hue: *f32, opts: Options) !bool {
+pub fn hueSlider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hue: *f32, opts: Options) !bool {
     var fraction = std.math.clamp(hue.* / 360, 0, 1);
     std.debug.assert(fraction >= 0);
     std.debug.assert(fraction <= 1);
@@ -267,7 +267,7 @@ pub fn hue_slider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hu
     }
 
     const uv_offset = comptime 0.5 / @as(f32, @floatFromInt(hue_selector_colors.len));
-    try dvui.renderTexture(try get_hue_selector_texture(dir), trackrs, .{
+    try dvui.renderTexture(try getHueSelectorTexture(dir), trackrs, .{
         .corner_radius = options.corner_radiusGet(),
         .uv = .{
             .x = uv_offset,
@@ -301,7 +301,7 @@ pub fn hue_slider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hu
     return ret;
 }
 
-pub fn get_hue_selector_texture(dir: dvui.enums.Direction) !dvui.Texture {
+pub fn getHueSelectorTexture(dir: dvui.enums.Direction) !dvui.Texture {
     const hue_texture_id = dvui.hashIdKey(@intFromEnum(dir), "hue_selector_texture");
     const res = try dvui.currentWindow().texture_cache.getOrPut(hue_texture_id);
     res.value_ptr.used = true;
@@ -316,7 +316,7 @@ pub fn get_hue_selector_texture(dir: dvui.enums.Direction) !dvui.Texture {
     return res.value_ptr.texture;
 }
 
-pub fn get_value_saturation_texture(hue: f32) !dvui.Texture {
+pub fn getValueSaturationTexture(hue: f32) !dvui.Texture {
     const hue_texture_id = dvui.hashIdKey(@intFromFloat(hue * 10000), "value_saturation_texture");
     const res = try dvui.currentWindow().texture_cache.getOrPut(hue_texture_id);
     res.value_ptr.used = true;

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -7,7 +7,7 @@
 
 pub const ColorPickerWidget = @This();
 
-id: u32,
+src: std.builtin.SourceLocation,
 opts: dvui.Options,
 init_opts: InitOptions,
 color_changed: bool = false,
@@ -24,7 +24,7 @@ pub var defaults = Options{
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) ColorPickerWidget {
     const self = ColorPickerWidget{
-        .id = dvui.parentGet().extendId(src, opts.idExtra()),
+        .src = src,
         .opts = defaults.override(opts),
         .init_opts = init_opts,
     };
@@ -32,7 +32,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *ColorPickerWidget) !void {
-    self.box = try dvui.box(@src(), self.init_opts.dir, self.opts);
+    self.box = try dvui.box(self.src, self.init_opts.dir, self.opts);
 
     if (try valueSaturationBox(@src(), self.init_opts.hsv, .{})) {
         self.color_changed = true;

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -260,22 +260,15 @@ pub fn hue_slider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hu
     }
 
     const uv_offset = comptime 0.5 / @as(f32, @floatFromInt(hue_selector_colors.len));
-    var vertexes = [_]dvui.Vertex{
-        .{ .pos = trackrs.r.topLeft(), .col = .white, .uv = @splat(uv_offset) },
-        .{ .pos = trackrs.r.bottomLeft(), .col = .white, .uv = @splat(if (dir == .horizontal) uv_offset else 1 - uv_offset) },
-        .{ .pos = trackrs.r.bottomRight(), .col = .white, .uv = @splat(1 - uv_offset) },
-        .{ .pos = trackrs.r.topRight(), .col = .white, .uv = @splat(if (dir == .vertical) uv_offset else 1 - uv_offset) },
-    };
-    var indices = [_]u16{ 0, 1, 2, 2, 3, 0 };
-    const triangles = dvui.Triangles{
-        .vertexes = vertexes[0..],
-        .indices = indices[0..],
-        .bounds = trackrs.r,
-    };
-
-    try dvui.renderTriangles(triangles, try get_hue_selector_texture(dir));
-
-    // try dvui.renderTexture(try get_hue_selector_texture(dir), b.data().contentRectScale(), .{});
+    try dvui.renderTexture(try get_hue_selector_texture(dir), trackrs, .{
+        .corner_radius = options.corner_radiusGet(),
+        .uv = .{
+            .x = uv_offset,
+            .y = if (dir == .vertical) uv_offset else 1 - uv_offset,
+            .w = 1 - uv_offset,
+            .h = if (dir == .horizontal) uv_offset else 1 - uv_offset,
+        },
+    });
 
     const knobRect = dvui.Rect.fromPoint(switch (dir) {
         .horizontal => .{ .x = (br.w - knobsize.w) * fraction },
@@ -303,8 +296,7 @@ pub fn hue_slider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hu
 
 pub fn get_hue_selector_texture(dir: dvui.enums.Direction) !dvui.Texture {
     const hue_texture_id = dvui.hashIdKey(@intFromEnum(dir), "hue_selector_texture");
-    const cw = dvui.currentWindow();
-    const res = try cw.texture_cache.getOrPut(hue_texture_id);
+    const res = try dvui.currentWindow().texture_cache.getOrPut(hue_texture_id);
     res.value_ptr.used = true;
     if (!res.found_existing) {
         const width: u32, const height: u32 = switch (dir) {

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -1,3 +1,10 @@
+//! ![color-picker](ColorPickerWidget.png)
+//!
+//! A widget that handles the basic color picker square and acompanying hue slider.
+//!
+//! This widget does not include any sliders or input fields for
+//! the individual color values.
+
 pub const ColorPickerWidget = @This();
 
 id: u32,
@@ -343,4 +350,25 @@ const dvui = @import("../dvui.zig");
 
 test {
     std.testing.refAllDecls(@This());
+}
+
+test "DOCIMG ColorPickerWidget" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 250, .h = 200 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var box = try dvui.box(@src(), .vertical, .{ .expand = .both, .background = true, .color_fill = .fill_window });
+            defer box.deinit();
+
+            var hsv: dvui.Color.HSV = .{ .h = 120, .s = 0.8, .v = 0.9 };
+            var picker = ColorPickerWidget.init(@src(), .{ .hsv = &hsv }, .{ .expand = .vertical, .gravity_x = 0.5 });
+            try picker.install();
+            defer picker.deinit();
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "ColorPickerWidget.png");
 }


### PR DESCRIPTION
Closes #78

![ColorPickerWidget](https://github.com/user-attachments/assets/e273296b-3395-4b22-8cf7-7613029c0f76)

This adds a HSV based color picker, mostly inspired by [photoshops color picker (see fig 16b)](https://en.wikipedia.org/wiki/HSL_and_HSV#Use_in_end-user_software). It uses two small 4 and 7 pixel textured and the builtin texture interpolation to make the colored rectangles. They are generated on demand with most of the pixel data being comptime known. 

Additionally this also adds `textEntryColor` which makes use of `Color.tryFromHex` to create a hex color input field. This was not needed for the color picker, but allows for the creation of a fairly complete color picker.

![Examples-styling](https://github.com/user-attachments/assets/9c673389-edcd-4660-8f2b-8aca12b43a0b)

Perhaps there should be a minimal version of the color picker in the image above available as `dvui.colorPicker`? I'd be happy to add it before merging this
