### PR TITLE
add resize observer to dvui web backend

### DIFF
--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -1132,6 +1132,12 @@ class Dvui {
         window.addEventListener("resize", (ev) => {
             requestRender();
         });
+        if (this.gl.canvas instanceof HTMLCanvasElement) {
+            const resizeObserver = new ResizeObserver(() => {
+                requestRender();
+            });
+            resizeObserver.observe(this.gl.canvas);
+        }
         this.gl.canvas.addEventListener("mousemove", (ev) => {
             let rect = this.gl.canvas.getBoundingClientRect();
             let x = (ev.clientX - rect.left) / (rect.right - rect.left) *


### PR DESCRIPTION
this prevents a "stretching" effect until rerender when resizing a DVUI canvas somewhere, such as using it embedded in other HTML/web content.

fixes #307