### PR TITLE
Path refactor

### DIFF
--- a/src/Color.zig
+++ b/src/Color.zig
@@ -36,6 +36,8 @@ pub const magenta = fuchsia;
 pub const darl_cyan = teal;
 pub const dark_magenta = purple;
 
+pub const transparent = Color{ .r = 0, .g = 0, .b = 0, .a = 0 };
+
 /// Convert normal color to premultiplied alpha.
 pub fn alphaMultiply(self: @This()) @This() {
     var c = self;
@@ -240,12 +242,14 @@ pub fn fromHSLuv(h: f32, s: f32, l: f32, a: f32) Color {
     };
 }
 
-pub fn transparent(x: Color, y: f32) Color {
+/// Multiply the current opacity with `mult`, usually between 0 and 1
+pub fn opacity(self: Color, mult: f32) Color {
+    if (mult > 1) return self;
     return Color{
-        .r = x.r,
-        .g = x.g,
-        .b = x.b,
-        .a = @as(u8, @intFromFloat(@as(f32, @floatFromInt(x.a)) * y)),
+        .r = self.r,
+        .g = self.g,
+        .b = self.b,
+        .a = @intFromFloat(std.math.clamp(@as(f32, @floatFromInt(self.a)) * mult, 0, 255)),
     };
 }
 

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -1432,7 +1432,7 @@ pub fn styling() !void {
             var triangles = try dvui.pathFillConvexTriangles(path.items, .{ .center = rs.r.center() });
 
             const ca0 = backbox_color.alphaMultiply();
-            const ca1 = backbox_color.transparent(0).alphaMultiply();
+            const ca1 = backbox_color.opacity(0).alphaMultiply();
 
             switch (gradient.*) {
                 1, 2 => |choice| {

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -2159,7 +2159,7 @@ pub fn reorderListsAdvanced() !void {
 
         if (reorderable.targetRectScale()) |rs| {
             // user is dragging a reorderable over this rect, could draw anything here
-            try rs.r.fill(.{ .color = .green });
+            try rs.r.fill(.{}, .{ .color = .green });
 
             // reset to use next space, need a separator
             try dvui.separator(@src(), .{ .expand = .horizontal, .margin = dvui.Rect.all(6) });
@@ -2190,7 +2190,7 @@ pub fn reorderListsAdvanced() !void {
 
         if (reorderable.targetRectScale()) |rs| {
             // user is dragging a reorderable over this rect
-            try rs.r.fill(.{ .color = .green });
+            try rs.r.fill(.{}, .{ .color = .green });
         }
     }
 
@@ -2686,12 +2686,12 @@ pub fn scrollCanvas(comptime data: u8) !void {
     try dvui.pathStroke(&.{
         dataRectScale.pointToPhysical(.{ .x = -10 }),
         dataRectScale.pointToPhysical(.{ .x = 10 }),
-    }, 1, dvui.Color.black, .{});
+    }, .{ .thickness = 1, .color = dvui.Color.black });
 
     try dvui.pathStroke(&.{
         dataRectScale.pointToPhysical(.{ .y = -10 }),
         dataRectScale.pointToPhysical(.{ .y = 10 }),
-    }, 1, dvui.Color.black, .{});
+    }, .{ .thickness = 1, .color = dvui.Color.black });
 
     // keep record of bounding box
     var mbbox: ?Rect.Physical = null;
@@ -3714,7 +3714,7 @@ pub const StrokeTest = struct {
     var points: []dvui.Point = pointsArray[0..0];
     var dragi: ?usize = null;
     var thickness: f32 = 1.0;
-    var endcap_style: dvui.EndCapStyle = .none;
+    var endcap_style: dvui.PathStrokeOptions.EndCapStyle = .none;
 
     wd: dvui.WidgetData = undefined,
 
@@ -3741,7 +3741,7 @@ pub const StrokeTest = struct {
         const fill_color = dvui.Color{ .r = 200, .g = 200, .b = 200, .a = 255 };
         for (points, 0..) |p, i| {
             const rect = dvui.Rect.fromPoint(p.plus(.{ .x = -10, .y = -10 })).toSize(.{ .w = 20, .h = 20 });
-            try rs.rectToPhysical(rect).fill(.{ .radius = dvui.Rect.Physical.all(1), .color = fill_color });
+            try rs.rectToPhysical(rect).fill(.all(1), .{ .color = fill_color });
 
             _ = i;
             //_ = try dvui.button(@src(), i, "Floating", .{}, .{ .rect = dvui.Rect.fromPoint(p) });
@@ -3755,7 +3755,7 @@ pub const StrokeTest = struct {
         }
 
         const stroke_color = dvui.Color{ .r = 0, .g = 0, .b = 255, .a = 150 };
-        try dvui.pathStroke(path.items, rs.s * thickness, stroke_color, .{ .closed = stroke_test_closed, .endcap_style = StrokeTest.endcap_style });
+        try dvui.pathStroke(path.items, .{ .thickness = rs.s * thickness, .color = stroke_color, .closed = stroke_test_closed, .endcap_style = StrokeTest.endcap_style });
     }
 
     pub fn widget(self: *Self) dvui.Widget {

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -178,7 +178,7 @@ pub const BoxShadow = struct {
             .name => |from_theme| Color.fromTheme(from_theme),
         };
 
-        return col.transparent(dvui.themeGet().alpha);
+        return col.opacity(dvui.themeGet().alpha);
     }
 };
 
@@ -248,7 +248,7 @@ pub fn color(self: *const Options, ask: ColorAsk) Color {
         .name => |from_theme| Color.fromTheme(from_theme),
     };
 
-    return col.transparent(dvui.themeGet().alpha);
+    return col.opacity(dvui.themeGet().alpha);
 }
 
 pub fn fontGet(self: *const Options) Font {

--- a/src/Rect.zig
+++ b/src/Rect.zig
@@ -200,21 +200,15 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
         /// - h is bottom-left corner
         ///
         /// Only valid between dvui.Window.begin() and end().
-        pub fn stroke(self: Rect.Physical, radius: Rect.Physical, thickness: f32, color: dvui.Color, opts: dvui.PathStrokeOptions) !void {
+        pub fn stroke(self: Rect.Physical, radius: Rect.Physical, opts: dvui.PathStrokeOptions) !void {
             var path: dvui.PathArrayList = .init(dvui.currentWindow().arena());
             defer path.deinit();
 
             try dvui.pathAddRect(&path, self, radius);
             var options = opts;
             options.closed = true;
-            try dvui.pathStroke(path.items, thickness, color, options);
+            try dvui.pathStroke(path.items, options);
         }
-
-        pub const fillOptions = struct {
-            radius: Rect.Physical = .{},
-            color: ?dvui.Color = null,
-            blur: f32 = 1.0,
-        };
 
         /// Fill a rounded rect.
         ///
@@ -225,12 +219,12 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
         /// - h is bottom-left corner
         ///
         /// Only valid between dvui.Window.begin() and end().
-        pub fn fill(self: Rect.Physical, opts: fillOptions) !void {
+        pub fn fill(self: Rect.Physical, radius: Rect.Physical, opts: dvui.PathFillConvexOptions) !void {
             var path: dvui.PathArrayList = .init(dvui.currentWindow().arena());
             defer path.deinit();
 
-            try dvui.pathAddRect(&path, self, opts.radius);
-            try dvui.pathFillConvex(path.items, opts.color orelse dvui.themeGet().color_fill, opts.blur);
+            try dvui.pathAddRect(&path, self, radius);
+            try dvui.pathFillConvex(path.items, opts);
         }
 
         /// True if self would be modified when clipped by r.
@@ -265,8 +259,8 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
 
                     var box = try dvui.box(@src(), .horizontal, .{ .background = true, .color_fill = .{ .name = .fill_window }, .expand = .both });
                     defer box.deinit();
-                    try Rect.Physical.cast(rect).stroke(.{}, 1, .gray, .{ .closed = true });
-                    try Rect.Physical.cast(res).stroke(.{}, 1, .red, .{ .closed = true });
+                    try Rect.Physical.cast(rect).stroke(.{}, .{ .thickness = 1, .color = .gray, .closed = true });
+                    try Rect.Physical.cast(res).stroke(.{}, .{ .thickness = 1, .color = .red, .closed = true });
                     return .ok;
                 }
             }.frame;
@@ -294,8 +288,8 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
 
                     var box = try dvui.box(@src(), .horizontal, .{ .background = true, .color_fill = .{ .name = .fill_window }, .expand = .both });
                     defer box.deinit();
-                    try Rect.Physical.cast(rect).stroke(.{}, 1, .gray, .{ .closed = true });
-                    try Rect.Physical.cast(res).stroke(.{}, 1, .red, .{ .closed = true });
+                    try Rect.Physical.cast(rect).stroke(.{}, .{ .thickness = 1, .color = .gray, .closed = true });
+                    try Rect.Physical.cast(res).stroke(.{}, .{ .thickness = 1, .color = .red, .closed = true });
                     return .ok;
                 }
             }.frame;
@@ -329,8 +323,8 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
 
                     var box = try dvui.box(@src(), .horizontal, .{ .background = true, .color_fill = .{ .name = .fill_window }, .expand = .both });
                     defer box.deinit();
-                    try Rect.Physical.cast(rect).stroke(.{}, 1, .gray, .{ .closed = true });
-                    try Rect.Physical.cast(res).stroke(.{}, 1, .red, .{ .closed = true });
+                    try Rect.Physical.cast(rect).stroke(.{}, .{ .thickness = 1, .color = .gray, .closed = true });
+                    try Rect.Physical.cast(res).stroke(.{}, .{ .thickness = 1, .color = .red, .closed = true });
                     return .ok;
                 }
             }.frame;
@@ -362,9 +356,9 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
 
                     var box = try dvui.box(@src(), .horizontal, .{ .background = true, .color_fill = .{ .name = .fill_window }, .expand = .both });
                     defer box.deinit();
-                    try Rect.Physical.cast(a).stroke(.{}, 1, .gray, .{ .closed = true });
-                    try Rect.Physical.cast(b).stroke(.{}, 1, .gray, .{ .closed = true });
-                    try Rect.Physical.cast(ab).stroke(.{}, 1, .red, .{ .closed = true });
+                    try Rect.Physical.cast(a).stroke(.{}, .{ .thickness = 1, .color = .gray, .closed = true });
+                    try Rect.Physical.cast(b).stroke(.{}, .{ .thickness = 1, .color = .gray, .closed = true });
+                    try Rect.Physical.cast(ab).stroke(.{}, .{ .thickness = 1, .color = .red, .closed = true });
                     return .ok;
                 }
             }.frame;
@@ -396,9 +390,9 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
 
                     var box = try dvui.box(@src(), .horizontal, .{ .background = true, .color_fill = .{ .name = .fill_window }, .expand = .both });
                     defer box.deinit();
-                    try Rect.Physical.cast(a).stroke(.{}, 1, .gray, .{ .closed = true });
-                    try Rect.Physical.cast(b).stroke(.{}, 1, .gray, .{ .closed = true });
-                    try Rect.Physical.cast(ab).stroke(.{}, 1, .red, .{ .closed = true });
+                    try Rect.Physical.cast(a).stroke(.{}, .{ .thickness = 1, .color = .gray, .closed = true });
+                    try Rect.Physical.cast(b).stroke(.{}, .{ .thickness = 1, .color = .gray, .closed = true });
+                    try Rect.Physical.cast(ab).stroke(.{}, .{ .thickness = 1, .color = .red, .closed = true });
                     return .ok;
                 }
             }.frame;
@@ -425,8 +419,8 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
 
                     var box = try dvui.box(@src(), .horizontal, .{ .background = true, .color_fill = .{ .name = .fill_window }, .expand = .both });
                     defer box.deinit();
-                    try Rect.Physical.cast(rect).stroke(.{}, 1, .gray, .{ .closed = true });
-                    try Rect.Physical.cast(res).stroke(.{}, 1, .red, .{ .closed = true });
+                    try Rect.Physical.cast(rect).stroke(.{}, .{ .thickness = 1, .color = .gray, .closed = true });
+                    try Rect.Physical.cast(res).stroke(.{}, .{ .thickness = 1, .color = .red, .closed = true });
                     return .ok;
                 }
             }.frame;
@@ -459,8 +453,8 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
 
                     var box = try dvui.box(@src(), .horizontal, .{ .background = true, .color_fill = .{ .name = .fill_window }, .expand = .both });
                     defer box.deinit();
-                    try Rect.Physical.cast(rect).stroke(.{}, 1, .gray, .{ .closed = true });
-                    try Rect.Physical.cast(res).stroke(.{}, 1, .red, .{ .closed = true });
+                    try Rect.Physical.cast(rect).stroke(.{}, .{ .thickness = 1, .color = .gray, .closed = true });
+                    try Rect.Physical.cast(res).stroke(.{}, .{ .thickness = 1, .color = .red, .closed = true });
                     return .ok;
                 }
             }.frame;

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -163,7 +163,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct { fill_color: ?
 
         const prect = rs.r.insetAll(rs.s * bs.shrink).offsetPoint(bs.offset.scale(rs.s, dvui.Point.Physical));
 
-        try prect.fill(radius.scale(rs.s, Rect.Physical), .{ .color = bs.colorGet().transparent(bs.alpha), .blur = rs.s * bs.blur });
+        try prect.fill(radius.scale(rs.s, Rect.Physical), .{ .color = bs.colorGet().opacity(bs.alpha), .blur = rs.s * bs.blur });
     }
 
     var bg = self.options.backgroundGet();

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -139,7 +139,7 @@ pub fn register(self: *WidgetData) !void {
                 outline_rect.y = @ceil(outline_rect.y) - 0.5;
             }
 
-            try outline_rect.stroke(.{}, 1 * rs.s, dvui.themeGet().color_err, .{ .after = true });
+            try outline_rect.stroke(.{}, .{ .thickness = 1 * rs.s, .color = dvui.themeGet().color_err, .after = true });
 
             dvui.clipSet(clipr);
 
@@ -163,7 +163,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct { fill_color: ?
 
         const prect = rs.r.insetAll(rs.s * bs.shrink).offsetPoint(bs.offset.scale(rs.s, dvui.Point.Physical));
 
-        try prect.fill(.{ .radius = radius.scale(rs.s, Rect.Physical), .color = bs.colorGet().transparent(bs.alpha), .blur = rs.s * bs.blur });
+        try prect.fill(radius.scale(rs.s, Rect.Physical), .{ .color = bs.colorGet().transparent(bs.alpha), .blur = rs.s * bs.blur });
     }
 
     var bg = self.options.backgroundGet();
@@ -174,7 +174,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct { fill_color: ?
             // draw border as stroked path
             const r = self.borderRect().inset(b);
             const rs = self.rectScale().rectToRectScale(r.offsetNeg(self.rect));
-            try rs.r.stroke(self.options.corner_radiusGet().scale(rs.s, Rect.Physical), b.x * rs.s, self.options.color(.border), .{});
+            try rs.r.stroke(self.options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .thickness = b.x * rs.s, .color = self.options.color(.border) });
         } else {
             // draw border as large rect with background on top
             if (!bg) {
@@ -184,7 +184,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct { fill_color: ?
 
             const rs = self.borderRectScale();
             if (!rs.r.empty()) {
-                try rs.r.fill(.{ .radius = self.options.corner_radiusGet().scale(rs.s, Rect.Physical), .color = self.options.color(.border) });
+                try rs.r.fill(self.options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = self.options.color(.border) });
             }
         }
     }
@@ -192,7 +192,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct { fill_color: ?
     if (bg) {
         const rs = self.backgroundRectScale();
         if (!rs.r.empty()) {
-            try rs.r.fill(.{ .radius = self.options.corner_radiusGet().scale(rs.s, Rect.Physical), .color = opts.fill_color orelse self.options.color(.fill) });
+            try rs.r.fill(self.options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = opts.fill_color orelse self.options.color(.fill) });
         }
     }
 }
@@ -202,7 +202,7 @@ pub fn focusBorder(self: *const WidgetData) !void {
         const rs = self.borderRectScale();
         const thick = 2 * rs.s;
 
-        try rs.r.stroke(self.options.corner_radiusGet().scale(rs.s, Rect.Physical), thick, dvui.themeGet().color_accent, .{ .after = true });
+        try rs.r.stroke(self.options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .thickness = thick, .color = dvui.themeGet().color_accent, .after = true });
     }
 }
 

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1246,12 +1246,14 @@ pub fn renderCommands(self: *Self, queue: std.ArrayList(dvui.RenderCommand)) !vo
                 try dvui.renderTexture(t.tex, t.rs, t.opts);
             },
             .pathFillConvex => |pf| {
-                try dvui.pathFillConvex(pf.path, pf.color, pf.blur);
-                self.arena().free(pf.path);
+                var triangles = try dvui.pathFillConvexTriangles(pf.path, pf.opts);
+                defer triangles.deinit(self.arena());
+                try dvui.renderTriangles(triangles, null);
             },
             .pathStroke => |ps| {
-                try dvui.pathStroke(ps.path, ps.thickness, ps.color, .{ .closed = ps.closed, .endcap_style = ps.endcap_style });
-                self.arena().free(ps.path);
+                var triangles = try dvui.pathStrokeTriangles(ps.path, ps.opts);
+                defer triangles.deinit(self.arena());
+                try dvui.renderTriangles(triangles, null);
             },
             .triangles => |t| {
                 try dvui.renderTriangles(t.tri, t.tex);

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1250,7 +1250,7 @@ pub fn renderCommands(self: *Self, queue: std.ArrayList(dvui.RenderCommand)) !vo
                 self.arena().free(pf.path);
             },
             .pathStroke => |ps| {
-                try dvui.pathStrokeRaw(ps.path, ps.thickness, ps.color, ps.closed, ps.endcap_style);
+                try dvui.pathStroke(ps.path, ps.thickness, ps.color, .{ .closed = ps.closed, .endcap_style = ps.endcap_style });
                 self.arena().free(ps.path);
             },
             .triangles => |t| {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1658,6 +1658,7 @@ pub const Triangles = struct {
             return .{
                 .vertexes = self.vertexes.items,
                 .indices = self.indices.items,
+                // convert bounds w/h back to width/height
                 .bounds = self.bounds.toPoint(.{
                     .x = self.bounds.w,
                     .y = self.bounds.h,

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1257,7 +1257,6 @@ pub fn pathFillConvexTriangles(path: PathSlice, opts: PathFillConvexOptions) !Tr
     errdefer comptime unreachable; // No errors from this point on
 
     const col: Color = if (opts.color) |color| color.alphaMultiply() else .white;
-    const col_trans: Color = .{ .r = 0, .g = 0, .b = 0, .a = 0 };
 
     var i: usize = 0;
     while (i < path.len) : (i += 1) {
@@ -1317,7 +1316,7 @@ pub fn pathFillConvexTriangles(path: PathSlice, opts: PathFillConvexOptions) !Tr
                     .x = bb.x + norm.x * outside_len,
                     .y = bb.y + norm.y * outside_len,
                 },
-                .col = col_trans,
+                .col = .transparent,
                 .uv = undefined,
             });
 
@@ -1426,7 +1425,6 @@ pub fn pathStrokeTriangles(path: PathSlice, opts: PathStrokeOptions) !Triangles 
     errdefer comptime unreachable; // No errors from this point on
 
     const col = opts.color.alphaMultiply();
-    const col_trans = Color{ .r = 0, .g = 0, .b = 0, .a = 0 };
 
     const aa_size = 1.0;
     var vtx_start: u16 = 0;
@@ -1463,7 +1461,7 @@ pub fn pathStrokeTriangles(path: PathSlice, opts: PathStrokeOptions) !Triangles 
                         .x = bb.x - halfnorm.x * (opts.thickness + aa_size) + diffbc.x * aa_size,
                         .y = bb.y - halfnorm.y * (opts.thickness + aa_size) + diffbc.y * aa_size,
                     },
-                    .col = col_trans,
+                    .col = .transparent,
                     .uv = undefined,
                 });
 
@@ -1472,7 +1470,7 @@ pub fn pathStrokeTriangles(path: PathSlice, opts: PathStrokeOptions) !Triangles 
                         .x = bb.x + halfnorm.x * (opts.thickness + aa_size) + diffbc.x * aa_size,
                         .y = bb.y + halfnorm.y * (opts.thickness + aa_size) + diffbc.y * aa_size,
                     },
-                    .col = col_trans,
+                    .col = .transparent,
                     .uv = undefined,
                 });
 
@@ -1531,7 +1529,7 @@ pub fn pathStrokeTriangles(path: PathSlice, opts: PathStrokeOptions) !Triangles 
                 .x = bb.x - halfnorm.x * (opts.thickness + aa_size),
                 .y = bb.y - halfnorm.y * (opts.thickness + aa_size),
             },
-            .col = col_trans,
+            .col = .transparent,
             .uv = undefined,
         });
 
@@ -1551,7 +1549,7 @@ pub fn pathStrokeTriangles(path: PathSlice, opts: PathStrokeOptions) !Triangles 
                 .x = bb.x + halfnorm.x * (opts.thickness + aa_size),
                 .y = bb.y + halfnorm.y * (opts.thickness + aa_size),
             },
-            .col = col_trans,
+            .col = .transparent,
             .uv = undefined,
         });
 
@@ -1577,7 +1575,7 @@ pub fn pathStrokeTriangles(path: PathSlice, opts: PathStrokeOptions) !Triangles 
                     .x = bb.x - halfnorm.x * (opts.thickness + aa_size) - diffab.x * aa_size,
                     .y = bb.y - halfnorm.y * (opts.thickness + aa_size) - diffab.y * aa_size,
                 },
-                .col = col_trans,
+                .col = .transparent,
                 .uv = undefined,
             });
             builder.appendVertex(.{
@@ -1585,7 +1583,7 @@ pub fn pathStrokeTriangles(path: PathSlice, opts: PathStrokeOptions) !Triangles 
                     .x = bb.x + halfnorm.x * (opts.thickness + aa_size) - diffab.x * aa_size,
                     .y = bb.y + halfnorm.y * (opts.thickness + aa_size) - diffab.y * aa_size,
                 },
-                .col = col_trans,
+                .col = .transparent,
                 .uv = undefined,
             });
 

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -246,7 +246,7 @@ pub fn drawBackground(self: *FloatingWindowWidget) !void {
         // paint over everything below
         var col = self.options.color(.text);
         col.a = if (dvui.themeGet().dark) 60 else 80;
-        try dvui.windowRectPixels().fill(.{ .color = col });
+        try dvui.windowRectPixels().fill(.{}, .{ .color = col });
     }
 
     // we are using BoxWidget to do border/background

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -87,14 +87,14 @@ pub fn drawBackground(self: *MenuItemWidget, opts: struct { focus_as_outline: bo
                 try self.wd.focusBorder();
             } else {
                 const rs = self.wd.backgroundRectScale();
-                try rs.r.fill(.{ .radius = self.wd.options.corner_radiusGet().scale(rs.s, Rect.Physical), .color = self.wd.options.color(.accent) });
+                try rs.r.fill(self.wd.options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = self.wd.options.color(.accent) });
             }
         } else if ((self.wd.id == dvui.focusedWidgetIdInCurrentSubwindow()) or self.highlight) {
             const rs = self.wd.backgroundRectScale();
-            try rs.r.fill(.{ .radius = self.wd.options.corner_radiusGet().scale(rs.s, Rect.Physical), .color = self.wd.options.color(.fill_hover) });
+            try rs.r.fill(self.wd.options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = self.wd.options.color(.fill_hover) });
         } else if (self.wd.options.backgroundGet()) {
             const rs = self.wd.backgroundRectScale();
-            try rs.r.fill(.{ .radius = self.wd.options.corner_radiusGet().scale(rs.s, Rect.Physical), .color = self.wd.options.color(.fill) });
+            try rs.r.fill(self.wd.options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = self.wd.options.color(.fill) });
         }
     }
 }

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -139,7 +139,7 @@ pub fn draw(self: *PanedWidget) !void {
                     r.w = width;
                 },
             }
-            try r.fill(.all(thick), .{ .color = self.wd.options.color(.text).transparent(0.5) });
+            try r.fill(.all(thick), .{ .color = self.wd.options.color(.text).opacity(0.5) });
         }
     }
 }

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -139,7 +139,7 @@ pub fn draw(self: *PanedWidget) !void {
                     r.w = width;
                 },
             }
-            try r.fill(.{ .radius = Rect.Physical.all(thick), .color = self.wd.options.color(.text).transparent(0.5) });
+            try r.fill(.all(thick), .{ .color = self.wd.options.color(.text).transparent(0.5) });
         }
     }
 }

--- a/src/widgets/PlotWidget.zig
+++ b/src/widgets/PlotWidget.zig
@@ -63,7 +63,7 @@ pub const Line = struct {
     }
 
     pub fn stroke(self: *Line, thick: f32, color: dvui.Color) !void {
-        try dvui.pathStroke(self.path.items, thick * self.plot.data_rs.s, color, .{});
+        try dvui.pathStroke(self.path.items, .{ .thickness = thick * self.plot.data_rs.s, .color = color });
     }
 
     pub fn deinit(self: *Line) void {
@@ -180,7 +180,7 @@ pub fn install(self: *PlotWidget) !void {
 
     const bt: f32 = self.init_options.border_thick orelse 0.0;
     if (bt > 0) {
-        try self.data_rs.r.stroke(.{}, bt * self.data_rs.s, self.box.data().options.color(.text), .{});
+        try self.data_rs.r.stroke(.{}, .{ .thickness = bt * self.data_rs.s, .color = self.box.data().options.color(.text) });
     }
 
     const pad = 2 * self.data_rs.s;

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -272,7 +272,7 @@ pub const Reorderable = struct {
                     self.reorder.found_slot = true;
 
                     if (self.init_options.draw_target) {
-                        try rs.r.fill(.{ .color = dvui.themeGet().color_accent });
+                        try rs.r.fill(.{}, .{ .color = dvui.themeGet().color_accent });
                     }
 
                     if (self.init_options.reinstall and !self.init_options.last_slot) {

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -181,9 +181,9 @@ pub fn processEvents(self: *ScrollBarWidget, grabrs: Rect.Physical) void {
 }
 
 pub fn deinit(self: *ScrollBarWidget) void {
-    var fill = self.wd.options.color(.text).transparent(0.5);
+    var fill = self.wd.options.color(.text).opacity(0.5);
     if (dvui.captured(self.wd.id) or self.highlight) {
-        fill = self.wd.options.color(.text).transparent(0.3);
+        fill = self.wd.options.color(.text).opacity(0.3);
     }
     self.grabRect = self.grabRect.insetAll(2);
     const grabrs = self.wd.parent.screenRectScale(self.grabRect);

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -187,7 +187,7 @@ pub fn deinit(self: *ScrollBarWidget) void {
     }
     self.grabRect = self.grabRect.insetAll(2);
     const grabrs = self.wd.parent.screenRectScale(self.grabRect);
-    grabrs.r.fill(.{ .radius = Rect.Physical.all(100), .color = fill }) catch {};
+    grabrs.r.fill(.all(100), .{ .color = fill }) catch {};
 
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -48,7 +48,7 @@ pub fn install(self: *TabsWidget) !void {
                 r.w -= 1.0;
                 r.y = @floor(r.y) - 0.5;
             }
-            try dvui.pathStroke(&.{ r.bottomLeft(), r.bottomRight() }, 1, dvui.themeGet().color_border, .{});
+            try dvui.pathStroke(&.{ r.bottomLeft(), r.bottomRight() }, .{ .thickness = 1, .color = dvui.themeGet().color_border });
         },
         .vertical => {
             if (dvui.currentWindow().snap_to_pixels) {
@@ -56,7 +56,7 @@ pub fn install(self: *TabsWidget) !void {
                 r.h -= 1.0;
                 r.x = @floor(r.x) - 0.5;
             }
-            try dvui.pathStroke(&.{ r.topRight(), r.bottomRight() }, 1, dvui.themeGet().color_border, .{});
+            try dvui.pathStroke(&.{ r.topRight(), r.bottomRight() }, .{ .thickness = 1, .color = dvui.themeGet().color_border });
         },
     }
 }
@@ -130,7 +130,7 @@ pub fn addTab(self: *TabsWidget, selected: bool, opts: Options) !*ButtonWidget {
 
                 try path.append(r.bottomLeft());
 
-                try dvui.pathStroke(path.items, 2 * rs.s, self.options.color(.accent), .{ .after = true });
+                try dvui.pathStroke(path.items, .{ .thickness = 2 * rs.s, .color = self.options.color(.accent), .after = true });
             },
             .vertical => {
                 var path: dvui.PathArrayList = .init(dvui.currentWindow().arena());
@@ -146,7 +146,7 @@ pub fn addTab(self: *TabsWidget, selected: bool, opts: Options) !*ButtonWidget {
 
                 try path.append(r.bottomRight());
 
-                try dvui.pathStroke(path.items, 2 * rs.s, self.options.color(.accent), .{ .after = true });
+                try dvui.pathStroke(path.items, .{ .thickness = 2 * rs.s, .color = self.options.color(.accent), .after = true });
             },
         }
     }

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -152,7 +152,7 @@ pub fn install(self: *TextEntryWidget) !void {
         if (self.init_opts.placeholder) |placeholder| {
             try dvui.renderText(.{
                 .font = self.textLayout.wd.options.fontGet(),
-                .color = self.textLayout.wd.options.color(.text).transparent(0.75),
+                .color = self.textLayout.wd.options.color(.text).opacity(0.75),
                 .rs = self.textLayout.wd.contentRectScale(),
                 .text = placeholder,
             });

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -308,7 +308,7 @@ pub fn drawCursor(self: *TextEntryWidget) !void {
 
         var crect = self.textLayout.cursor_rect.plus(.{ .x = -1 });
         crect.w = 2;
-        try self.textLayout.screenRectScale(crect).r.fill(.{ .color = self.wd.options.color(.accent) });
+        try self.textLayout.screenRectScale(crect).r.fill(.{}, .{ .color = self.wd.options.color(.accent) });
     }
 }
 

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -340,8 +340,8 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
                 try path.append(.{ .x = fcrs.r.x + fcrs.r.w, .y = fcrs.r.y });
                 try dvui.pathAddArc(&path, .{ .x = fcrs.r.x + fcrs.r.w / 2, .y = fcrs.r.y + fcrs.r.h / 2 }, fcrs.r.w / 2, std.math.pi, 0, true);
 
-                try dvui.pathFillConvex(path.items, dvui.themeGet().color_fill_control, 0.5);
-                try dvui.pathStroke(path.items, 1.0 * fcrs.s, self.wd.options.color(.border), .{ .closed = true });
+                try dvui.pathFillConvex(path.items, .{ .color = dvui.themeGet().color_fill_control, .blur = 0.5 });
+                try dvui.pathStroke(path.items, .{ .thickness = 1.0 * fcrs.s, .color = self.wd.options.color(.border), .closed = true });
             }
 
             dvui.dataSet(null, fc.wd.id, "_offset", offset);
@@ -411,8 +411,8 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
                 try path.append(.{ .x = fcrs.r.x, .y = fcrs.r.y });
                 try dvui.pathAddArc(&path, .{ .x = fcrs.r.x + fcrs.r.w / 2, .y = fcrs.r.y + fcrs.r.h / 2 }, fcrs.r.w / 2, std.math.pi, 0, true);
 
-                try dvui.pathFillConvex(path.items, dvui.themeGet().color_fill_control, 0.5);
-                try dvui.pathStroke(path.items, 1.0 * fcrs.s, self.wd.options.color(.border), .{ .closed = true });
+                try dvui.pathFillConvex(path.items, .{ .color = dvui.themeGet().color_fill_control, .blur = 0.5 });
+                try dvui.pathStroke(path.items, .{ .thickness = 1.0 * fcrs.s, .color = self.wd.options.color(.border), .closed = true });
             }
 
             dvui.dataSet(null, fc.wd.id, "_offset", offset);


### PR DESCRIPTION
This is only motivated by me noticing inconsistencies in functions that should be very similar. The triangle builder gives some more guarantees for indices needing to be in sets of 3 as well as you needing to specify the exact amount of vertexes and indices needed. 

0511df413820dd2951444da26636e8ba5933e0ad touches a lot of api surface area and I would be okay with reverting it.

This also includes changing `Color.transparent` to be a decl for a transparent color, and the previous function taking the name `opacity`, inspired by CSS. 