### PR TITLE
GridWidget implementation

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -17,6 +17,7 @@ const ButtonWidget = dvui.ButtonWidget;
 const FloatingWindowWidget = dvui.FloatingWindowWidget;
 const LabelWidget = dvui.LabelWidget;
 const TextLayoutWidget = dvui.TextLayoutWidget;
+const GridWidget = dvui.GridWidget;
 
 const enums = dvui.enums;
 
@@ -316,6 +317,7 @@ pub const demoKind = enum {
     animations,
     struct_ui,
     debugging,
+    grid,
 
     pub fn name(self: demoKind) []const u8 {
         return switch (self) {
@@ -335,6 +337,7 @@ pub const demoKind = enum {
             .animations => "Animations",
             .struct_ui => "Struct UI\n(Experimental)",
             .debugging => "Debugging",
+            .grid => "Grid",
         };
     }
 
@@ -356,6 +359,7 @@ pub const demoKind = enum {
             .animations => .{ .scale = 0.45, .offset = .{} },
             .struct_ui => .{ .scale = 0.45, .offset = .{} },
             .debugging => .{ .scale = 0.45, .offset = .{} },
+            .grid => .{ .scale = 0.45, .offset = .{} },
         };
     }
 };
@@ -468,6 +472,7 @@ pub fn demo() !void {
                     .animations => try animations(),
                     .struct_ui => try structUI(),
                     .debugging => try debuggingErrors(),
+                    .grid => try grids(0),
                 }
             }
 
@@ -520,6 +525,7 @@ pub fn demo() !void {
             .animations => animations(),
             .struct_ui => structUI(),
             .debugging => debuggingErrors(),
+            .grid => grids(scroll.si.viewport.h - hbox.data().rect.h - 10),
         };
     }
 
@@ -3651,6 +3657,653 @@ pub fn icon_browser(src: std.builtin.SourceLocation, show_flag: *bool, comptime 
         }
 
         cursor += settings.row_height;
+    }
+}
+
+const grid_panel_size: Size = .{ .w = 250 };
+
+pub fn grids(height: f32) !void {
+    // Below is a workaround for standaline demos being placed in a scroll-area.
+    // By default the scroll-area will scroll instead of the grid.
+    // Fix the height of the     // grid to the scroll area's viewport to prevent this.
+    // This would not be required for normal usage.
+    const vbox = if (height > 0)
+        try dvui.box(@src(), .vertical, .{ .min_size_content = .{ .h = height }, .max_size_content = .height(height), .expand = .horizontal })
+    else
+        null;
+
+    defer if (vbox) |vb| {
+        vb.deinit();
+    };
+
+    const GridType = enum {
+        styling,
+        layout,
+        scrolling,
+        row_heights,
+        const num_grids = @typeInfo(@This()).@"enum".fields.len;
+    };
+    const local = struct {
+        var active_grid: GridType = .styling;
+
+        fn tabSelected(grid_type: GridType) bool {
+            return active_grid == grid_type;
+        }
+
+        fn tabName(grid_type: GridType) []const u8 {
+            return switch (grid_type) {
+                .styling => "Styling and sorting",
+                .layout => "Layouts and data",
+                .scrolling => "Virtual scrolling",
+                .row_heights => "Variable row heigts",
+            };
+        }
+    };
+    {
+        var tbox = try dvui.box(@src(), .vertical, .{ .border = Rect.all(1), .expand = .horizontal });
+        defer tbox.deinit();
+        {
+            var tabs = dvui.TabsWidget.init(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });
+            try tabs.install();
+            defer tabs.deinit();
+
+            for (0..GridType.num_grids) |tab_num| {
+                const this_tab: GridType = @enumFromInt(tab_num);
+
+                if (try tabs.addTabLabel(local.tabSelected(this_tab), local.tabName(this_tab))) {
+                    local.active_grid = this_tab;
+                }
+            }
+        }
+    }
+    switch (local.active_grid) {
+        .styling => try gridStyling(),
+        .layout => try gridLayouts(),
+        .scrolling => try gridVirtualScrolling(),
+        .row_heights => try gridVariableRowHeights(),
+    }
+}
+
+fn gridStyling() !void {
+    const local = struct {
+        var resize_rows: bool = false;
+        var sort_dir: dvui.GridWidget.SortDirection = .unsorted;
+        var borders: Rect = .all(0);
+        var banding: Banding = .none;
+        var margin: f32 = 0;
+        var padding: f32 = 0;
+
+        fn rowColorFill(row_num: usize) ?dvui.Options.ColorOrName {
+            if (banding == .rows and row_num % 2 == 0) {
+                return .{ .name = .fill_press };
+            }
+            return null;
+        }
+
+        fn colColorFill(col_num: usize) ?dvui.Options.ColorOrName {
+            if (banding == .cols and col_num % 2 == 0) {
+                return .{ .name = .fill_press };
+            }
+            return null;
+        }
+
+        const Banding = enum { none, rows, cols };
+    };
+
+    var outer_hbox = try dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
+    defer outer_hbox.deinit();
+    const row_background = local.banding == .rows or local.borders.nonZero();
+
+    {
+        var grid = try dvui.grid(@src(), .{ .resize_rows = local.resize_rows }, .{
+            .expand = .both,
+            .background = true,
+            .border = Rect.all(1),
+            .padding = .{ .x = 5 },
+        });
+        defer grid.deinit();
+        local.resize_rows = false; // Only resize rows when needed.
+
+        // Set start, end and interval based on sort direction.
+        const start_temp: i32, //
+        const end_temp: i32, //
+        const interval: i32 = switch (local.sort_dir) {
+            .ascending, .unsorted => .{ 0, 100, 5 },
+            .descending => .{ 100, 0, -5 },
+        };
+        std.debug.assert(@mod(end_temp - start_temp, interval) == 0); // Temperature range must be a multiple of interval
+
+        // Manually control sorting, so that sort direction is always reversed regardless of
+        // which column header is clicked.
+        const current_sort_dir = local.sort_dir;
+
+        // First column displays temperature in Celcius.
+        {
+            var col = try grid.column(@src(), .{ .color_fill = local.colColorFill(0), .background = true });
+            defer col.deinit();
+            // Set this column as the default sort
+            if (current_sort_dir == .unsorted) {
+                local.sort_dir = .ascending;
+                grid.colSortSet(local.sort_dir);
+            }
+
+            if (try dvui.gridHeadingSortable(@src(), grid, "Celcius", &local.sort_dir, .{}, .{})) {
+                grid.colSortSet(current_sort_dir.reverse());
+            }
+
+            var temp: i32 = start_temp;
+            var row_num: usize = 0;
+            while (temp != end_temp + interval) : ({
+                temp += interval;
+                row_num += 1;
+            }) {
+                var cell = try grid.bodyCell(@src(), row_num, .{
+                    .border = local.borders,
+                    .background = row_background,
+                    .color_fill = local.rowColorFill(row_num),
+                    .margin = Rect.all(local.margin),
+                    .padding = Rect.all(local.padding),
+                });
+                defer cell.deinit();
+                try dvui.label(@src(), "{d}", .{temp}, .{ .gravity_x = 0.5, .expand = .horizontal });
+            }
+        }
+        // Second column displays temperature in Farenheight.
+        {
+            var col = try grid.column(@src(), .{
+                .color_fill = local.colColorFill(1),
+                .background = local.banding == .cols,
+            });
+            defer col.deinit();
+            if (try dvui.gridHeadingSortable(@src(), grid, "Fahrenheit", &local.sort_dir, .{}, .{})) {
+                grid.colSortSet(current_sort_dir.reverse());
+            }
+
+            var temp: i32 = start_temp;
+            var row_num: usize = 0;
+            while (temp != end_temp + interval) : ({
+                temp += interval;
+                row_num += 1;
+            }) {
+                var cell = try grid.bodyCell(@src(), row_num, .{
+                    .border = local.borders,
+                    .background = row_background,
+                    .color_fill = local.rowColorFill(row_num),
+                    .margin = Rect.all(local.margin),
+                    .padding = Rect.all(local.padding),
+                });
+                defer cell.deinit();
+                try dvui.label(@src(), "{d}", .{@divFloor(temp * 9, 5) + 32}, .{ .gravity_x = 0.5, .expand = .horizontal });
+            }
+        }
+    }
+    {
+        var outer_vbox = try dvui.box(@src(), .vertical, .{
+            .min_size_content = grid_panel_size,
+            .max_size_content = .size(grid_panel_size),
+            .expand = .vertical,
+            .border = Rect.all(1),
+        });
+        defer outer_vbox.deinit();
+
+        if (try dvui.expander(@src(), "Borders", .{ .default_expanded = true }, .{ .expand = .horizontal })) {
+            var top: bool = local.borders.y > 0;
+            var bottom: bool = local.borders.h > 0;
+            var left: bool = local.borders.x > 0;
+            var right: bool = local.borders.w > 0;
+            var hbox = try dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
+            defer hbox.deinit();
+            {
+                var vbox = try dvui.box(@src(), .vertical, .{ .expand = .horizontal });
+                defer vbox.deinit();
+                _ = try dvui.checkbox(@src(), &top, "Top", .{});
+                _ = try dvui.checkbox(@src(), &left, "Left", .{});
+            }
+            {
+                var vbox = try dvui.box(@src(), .vertical, .{ .expand = .horizontal });
+                defer vbox.deinit();
+                _ = try dvui.checkbox(@src(), &right, "Right", .{});
+                _ = try dvui.checkbox(@src(), &bottom, "Bottom", .{});
+            }
+            local.borders = .{
+                .y = if (top) 1 else 0,
+                .h = if (bottom) 1 else 0,
+                .x = if (left) 1 else 0,
+                .w = if (right) 1 else 0,
+            };
+            if (local.borders.nonZero() and local.banding == .cols) {
+                local.banding = .none;
+            }
+        }
+        if (try dvui.expander(@src(), "Banding", .{ .default_expanded = true }, .{ .expand = .horizontal })) {
+            if (try dvui.radio(@src(), local.banding == .none, "None", .{})) {
+                local.banding = .none;
+            }
+            if (try dvui.radio(@src(), local.banding == .rows, "Rows", .{})) {
+                local.banding = .rows;
+            }
+            if (try dvui.radio(@src(), local.banding == .cols, "Cols", .{})) {
+                local.banding = .cols;
+                local.borders = Rect.all(0);
+            }
+        }
+        if (try dvui.expander(@src(), "Other", .{ .default_expanded = true }, .{ .expand = .horizontal })) {
+            {
+                var hbox = try dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
+                defer hbox.deinit();
+                try dvui.labelNoFmt(@src(), "Margin:", .{ .min_size_content = .{ .w = 60 }, .gravity_y = 0.5 });
+                const result = try dvui.textEntryNumber(@src(), f32, .{ .min = 0, .max = 10, .value = &local.margin, .show_min_max = true }, .{});
+                if (result.changed and result.value == .Valid) {
+                    local.margin = result.value.Valid;
+                    local.resize_rows = true;
+                }
+            }
+            {
+                var hbox = try dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
+                defer hbox.deinit();
+                try dvui.labelNoFmt(@src(), "Padding:", .{ .min_size_content = .{ .w = 60 }, .gravity_y = 0.5 });
+                const result = try dvui.textEntryNumber(@src(), f32, .{ .min = 0, .max = 10, .value = &local.padding, .show_min_max = true }, .{});
+                if (result.changed and result.value == .Valid) {
+                    local.padding = result.value.Valid;
+                    local.resize_rows = true;
+                }
+            }
+        }
+    }
+}
+
+fn gridLayouts() !void {
+    const Car = struct {
+        selected: bool = false,
+        model: []const u8,
+        make: []const u8,
+        year: u32,
+        mileage: u32,
+        condition: Condition,
+        description: []const u8,
+
+        const Condition = enum { Poor, Fair, Good, Excellent, New };
+    };
+
+    const Layout = enum {
+        proportional,
+        equal_spacing,
+        fixed_width,
+        fit_window,
+    };
+
+    const local = struct {
+        const num_cols = 6;
+        const col_num_descr = 5;
+        const checkbox_w = 40;
+
+        var col_widths: [num_cols]f32 = @splat(100); // Default width to 100
+        const column_ratios = [num_cols]f32{ checkbox_w, -10, -10, -7, -15, -30 };
+        const fixed_widths = [num_cols]f32{ checkbox_w, 80, 120, 80, 100, 300 };
+        const equal_spacing = [num_cols]f32{ checkbox_w, -1, -1, -1, -1, -1 };
+        var selection_state: dvui.GridColumnSelectAllState = .select_none;
+        var sort_dir: GridWidget.SortDirection = .unsorted;
+        var layout: Layout = .proportional;
+        var h_scroll: bool = false;
+        var resize_rows: bool = false;
+
+        /// Create a textArea for the description so that the text can wrap.
+        fn customDescriptionColumn(src: std.builtin.SourceLocation, grid: *GridWidget, data: []Car, opts: dvui.Options) !void {
+            // Creating the description cells with a multi-line text area.
+            for (data, 0..) |*car, row_num| {
+                var col = try grid.bodyCell(src, row_num, rowBanding(col_num_descr, row_num));
+                defer col.deinit();
+                var text = try dvui.textLayout(@src(), .{ .break_lines = true }, .{ .expand = .both, .background = false });
+                defer text.deinit();
+                try text.addText(car.description, opts);
+            }
+        }
+
+        /// Set background of all odd rows to the theme's fill_press color.
+        fn rowBanding(_: usize, col_num: usize) GridWidget.CellOptions {
+            if (col_num % 2 == 1)
+                return .{ .color_fill = .{ .name = .fill_press }, .background = true }
+            else
+                return .{};
+        }
+
+        /// Set the text color of the Condition text, based on the condition.
+        fn conditionTextColor(_: usize, row_num: usize) Options {
+            return .{
+                .expand = .horizontal,
+                .gravity_x = 0.5,
+                .color_text = switch (all_cars[row_num].condition) {
+                    .New => .{ .color = dvui.Color.fromHex("#4bbfc3") },
+                    .Excellent => .{ .color = dvui.Color.fromHex("#6ca96c") },
+                    .Good => .{ .color = dvui.Color.fromHex("#a3b76b") },
+                    .Fair => .{ .color = dvui.Color.fromHex("#d3b95f") },
+                    .Poor => .{ .color = dvui.Color.fromHex("#c96b6b") },
+                },
+            };
+        }
+
+        fn sort(key: []const u8) void {
+            switch (sort_dir) {
+                .descending,
+                => std.mem.sort(Car, &all_cars, key, sortDesc),
+                .ascending,
+                .unsorted,
+                => std.mem.sort(Car, &all_cars, key, sortAsc),
+            }
+        }
+
+        fn sortAsc(key: []const u8, lhs: Car, rhs: Car) bool {
+            if (std.mem.eql(u8, key, "Model")) return std.mem.lessThan(u8, lhs.model, rhs.model);
+            if (std.mem.eql(u8, key, "Year")) return lhs.year < rhs.year;
+            if (std.mem.eql(u8, key, "Mileage")) return lhs.mileage < rhs.mileage;
+            if (std.mem.eql(u8, key, "Condition")) return @intFromEnum(lhs.condition) < @intFromEnum(rhs.condition);
+            if (std.mem.eql(u8, key, "Description")) return std.mem.lessThan(u8, lhs.description, rhs.description);
+            // default sort on Make
+            return std.mem.lessThan(u8, lhs.make, rhs.make);
+        }
+
+        fn sortDesc(key: []const u8, lhs: Car, rhs: Car) bool {
+            if (std.mem.eql(u8, key, "Model")) return std.mem.lessThan(u8, rhs.model, lhs.model);
+            if (std.mem.eql(u8, key, "Year")) return rhs.year < lhs.year;
+            if (std.mem.eql(u8, key, "Mileage")) return rhs.mileage < lhs.mileage;
+            if (std.mem.eql(u8, key, "Condition")) return @intFromEnum(rhs.condition) < @intFromEnum(lhs.condition);
+            if (std.mem.eql(u8, key, "Description")) return std.mem.lessThan(u8, rhs.description, lhs.description);
+            // default sort on Make
+            return std.mem.lessThan(u8, rhs.make, lhs.make);
+        }
+
+        var all_cars = [_]Car{
+            .{ .model = "Civic", .make = "Honda", .year = 2022, .mileage = 8500, .condition = .New, .description = "Still smells like optimism and plastic wrap." },
+            .{ .model = "Model 3", .make = "Tesla", .year = 2021, .mileage = 15000, .condition = .Excellent, .description = "Drives itself better than I drive myself." },
+            .{ .model = "Camry", .make = "Toyota", .year = 2018, .mileage = 43000, .condition = .Good, .description = "Reliable enough to make your toaster jealous." },
+            .{ .model = "F-150", .make = "Ford", .year = 2015, .mileage = 78000, .condition = .Fair, .description = "Hauls stuff, occasional emotions." },
+            .{ .model = "Altima", .make = "Nissan", .year = 2010, .mileage = 129000, .condition = .Poor, .description = "Drives like it’s got beef with the road." },
+            .{ .model = "Accord", .make = "Honda", .year = 2019, .mileage = 78000, .condition = .Excellent, .description = "Sensible and smooth, like your friend with a Costco card." },
+            .{ .model = "Impreza", .make = "Subaru", .year = 2016, .mileage = 78000, .condition = .Good, .description = "All-wheel drive and all-weather vibes." },
+            .{ .model = "Charger", .make = "Dodge", .year = 2014, .mileage = 97000, .condition = .Fair, .description = "Goes fast, stops… usually." },
+            .{ .model = "Beetle", .make = "Volkswagen", .year = 2006, .mileage = 142000, .condition = .Poor, .description = "Quirky, creaky, and still kinda cute." },
+            .{ .model = "Mustang", .make = "Ford", .year = 2020, .mileage = 24000, .condition = .Good, .description = "Makes you feel 20% cooler just sitting in it." },
+            .{ .model = "CX-5", .make = "Mazda", .year = 2019, .mileage = 32000, .condition = .Excellent, .description = "Zoom zoom, but responsibly." },
+            .{ .model = "Outback", .make = "Subaru", .year = 2017, .mileage = 61000, .condition = .Good, .description = "Always looks ready for a camping trip, even when it's not." },
+            .{ .model = "Civic", .make = "Honda", .year = 2022, .mileage = 8500, .condition = .New, .description = "Still smells like optimism and plastic wrap." },
+            .{ .model = "Model 3", .make = "Tesla", .year = 2021, .mileage = 15000, .condition = .Excellent, .description = "Drives itself better than I drive myself." },
+            .{ .model = "Camry", .make = "Toyota", .year = 2018, .mileage = 43000, .condition = .Good, .description = "Reliable enough to make your toaster jealous." },
+            .{ .model = "F-150", .make = "Ford", .year = 2015, .mileage = 78000, .condition = .Fair, .description = "Hauls stuff, occasional emotions." },
+            .{ .model = "Altima", .make = "Nissan", .year = 2010, .mileage = 129000, .condition = .Poor, .description = "Drives like it’s got beef with the road." },
+            .{ .model = "Accord", .make = "Honda", .year = 2019, .mileage = 78000, .condition = .Excellent, .description = "Sensible and smooth, like your friend with a Costco card." },
+            .{ .model = "Impreza", .make = "Subaru", .year = 2016, .mileage = 78000, .condition = .Good, .description = "All-wheel drive and all-weather vibes." },
+            .{ .model = "Charger", .make = "Dodge", .year = 2014, .mileage = 97000, .condition = .Fair, .description = "Goes fast, stops… usually." },
+            .{ .model = "Beetle", .make = "Volkswagen", .year = 2006, .mileage = 142000, .condition = .Poor, .description = "Quirky, creaky, and still kinda cute." },
+            .{ .model = "Mustang with a really long name", .make = "Ford", .year = 2020, .mileage = 24000, .condition = .Good, .description = "Makes you feel 20% cooler just sitting in it." },
+        };
+    };
+    const all_cars = local.all_cars[0..];
+
+    const panel_height = 250;
+    const content_h = dvui.parentGet().data().contentRect().h - panel_height;
+    {
+        const scroll_opts: ?dvui.ScrollAreaWidget.InitOpts = if (local.h_scroll)
+            .{ .horizontal = .auto, .horizontal_bar = .show, .vertical = .auto, .vertical_bar = .show }
+        else
+            null;
+
+        const col_widths: ?[]f32 = switch (local.layout) {
+            .fit_window => null,
+            else => &local.col_widths,
+        };
+
+        var grid = try dvui.grid(@src(), .{
+            .col_widths = col_widths,
+            .scroll_opts = scroll_opts,
+            .resize_rows = local.resize_rows,
+        }, .{
+            .expand = .both,
+            .background = true,
+            .border = Rect.all(2),
+            .min_size_content = .{ .h = content_h },
+            .max_size_content = .height(content_h),
+            .padding = .{ .x = 5 },
+        });
+        defer grid.deinit();
+
+        // Fit columns to the grid visible area, or to the virtual scroll area if horizontal scorlling is enabled.
+        if (local.layout != .fit_window) {
+            const ratio = switch (local.layout) {
+                .equal_spacing => &local.equal_spacing,
+                .fixed_width => &local.fixed_widths,
+                .proportional => &local.column_ratios,
+                .fit_window => unreachable,
+            };
+            dvui.columnLayoutProportional(ratio, &local.col_widths, if (local.h_scroll) 1024 else grid.data().contentRect().w);
+        }
+        local.resize_rows = false;
+
+        // Selection
+        {
+            // Make the checkbox column fixed width. (This width is used if init_opts.col_widths is null)
+            var col = try grid.column(@src(), .{ .width = local.checkbox_w });
+            defer col.deinit();
+            if (try dvui.gridHeadingCheckbox(@src(), grid, &local.selection_state, .{}, .{})) {
+                for (all_cars) |*car| {
+                    car.selected = switch (local.selection_state) {
+                        .select_all => true,
+                        .select_none => false,
+                        .unchanged => break,
+                    };
+                }
+            }
+            _ = try dvui.gridColumnCheckbox(@src(), grid, Car, all_cars[0..], "selected", .{ .callback = local.rowBanding }, .{ .options = .{ .gravity_y = 0.0 } });
+        }
+        // Make
+        {
+            var col = try grid.column(@src(), .{});
+            defer col.deinit();
+            if (try dvui.gridHeadingSortable(@src(), grid, "Make", &local.sort_dir, .{}, .{})) {
+                local.sort("Make");
+            }
+            try dvui.gridColumnFromSlice(@src(), grid, Car, all_cars[0..], "make", "{s}", .{ .callback = local.rowBanding }, .none);
+        }
+        // Model
+        {
+            var col = try grid.column(@src(), .{});
+            defer col.deinit();
+            if (try dvui.gridHeadingSortable(@src(), grid, "Model", &local.sort_dir, .{}, .{})) {
+                local.sort("Model");
+            }
+            try dvui.gridColumnFromSlice(@src(), grid, Car, all_cars[0..], "model", "{s}", .{ .callback = local.rowBanding }, .none);
+        }
+        // Year
+        {
+            var col = try grid.column(@src(), .{});
+            defer col.deinit();
+            if (try dvui.gridHeadingSortable(@src(), grid, "Year", &local.sort_dir, .{}, .{})) {
+                local.sort("Year");
+            }
+            try dvui.gridColumnFromSlice(@src(), grid, Car, all_cars[0..], "year", "{d}", .{ .callback = local.rowBanding }, .none);
+        }
+        // Condition
+        {
+            var col = try grid.column(@src(), .{});
+            defer col.deinit();
+            if (try dvui.gridHeadingSortable(@src(), grid, "Condition", &local.sort_dir, .{}, .{ .gravity_x = 0.5, .expand = .horizontal })) {
+                local.sort("Condition");
+            }
+            try dvui.gridColumnFromSlice(@src(), grid, Car, all_cars[0..], "condition", "{s}", .{ .callback = local.rowBanding }, .{ .callback = local.conditionTextColor });
+        }
+        // Description
+        {
+            var col = try grid.column(@src(), .{});
+            defer col.deinit();
+            if (try dvui.gridHeadingSortable(@src(), grid, "Description", &local.sort_dir, .{}, .{})) {
+                local.sort("Description");
+            }
+            try local.customDescriptionColumn(@src(), grid, all_cars[0..], .{});
+        }
+    }
+    {
+        var outer_vbox = try dvui.box(@src(), .vertical, .{
+            .expand = .horizontal,
+            .border = Rect.all(1),
+        });
+        defer outer_vbox.deinit();
+
+        if (try dvui.expander(@src(), "Layouts", .{ .default_expanded = true }, .{ .expand = .horizontal })) {
+            {
+                var hbox = try dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
+                defer hbox.deinit();
+
+                if (try dvui.radio(@src(), local.layout == .proportional, "Proportional", .{})) {
+                    local.layout = .proportional;
+                }
+                if (try dvui.radio(@src(), local.layout == .equal_spacing, "Equal spacing", .{})) {
+                    local.layout = .equal_spacing;
+                }
+                if (try dvui.radio(@src(), local.layout == .fixed_width, "Fixed widths", .{})) {
+                    local.layout = .fixed_width;
+                }
+                if (try dvui.radio(@src(), local.layout == .fit_window, "Fit window", .{})) {
+                    local.h_scroll = false;
+                    local.layout = .fit_window;
+                }
+            }
+            {
+                var hbox = try dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
+                defer hbox.deinit();
+                if (try dvui.checkbox(@src(), &local.h_scroll, "Horizontal scrolling", .{})) {
+                    if (local.layout == .fit_window) {
+                        local.layout = .proportional;
+                    }
+                }
+                if (try dvui.button(@src(), "Resize Rows", .{}, .{})) {
+                    local.resize_rows = true;
+                }
+            }
+        }
+    }
+}
+
+fn gridVirtualScrolling() !void {
+    const num_rows = 1_000_000;
+    const local = struct {
+        var scroll_info: dvui.ScrollInfo = .{ .vertical = .given, .horizontal = .none };
+        var primes: std.StaticBitSet(num_rows) = .initFull();
+        var generated_primes: bool = false;
+        var highlighted_row: ?usize = null;
+
+        fn generatePrimes() void {
+            const limit = std.math.sqrt(num_rows);
+            if (num_rows > 0) primes.unset(0);
+            if (num_rows > 1) primes.unset(1);
+            var current: u32 = 2;
+            while (current < limit) : (current += 1) {
+                if (primes.isSet(current)) {
+                    var multiples = current * current;
+                    while (multiples < num_rows) : (multiples += current) {
+                        primes.unset(multiples);
+                    }
+                }
+            }
+        }
+
+        fn isPrime(num: usize) bool {
+            return primes.isSet(num);
+        }
+
+        fn highlightIfHovered(box: *dvui.BoxWidget, row_num: usize) !void {
+            if (highlighted_row != null and highlighted_row.? == row_num) {
+                box.wd.options.background = true;
+                box.wd.options.color_fill = .fill_hover;
+                try box.drawBackground();
+            }
+        }
+    };
+
+    if (!local.generated_primes) {
+        local.generatePrimes();
+        local.generated_primes = true;
+    }
+
+    var vbox = try dvui.box(@src(), .vertical, .{ .expand = .both });
+    defer vbox.deinit();
+    var grid = try dvui.grid(@src(), .{ .scroll_opts = .{ .scroll_info = &local.scroll_info } }, .{
+        .expand = .both,
+        .background = true,
+        .border = Rect.all(1),
+        .padding = .{ .x = 5 },
+    });
+    defer grid.deinit();
+
+    // Check if a row is being hovered.
+    const evts = dvui.events();
+    for (evts) |*e| {
+        if (dvui.eventMatchSimple(e, grid.scroll.data())) {
+            if (e.evt == .mouse and e.evt.mouse.action == .position) {
+                if (grid.row_height > 1) {
+                    // Convert mouse screen co-ords into co-ords relative to the scroll area's top-left.
+                    const scroll_rect = grid.scroll.data().rectScale();
+                    const offset = scroll_rect.pointFromPhysical(e.evt.mouse.p).y - grid.header_height;
+                    if (offset > 0) {
+                        // If the mouse is in the body part, not in the header part of the scroll area
+                        local.highlighted_row = @intFromFloat((local.scroll_info.viewport.y + offset) / grid.row_height);
+                        break;
+                    }
+                }
+            }
+        }
+        local.highlighted_row = null;
+    }
+
+    const scroller: dvui.GridWidget.VirtualScroller = .init(grid, .{ .total_rows = num_rows, .scroll_info = &local.scroll_info });
+    const first = scroller.startRow();
+    const last = scroller.endRow(); // Note that endRow is exclusive meaning it can be used as a slice ending index.
+
+    // Number column
+    {
+        var col = try grid.column(@src(), .{});
+        defer col.deinit();
+        try dvui.gridHeading(@src(), grid, "Number", .{}, .{});
+
+        for (first..last) |num| {
+            var cell = try grid.bodyCell(@src(), num, .{ .border = .{ .x = 1, .w = 1, .h = 1 }, .background = true });
+            defer cell.deinit();
+            try local.highlightIfHovered(cell, num);
+            try dvui.label(@src(), "{d}", .{num}, .{});
+        }
+    }
+    // Prime column
+    {
+        const check_img = @embedFile("icons/entypo/check.tvg");
+        var col = try grid.column(@src(), .{});
+        defer col.deinit();
+        try dvui.gridHeading(@src(), grid, "Is prime?", .{}, .{});
+
+        for (first..last) |num| {
+            var cell = try grid.bodyCell(@src(), num, .{ .border = .{ .w = 1, .h = 1 }, .background = true });
+            defer cell.deinit();
+            try local.highlightIfHovered(cell, num);
+            if (local.isPrime(num)) {
+                // TODO: Can't currently use gravity to centre the icon as it can't .expand. So pad it instead.
+                const pad_w = cell.data().contentRect().w / 2 - 15;
+                try dvui.icon(@src(), "Check", check_img, .{ .gravity_x = 0.5, .gravity_y = 0.5, .padding = .{ .x = pad_w }, .background = false });
+            }
+        }
+    }
+}
+
+fn gridVariableRowHeights() !void {
+    var grid = try dvui.grid(@src(), .{}, .{
+        .expand = .both,
+    });
+    defer grid.deinit();
+
+    var col = try grid.column(@src(), .{});
+    defer col.deinit();
+    for (1..10) |row_num| {
+        const row_num_i: i32 = @intCast(row_num);
+        const row_height = 70 - (@abs(row_num_i - 5) * 10);
+        var cell = try grid.bodyCell(@src(), row_num, .{ .height = @floatFromInt(row_height), .border = Rect.all(1) });
+        defer cell.deinit();
+        try dvui.label(@src(), "h = {d}", .{row_height}, .{ .gravity_x = 0.5, .expand = .horizontal });
     }
 }
 

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -80,7 +80,7 @@ pub const TabsWidget = widgets.TabsWidget;
 pub const TextEntryWidget = widgets.TextEntryWidget;
 pub const TextLayoutWidget = widgets.TextLayoutWidget;
 pub const VirtualParentWidget = widgets.VirtualParentWidget;
-
+pub const GridWidget = widgets.GridWidget;
 const se = @import("structEntry.zig");
 pub const structEntry = se.structEntry;
 pub const structEntryEx = se.structEntryEx;
@@ -4070,6 +4070,324 @@ pub fn scrollArea(src: std.builtin.SourceLocation, init_opts: ScrollAreaWidget.I
     return ret;
 }
 
+pub fn grid(src: std.builtin.SourceLocation, init_opts: GridWidget.InitOpts, opts: Options) !*GridWidget {
+    const ret = try currentWindow().arena().create(GridWidget);
+    ret.* = try GridWidget.init(src, init_opts, opts);
+    try ret.install();
+    return ret;
+}
+
+/// Create a heading with a static label
+pub fn gridHeading(src: std.builtin.SourceLocation, g: *GridWidget, heading: []const u8, cell_opts: dvui.GridWidget.CellOptions, opts: dvui.Options) !void {
+    const label_defaults: Options = .{
+        .corner_radius = Rect.all(0),
+        .expand = .horizontal,
+        .gravity_x = 0.5,
+        .gravity_y = 0.5,
+        .color_fill = .{ .name = .fill_control },
+        .background = true,
+    };
+    const label_options = label_defaults.override(opts);
+    var cell = try g.headerCell(src, cell_opts);
+    defer cell.deinit();
+
+    try labelNoFmt(@src(), heading, label_options);
+    try separator(@src(), .{ .expand = .vertical });
+}
+
+/// Create a heading and allow the column to be sorted.
+///
+/// Returns true if the sort direction has changed.
+/// sort_dir is an out parameter containing the current sort direction.
+pub fn gridHeadingSortable(
+    src: std.builtin.SourceLocation,
+    g: *GridWidget,
+    heading: []const u8,
+    dir: *GridWidget.SortDirection,
+    cell_opts: GridWidget.CellOptions,
+    opts: dvui.Options,
+) !bool {
+    const icon_ascending = @embedFile("icons/entypo/chevron-small-down.tvg");
+    const icon_descending = @embedFile("icons/entypo/chevron-small-up.tvg");
+    const icon_width = 27.5; // TODO: This is not const.
+    const padding = ButtonWidget.defaults.padding orelse Rect.all(6);
+
+    // Pad buttons with extra space if there is no sort indicator.
+    const padding_opts: Options = .{ .padding = .{ .x = icon_width / 2.0, .w = icon_width / 2.0, .y = padding.y, .h = padding.h } };
+    const heading_defaults: Options = .{
+        .expand = .horizontal,
+        .corner_radius = Rect.all(0),
+    };
+    const heading_opts = heading_defaults.override(opts);
+
+    var cell = try g.headerCell(src, cell_opts);
+    defer cell.deinit();
+
+    const sort_changed = switch (g.colSortOrder()) {
+        .unsorted => try button(@src(), heading, .{ .draw_focus = false }, padding_opts.override(heading_opts)),
+        .ascending => try buttonLabelAndIcon(@src(), heading, icon_ascending, .{ .draw_focus = false }, heading_opts),
+        .descending => try buttonLabelAndIcon(@src(), heading, icon_descending, .{ .draw_focus = false }, heading_opts),
+    };
+
+    if (sort_changed) {
+        g.sortChanged();
+    }
+    try separator(@src(), .{ .expand = .vertical, .gravity_x = 1.0 });
+    dir.* = g.sort_direction;
+    return sort_changed;
+}
+
+pub const CellOptionsOrCallback = union(enum) {
+    options: GridWidget.CellOptions,
+    callback: *const fn (col_num: usize, row_num: usize) GridWidget.CellOptions,
+
+    pub const none: CellOptionsOrCallback = .{ .options = .{} };
+};
+
+pub const OptionsOrCallback = union(enum) {
+    options: Options,
+    callback: *const fn (col_num: usize, row_num: usize) Options,
+
+    pub const none: OptionsOrCallback = .{ .options = .{} };
+};
+
+/// Create a column from a slice
+///
+/// If data is a slice of struct field_name must be supplied
+/// Enums are displayed as their @tagName and fmt must be "{s}"
+/// Bools are displayed as Y or N and fmt must be "{s}"
+/// Other types are formatted using the supplied fmt string.
+pub fn gridColumnFromSlice(
+    src: std.builtin.SourceLocation,
+    g: *GridWidget,
+    comptime T: type,
+    data: []const T,
+    comptime field_name: ?[]const u8,
+    comptime fmt: []const u8,
+    cell_opts: CellOptionsOrCallback,
+    opts: OptionsOrCallback,
+) !void {
+    // TODO: Support pointer to direct value.
+    comptime var TypeToValidate = T;
+    comptime validate: switch (@typeInfo(T)) {
+        .pointer => |ptr| {
+            if (ptr.size != .one) @compileError("T cannot be an array, slice or vector");
+            const child_type = @typeInfo(ptr.child);
+            if (child_type == .pointer) @compileError("T cannot be a pointer to a pointer");
+            if (child_type == .@"struct") {
+                // If pointer to struct then validate the child struct.
+                TypeToValidate = ptr.child;
+                continue :validate child_type;
+            }
+        },
+        .@"struct" => {
+            if (field_name) |_field_name| {
+                if (!@hasField(TypeToValidate, _field_name)) {
+                    @compileError(std.fmt.comptimePrint("{s} does not contain field {s}.", .{ @typeName(T), _field_name }));
+                }
+            } else @compileError("field_name must be supplied when T is a struct or pointer to a struct");
+        },
+        else => {},
+    };
+
+    const label_defaults: Options = .{
+        .expand = .horizontal,
+    };
+    // If options are supplied create the default options.
+    const row_label_opts: Options = switch (opts) {
+        .options => |o| label_defaults.override(o),
+        .callback => .{},
+    };
+    const row_cell_opts: GridWidget.CellOptions = switch (cell_opts) {
+        .options => |o| o,
+        .callback => .{},
+    };
+    for (data, 0..) |item, row_num| {
+        var cell = try g.bodyCell(
+            src,
+            row_num,
+            switch (cell_opts) {
+                .options => row_cell_opts,
+                .callback => |callback| callback(g.col_num, row_num),
+            },
+        );
+        defer cell.deinit();
+        const cell_value = value: {
+            if (field_name) |_field_name| {
+                // populate value from struct field.
+                break :value switch (@typeInfo(@TypeOf(@field(item, _field_name)))) {
+                    .@"enum" => @tagName(@field(item, _field_name)),
+                    .bool => if (@field(item, _field_name)) "Y" else "N",
+                    else => @field(item, _field_name),
+                };
+            } else {
+                // populate value directly from slice
+                break :value switch (@typeInfo(T)) {
+                    .@"enum" => @tagName(item),
+                    .bool => if (item) "Y" else "N",
+                    else => item,
+                };
+            }
+        };
+        try label(
+            @src(),
+            fmt,
+            .{cell_value},
+            switch (opts) {
+                .options => |o| row_label_opts.override(o),
+                .callback => |callback| label_defaults.override(callback(g.col_num, row_num)),
+            },
+        );
+    }
+}
+
+pub const GridColumnSelectAllState = enum {
+    select_all,
+    select_none,
+    unchanged,
+};
+
+/// A grid heading with a checkbox for select-all and select-none
+///
+/// Returns true if the selection state has changed.
+/// selection - out parameter containing the current selection state.
+pub fn gridHeadingCheckbox(src: std.builtin.SourceLocation, g: *GridWidget, selection: *GridColumnSelectAllState, cell_opts: GridWidget.CellOptions, opts: Options) !bool {
+    const header_defaults: Options = .{
+        .background = true,
+        .color_fill = .{ .name = .fill_control },
+        .margin = ButtonWidget.defaults.margin,
+        .expand = .vertical,
+        .gravity_y = 0.5,
+    };
+    const header_options = header_defaults.override(opts);
+    var cell = try g.headerCell(src, cell_opts);
+    defer cell.deinit();
+
+    var clicked = false;
+    var selected = false;
+    {
+        var hbox = try dvui.box(@src(), .horizontal, header_options);
+        defer hbox.deinit();
+        selected = dvui.dataGet(null, hbox.data().id, "_selected", bool) orelse false;
+        clicked = try dvui.checkbox(@src(), &selected, null, .{ .gravity_y = header_options.gravity_y, .gravity_x = header_options.gravity_x });
+        dvui.dataSet(null, hbox.data().id, "_selected", selected);
+    }
+    try dvui.separator(@src(), .{ .expand = .vertical });
+
+    if (clicked) {
+        selection.* = if (selected) .select_all else .select_none;
+    } else {
+        selection.* = .unchanged;
+    }
+    return clicked;
+}
+
+/// A checkbox column that allows selection of boolean items.
+///
+/// Returns true if any selections have changed.
+/// If field_name is null, T must be a bool.
+/// Otherwise field_name must refer to a bool field within a struct.
+pub fn gridColumnCheckbox(
+    src: std.builtin.SourceLocation,
+    g: *dvui.GridWidget,
+    comptime T: type,
+    data: []T,
+    comptime field_name: ?[]const u8,
+    cell_opts: CellOptionsOrCallback,
+    opts: OptionsOrCallback,
+) !bool {
+    if (T != bool) {
+        if (field_name) |_field_name| {
+            if (!@hasField(T, _field_name)) {
+                @compileError(std.fmt.comptimePrint("'{s}' does has no member named {s}.", .{ @typeName(T), _field_name }));
+            } else if (@FieldType(T, _field_name) != bool) {
+                @compileError(std.fmt.comptimePrint("{s}.{s} must be of type bool.", .{ @typeName(T), _field_name }));
+            }
+        } else {
+            @compileError("data must be of type []bool when field_name is null.");
+        }
+    }
+    const check_defaults: Options = .{
+        .gravity_x = 0.5,
+        .gravity_y = 0.5,
+    };
+    const check_opts = switch (opts) {
+        .options => |o| check_defaults.override(o),
+        .callback => check_defaults,
+    };
+
+    var selection_changed = false;
+    for (data, 0..) |*item, row_num| {
+        var cell = try g.bodyCell(
+            src,
+            row_num,
+            switch (cell_opts) {
+                .options => |o| o,
+                .callback => |callback| callback(g.col_num, row_num),
+            },
+        );
+        defer cell.deinit();
+        const is_selected: *bool = if (T == bool) item else &@field(item, field_name.?);
+        const was_selected = is_selected.*;
+        _ = try dvui.checkbox(
+            @src(),
+            is_selected,
+            null,
+            switch (opts) {
+                .options => check_opts,
+                .callback => |callback| check_defaults.override(callback(g.col_num, row_num)),
+            },
+        );
+        selection_changed = selection_changed or was_selected != is_selected.*;
+    }
+    return selection_changed;
+}
+
+/// Size columns widths using ratios.
+///
+/// Positive widths are treated as fixed widths and are not modified.
+/// Negative widths are treated as ratios and are replaced by a calculated width.
+/// Results are returned in col_widths, which will always be positive (or zero) values.
+/// If content_width is larger than the grid's visible area, horizontal scrolling should be enabled via the grid's init_opts.
+///
+/// Examples:
+/// To lay out three columns with equal widths, use the same negative ratio for each column:
+///     { -1, -1, -1 } or { -0.33, -0.33, -0.33 }
+/// To make the second column with twice the width of the first, use a negative ratio twice as large.
+///     {-1, -2 } or { -50, -100 }
+/// To lay out a fixed column width with all other columns sharing the remaining, use a positive width for the fixed column and
+/// the same negative ratio for the variable columns.
+///     { -1, 50, -1 }.
+pub fn columnLayoutProportional(ratio_widths: []const f32, col_widths: []f32, content_width: f32) void {
+    const scroll_bar_w: f32 = 10; // TODO: Don't necessarily know if SB is showing? There needs ot be a grid function to work this out.
+    std.debug.assert(ratio_widths.len == col_widths.len); // input and output slices must be the same length
+
+    // Count all of the positive widths as reserved widths.
+    // Total all of the negative widths.
+    const reserved_w, const ratio_w_total: f32 = blk: {
+        var res_width: f32 = 0;
+        var total_ratio_w: f32 = 0;
+        for (ratio_widths) |w| {
+            if (w <= 0) {
+                total_ratio_w += -w;
+            } else {
+                res_width += w;
+            }
+        }
+        break :blk .{ res_width, total_ratio_w };
+    };
+    const available_w = content_width - reserved_w - scroll_bar_w;
+
+    // For each negative width, replace it width a positive calculated width.
+    for (col_widths, ratio_widths) |*col_w, ratio_w| {
+        if (ratio_w <= 0) {
+            col_w.* = -ratio_w / ratio_w_total * available_w;
+        } else {
+            col_w.* = ratio_w;
+        }
+    }
+}
+
 pub fn separator(src: std.builtin.SourceLocation, opts: Options) !void {
     const defaults: Options = .{
         .name = "Separator",
@@ -4519,6 +4837,36 @@ pub fn buttonIcon(src: std.builtin.SourceLocation, name: []const u8, tvg_bytes: 
 
     const click = bw.clicked();
     try bw.drawFocus();
+    bw.deinit();
+    return click;
+}
+
+pub fn buttonLabelAndIcon(src: std.builtin.SourceLocation, label_str: []const u8, tvg_bytes: []const u8, init_opts: ButtonWidget.InitOptions, opts: Options) !bool {
+    // initialize widget and get rectangle from parent
+    var bw = ButtonWidget.init(src, init_opts, opts);
+
+    // make ourselves the new parent
+    try bw.install();
+
+    // process events (mouse and keyboard)
+    bw.processEvents();
+    var options = opts.strip().override(.{ .gravity_x = 0.5, .gravity_y = 0.5 });
+    if (bw.pressed()) options = options.override(.{ .color_text = .{ .color = opts.color(.text_press) } });
+
+    // draw background/border
+    try bw.drawBackground();
+    {
+        var hbox = try box(src, .horizontal, .{ .expand = .horizontal });
+        defer hbox.deinit();
+
+        try labelNoFmt(@src(), label_str, options.override(.{ .expand = .horizontal }));
+        try icon(@src(), label_str, tvg_bytes, opts.strip().override(.{ .gravity_y = 0.5 }));
+    }
+
+    const click = bw.clicked();
+
+    try bw.drawFocus();
+
     bw.deinit();
     return click;
 }

--- a/src/import_widgets.zig
+++ b/src/import_widgets.zig
@@ -35,7 +35,7 @@ pub const TabsWidget = @import("widgets/TabsWidget.zig");
 pub const TextEntryWidget = @import("widgets/TextEntryWidget.zig");
 pub const TextLayoutWidget = @import("widgets/TextLayoutWidget.zig");
 pub const VirtualParentWidget = @import("widgets/VirtualParentWidget.zig");
-
+pub const GridWidget = @import("widgets/GridWidget.zig");
 // Needed for autodocs "backlink" to work
 const dvui = @import("dvui");
 

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -1,0 +1,397 @@
+const std = @import("std");
+const dvui = @import("../dvui.zig");
+
+const Options = dvui.Options;
+const ColorOrName = Options.ColorOrName;
+const Rect = dvui.Rect;
+const Size = dvui.Size;
+const MaxSize = Options.MaxSize;
+const ScrollInfo = dvui.ScrollInfo;
+const WidgetData = dvui.WidgetData;
+const BoxWidget = dvui.BoxWidget;
+const ScrollAreaWidget = dvui.ScrollAreaWidget;
+const GridWidget = @This();
+pub var defaults: Options = .{
+    .name = "GridWidget",
+    .background = true,
+    .corner_radius = Rect{ .x = 0, .y = 0, .w = 5, .h = 5 },
+};
+
+pub const ColOptions = struct {
+    width: ?f32 = null,
+    border: ?Rect = null,
+    background: ?bool = null,
+    color_fill: ?ColorOrName = null,
+    color_border: ?ColorOrName = null,
+
+    pub fn toOptions(self: *const ColOptions) Options {
+        return .{
+            // height is not converted
+            .border = self.border,
+            .background = self.background,
+            .color_fill = self.color_fill,
+            .color_border = self.color_border,
+        };
+    }
+};
+
+pub const CellOptions = struct {
+    height: ?f32 = null,
+    margin: ?Rect = null,
+    border: ?Rect = null,
+    padding: ?Rect = null,
+    background: ?bool = null,
+    color_fill: ?ColorOrName = null,
+    color_border: ?ColorOrName = null,
+
+    pub fn toOptions(self: *const CellOptions) Options {
+        return .{
+            // does not convert height
+            .margin = self.margin,
+            .border = self.border,
+            .padding = self.padding,
+            .background = self.background,
+            .color_fill = self.color_fill,
+            .color_border = self.color_border,
+        };
+    }
+};
+
+pub const SortDirection = enum {
+    unsorted,
+    ascending,
+    descending,
+
+    pub fn reverse(dir: SortDirection) SortDirection {
+        return switch (dir) {
+            .descending => .ascending,
+            else => .descending,
+        };
+    }
+};
+
+pub const InitOpts = struct {
+    scroll_opts: ?ScrollAreaWidget.InitOpts = null,
+    col_widths: ?[]f32 = null,
+    // Recalculate row heights. Only set this when row heights could have changed, .e.g on column resize.
+    resize_rows: bool = false,
+};
+pub const default_col_width: f32 = 100;
+
+vbox: BoxWidget = undefined,
+scroll: ScrollAreaWidget = undefined,
+hbox: BoxWidget = undefined,
+init_opts: InitOpts = undefined,
+current_col: ?*BoxWidget = null,
+next_row_y: f32 = 0,
+last_height: f32 = 0,
+header_height: f32 = 0,
+row_height: f32 = 0,
+last_row_height: f32 = 0,
+col_num: usize = std.math.maxInt(usize),
+sort_col_number: usize = 0,
+sort_direction: SortDirection = .unsorted,
+saved_clip_rect: ?Rect.Physical = null,
+resizing: bool = false,
+rows_y_offset: f32 = 0,
+
+pub fn init(src: std.builtin.SourceLocation, init_opts: InitOpts, opts: Options) !GridWidget {
+    var self = GridWidget{};
+    self.init_opts = init_opts;
+    const options = defaults.override(opts);
+    self.vbox = BoxWidget.init(src, .vertical, false, options);
+    if (dvui.dataGet(null, self.data().id, "_last_height", f32)) |last_height| {
+        self.last_height = last_height;
+    }
+    if (dvui.dataGet(null, self.data().id, "_resizing", bool)) |resizing| {
+        self.resizing = resizing;
+    }
+    if (dvui.dataGet(null, self.data().id, "_header_height", f32)) |header_height| {
+        self.header_height = header_height;
+    }
+    if (dvui.dataGet(null, self.data().id, "_row_height", f32)) |row_height| {
+        self.last_row_height = row_height;
+        self.row_height = row_height;
+    }
+    if (dvui.dataGet(null, self.data().id, "_sort_col", usize)) |sort_col| {
+        self.sort_col_number = sort_col;
+    }
+    if (dvui.dataGet(null, self.data().id, "_sort_direction", SortDirection)) |sort_direction| {
+        self.sort_direction = sort_direction;
+    }
+    // Ensure resize on first initialization.
+    if (self.last_height == 0) {
+        self.resizing = true;
+    }
+    if (init_opts.resize_rows or self.resizing) {
+        self.row_height = 0;
+        dvui.refresh(null, @src(), self.data().id);
+    }
+
+    return self;
+}
+
+pub fn install(self: *GridWidget) !void {
+    try self.vbox.install();
+    try self.vbox.drawBackground();
+
+    self.scroll = ScrollAreaWidget.init(@src(), self.init_opts.scroll_opts orelse .{}, .{ .name = "GridWidgetScrollArea", .expand = .both });
+    try self.scroll.install();
+
+    // Lay out columns horizontally.
+    self.hbox = BoxWidget.init(@src(), .horizontal, false, .{
+        .expand = .both,
+    });
+    try self.hbox.install();
+    try self.hbox.drawBackground();
+}
+
+pub fn deinit(self: *GridWidget) void {
+    self.clipReset();
+
+    // resizing if row heights changed or a resize was requested via init options.
+    self.resizing =
+        self.init_opts.resize_rows or
+        !std.math.approxEqAbs(f32, self.row_height, self.last_row_height, 0.01);
+
+    dvui.dataSet(null, self.data().id, "_last_height", self.next_row_y);
+    dvui.dataSet(null, self.data().id, "_header_height", self.header_height);
+    dvui.dataSet(null, self.data().id, "_resizing", self.resizing);
+    dvui.dataSet(null, self.data().id, "_row_height", self.row_height);
+    dvui.dataSet(null, self.data().id, "_sort_col", self.sort_col_number);
+    dvui.dataSet(null, self.data().id, "_sort_direction", self.sort_direction);
+
+    self.hbox.deinit();
+    self.scroll.deinit();
+    self.vbox.deinit();
+}
+
+pub fn data(self: *GridWidget) *WidgetData {
+    return &self.vbox.wd;
+}
+
+/// Set the starting y value to begin rendering rows.
+/// Used for setting the y location of the first row when virtual scrolling.
+pub fn offsetRowsBy(self: *GridWidget, offset: f32) void {
+    self.rows_y_offset = offset;
+}
+
+/// Start a new grid column.
+/// Returns a vbox.
+/// Ensure deinit() is called on the returned vbox before creating a new column.
+/// Column width is determined from:
+/// 1) init_opts.col_width if supplied
+/// 2) opts.width if supplied
+/// 3) Otherewise column will expand to the available space.
+/// It is recommended that widths are provided for all columns.
+pub fn column(self: *GridWidget, src: std.builtin.SourceLocation, opts: ColOptions) !*BoxWidget {
+    self.clipReset();
+    self.current_col = null;
+
+    self.col_num +%= 1; // maxint wraps to 0 for first col.
+    self.next_row_y = self.rows_y_offset;
+
+    const w: f32, const expand: ?Options.Expand = width: {
+        // Take width from col_opts if it is set.
+        if (self.init_opts.col_widths) |col_info| {
+            if (self.col_num < col_info.len) {
+                break :width .{ col_info[self.col_num], null };
+            } else {
+                dvui.log.debug("GridWidget {x} has more columns than set in init_opts.col_widths. Using default column width of {d}\n", .{ self.data().id, default_col_width });
+                break :width .{ default_col_width, null };
+            }
+        } else {
+            if (opts.width) |w| {
+                if (w > 0) {
+                    break :width .{ w, null };
+                } else {
+                    dvui.log.debug("GridWidget {x} invalid opts.width provided to column(). Using default column width of {d}\n", .{ self.data().id, default_col_width });
+                    break :width .{ default_col_width, null };
+                }
+            } else {
+                // If there is no width specified either in col_info or col_opts,
+                // just expand to fill available width.
+                break :width .{ 0, .horizontal };
+            }
+        }
+    };
+    var col_opts = opts.toOptions();
+    col_opts.expand = expand;
+    col_opts.min_size_content = .{ .w = w, .h = self.last_height };
+    col_opts.max_size_content = if (w > 0) .width(w) else null;
+
+    var col = try dvui.currentWindow().arena().create(BoxWidget);
+    col.* = BoxWidget.init(src, .vertical, false, col_opts);
+    try col.install();
+    try col.drawBackground();
+    self.current_col = col;
+    return col;
+}
+
+/// Restore saved clip region.
+fn clipReset(self: *GridWidget) void {
+    if (self.saved_clip_rect) |cr| {
+        dvui.clipSet(cr);
+        self.saved_clip_rect = null;
+    }
+}
+
+/// Create a new header cell within a column
+/// Returns a hbox. deinit() must be called on this hbox before creating a new cell.
+/// Only one header cell is allowed per column.
+/// Height is taken from opts.height if provided, otherwise height is automatically determined.
+pub fn headerCell(self: *GridWidget, src: std.builtin.SourceLocation, opts: CellOptions) !*BoxWidget {
+    const y: f32 = self.scroll.si.viewport.y;
+    const parent_rect = self.current_col.?.data().contentRect();
+
+    const header_height: f32 = height: {
+        if (opts.height) |height| {
+            break :height height;
+        } else {
+            break :height if (self.resizing) 0 else self.header_height;
+        }
+    };
+    var cell_opts = opts.toOptions();
+    cell_opts.rect = .{ .x = 0, .y = y, .w = parent_rect.w, .h = header_height };
+
+    // Create the cell and install as parent.
+    var cell = try dvui.currentWindow().arena().create(BoxWidget);
+    cell.* = BoxWidget.init(src, .horizontal, false, cell_opts);
+    try cell.install();
+    try cell.drawBackground();
+
+    // Determine heights for next frame.
+    if (cell.data().contentRect().h > 0) {
+        const height = cell.data().rect.h;
+        self.header_height = @max(self.header_height, height);
+    }
+    self.next_row_y += self.header_height;
+    return cell;
+}
+
+/// Create a new body cell within a column
+/// Returns a hbox. deinit() must be called on this hbox before creating a new cell.
+/// Height is taken from opts.height if provided, otherwise height is automatically determined.
+pub fn bodyCell(self: *GridWidget, src: std.builtin.SourceLocation, row_num: usize, opts: CellOptions) !*BoxWidget {
+    const parent_rect = self.current_col.?.data().contentRect();
+
+    const cell_height: f32 = height: {
+        if (opts.height) |height| {
+            break :height height;
+        } else {
+            break :height if (self.resizing) 0 else self.row_height;
+        }
+    };
+
+    // Prevent the header from being overwritten when scrolling.
+    if (self.saved_clip_rect == null) {
+        const rect_scale = self.vbox.data().rectScale();
+        const header_height_scaled = self.header_height * rect_scale.s;
+
+        var clip_rect = rect_scale.r;
+        clip_rect.y += header_height_scaled;
+        clip_rect.h = self.scroll.si.viewport.h * rect_scale.s - header_height_scaled;
+
+        self.saved_clip_rect = dvui.clip(clip_rect);
+    }
+
+    var cell_opts = opts.toOptions();
+    cell_opts.rect = .{ .x = 0, .y = self.next_row_y, .w = parent_rect.w, .h = cell_height };
+    cell_opts.id_extra = row_num;
+
+    var cell = try dvui.currentWindow().arena().create(BoxWidget);
+    cell.* = BoxWidget.init(src, .horizontal, false, cell_opts);
+    try cell.install();
+    try cell.drawBackground();
+
+    if (cell.data().contentRect().h > 0) {
+        const measured_cell_height = cell.data().rect.h;
+        self.row_height = @max(self.row_height, measured_cell_height);
+    }
+
+    // If user provided a height, use that to position the next row, otherwise use the
+    // calculated row_height.
+    self.next_row_y += if (opts.height) |height| height else self.row_height;
+
+    return cell;
+}
+
+/// Set the grid's sort order when manually managing column sorting.
+pub fn colSortSet(self: *GridWidget, dir: SortDirection) void {
+    self.sort_col_number = self.col_num;
+    self.sort_direction = dir;
+}
+
+/// For automatic management of sort order, this must be called whenever
+/// the sort order for any column has changed.
+pub fn sortChanged(self: *GridWidget) void {
+    // If sorting on a new column, change current sort column to unsorted.
+    if (self.col_num != self.sort_col_number) {
+        self.sort_direction = .unsorted;
+        self.sort_col_number = self.col_num;
+    }
+    // If new sort column, then ascending, otherwise opposite of current sort.
+    self.sort_direction = if (self.sort_direction != .ascending) .ascending else .descending;
+}
+
+/// Returns the sort order for the current column.
+pub fn colSortOrder(self: *const GridWidget) SortDirection {
+    if (self.col_num == self.sort_col_number) {
+        return self.sort_direction;
+    } else {
+        return .unsorted;
+    }
+}
+
+/// Provides vitrual scrolling for a grid so that only the visibile rows are rendered.
+/// GridVirtualScroller requires that a scroll_info has been passed as an init_option
+/// to the GridBodyWidget.
+/// Note: Requires all rows to be the same height for the entire dataset. It is recommended
+/// to supply row heights to each cell when using the virtual scroller.
+pub const VirtualScroller = struct {
+    pub const InitOpts = struct {
+        // Total rows in the columns displayed
+        total_rows: usize,
+        scroll_info: *ScrollInfo,
+    };
+    grid: *GridWidget,
+    si: *ScrollInfo,
+    total_rows: usize,
+    pub fn init(grid: *GridWidget, init_opts: VirtualScroller.InitOpts) VirtualScroller {
+        const si = init_opts.scroll_info;
+        const total_rows_f: f32 = @floatFromInt(init_opts.total_rows);
+        si.virtual_size.h = @max(total_rows_f * grid.row_height + 10, si.viewport.h); // TODO: 10 = scrollbar padding
+        const first_row: f32 = @floatFromInt(_startRow(grid, si, init_opts.total_rows));
+        grid.offsetRowsBy(first_row * grid.row_height);
+        return .{
+            .grid = grid,
+            .si = si,
+            .total_rows = init_opts.total_rows,
+        };
+    }
+
+    fn _startRow(grid: *const GridWidget, si: *ScrollInfo, total_rows: usize) usize {
+        if (grid.row_height < 1) {
+            return 0;
+        }
+        const first_row_in_viewport: usize = @intFromFloat(@round(si.viewport.y / grid.row_height));
+        if (first_row_in_viewport == 0) {
+            return 0;
+        }
+        return @min(first_row_in_viewport - 1, total_rows);
+    }
+    /// Return the first row to render (inclusive)
+    pub fn startRow(self: *const VirtualScroller) usize {
+        return _startRow(self.grid, self.si, self.total_rows);
+    }
+
+    /// Return the end row to render (exclusive)
+    pub fn endRow(self: *const VirtualScroller) usize {
+        const last_row_in_viewport: usize =
+            if (self.grid.row_height < 1)
+                0
+            else
+                @intFromFloat(@round((self.si.viewport.y + self.si.viewport.h) / self.grid.row_height));
+        return @min(last_row_in_viewport + 1, self.total_rows);
+    }
+};


### PR DESCRIPTION
# Grid Widget

This seems to be in a pretty reasonable state now. Please review for merge.

Partially implements #268

## Discussion / Questions

Things I'd like your input on below:
1) Does columnFromSlice provide enough value vs the complexity of the generic function and the need for styling callbacks? It is saving the user from writing the following code for each column:
```
{
    for (data_set[0..], 0..) | *item, num | {
            var cell = try grid.bodyCell(@src(), num, .{ });
            defer cell.deinit();
            try dvui.labelNoFmt(@src(), item.name,  .{});
    }
}
```
2) Should VirtualScroller live in the GridWidget namespace or be exported through the dvui namespace? Or anything else exported for that matter. Only GridWidget is currently exported.
3) Unsure about the naming of the "add column" function in GridWidget. Currently named column() vs addCol/colAdd? Which is different to addTab(), but similar to dvui.label() etc.
4) Decided that supporting margins and padding on columns as well as cells wasn't required as user can just set them on each cell. This makes layout simpler as don't have to place each row in the column's content rect. And top padding to a column would apply before the header and bottom padding after the bottom row, which doesn't seem useful as they can just pad the top and bottom of the grid instead. Thoughts?
5) The row highlighting on hover in the virtual scrolling example feels a bit awkward? Is it OK or have any suggestions? The code makes perfect sense once you understand how dvui works, but for a beginner it may seem difficult to understand? At least there is an example they can copy.
6) That issue came up again with gravity_x = 0.5 not working for boxes unless .expand is used on the inner widget. See the virtual scrolling demo and placement of the tick box. I couldn't use the .expand as it would distort the image, so I had to center it "manually" instead.

Please feel free to be as picky/thorough as you need when reviewing. 

## Completed
- [X] Display of a fixed header row with a scrollable data area beneath it.
- [X] Provide various column layouts (e.g. fit to window, proportional layout, fixed_width, user calculated)
- [X] Ability to sort data by clicking on header rows
- [X] Display sort direction
- [X] Ability to select rows via checkbox
- [X] Horizontal / Vertical scrolling
- [X] Virtual scrolling (only render visible elements)
- [X] "Databound" columns - gridColumnFromSlice
- [X] User customizable cell and column styling and layouts
- [X] Ability to highlight hovered rows (userland)

## TODO
- [ ] Get rid of the padding for the sortable header. It isn't const the size of the symbol is dependent on the font size?
- [ ] Handle padding when header column width is smaller than the heading button width. Currently doesn't show the separator.
- [ ] Need some default padding, so the first column isn't hard against the edge of the grid.
- [ ] Support single select vs multiple select on the checkbox columns?
- [ ] Fix checkbox separator location when placed in a too big or too small column
- [ ] Change mouse pointer and behavior when hovering over grid. i.e. stop the "move window" that happens when clicking on a demo grid.
- [ ] Fix alignment of checkbox headers vs checkbox rows.

## Issues
- [ ] Grid header widget assumes vertical scroll bar width is 10 and that it will always be displayed. 
- [ ] Headers "wobble" with large virtual row heights. Almost certainly fp precision issue
        - Header is set to y position of scroll_info.virtual_size.y, but this doesn't always correspond to the top-left of the window.
        - Doubt this is solvable unless draw headers independently of the scroll canvas. i.e. relative to the outer grid's box?
- [ ] For 1 million rows our scroll height calc is out by 0.5 lines. Maybe work out some small padding to add to compensate for large numbers.
- [ ] Variable row heights demo seems to have an extra pixel between rows?

## Remaining Features
* Row headings?
* Some better visual indication that columns are sortable.
* Resize columns via dragging 
* Filtering headers - May not be worth providing anything generic here. Likely just an example of string filtering.
* Drag / Drop? - Guessing this can be implemented in user-land. Likely just needs an example.
* Keyboard navigation / selection - Likely userland and example only as well.



