### PR TITLE
Floating window limit dragging proto

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -375,7 +375,7 @@ pub fn demo() !void {
 
     const width = 600;
 
-    var float = try dvui.floatingWindow(@src(), .{ .open_flag = &show_demo_window }, .{ .min_size_content = .{ .w = width, .h = 400 }, .max_size_content = .width(width), .tag = demo_window_tag });
+    var float = try dvui.floatingWindow(@src(), .{ .open_flag = &show_demo_window, .drag_rect = dvui.header_rect }, .{ .min_size_content = .{ .w = width, .h = 400 }, .max_size_content = .width(width), .tag = demo_window_tag });
     defer float.deinit();
 
     // pad the fps label so that it doesn't trigger refresh when the number

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -3121,9 +3121,11 @@ pub fn floatingWindow(src: std.builtin.SourceLocation, floating_opts: FloatingWi
     return ret;
 }
 
+pub var header_rect: Rect = Rect.all(0);
+
 pub fn windowHeader(str: []const u8, right_str: []const u8, openflag: ?*bool) !void {
     var over = try dvui.overlay(@src(), .{ .expand = .horizontal, .name = "WindowHeader" });
-
+    header_rect = over.wd.rect;
     try dvui.labelNoFmt(@src(), str, .{ .gravity_x = 0.5, .gravity_y = 0.5, .expand = .horizontal, .font_style = .heading, .padding = .{ .x = 6, .y = 6, .w = 6, .h = 4 } });
 
     if (openflag) |of| {

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -100,7 +100,6 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     self.options.name = null; // so our layout Box isn't named FloatingWindow
 
     self.init_options = init_opts;
-    self.drag_rect = if (init_opts.drag_rect) |dr| self.wd.rectScale().rectToPhysical(dr) else self.wd.rectScale().r;
 
     var autopossize = true;
     if (self.init_options.rect) |ior| {
@@ -114,6 +113,8 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
         // we store the rect (only while the window is open)
         self.wd.rect = dvui.dataGet(null, self.wd.id, "_rect", Rect) orelse Rect{};
     }
+
+    self.drag_rect = if (init_opts.drag_rect) |dr| self.wd.rectScale().rectToPhysical(dr) else self.wd.rectScale().r;
 
     if (autopossize) {
         if (dvui.dataGet(null, self.wd.id, "_auto_size", @TypeOf(self.auto_size))) |as| {


### PR DESCRIPTION
This is prototype code to demonstrate the concept for #318

The issue I see is that the window heading is created separately to the floating window, or might not be created at all. So either we:
1) Remove the dragging code out of FloatingWindow and into the window header. But this means there is no way to move floating windows without headers and each different style of window heading would need to implement it. Not good.
2) Allow the user to specify the area of the floating window that allows dragging.
3) Have the header widget register itself with the floating window and set the drag rect. (Which is just option 2 with the header widget passing the rect instead of the user). 

I feel like option 2 returning the rect of the overlay widget is the best of those options? It will still break all users of dvui.windowHeader(), but in a way that people can just put a _ = in front of it if they want to keep existing behavior.

So I propose that:
1) dvui.windowHeader either return the overlay widget or some other way to access the window header rect.
2) FloatingWindowWidget take an init option of "drag_rect" or similar which optionally limits dragging functionality to within that rect.

While this solution is going to be fairly simple to implement, it does feel a little inelegant? Though I'm not sure what other solution we'd come up with if designing this from the beginning assuming the desire is to have floating windows draggable. It is quite flexible as someone could add a drag handle or similar to the window using this.

