### PR TITLE
Add shrinking arena allocator to prevent capacity leak

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -102,7 +102,7 @@ capture: ?dvui.CaptureMouse = null,
 captured_last_frame: bool = false,
 
 gpa: std.mem.Allocator,
-_arena: std.heap.ArenaAllocator,
+_arena: dvui.ShrinkingArenaAllocator,
 texture_trash: std.ArrayList(dvui.Texture) = undefined,
 render_target: dvui.RenderTarget = .{ .texture = null, .offset = .{} },
 end_rendering_done: bool = false,
@@ -171,7 +171,7 @@ const SavedData = struct {
 
 pub const InitOptions = struct {
     id_extra: usize = 0,
-    arena: ?std.heap.ArenaAllocator = null,
+    arena: ?dvui.ShrinkingArenaAllocator = null,
     theme: ?*Theme = null,
     keybinds: ?enum {
         none,
@@ -190,26 +190,26 @@ pub fn init(
 
     var self = Self{
         .gpa = gpa,
-        ._arena = init_opts.arena orelse std.heap.ArenaAllocator.init(gpa),
-        .subwindows = std.ArrayList(Subwindow).init(gpa),
-        .min_sizes = std.AutoHashMap(WidgetId, SavedSize).init(gpa),
-        .tags = std.StringHashMap(SavedTagData).init(gpa),
-        .data_mutex = std.Thread.Mutex{},
-        .datas = std.AutoHashMap(u64, SavedData).init(gpa),
-        .animations = std.AutoHashMap(u64, Animation).init(gpa),
-        .tab_index_prev = std.ArrayList(dvui.TabIndex).init(gpa),
-        .tab_index = std.ArrayList(dvui.TabIndex).init(gpa),
-        .font_cache = std.AutoHashMap(u64, dvui.FontCacheEntry).init(gpa),
-        .texture_cache = std.AutoHashMap(u64, dvui.TextureCacheEntry).init(gpa),
-        .dialog_mutex = std.Thread.Mutex{},
-        .dialogs = std.ArrayList(Dialog).init(gpa),
-        .toasts = std.ArrayList(Toast).init(gpa),
-        .keybinds = std.StringHashMap(dvui.enums.Keybind).init(gpa),
-        .debug_toggle_mutex = std.Thread.Mutex{},
+        ._arena = init_opts.arena orelse .init(gpa),
+        .subwindows = .init(gpa),
+        .min_sizes = .init(gpa),
+        .tags = .init(gpa),
+        .data_mutex = .{},
+        .datas = .init(gpa),
+        .animations = .init(gpa),
+        .tab_index_prev = .init(gpa),
+        .tab_index = .init(gpa),
+        .font_cache = .init(gpa),
+        .texture_cache = .init(gpa),
+        .dialog_mutex = .{},
+        .dialogs = .init(gpa),
+        .toasts = .init(gpa),
+        .keybinds = .init(gpa),
+        .debug_toggle_mutex = .{},
         .wd = WidgetData{ .src = src, .id = hashval, .init_options = .{ .subwindow = true }, .options = .{ .name = "Window" } },
         .backend = backend_ctx,
         .font_bytes = try dvui.Font.initTTFBytesDatabase(gpa),
-        .themes = std.StringArrayHashMap(Theme).init(gpa),
+        .themes = .init(gpa),
     };
 
     try self.themes.putNoClobber("Adwaita Light", @import("themes/Adwaita.zig").light);
@@ -1708,7 +1708,7 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
     // event to the end this will print a debug message.
     self.positionMouseEventRemove();
 
-    _ = self._arena.reset(.retain_capacity);
+    _ = self._arena.reset();
 
     try self.initEvents();
 

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -91,6 +91,7 @@ pub const StructFieldOptions = se.StructFieldOptions;
 pub const enums = @import("enums.zig");
 pub const easing = @import("easing.zig");
 pub const testing = @import("testing.zig");
+pub const ShrinkingArenaAllocator = @import("shrinking_arena_allocator.zig");
 
 pub const wasm = (builtin.target.cpu.arch == .wasm32 or builtin.target.cpu.arch == .wasm64);
 pub const useFreeType = !wasm;

--- a/src/shrinking_arena_allocator.zig
+++ b/src/shrinking_arena_allocator.zig
@@ -1,0 +1,98 @@
+//! This is a wrapper of the `ArenaAllocator` that keeps track of the peak memory used
+//! in order to retain only the most minimal allocation.
+//!
+//! This is important because dvui applications may allocate large files like images
+//! on the arena, but never again for the lifetime of the application. Retaining the
+//! capacity for these the large files does no make sense when only a fraction of
+//! that is used during a normal frame.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Alignment = std.mem.Alignment;
+const ArenaAllocator = std.heap.ArenaAllocator;
+
+const ShrinkingArenaAllocator = @This();
+
+const allowed_extra_capacity = 0x1000;
+
+arena: ArenaAllocator,
+peak_usage: usize = 0,
+current_usage: usize = 0,
+
+pub fn init(child_allocator: Allocator) ShrinkingArenaAllocator {
+    return .{ .arena = .init(child_allocator) };
+}
+
+pub fn deinit(self: ShrinkingArenaAllocator) void {
+    self.arena.deinit();
+}
+
+/// Resets the inner arena, limiting the retained capacity to the peak amount used + the extra allowed capacity
+pub fn reset(self: *ShrinkingArenaAllocator) bool {
+    // std.log.debug("SAA peak used: {d}", .{self.peak_usage});
+    // std.log.debug("SAA arena buf len: {d}", .{self.arena.state.buffer_list.len()});
+    // std.log.debug("SAA arena capacity: {d}", .{self.arena.queryCapacity()});
+    // defer std.log.debug("SAA retained capacity: {d}", .{self.arena.queryCapacity()});
+    defer self.current_usage = 0;
+    defer self.peak_usage = 0;
+    return self.arena.reset(.{ .retain_with_limit = self.peak_usage + allowed_extra_capacity });
+}
+
+pub fn allocator(self: *ShrinkingArenaAllocator) Allocator {
+    return .{
+        .ptr = self,
+        .vtable = &.{
+            .alloc = alloc,
+            .resize = resize,
+            .remap = remap,
+            .free = free,
+        },
+    };
+}
+
+fn alloc(ctx: *anyopaque, len: usize, alignment: Alignment, ret_addr: usize) ?[*]u8 {
+    const self: *ShrinkingArenaAllocator = @ptrCast(@alignCast(ctx));
+    const buf = self.arena.allocator().rawAlloc(len, alignment, ret_addr) orelse return null;
+    self.current_usage += len;
+    self.peak_usage = @max(self.peak_usage, self.current_usage);
+    return buf;
+}
+
+fn free(ctx: *anyopaque, memory: []u8, alignment: Alignment, ret_addr: usize) void {
+    const self: *ShrinkingArenaAllocator = @ptrCast(@alignCast(ctx));
+    const end_before = self.arena.state.end_index;
+    self.arena.allocator().rawFree(memory, alignment, ret_addr);
+    if (self.arena.state.end_index < end_before) {
+        self.current_usage -= memory.len;
+    }
+}
+
+fn remap(ctx: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
+    const self: *ShrinkingArenaAllocator = @ptrCast(@alignCast(ctx));
+    const end_before = self.arena.state.end_index;
+    const buf = self.arena.allocator().rawRemap(memory, alignment, new_len, ret_addr) orelse return null;
+    if (self.arena.state.end_index != end_before) {
+        if (new_len < memory.len) {
+            self.current_usage -= memory.len - new_len;
+        } else {
+            self.current_usage += new_len - memory.len;
+            self.peak_usage = @max(self.peak_usage, self.current_usage);
+        }
+    }
+    return buf;
+}
+
+fn resize(ctx: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, ret_addr: usize) bool {
+    const self: *ShrinkingArenaAllocator = @ptrCast(@alignCast(ctx));
+    if (self.arena.allocator().rawResize(memory, alignment, new_len, ret_addr)) {
+        if (new_len < memory.len) {
+            self.current_usage -= memory.len - new_len;
+        } else {
+            self.current_usage += new_len - memory.len;
+            self.peak_usage = @max(self.peak_usage, self.current_usage);
+        }
+        return true;
+    } else {
+        return false;
+    }
+}


### PR DESCRIPTION
I mentioned this before in https://github.com/david-vanderson/dvui/issues/192#issuecomment-2925202681.

Before when using the `std.heap.ArenaAllocator` the capacity would never shrinking as the `.retain_capacity` option was passed to the arena. We could not easily use `.retain_with_limit` before as the reasonable limit would change per application or view in the application.

To address this a wrapper around the `std.heap.ArenaAllocator` was created that keeps track of the peak memory usage before the reset and retains only that much, with some padding. This allows the arena to shrinking over time but still adapt and be as fast as before on "static" views.

I first tried to calculate the memory used based on the capacity and `end_index` of the `std.heap.ArenaAllocator`. This was unreliable as memory could have been freed before the check, like in the plot example, causing the needed capacity to be freed and reallocated every frame.