### PR TITLE
Use stb_truetype when cpu == wasm64

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -472,7 +472,7 @@ fn addDvuiModule(
 
     dvui_mod.addIncludePath(b.path("src/stb"));
 
-    if (target.result.cpu.arch == .wasm32) {
+    if (target.result.cpu.arch == .wasm32 or target.result.cpu.arch == .wasm64) {
         dvui_mod.addCSourceFiles(.{
             .files = &.{
                 "src/stb/stb_image_impl.c",


### PR DESCRIPTION
When I build for wasm64 I get error

```
~/.cache/zig/p/freetype-2.13.0-AAAAAI6NqAA4EbABl7qfk5qBFJQb2xjUIcP6SY7EBFvJ/include/freetype/config/ftstdlib.h:88:10: error: 'string.h' file not found
```

After this fix my build passes.