### PR TITLE
PanedWidget: New option `handle_interactive` 

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -1830,7 +1830,7 @@ pub fn layout() !void {
     }
     try dvui.label(@src(), "Collapsible Pane with Draggable Sash", .{}, .{});
     {
-        var paned = try dvui.paned(@src(), .{ .direction = .horizontal, .collapsed_size = paned_collapsed_width }, .{ .expand = .both, .background = false, .min_size_content = .{ .h = 100 } });
+        var paned = try dvui.paned(@src(), .{ .direction = .horizontal, .collapsed_size = paned_collapsed_width }, .{ .expand = .both, .background = false, .min_size_content = .{ .h = 130 } });
         defer paned.deinit();
 
         if (paned.showFirst()) {

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -31,11 +31,11 @@ pub const InitOptions = struct {
     handle_dynamic: ?struct {
         /// Handle thickness is between handle_size (min) and handle_size_max
         /// (max) based on how close the mouse is.
-        handle_size_max: f32 = 8,
+        handle_size_max: f32 = 10,
 
         /// Show and dynamically adjust size of sash handle when mouse is
         /// closer than this (logical).
-        distance_max: f32 = 30,
+        distance_max: f32 = 20,
     } = null,
 };
 
@@ -290,7 +290,7 @@ pub fn processEvent(self: *PanedWidget, e: *Event, bubbling: bool) void {
             self.handle_thick = std.math.clamp(hd.handle_size_max - mouse_dist_outside / 2, self.init_opts.handle_size, hd.handle_size_max);
         }
 
-        if (dvui.captured(self.wd.id) or self.mouse_dist <= self.handle_thick + 3) {
+        if (dvui.captured(self.wd.id) or self.mouse_dist <= @max(self.handle_thick / 2, 2)) {
             if (e.evt.mouse.action == .press and e.evt.mouse.button.pointer()) {
                 e.handle(@src(), self.data());
                 // capture and start drag

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -49,6 +49,8 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
         .vertical => rect.r.h,
     };
 
+    self.handle_interactive = init_opts.handle_interactive;
+
     if (!self.handle_interactive)
         self.handle_size = init_opts.handle_size
     else

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -32,7 +32,7 @@ pub const InitOptions = struct {
 
         /// Show and dynamically adjust size of sash handle when mouse is
         /// closer than this (logical).
-        dist_max: f32 = 30,
+        distance_max: f32 = 30,
     } = null,
 };
 
@@ -145,10 +145,10 @@ pub fn draw(self: *PanedWidget) !void {
     var len_ratio: f32 = 1.0 / 5.0;
 
     if (self.init_opts.handle_dynamic) |hd| {
-        if (self.mouse_dist > self.handle_thick + hd.dist_max) {
+        if (self.mouse_dist > self.handle_thick + hd.distance_max) {
             return;
         } else {
-            len_ratio *= 1.0 - std.math.clamp((self.mouse_dist - self.handle_thick) / hd.dist_max, 0.0, 1.0);
+            len_ratio *= 1.0 - std.math.clamp((self.mouse_dist - self.handle_thick) / hd.distance_max, 0.0, 1.0);
         }
     } else {
         if (self.mouse_dist > self.handle_thick + 3) return;

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -84,8 +84,11 @@ pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Op
         } else {
             self.animateSplit(0.0);
         }
-    } else if (!self.collapsing and self.collapsed_state and our_size >= self.init_opts.collapsed_size) {
+    }
+
+    if ((self.collapsing or self.collapsed_state) and our_size >= self.init_opts.collapsed_size) {
         // expanding
+        self.collapsing = false;
         self.collapsed_state = false;
         if (self.split_ratio.* > 0.5) {
             self.animateSplit(0.5);
@@ -101,7 +104,7 @@ pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Op
 
         if (self.collapsing and a.done()) {
             self.collapsing = false;
-            self.collapsed_state = our_size < self.init_opts.collapsed_size;
+            self.collapsed_state = true;
         }
     }
 


### PR DESCRIPTION
When true enables the handle to grow/shrink based on mouse position, rather than just toggling visibility. `false` by default, so everything should remain as is currently.