### PR TITLE
GridWidget: Fix minor issues

### DIFF
--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -4177,8 +4177,8 @@ pub fn gridHeading(src: std.builtin.SourceLocation, g: *GridWidget, heading: []c
     var cell = try g.headerCell(src, cell_opts);
     defer cell.deinit();
 
-    try separator(@src(), .{ .expand = .vertical, .gravity_x = 1.0 });
     try labelNoFmt(@src(), heading, label_options);
+    try separator(@src(), .{ .expand = .vertical, .gravity_x = 1.0 });
 }
 
 /// Create a heading and allow the column to be sorted.
@@ -4193,8 +4193,8 @@ pub fn gridHeadingSortable(
     cell_opts: GridWidget.CellOptions,
     opts: dvui.Options,
 ) !bool {
-    const icon_ascending = dvui.entypo.chevron_small_down;
-    const icon_descending = dvui.entypo.chevron_small_up;
+    const icon_ascending = dvui.entypo.chevron_small_up;
+    const icon_descending = dvui.entypo.chevron_small_down;
 
     // Pad buttons with extra space if there is no sort indicator.
     const heading_defaults: Options = .{


### PR DESCRIPTION
1. Sorting chevron directions were reversed
2. Header divider was not showing in non-sortable grid headers.