### PR TITLE
Add TrackingAutoHashMap with support for usage tracking

### DIFF
--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -292,7 +292,7 @@ pub fn minSizeSetAndRefresh(self: *WidgetData) void {
 
     var cw = dvui.currentWindow();
 
-    const existing_min_size = cw.min_sizes.fetchPut(self.id, .{ .size = self.min_size }) catch |err| blk: {
+    const existing_min_size = cw.min_sizes.fetchPut(cw.gpa, self.id, self.min_size) catch |err| blk: {
         // returning an error here means that all widgets deinit can return
         // it, which is very annoying because you can't "defer try
         // widget.deinit()".  Also if we are having memory issues then we
@@ -303,7 +303,7 @@ pub fn minSizeSetAndRefresh(self: *WidgetData) void {
     };
 
     if (existing_min_size) |kv| {
-        if (kv.value.used) {
+        if (kv.used) {
             const name: []const u8 = self.options.name orelse "???";
             dvui.log.err("{s}:{d} duplicate widget id {x} (widget \"{s}\" highlighted in red); you may need to pass .{{.id_extra=<loop index>}} as widget options (see https://github.com/david-vanderson/dvui/blob/master/readme-implementation.md#widget-ids )\n", .{ self.src.file, self.src.line, self.id, name });
             cw.debug_widget_id = self.id;

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -92,6 +92,7 @@ pub const enums = @import("enums.zig");
 pub const easing = @import("easing.zig");
 pub const testing = @import("testing.zig");
 pub const ShrinkingArenaAllocator = @import("shrinking_arena_allocator.zig");
+pub const TrackingAutoHashMap = @import("tracking_hash_map.zig").TrackingAutoHashMap;
 
 pub const wasm = (builtin.target.cpu.arch == .wasm32 or builtin.target.cpu.arch == .wasm64);
 pub const useFreeType = !wasm;
@@ -207,14 +208,13 @@ pub const TagData = struct {
 
 pub fn tag(name: []const u8, data: TagData) void {
     var cw = currentWindow();
-    const existing_tag = cw.tags.fetchPut(name, .{ .data = data }) catch |err| blk: {
+    const existing_tag = cw.tags.fetchPut(cw.gpa, name, data) catch |err| blk: {
         dvui.log.err("tag() \"{s}\" got {!} for id {x}\n", .{ name, err, data.id });
-
         break :blk null;
     };
 
     if (existing_tag) |kv| {
-        if (kv.value.used) {
+        if (kv.used) {
             dvui.log.err("duplicate tag name \"{s}\" id {x} (highlighted in red); you may need to pass .{{.id_extra=<loop index>}} as widget options (see https://github.com/david-vanderson/dvui/blob/master/readme-implementation.md#widget-ids )\n", .{ name, data.id });
             cw.debug_widget_id = data.id;
         }
@@ -222,13 +222,7 @@ pub fn tag(name: []const u8, data: TagData) void {
 }
 
 pub fn tagGet(name: []const u8) ?TagData {
-    var cw = currentWindow();
-    const saved_tag = cw.tags.getPtr(name);
-    if (saved_tag) |st| {
-        return st.data;
-    } else {
-        return null;
-    }
+    return currentWindow().tags.get(name);
 }
 
 /// Help left-align widgets by adding horizontal spacers.
@@ -441,7 +435,6 @@ const GlyphInfo = struct {
 };
 
 pub const FontCacheEntry = struct {
-    used: bool = true,
     face: if (useFreeType) c.FT_Face else c.stbtt_fontinfo,
     scaleFactor: f32,
     height: f32,
@@ -761,10 +754,7 @@ pub const FontCacheEntry = struct {
 pub fn fontCacheGet(font: Font) !*FontCacheEntry {
     var cw = currentWindow();
     const fontHash = FontCacheEntry.hash(font);
-    if (cw.font_cache.getPtr(fontHash)) |fce| {
-        fce.used = true;
-        return fce;
-    }
+    if (cw.font_cache.getPtr(fontHash)) |fce| return fce;
 
     //ttf bytes
     const bytes = blk: {
@@ -858,7 +848,7 @@ pub fn fontCacheGet(font: Font) !*FontCacheEntry {
     errdefer {
         textureDestroyLater(entry.texture_atlas);
     }
-    try cw.font_cache.putNoClobber(fontHash, entry);
+    try cw.font_cache.putNoClobber(cw.gpa, fontHash, entry);
 
     return cw.font_cache.getPtr(fontHash).?;
 }
@@ -881,7 +871,6 @@ pub const TextureTarget = struct {
 /// how dvui caches icon and image rasterizations.
 pub const TextureCacheEntry = struct {
     texture: Texture,
-    used: bool = true,
 
     pub fn hash(bytes: []const u8, height: u32) u64 {
         var h = fnv.init();
@@ -928,10 +917,8 @@ pub fn iconTexture(name: []const u8, tvg_bytes: []const u8, height: u32, icon_op
     var cw = currentWindow();
     const icon_hash = TextureCacheEntry.hash_icon(tvg_bytes, height, icon_opts);
 
-    if (cw.texture_cache.getPtr(icon_hash)) |tce| {
-        tce.used = true;
-        return tce.*;
-    }
+    if (cw.texture_cache.get(icon_hash)) |tce| return tce;
+
     const ImageAdapter = struct {
         pixels: []u8,
         width: u32,
@@ -992,7 +979,7 @@ pub fn iconTexture(name: []const u8, tvg_bytes: []const u8, height: u32, icon_op
     //std.debug.print("created icon texture \"{s}\" ask height {d} size {d}x{d}\n", .{ name, height, render.width, render.height });
 
     const entry = TextureCacheEntry{ .texture = texture };
-    try cw.texture_cache.put(icon_hash, entry);
+    try cw.texture_cache.put(cw.gpa, icon_hash, entry);
 
     return entry;
 }
@@ -2388,13 +2375,7 @@ pub fn firstFrame(id: WidgetId) bool {
 ///
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn minSizeGet(id: WidgetId) ?Size {
-    var cw = currentWindow();
-    const saved_size = cw.min_sizes.getPtr(id);
-    if (saved_size) |ss| {
-        return ss.size;
-    } else {
-        return null;
-    }
+    return currentWindow().min_sizes.get(id);
 }
 
 /// Return the maximum of min_size and the min size for id from last frame.
@@ -2877,7 +2858,6 @@ pub fn eventMatch(e: *Event, opts: EventMatchOptions) bool {
 /// deleted at the beginning of the next frame.  See `spinner` for an example of
 /// how to have a seamless continuous animation.
 pub const Animation = struct {
-    used: bool = true,
     easing: *const easing.EasingFn = easing.linear,
     start_val: f32 = 0,
     end_val: f32 = 1,
@@ -2913,7 +2893,7 @@ pub const Animation = struct {
 pub fn animation(id: WidgetId, key: []const u8, a: Animation) void {
     var cw = currentWindow();
     const h = hashIdKey(id, key);
-    cw.animations.put(h, a) catch |err| switch (err) {
+    cw.animations.put(cw.gpa, h, a) catch |err| switch (err) {
         error.OutOfMemory => {
             log.err("animation got {!} for id {x} key {s}\n", .{ err, id, key });
         },
@@ -2924,15 +2904,8 @@ pub fn animation(id: WidgetId, key: []const u8, a: Animation) void {
 ///
 /// Only valid between `Window.begin` and `Window.end`.
 pub fn animationGet(id: WidgetId, key: []const u8) ?Animation {
-    var cw = currentWindow();
     const h = hashIdKey(id, key);
-    const val = cw.animations.getPtr(h);
-    if (val) |v| {
-        v.used = true;
-        return v.*;
-    }
-
-    return null;
+    return currentWindow().animations.get(h);
 }
 
 /// Add a timer for id that will be `timerDone` on the first frame after micros
@@ -6695,10 +6668,7 @@ pub fn imageTexture(name: []const u8, image_bytes: []const u8) !TextureCacheEntr
     var cw = currentWindow();
     const hash = TextureCacheEntry.hash(image_bytes, 0);
 
-    if (cw.texture_cache.getPtr(hash)) |tce| {
-        tce.used = true;
-        return tce.*;
-    }
+    if (cw.texture_cache.get(hash)) |tce| return tce;
 
     var w: c_int = undefined;
     var h: c_int = undefined;
@@ -6733,7 +6703,7 @@ pub fn imageTexture(name: []const u8, image_bytes: []const u8) !TextureCacheEntr
     //}
 
     const entry = TextureCacheEntry{ .texture = texture };
-    try cw.texture_cache.put(hash, entry);
+    try cw.texture_cache.put(cw.gpa, hash, entry);
 
     return entry;
 }

--- a/src/tracking_hash_map.zig
+++ b/src/tracking_hash_map.zig
@@ -1,0 +1,213 @@
+pub fn Tracked(comptime V: type) type {
+    return struct {
+        inner: V,
+        used: bool = true,
+    };
+}
+
+pub const TrackingKind = enum {
+    /// Sets the used flag when an item is added or accessed
+    get_and_put,
+    /// Only set the used flag when adding an item. Useful for
+    /// detecting if items are added more than once per `reset`
+    put_only,
+};
+
+/// A wrapper around `std.HashMapUnmanaged` that stores a `used` flag next
+/// to the value to allow for removal on unused values.
+///
+/// Calling `TrackingAutoHashMap.reset` gives a list of keys that has not been
+/// accessed since the last call to `TrackingAutoHashMap.reset`.
+pub fn TrackingAutoHashMap(
+    comptime K: type,
+    comptime V: type,
+    comptime tracking: TrackingKind,
+) type {
+    return struct {
+        map: HashMap = .empty,
+
+        pub const empty = Self{};
+
+        const Self = @This();
+
+        pub const HashMap = std.HashMapUnmanaged(K, Tracked(V), if (K == []const u8) std.hash_map.StringContext else std.hash_map.AutoContext(K), std.hash_map.default_max_load_percentage);
+
+        pub const Entry = struct {
+            key_ptr: *K,
+            value_ptr: *V,
+        };
+
+        pub const KV = struct {
+            key: K,
+            value: V,
+            used: bool,
+        };
+
+        const GetOrPutResult = struct {
+            key_ptr: *K,
+            value_ptr: *V,
+            found_existing: bool,
+        };
+
+        /// See `HashMap.Iterator`
+        pub const Iterator = struct {
+            map_it: HashMap.Iterator,
+
+            /// Sets each entry as used if get tracking is enabled
+            pub fn next(it: *Iterator) ?Entry {
+                const entry = it.map_it.next() orelse return null;
+                if (tracking != .put_only) entry.value_ptr.used = true;
+                return .{
+                    .key_ptr = entry.key_ptr,
+                    .value_ptr = &entry.value_ptr.inner,
+                };
+            }
+
+            /// A version of `next` that only returns items that has been used
+            pub fn next_used(it: *Iterator) ?Entry {
+                var entry = it.map_it.next() orelse return null;
+                while (!entry.value_ptr.used) {
+                    entry = it.map_it.next() orelse return null;
+                }
+                return .{
+                    .key_ptr = entry.key_ptr,
+                    .value_ptr = &entry.value_ptr.inner,
+                };
+            }
+        };
+
+        /// See `HashMap.deinit`
+        pub fn deinit(self: *Self, allocator: Allocator) void {
+            self.map.deinit(allocator);
+        }
+
+        /// See `HashMap.count`
+        pub fn count(self: Self) HashMap.Size {
+            return self.map.size;
+        }
+
+        /// See `HashMap.iterator`
+        pub fn iterator(self: *const Self) Iterator {
+            return .{ .map_it = self.map.iterator() };
+        }
+
+        /// See `HashMap.put`
+        pub fn put(self: *Self, allocator: Allocator, key: K, value: V) Allocator.Error!void {
+            return self.map.put(allocator, key, .{ .inner = value });
+        }
+
+        /// See `HashMap.putNoClobber`
+        pub fn putNoClobber(self: *Self, allocator: Allocator, key: K, value: V) Allocator.Error!void {
+            return self.map.putNoClobber(allocator, key, .{ .inner = value });
+        }
+
+        /// See `HashMap.fetchPut`
+        ///
+        /// Additionally contains `KV.used` to indicate if the value was used before the fetch
+        pub fn fetchPut(self: *Self, allocator: Allocator, key: K, value: V) Allocator.Error!?KV {
+            const kv = try self.map.fetchPut(allocator, key, .{ .inner = value }) orelse return null;
+            return .{ .key = kv.key, .value = kv.value.inner, .used = kv.value.used };
+        }
+
+        /// See `HashMap.getPtr`
+        pub fn getPtr(self: Self, key: K) ?*V {
+            const item = self.map.getPtr(key) orelse return null;
+            if (tracking != .put_only) item.used = true;
+            return &item.inner;
+        }
+
+        /// See `HashMap.get`
+        pub fn get(self: Self, key: K) ?V {
+            return if (self.getPtr(key)) |v| v.* else null;
+        }
+
+        /// See `HashMap.getOrPut`
+        pub fn getOrPut(self: *Self, allocator: Allocator, key: K) Allocator.Error!GetOrPutResult {
+            const entry = try self.map.getOrPut(allocator, key);
+            if (tracking != .put_only) entry.value_ptr.used = true;
+            return .{
+                .key_ptr = entry.key_ptr,
+                .value_ptr = &entry.value_ptr.inner,
+                .found_existing = entry.found_existing,
+            };
+        }
+
+        /// See `HashMap.remove`
+        pub fn remove(self: *Self, key: K) bool {
+            return self.map.remove(key);
+        }
+
+        /// See `HashMap.fetchRemove`
+        ///
+        /// Additionally contains `KV.used` to indicate if the value was used before the fetch
+        pub fn fetchRemove(self: *Self, key: K) ?KV {
+            const kv = self.map.fetchRemove(key) orelse return null;
+            return .{ .key = kv.key, .value = kv.value.inner, .used = kv.value.used };
+        }
+
+        /// Takes a `value_ptr` from and iterator `Entry` or from `getPtr`and sets the used
+        /// state to the value provided.
+        pub fn setUsed(value_ptr: *V, used: bool) void {
+            const tracked: *Tracked(V) = @fieldParentPtr("inner", value_ptr);
+            tracked.used = used;
+        }
+
+        /// Returns all keys that had not been used since the last call to this function
+        pub fn reset(self: *Self, allocator: std.mem.Allocator) ![]const K {
+            var unused = std.ArrayListUnmanaged(K).empty;
+            var map_it = self.map.iterator();
+            while (map_it.next()) |entry| {
+                if (entry.value_ptr.used) {
+                    entry.value_ptr.used = false;
+                } else {
+                    try unused.append(allocator, entry.key_ptr.*);
+                }
+            }
+            return unused.toOwnedSlice(allocator);
+        }
+    };
+}
+
+test TrackingAutoHashMap {
+    var map = TrackingAutoHashMap(u32, u32, .get_and_put).empty;
+    defer map.deinit(std.testing.allocator);
+    try std.testing.expectEqual(0, map.count());
+
+    try map.put(std.testing.allocator, 1, 11);
+    try map.put(std.testing.allocator, 2, 22);
+    try map.put(std.testing.allocator, 3, 33);
+
+    try std.testing.expectEqual(3, map.count());
+
+    { // Reset
+        const unused_keys = try map.reset(std.testing.allocator);
+        defer std.testing.allocator.free(unused_keys);
+        try std.testing.expectEqualSlices(u32, &.{}, unused_keys);
+    }
+
+    try map.put(std.testing.allocator, 4, 44);
+    const prev = try map.fetchPut(std.testing.allocator, 3, 333);
+    try std.testing.expect(prev != null);
+    try std.testing.expectEqual(false, prev.?.used);
+    try std.testing.expectEqual(33, prev.?.value);
+
+    try std.testing.expectEqual(4, map.count());
+
+    // key 2 is set to used because of `.get_and_put`. With `.put_only`
+    // it would not be
+    const get = map.get(2);
+    try std.testing.expectEqual(22, get);
+
+    { // Reset
+        const unused_keys = try map.reset(std.testing.allocator);
+        defer std.testing.allocator.free(unused_keys);
+        try std.testing.expectEqualSlices(u32, &.{1}, unused_keys);
+    }
+}
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -306,8 +306,8 @@ pub fn hueSlider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hue
 
 pub fn getHueSelectorTexture(dir: dvui.enums.Direction) !dvui.Texture {
     const hue_texture_id = dvui.hashIdKey(@enumFromInt(@as(u64, @intFromEnum(dir))), "hue_selector_texture");
-    const res = try dvui.currentWindow().texture_cache.getOrPut(hue_texture_id);
-    res.value_ptr.used = true;
+    const cw = dvui.currentWindow();
+    const res = try cw.texture_cache.getOrPut(cw.gpa, hue_texture_id);
     if (!res.found_existing) {
         const width: u32, const height: u32 = switch (dir) {
             .horizontal => .{ hue_selector_colors.len, 1 },
@@ -321,8 +321,8 @@ pub fn getHueSelectorTexture(dir: dvui.enums.Direction) !dvui.Texture {
 
 pub fn getValueSaturationTexture(hue: f32) !dvui.Texture {
     const hue_texture_id = dvui.hashIdKey(@enumFromInt(@as(u64, @intFromFloat(hue * 10000))), "value_saturation_texture");
-    const res = try dvui.currentWindow().texture_cache.getOrPut(hue_texture_id);
-    res.value_ptr.used = true;
+    const cw = dvui.currentWindow();
+    const res = try cw.texture_cache.getOrPut(cw.gpa, hue_texture_id);
     if (!res.found_existing) {
         var pixels = Color.white.toRGBA() ** 2 ++ Color.black.toRGBA() ** 2;
         comptime std.debug.assert(pixels.len == 2 * 2 * 4);


### PR DESCRIPTION
This removes the need for the structs contained within to maintain a `used` field. The tracking can be customized to only apply on insertions like for tags and min_size where the used flag indicates multiple insertions in a single frame.

The `TrackingAutoHashMap` is an unmanaged hashmap, which I deemed to be most flexible but I can easily make it a managed hashmap like before. What is your thoughts on unmanaged hashmaps and arraylists?