### PR TITLE
Add Path namespace and add improved Builder experience

### DIFF
--- a/src/Rect.zig
+++ b/src/Rect.zig
@@ -200,14 +200,14 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
         /// - h is bottom-left corner
         ///
         /// Only valid between dvui.Window.begin() and end().
-        pub fn stroke(self: Rect.Physical, radius: Rect.Physical, opts: dvui.PathStrokeOptions) !void {
-            var path: dvui.PathArrayList = .init(dvui.currentWindow().arena());
+        pub fn stroke(self: Rect.Physical, radius: Rect.Physical, opts: dvui.Path.StrokeOptions) !void {
+            var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
             defer path.deinit();
 
-            try dvui.pathAddRect(&path, self, radius);
+            try path.addRect(self, radius);
             var options = opts;
             options.closed = true;
-            try dvui.pathStroke(path.items, options);
+            try path.build().stroke(options);
         }
 
         /// Fill a rounded rect.
@@ -219,12 +219,12 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
         /// - h is bottom-left corner
         ///
         /// Only valid between dvui.Window.begin() and end().
-        pub fn fill(self: Rect.Physical, radius: Rect.Physical, opts: dvui.PathFillConvexOptions) !void {
-            var path: dvui.PathArrayList = .init(dvui.currentWindow().arena());
+        pub fn fill(self: Rect.Physical, radius: Rect.Physical, opts: dvui.Path.FillConvexOptions) !void {
+            var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
             defer path.deinit();
 
-            try dvui.pathAddRect(&path, self, radius);
-            try dvui.pathFillConvex(path.items, opts);
+            try path.addRect(self, radius);
+            try path.build().fillConvex(opts);
         }
 
         /// True if self would be modified when clipped by r.

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1246,12 +1246,12 @@ pub fn renderCommands(self: *Self, queue: std.ArrayList(dvui.RenderCommand)) !vo
                 try dvui.renderTexture(t.tex, t.rs, t.opts);
             },
             .pathFillConvex => |pf| {
-                var triangles = try dvui.pathFillConvexTriangles(pf.path, pf.opts);
+                var triangles = try pf.path.fillConvexTriangles(pf.opts);
                 defer triangles.deinit(self.arena());
                 try dvui.renderTriangles(triangles, null);
             },
             .pathStroke => |ps| {
-                var triangles = try dvui.pathStrokeTriangles(ps.path, ps.opts);
+                var triangles = try ps.path.strokeTriangles(ps.opts);
                 defer triangles.deinit(self.arena());
                 try dvui.renderTriangles(triangles, null);
             },

--- a/src/widgets/PlotWidget.zig
+++ b/src/widgets/PlotWidget.zig
@@ -46,7 +46,7 @@ pub const Data = struct {
 
 pub const Line = struct {
     plot: *PlotWidget,
-    path: dvui.PathArrayList,
+    path: dvui.Path.Builder,
 
     pub fn point(self: *Line, x: f64, y: f64) !void {
         const data: Data = .{ .x = x, .y = y };
@@ -59,11 +59,11 @@ pub const Line = struct {
                 self.plot.hover_data = data;
             }
         }
-        try self.path.append(screen_p);
+        try self.path.points.append(screen_p);
     }
 
     pub fn stroke(self: *Line, thick: f32, color: dvui.Color) !void {
-        try dvui.pathStroke(self.path.items, .{ .thickness = thick * self.plot.data_rs.s, .color = color });
+        try self.path.build().stroke(.{ .thickness = thick * self.plot.data_rs.s, .color = color });
     }
 
     pub fn deinit(self: *Line) void {

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -48,7 +48,7 @@ pub fn install(self: *TabsWidget) !void {
                 r.w -= 1.0;
                 r.y = @floor(r.y) - 0.5;
             }
-            try dvui.pathStroke(&.{ r.bottomLeft(), r.bottomRight() }, .{ .thickness = 1, .color = dvui.themeGet().color_border });
+            try dvui.Path.stroke(.{ .points = &.{ r.bottomLeft(), r.bottomRight() } }, .{ .thickness = 1, .color = dvui.themeGet().color_border });
         },
         .vertical => {
             if (dvui.currentWindow().snap_to_pixels) {
@@ -56,7 +56,7 @@ pub fn install(self: *TabsWidget) !void {
                 r.h -= 1.0;
                 r.x = @floor(r.x) - 0.5;
             }
-            try dvui.pathStroke(&.{ r.topRight(), r.bottomRight() }, .{ .thickness = 1, .color = dvui.themeGet().color_border });
+            try dvui.Path.stroke(.{ .points = &.{ r.topRight(), r.bottomRight() } }, .{ .thickness = 1, .color = dvui.themeGet().color_border });
         },
     }
 }
@@ -117,36 +117,36 @@ pub fn addTab(self: *TabsWidget, selected: bool, opts: Options) !*ButtonWidget {
 
         switch (self.init_options.dir) {
             .horizontal => {
-                var path: dvui.PathArrayList = .init(dvui.currentWindow().arena());
+                var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
                 defer path.deinit();
 
-                try path.append(r.bottomRight());
+                try path.points.append(r.bottomRight());
 
                 const tr = Point.Physical{ .x = r.x + r.w - cr.y, .y = r.y + cr.y };
-                try dvui.pathAddArc(&path, tr, cr.y, math.pi * 2.0, math.pi * 1.5, false);
+                try path.addArc(tr, cr.y, math.pi * 2.0, math.pi * 1.5, false);
 
                 const tl = Point.Physical{ .x = r.x + cr.x, .y = r.y + cr.x };
-                try dvui.pathAddArc(&path, tl, cr.x, math.pi * 1.5, math.pi, false);
+                try path.addArc(tl, cr.x, math.pi * 1.5, math.pi, false);
 
-                try path.append(r.bottomLeft());
+                try path.points.append(r.bottomLeft());
 
-                try dvui.pathStroke(path.items, .{ .thickness = 2 * rs.s, .color = dvui.themeGet().color_accent, .after = true });
+                try path.build().stroke(.{ .thickness = 2 * rs.s, .color = dvui.themeGet().color_accent, .after = true });
             },
             .vertical => {
-                var path: dvui.PathArrayList = .init(dvui.currentWindow().arena());
+                var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
                 defer path.deinit();
 
-                try path.append(r.topRight());
+                try path.points.append(r.topRight());
 
                 const tl = Point.Physical{ .x = r.x + cr.x, .y = r.y + cr.x };
-                try dvui.pathAddArc(&path, tl, cr.x, math.pi * 1.5, math.pi, false);
+                try path.addArc(tl, cr.x, math.pi * 1.5, math.pi, false);
 
                 const bl = Point.Physical{ .x = r.x + cr.h, .y = r.y + r.h - cr.h };
-                try dvui.pathAddArc(&path, bl, cr.h, math.pi, math.pi * 0.5, false);
+                try path.addArc(bl, cr.h, math.pi, math.pi * 0.5, false);
 
-                try path.append(r.bottomRight());
+                try path.points.append(r.bottomRight());
 
-                try dvui.pathStroke(path.items, .{ .thickness = 2 * rs.s, .color = dvui.themeGet().color_accent, .after = true });
+                try path.build().stroke(.{ .thickness = 2 * rs.s, .color = dvui.themeGet().color_accent, .after = true });
             },
         }
     }

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -334,14 +334,14 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
             }
 
             if (visible) {
-                var path: dvui.PathArrayList = .init(dvui.currentWindow().arena());
+                var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
                 defer path.deinit();
 
-                try path.append(.{ .x = fcrs.r.x + fcrs.r.w, .y = fcrs.r.y });
-                try dvui.pathAddArc(&path, .{ .x = fcrs.r.x + fcrs.r.w / 2, .y = fcrs.r.y + fcrs.r.h / 2 }, fcrs.r.w / 2, std.math.pi, 0, true);
+                try path.points.append(.{ .x = fcrs.r.x + fcrs.r.w, .y = fcrs.r.y });
+                try path.addArc(.{ .x = fcrs.r.x + fcrs.r.w / 2, .y = fcrs.r.y + fcrs.r.h / 2 }, fcrs.r.w / 2, std.math.pi, 0, true);
 
-                try dvui.pathFillConvex(path.items, .{ .color = dvui.themeGet().color_fill_control, .blur = 0.5 });
-                try dvui.pathStroke(path.items, .{ .thickness = 1.0 * fcrs.s, .color = self.wd.options.color(.border), .closed = true });
+                try path.build().fillConvex(.{ .color = dvui.themeGet().color_fill_control, .blur = 0.5 });
+                try path.build().stroke(.{ .thickness = 1.0 * fcrs.s, .color = self.wd.options.color(.border), .closed = true });
             }
 
             dvui.dataSet(null, fc.wd.id, "_offset", offset);
@@ -405,14 +405,14 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
             }
 
             if (visible) {
-                var path: dvui.PathArrayList = .init(dvui.currentWindow().arena());
+                var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
                 defer path.deinit();
 
-                try path.append(.{ .x = fcrs.r.x, .y = fcrs.r.y });
-                try dvui.pathAddArc(&path, .{ .x = fcrs.r.x + fcrs.r.w / 2, .y = fcrs.r.y + fcrs.r.h / 2 }, fcrs.r.w / 2, std.math.pi, 0, true);
+                try path.points.append(.{ .x = fcrs.r.x, .y = fcrs.r.y });
+                try path.addArc(.{ .x = fcrs.r.x + fcrs.r.w / 2, .y = fcrs.r.y + fcrs.r.h / 2 }, fcrs.r.w / 2, std.math.pi, 0, true);
 
-                try dvui.pathFillConvex(path.items, .{ .color = dvui.themeGet().color_fill_control, .blur = 0.5 });
-                try dvui.pathStroke(path.items, .{ .thickness = 1.0 * fcrs.s, .color = self.wd.options.color(.border), .closed = true });
+                try path.build().fillConvex(.{ .color = dvui.themeGet().color_fill_control, .blur = 0.5 });
+                try path.build().stroke(.{ .thickness = 1.0 * fcrs.s, .color = self.wd.options.color(.border), .closed = true });
             }
 
             dvui.dataSet(null, fc.wd.id, "_offset", offset);


### PR DESCRIPTION
This change makes the API easier to discover as well as minimizing the pollution of the dvui namespace, which is quite large. Keeping all related path functions within a struct also allows for better documentation as the relationship between parts are clearer.

I've though about how dvui makes almost everything available under `dvui.xxx` but some amount of namespacing for related operations would be nice for API discoverability and code navigation. This moves all functions that were already pseudo namespaced with `dvui.pathXxx` to a real namespace of `dvui.Path.xxx`, with the added benefit of `Path` being able to be a struct passed to the related functions. I have a branch doing similar namespacing for `dvui.dataXxx`. What are you thoughs on this kind of namespacing @david-vanderson? 