### PR TITLE
Make all render functions to use `renderTriangles` 

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1167,9 +1167,6 @@ pub fn renderCommands(self: *Self, queue: std.ArrayList(dvui.RenderCommand)) !vo
             .text => |t| {
                 try dvui.renderText(t);
             },
-            .debug_font_atlases => |t| {
-                try dvui.debugRenderFontAtlases(t.rs, t.color);
-            },
             .texture => |t| {
                 try dvui.renderTexture(t.tex, t.rs, t.opts);
             },

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1733,11 +1733,19 @@ pub const Triangles = struct {
         },
 
         pub fn init(allocator: std.mem.Allocator, vtx_count: usize, idx_count: usize) !Builder {
+            std.debug.assert(vtx_count >= 3);
             std.debug.assert(idx_count % 3 == 0);
             return .{
-                .vertexes = .initBuffer(try allocator.alloc(Vertex, vtx_count)),
-                .indices = .initBuffer(try allocator.alloc(u16, idx_count)),
+                .vertexes = try .initCapacity(allocator, vtx_count),
+                .indices = try .initCapacity(allocator, idx_count),
             };
+        }
+
+        pub fn deinit(self: *Builder, allocator: std.mem.Allocator) void {
+            // NOTE: Should be in the opposite order to `init`
+            self.indices.deinit(allocator);
+            self.vertexes.deinit(allocator);
+            self.* = undefined;
         }
 
         /// Appends a vertex and updates the bounds
@@ -1759,10 +1767,21 @@ pub const Triangles = struct {
 
         /// Asserts that the entire array has been filled
         ///
-        /// The memory ownership is transferred to `Triangles`
-        pub fn build(self: *const Builder) Triangles {
+        /// The memory ownership is transferred to `Triangles`.
+        /// making `Builder.deinit` unnecessary, but safe, to call
+        pub fn build(self: *Builder) Triangles {
             std.debug.assert(self.vertexes.items.len == self.vertexes.capacity);
             std.debug.assert(self.indices.items.len == self.indices.capacity);
+            defer self.* = .{ .vertexes = .empty, .indices = .empty };
+            // Ownership is transferred as the the full allocated slices are returned
+            return self.build_unowned();
+        }
+
+        /// Creates `Triangles`, ignoring any extra capacity.
+        ///
+        /// Calling `Triangles.deinit` is invalid and `Builder.deinit`
+        /// should always be called instead
+        pub fn build_unowned(self: *Builder) Triangles {
             return .{
                 .vertexes = self.vertexes.items,
                 .indices = self.indices.items,
@@ -1786,6 +1805,7 @@ pub const Triangles = struct {
     pub fn deinit(self: *Triangles, allocator: std.mem.Allocator) void {
         allocator.free(self.indices);
         allocator.free(self.vertexes);
+        self.* = undefined;
     }
 
     /// Multiply `col` into vertex colors.
@@ -6165,8 +6185,6 @@ pub fn renderText(opts: renderTextOptions) !void {
         return;
     }
 
-    const r = opts.rs.r.offsetNegPoint(cw.render_target.offset);
-
     const target_size = opts.font.size * opts.rs.s;
     const sized_font = opts.font.resize(target_size);
 
@@ -6307,21 +6325,19 @@ pub fn renderText(opts: renderTextOptions) !void {
         fce.texture_atlas = textureCreate(.cast(pixels), @as(u32, @intFromFloat(size.w)), @as(u32, @intFromFloat(size.h)), .linear);
     }
 
-    var vtx = std.ArrayList(Vertex).init(cw.arena());
-    defer vtx.deinit();
-    var idx = std.ArrayList(u16).init(cw.arena());
-    defer idx.deinit();
+    // Over allocate the internal buffers assuming each byte is a character
+    var builder = try Triangles.Builder.init(cw.arena(), 4 * opts.text.len, 6 * opts.text.len);
+    defer builder.deinit(cw.arena());
 
-    const x_start: f32 = if (cw.snap_to_pixels) @round(r.x) else r.x;
+    const x_start: f32 = if (cw.snap_to_pixels) @round(opts.rs.r.x) else opts.rs.r.x;
     var x = x_start;
     var max_x = x_start;
-    const y: f32 = if (cw.snap_to_pixels) @round(r.y) else r.y;
+    const y: f32 = if (cw.snap_to_pixels) @round(opts.rs.r.y) else opts.rs.r.y;
 
     if (opts.debug) {
         log.debug("renderText x {d} y {d}\n", .{ x, y });
     }
 
-    var sel: bool = false;
     var sel_in: bool = false;
     var sel_start_x: f32 = x;
     var sel_end_x: f32 = x;
@@ -6330,10 +6346,8 @@ pub fn renderText(opts: renderTextOptions) !void {
     sel_start = @min(sel_start, opts.text.len);
     var sel_end: usize = opts.sel_end orelse 0;
     sel_end = @min(sel_end, opts.text.len);
-    if (sel_start < sel_end) {
-        // we will definitely have a selected region
-        sel = true;
-    }
+    // if we will definitely have a selected region or not
+    const sel: bool = sel_start < sel_end;
 
     const atlas_size: Size = .{ .w = @floatFromInt(fce.texture_atlas.width), .h = @floatFromInt(fce.texture_atlas.height) };
 
@@ -6389,14 +6403,14 @@ pub fn renderText(opts: renderTextOptions) !void {
 
         // don't output triangles for a zero-width glyph (space seems to be the only one)
         if (gi.w > 0) {
-            const len = @as(u32, @intCast(vtx.items.len));
+            const vtx_offset: u16 = @intCast(builder.vertexes.items.len);
             var v: Vertex = undefined;
 
             v.pos.x = x + gi.leftBearing * target_fraction;
             v.pos.y = y + gi.topBearing * target_fraction;
             v.col = .fromColor(if (sel_in) opts.sel_color orelse opts.color else opts.color);
             v.uv = gi.uv;
-            try vtx.append(v);
+            builder.appendVertex(v);
 
             if (opts.debug) {
                 log.debug(" - x {d} y {d}", .{ v.pos.x, v.pos.y });
@@ -6410,24 +6424,22 @@ pub fn renderText(opts: renderTextOptions) !void {
             v.pos.x = x + (gi.leftBearing + gi.w) * target_fraction;
             max_x = v.pos.x;
             v.uv[0] = gi.uv[0] + gi.w / atlas_size.w;
-            try vtx.append(v);
+            builder.appendVertex(v);
 
             v.pos.y = y + (gi.topBearing + gi.h) * target_fraction;
             sel_max_y = @max(sel_max_y, v.pos.y);
             v.uv[1] = gi.uv[1] + gi.h / atlas_size.h;
-            try vtx.append(v);
+            builder.appendVertex(v);
 
             v.pos.x = x + gi.leftBearing * target_fraction;
             v.uv[0] = gi.uv[0];
-            try vtx.append(v);
+            builder.appendVertex(v);
 
             // triangles must be counter-clockwise (y going down) to avoid backface culling
-            try idx.append(@as(u16, @intCast(len + 0)));
-            try idx.append(@as(u16, @intCast(len + 2)));
-            try idx.append(@as(u16, @intCast(len + 1)));
-            try idx.append(@as(u16, @intCast(len + 0)));
-            try idx.append(@as(u16, @intCast(len + 3)));
-            try idx.append(@as(u16, @intCast(len + 2)));
+            builder.appendTriangles(&.{
+                vtx_offset + 0, vtx_offset + 2, vtx_offset + 1,
+                vtx_offset + 0, vtx_offset + 3, vtx_offset + 2,
+            });
         }
 
         x = nextx;
@@ -6435,39 +6447,16 @@ pub fn renderText(opts: renderTextOptions) !void {
 
     if (sel) {
         if (opts.sel_color_bg) |bgcol| {
-            var sel_vtx: [4]Vertex = undefined;
-            sel_vtx[0].pos.x = sel_start_x;
-            sel_vtx[0].pos.y = r.y;
-            sel_vtx[3].pos.x = sel_start_x;
-            sel_vtx[3].pos.y = @max(sel_max_y, r.y + fce.height * target_fraction * opts.font.line_height_factor);
-            sel_vtx[1].pos.x = sel_end_x;
-            sel_vtx[1].pos.y = sel_vtx[0].pos.y;
-            sel_vtx[2].pos.x = sel_end_x;
-            sel_vtx[2].pos.y = sel_vtx[3].pos.y;
-
-            for (&sel_vtx) |*v| {
-                v.col = .fromColor(bgcol);
-                v.uv[0] = 0;
-                v.uv[1] = 0;
-            }
-
-            const selr = Rect.Physical.fromPoint(sel_vtx[0].pos).toPoint(sel_vtx[2].pos);
-            const clip_offset = clipGet().offsetNegPoint(cw.render_target.offset);
-            const clipr: ?Rect.Physical = if (selr.clippedBy(clip_offset)) clip_offset else null;
-
-            // triangles must be counter-clockwise (y going down) to avoid backface culling
-            cw.backend.drawClippedTriangles(null, &sel_vtx, &[_]u16{ 0, 2, 1, 0, 3, 2 }, clipr);
+            try Rect.Physical.fromPoint(.{ .x = sel_start_x, .y = opts.rs.r.y })
+                .toPoint(.{
+                    .x = sel_end_x,
+                    .y = @max(sel_max_y, opts.rs.r.y + fce.height * target_fraction * opts.font.line_height_factor),
+                })
+                .fill(.{}, .{ .color = bgcol, .blur = 0 });
         }
     }
 
-    if (vtx.items.len > 0) {
-        // due to floating point inaccuracies, shrink by 1/100 of a pixel before testing
-        const txtr = (Rect.Physical{ .x = x_start, .y = y, .w = max_x - x_start, .h = sel_max_y - y }).insetAll(0.01);
-        const clip_offset = clipGet().offsetNegPoint(cw.render_target.offset);
-        const clipr: ?Rect.Physical = if (txtr.clippedBy(clip_offset)) clip_offset else null;
-
-        cw.backend.drawClippedTriangles(fce.texture_atlas, vtx.items, idx.items, clipr);
-    }
+    try renderTriangles(builder.build_unowned(), fce.texture_atlas);
 }
 
 pub fn debugRenderFontAtlases(rs: RectScale, color: Color) !void {


### PR DESCRIPTION
This updates `renderText` and `debugFontAtlases` to use `renderTriangles` and `renderTexture` respectively. This now means all calls to `Backend.drawClippedTriangles` are done via `renderTriangles`, ensuring the safeties applied there is applied for all dvui rendering. Along with this, manual triangle creation is now limited to only `Path.fillConvexTriangles`, `Path.strokeTriangles` and `renderText`. 

Making `debugFontAtlas` use `renderTexture` also means it doesn't have to handle deferred rendering, so one `RenderCommand` variant can be removed. 