### PR TITLE
Error overhaul

### DIFF
--- a/examples/raylib-ontop.zig
+++ b/examples/raylib-ontop.zig
@@ -104,7 +104,7 @@ fn colorPicker(result: *dvui.Color) !void {
         result.* = RaylibBackend.raylibColorToDvui(c_color);
     }
 
-    const color_hex = try result.toHexString();
+    const color_hex = result.toHexString();
 
     {
         var hbox = try dvui.box(@src(), .horizontal, .{});

--- a/examples/sdl-ontop.zig
+++ b/examples/sdl-ontop.zig
@@ -96,15 +96,15 @@ pub fn main() !void {
         // cursor management
         if (win.cursorRequestedFloating()) |cursor| {
             // cursor is over floating window, dvui sets it
-            backend.setCursor(cursor);
+            try backend.setCursor(cursor);
         } else {
             // cursor should be handled by application
-            backend.setCursor(.bad);
+            try backend.setCursor(.bad);
         }
-        backend.textInputRect(win.textInputRequested());
+        try backend.textInputRect(win.textInputRequested());
 
         // render frame to OS
-        backend.renderPresent();
+        try backend.renderPresent();
     }
 
     c.SDL_DestroyRenderer(renderer);

--- a/examples/sdl-standalone.zig
+++ b/examples/sdl-standalone.zig
@@ -79,15 +79,15 @@ pub fn main() !void {
         const end_micros = try win.end(.{});
 
         // cursor management
-        backend.setCursor(win.cursorRequested());
-        backend.textInputRect(win.textInputRequested());
+        try backend.setCursor(win.cursorRequested());
+        try backend.textInputRect(win.textInputRequested());
 
         // render frame to OS
-        backend.renderPresent();
+        try backend.renderPresent();
 
         // waitTime and beginWait combine to achieve variable framerates
         const wait_event_micros = win.waitTime(end_micros, null);
-        interrupted = backend.waitEventTimeout(wait_event_micros);
+        interrupted = try backend.waitEventTimeout(wait_event_micros);
 
         // Example of how to show a dialog from another thread (outside of win.begin/win.end)
         if (show_dialog_outside_frame) {

--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -41,13 +41,13 @@ pub fn end(self: Backend) GenericError!void {
 
 /// Return size of the window in physical pixels.  For a 300x200 retina
 /// window (so actually 600x400), this should return 600x400.
-pub fn pixelSize(self: Backend) GenericError!dvui.Size.Physical {
+pub fn pixelSize(self: Backend) dvui.Size.Physical {
     return self.impl.pixelSize();
 }
 
 /// Return size of the window in logical pixels.  For a 300x200 retina
 /// window (so actually 600x400), this should return 300x200.
-pub fn windowSize(self: Backend) GenericError!dvui.Size.Natural {
+pub fn windowSize(self: Backend) dvui.Size.Natural {
     return self.impl.windowSize();
 }
 
@@ -55,7 +55,7 @@ pub fn windowSize(self: Backend) GenericError!dvui.Size.Natural {
 /// additional display scaling (usually set in their window system's
 /// settings).  Currently only called during `dvui.Window.init`, so currently
 /// this sets the initial content scale.
-pub fn contentScale(self: Backend) GenericError!f32 {
+pub fn contentScale(self: Backend) f32 {
     return self.impl.contentScale();
 }
 
@@ -122,7 +122,7 @@ pub fn openURL(self: Backend, url: []const u8) GenericError!void {
 /// thread.  Used to wake up the gui thread.  It only has effect if you
 /// are using `dvui.Window.waitTime` or some other method of waiting until
 /// a new event comes in.
-pub fn refresh(self: Backend) GenericError!void {
+pub fn refresh(self: Backend) void {
     return self.impl.refresh();
 }
 

--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -28,10 +28,10 @@ const VTableTypes = struct {
     pub const textureReadTarget = *const fn (ctx: Context, texture: dvui.TextureTarget, pixels_out: [*]u8) error{TextureRead}!void;
     pub const renderTarget = *const fn (ctx: Context, texture: ?dvui.TextureTarget) void;
 
-    pub const clipboardText = *const fn (ctx: Context) error{OutOfMemory}![]const u8;
-    pub const clipboardTextSet = *const fn (ctx: Context, text: []const u8) error{OutOfMemory}!void;
+    pub const clipboardText = *const fn (ctx: Context) std.mem.Allocator.Error![]const u8;
+    pub const clipboardTextSet = *const fn (ctx: Context, text: []const u8) std.mem.Allocator.Error!void;
 
-    pub const openURL = *const fn (ctx: Context, url: []const u8) error{OutOfMemory}!void;
+    pub const openURL = *const fn (ctx: Context, url: []const u8) std.mem.Allocator.Error!void;
     pub const refresh = *const fn (ctx: Context) void;
 };
 
@@ -178,17 +178,17 @@ pub fn renderTarget(self: *Backend, texture: ?dvui.TextureTarget) void {
 }
 
 /// Get clipboard content (text only)
-pub fn clipboardText(self: *Backend) error{OutOfMemory}![]const u8 {
+pub fn clipboardText(self: *Backend) std.mem.Allocator.Error![]const u8 {
     return self.vtable.clipboardText(self.ctx);
 }
 
 /// Set clipboard content (text only)
-pub fn clipboardTextSet(self: *Backend, text: []const u8) error{OutOfMemory}!void {
+pub fn clipboardTextSet(self: *Backend, text: []const u8) std.mem.Allocator.Error!void {
     return self.vtable.clipboardTextSet(self.ctx, text);
 }
 
 /// Open URL in system browser
-pub fn openURL(self: *Backend, url: []const u8) error{OutOfMemory}!void {
+pub fn openURL(self: *Backend, url: []const u8) std.mem.Allocator.Error!void {
     return self.vtable.openURL(self.ctx, url);
 }
 

--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -1,203 +1,126 @@
+//! Provides a consistent API for interacting with the backend
+
 const std = @import("std");
 const dvui = @import("dvui.zig");
 
-const Context = dvui.backend.Context;
+const Implementation = @import("backend");
 const Backend = @This();
 
-ctx: Context,
-vtable: VTable,
+/// The current implementation used
+pub const kind = Implementation.kind;
 
-const VTableTypes = struct {
-    pub const nanoTime = *const fn (ctx: Context) i128;
-    pub const sleep = *const fn (ctx: Context, ns: u64) void;
+impl: *Implementation,
 
-    pub const begin = *const fn (ctx: Context, arena: std.mem.Allocator) void;
-    pub const end = *const fn (ctx: Context) void;
-
-    pub const pixelSize = *const fn (ctx: Context) dvui.Size.Physical;
-    pub const windowSize = *const fn (ctx: Context) dvui.Size.Natural;
-    pub const contentScale = *const fn (ctx: Context) f32;
-
-    pub const drawClippedTriangles = *const fn (ctx: Context, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const u16, clipr: ?dvui.Rect.Physical) void;
-
-    pub const textureCreate = *const fn (ctx: Context, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) dvui.Texture;
-    pub const textureDestroy = *const fn (ctx: Context, texture: dvui.Texture) void;
-    pub const textureFromTarget = *const fn (ctx: Context, texture: dvui.TextureTarget) dvui.Texture;
-
-    pub const textureCreateTarget = *const fn (ctx: Context, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) error{ OutOfMemory, TextureCreate }!dvui.TextureTarget;
-    pub const textureReadTarget = *const fn (ctx: Context, texture: dvui.TextureTarget, pixels_out: [*]u8) error{TextureRead}!void;
-    pub const renderTarget = *const fn (ctx: Context, texture: ?dvui.TextureTarget) void;
-
-    pub const clipboardText = *const fn (ctx: Context) std.mem.Allocator.Error![]const u8;
-    pub const clipboardTextSet = *const fn (ctx: Context, text: []const u8) std.mem.Allocator.Error!void;
-
-    pub const openURL = *const fn (ctx: Context, url: []const u8) std.mem.Allocator.Error!void;
-    pub const refresh = *const fn (ctx: Context) void;
-};
-
-pub const VTable = struct {
-    pub const I = VTableTypes;
-
-    nanoTime: I.nanoTime,
-    sleep: I.sleep,
-    begin: I.begin,
-    end: I.end,
-    pixelSize: I.pixelSize,
-    windowSize: I.windowSize,
-    contentScale: I.contentScale,
-    drawClippedTriangles: I.drawClippedTriangles,
-    textureCreate: I.textureCreate,
-    textureDestroy: I.textureDestroy,
-    textureFromTarget: I.textureFromTarget,
-    textureCreateTarget: I.textureCreateTarget,
-    textureReadTarget: I.textureReadTarget,
-    renderTarget: I.renderTarget,
-    clipboardText: I.clipboardText,
-    clipboardTextSet: I.clipboardTextSet,
-    openURL: I.openURL,
-    refresh: I.refresh,
-};
-
-fn compile_assert(comptime x: bool, comptime msg: []const u8) void {
-    if (!x) @compileError(msg);
-}
-
-/// Create backend (vtable) from implementation
-///
-/// `impl`: the implementation struct. it should have declarations that match `VTableTypes`
-pub fn init(
-    ctx: Context,
-    comptime implementation: anytype,
-) Backend {
-    const I = VTableTypes;
-
-    compile_assert(
-        @sizeOf(Context) == @sizeOf(usize),
-        "(@TypeOf(ctx)) " ++ @typeName(Context) ++ " must be a pointer-sized; has size of " ++ std.fmt.comptimePrint("{d}", .{@sizeOf(Context)}),
-    ); // calling convention dictates that any type can work here after converted to usize
-
-    comptime var vtable: VTable = undefined;
-
-    inline for (@typeInfo(I).@"struct".decls) |decl| {
-        const hasField = @hasDecl(implementation, decl.name);
-        const DeclType = @field(I, decl.name);
-        compile_assert(hasField, "Backend type " ++ @typeName(implementation) ++ " has no declaration '" ++ decl.name ++ ": " ++ @typeName(DeclType) ++ "'");
-        const f: DeclType = &@field(implementation, decl.name);
-        @field(vtable, decl.name) = f;
-    }
-
-    return .{
-        .ctx = ctx,
-        .vtable = vtable,
-    };
+pub fn init(impl: *Implementation) Backend {
+    return .{ .impl = impl };
 }
 
 /// Get monotonic nanosecond timestamp. Doesn't have to be system time.
-pub fn nanoTime(self: *Backend) i128 {
-    return self.vtable.nanoTime(self.ctx);
+pub fn nanoTime(self: Backend) i128 {
+    return self.impl.nanoTime();
 }
 /// Sleep for nanoseconds.
-pub fn sleep(self: *Backend, ns: u64) void {
-    return self.vtable.sleep(self.ctx, ns);
+pub fn sleep(self: Backend, ns: u64) void {
+    return self.impl.sleep(ns);
 }
 /// Called by dvui during `dvui.Window.begin`, so prior to any dvui
 /// rendering.  Use to setup anything needed for this frame.  The arena
 /// arg is cleared before `dvui.Window.begin` is called next, useful for any
 /// temporary allocations needed only for this frame.
-pub fn begin(self: *Backend, arena: std.mem.Allocator) void {
-    return self.vtable.begin(self.ctx, arena);
+pub fn begin(self: Backend, arena: std.mem.Allocator) void {
+    return self.impl.begin(arena);
 }
 
 /// Called during `dvui.Window.end` before freeing any memory for the current frame.
-pub fn end(self: *Backend) void {
-    return self.vtable.end(self.ctx);
+pub fn end(self: Backend) void {
+    return self.impl.end();
 }
 
 /// Return size of the window in physical pixels.  For a 300x200 retina
 /// window (so actually 600x400), this should return 600x400.
-pub fn pixelSize(self: *Backend) dvui.Size.Physical {
-    return self.vtable.pixelSize(self.ctx);
+pub fn pixelSize(self: Backend) dvui.Size.Physical {
+    return self.impl.pixelSize();
 }
 
 /// Return size of the window in logical pixels.  For a 300x200 retina
 /// window (so actually 600x400), this should return 300x200.
-pub fn windowSize(self: *Backend) dvui.Size.Natural {
-    return self.vtable.windowSize(self.ctx);
+pub fn windowSize(self: Backend) dvui.Size.Natural {
+    return self.impl.windowSize();
 }
 
 /// Return the detected additional scaling.  This represents the user's
 /// additional display scaling (usually set in their window system's
 /// settings).  Currently only called during `dvui.Window.init`, so currently
 /// this sets the initial content scale.
-pub fn contentScale(self: *Backend) f32 {
-    return self.vtable.contentScale(self.ctx);
+pub fn contentScale(self: Backend) f32 {
+    return self.impl.contentScale();
 }
 
 /// Render a triangle list using the idx indexes into the vtx vertexes
 /// clipped to to `clipr` (if given).  Vertex positions and `clipr` are in
 /// physical pixels.  If `texture` is given, the vertexes uv coords are
 /// normalized (0-1).
-pub fn drawClippedTriangles(self: *Backend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const u16, clipr: ?dvui.Rect.Physical) void {
-    return self.vtable.drawClippedTriangles(self.ctx, texture, vtx, idx, clipr);
+pub fn drawClippedTriangles(self: Backend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const u16, clipr: ?dvui.Rect.Physical) void {
+    return self.impl.drawClippedTriangles(texture, vtx, idx, clipr);
 }
 
 /// Create a `dvui.Texture` from the given `pixels` in RGBA.  The returned
 /// pointer is what will later be passed to `drawClippedTriangles`.
-pub fn textureCreate(self: *Backend, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) dvui.Texture {
-    return self.vtable.textureCreate(self.ctx, pixels, width, height, interpolation);
+pub fn textureCreate(self: Backend, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) dvui.Texture {
+    return self.impl.textureCreate(pixels, width, height, interpolation);
 }
 
 /// Destroy `texture` made with `textureCreate`. After this call, this texture
 /// pointer will not be used by dvui.
-pub fn textureDestroy(self: *Backend, texture: dvui.Texture) void {
-    return self.vtable.textureDestroy(self.ctx, texture);
+pub fn textureDestroy(self: Backend, texture: dvui.Texture) void {
+    return self.impl.textureDestroy(texture);
 }
 
 /// Create a `dvui.Texture` that can be rendered to with `renderTarget`.  The
 /// returned pointer is what will later be passed to `drawClippedTriangles`.
-pub fn textureCreateTarget(self: *Backend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.TextureTarget {
-    return try self.vtable.textureCreateTarget(self.ctx, width, height, interpolation);
+pub fn textureCreateTarget(self: Backend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) error{ OutOfMemory, TextureCreate }!dvui.TextureTarget {
+    return self.impl.textureCreateTarget(width, height, interpolation);
 }
 
 /// Read pixel data (RGBA) from `texture` into `pixels_out`.
-pub fn textureReadTarget(self: *Backend, texture: dvui.TextureTarget, pixels_out: [*]u8) !void {
-    return try self.vtable.textureReadTarget(self.ctx, texture, pixels_out);
+pub fn textureReadTarget(self: Backend, texture: dvui.TextureTarget, pixels_out: [*]u8) error{TextureRead}!void {
+    return self.impl.textureReadTarget(texture, pixels_out);
 }
 
 /// Convert texture target made with `textureCreateTarget` into return texture
 /// as if made by `textureCreate`.  After this call, texture target will not be
 /// used by dvui.
-pub fn textureFromTarget(self: *Backend, texture: dvui.TextureTarget) dvui.Texture {
-    return self.vtable.textureFromTarget(self.ctx, texture);
+pub fn textureFromTarget(self: Backend, texture: dvui.TextureTarget) dvui.Texture {
+    return self.impl.textureFromTarget(texture);
 }
 
 /// Render future `drawClippedTriangles` to the passed `texture` (or screen
 /// if null).
-pub fn renderTarget(self: *Backend, texture: ?dvui.TextureTarget) void {
-    return self.vtable.renderTarget(self.ctx, texture);
+pub fn renderTarget(self: Backend, texture: ?dvui.TextureTarget) void {
+    return self.impl.renderTarget(texture);
 }
 
 /// Get clipboard content (text only)
-pub fn clipboardText(self: *Backend) std.mem.Allocator.Error![]const u8 {
-    return self.vtable.clipboardText(self.ctx);
+pub fn clipboardText(self: Backend) std.mem.Allocator.Error![]const u8 {
+    return try self.impl.clipboardText();
 }
 
 /// Set clipboard content (text only)
-pub fn clipboardTextSet(self: *Backend, text: []const u8) std.mem.Allocator.Error!void {
-    return self.vtable.clipboardTextSet(self.ctx, text);
+pub fn clipboardTextSet(self: Backend, text: []const u8) std.mem.Allocator.Error!void {
+    return self.impl.clipboardTextSet(text);
 }
 
 /// Open URL in system browser
-pub fn openURL(self: *Backend, url: []const u8) std.mem.Allocator.Error!void {
-    return self.vtable.openURL(self.ctx, url);
+pub fn openURL(self: Backend, url: []const u8) std.mem.Allocator.Error!void {
+    return self.impl.openURL(url);
 }
 
 /// Called by `dvui.refresh` when it is called from a background
 /// thread.  Used to wake up the gui thread.  It only has effect if you
 /// are using `dvui.Window.waitTime` or some other method of waiting until
 /// a new event comes in.
-pub fn refresh(self: *Backend) void {
-    return self.vtable.refresh(self.ctx);
+pub fn refresh(self: Backend) void {
+    return self.impl.refresh();
 }
 
 test {

--- a/src/Color.zig
+++ b/src/Color.zig
@@ -324,9 +324,9 @@ pub const PMA = extern struct {
 pub const HexString = [7]u8;
 
 /// Returns a hex color string in the format "#rrggbb"
-pub fn toHexString(self: Color) !HexString {
+pub fn toHexString(self: Color) HexString {
     var result: HexString = undefined;
-    _ = try std.fmt.bufPrint(&result, "#{x:0>2}{x:0>2}{x:0>2}", .{ self.r, self.g, self.b });
+    _ = std.fmt.bufPrint(&result, "#{x:0>2}{x:0>2}{x:0>2}", .{ self.r, self.g, self.b }) catch unreachable;
     return result;
 }
 

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -477,7 +477,7 @@ pub fn demo() !void {
             }
 
             if (use_cache) {
-                cache.deinit();
+                try cache.deinit();
             }
 
             try bw.drawFocus();
@@ -2009,7 +2009,7 @@ pub fn plots() !void {
     plot.deinit();
 
     if (pic) |*p| {
-        p.stop();
+        try p.stop();
         defer p.deinit();
 
         const arena = dvui.currentWindow().arena();
@@ -2252,7 +2252,7 @@ pub fn reorderListsAdvanced() !void {
 
             // reset to use next space, need a separator
             _ = try dvui.separator(@src(), .{ .expand = .horizontal, .margin = dvui.Rect.all(6) });
-            try reorderable.reinstall();
+            reorderable.reinstall();
         }
 
         // actual content of the list entry
@@ -3510,7 +3510,7 @@ pub fn animations() !void {
 
         std.mem.rotate(u8, &pixels, @intCast(frame * 4));
 
-        const tex = dvui.textureCreate(.cast(&pixels), 2, 2, .nearest);
+        const tex = try dvui.textureCreate(.cast(&pixels), 2, 2, .nearest);
         dvui.textureDestroyLater(tex);
 
         var frame_box = try dvui.box(@src(), .horizontal, .{ .min_size_content = .{ .w = 50, .h = 50 } });

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -4510,7 +4510,7 @@ pub const StrokeTest = struct {
 
         const defaults = dvui.Options{ .name = "StrokeTest" };
         self.wd = dvui.WidgetData.init(src, .{}, defaults.override(options));
-        try self.wd.register();
+        self.wd.register();
 
         const evts = dvui.events();
         for (evts) |*e| {

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -1186,7 +1186,7 @@ pub fn textEntryWidgets(demo_win_id: dvui.WidgetId) !void {
                     if (bytes) |b| blk: {
                         dvui.addFont(name, b, dvui.currentWindow().gpa) catch |err| switch (err) {
                             error.OutOfMemory => @panic("OOM"),
-                            error.freetypeError => {
+                            error.fontError => {
                                 dvui.currentWindow().gpa.free(b);
                                 try dvui.dialog(@src(), .{}, .{ .title = "Bad Font", .message = try std.fmt.allocPrint(dvui.currentWindow().arena(), "\"{s}\" is not a valid font", .{filename}) });
                                 break :blk;

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -3634,7 +3634,7 @@ pub fn debuggingErrors() !void {
         try tl.addText("\nCurrent keybinds:\n", .{});
         outer = dvui.currentWindow().keybinds.iterator();
         while (outer.next()) |okv| {
-            try tl.format("\n{s}\n    {s}\n", .{ okv.key_ptr.*, try okv.value_ptr.format(dvui.currentWindow().arena()) }, .{});
+            try tl.format("\n{s}\n    {}\n", .{ okv.key_ptr.*, okv.value_ptr }, .{});
         }
         tl.deinit();
     }

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -3565,6 +3565,12 @@ pub fn debuggingErrors() !void {
         }
     }
 
+    if (try dvui.expander(@src(), "Invalid utf-8 text", .{}, .{ .expand = .horizontal })) {
+        var b = try dvui.box(@src(), .vertical, .{ .expand = .horizontal, .margin = .{ .x = 10 } });
+        defer b.deinit();
+        try dvui.labelNoFmt(@src(), "this \xFFtext\xFF includes some \xFF invalid utf-8\xFF\xFF\xFF which is replaced with \xFF", .{});
+    }
+
     if (try dvui.expander(@src(), "Scroll child after expanded child (will log error)", .{}, .{ .expand = .horizontal })) {
         var scroll = try dvui.scrollArea(@src(), .{}, .{ .min_size_content = .{ .w = 200, .h = 80 } });
         defer scroll.deinit();

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -97,10 +97,7 @@ pub fn textSizeEx(self: Font, text: []const u8, max_width: ?f32, end_idx: ?*usiz
         max_width_sized = mwidth / target_fraction;
     }
 
-    var s = fce.textSizeRaw(self.name, text, max_width_sized, end_idx, end_metric) catch |err| {
-        dvui.log.err("textSizeRaw got {!} for font \"{s}\" text \"{s}\"", .{ err, self.name, text });
-        return .{ .w = 10, .h = 10 };
-    };
+    var s = fce.textSizeRaw(self.name, text, max_width_sized, end_idx, end_metric) catch return .{ .w = 10, .h = 10 };
 
     // do this check after calling textSizeRaw so that end_idx is set
     if (ask_size == 0.0) return Size{};

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -10,29 +10,41 @@ size: f32,
 line_height_factor: f32 = 1.2,
 name: []const u8,
 
-pub fn resize(self: *const Font, s: f32) Font {
+pub fn hash(font: Font) u64 {
+    var h = dvui.fnv.init();
+    const bytes = if (dvui.currentWindow().font_bytes.get(font.name)) |fbe| fbe.ttf_bytes else Font.default_ttf_bytes;
+    h.update(std.mem.asBytes(&bytes.ptr));
+    h.update(std.mem.asBytes(&font.size));
+    return h.final();
+}
+
+pub fn switchFontName(self: Font, name: []const u8) Font {
+    return Font{ .size = self.size, .line_height_factor = self.line_height_factor, .name = name };
+}
+
+pub fn resize(self: Font, s: f32) Font {
     return Font{ .size = s, .line_height_factor = self.line_height_factor, .name = self.name };
 }
 
-pub fn lineHeightFactor(self: *const Font, factor: f32) Font {
+pub fn lineHeightFactor(self: Font, factor: f32) Font {
     return Font{ .size = self.size, .line_height_factor = factor, .name = self.name };
 }
 
-pub fn textHeight(self: *const Font) f32 {
+pub fn textHeight(self: Font) f32 {
     return self.sizeM(1, 1).h;
 }
 
-pub fn lineHeight(self: *const Font) f32 {
+pub fn lineHeight(self: Font) f32 {
     return self.textHeight() * self.line_height_factor;
 }
 
-pub fn sizeM(self: *const Font, wide: f32, tall: f32) Size {
+pub fn sizeM(self: Font, wide: f32, tall: f32) Size {
     const msize: Size = self.textSize("M");
     return .{ .w = msize.w * wide, .h = msize.h * tall };
 }
 
 // handles multiple lines
-pub fn textSize(self: *const Font, text: []const u8) Size {
+pub fn textSize(self: Font, text: []const u8) Size {
     if (text.len == 0) {
         // just want the normal text height
         return .{ .w = 0, .h = self.textHeight() };
@@ -65,7 +77,7 @@ pub const EndMetric = enum {
 };
 
 /// textSizeEx always stops at a newline, use textSize to get multiline sizes
-pub fn textSizeEx(self: *const Font, text: []const u8, max_width: ?f32, end_idx: ?*usize, end_metric: EndMetric) Size {
+pub fn textSizeEx(self: Font, text: []const u8, max_width: ?f32, end_idx: ?*usize, end_metric: EndMetric) Size {
     // ask for a font that matches the natural display pixels so we get a more
     // accurate size
 

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -131,7 +131,7 @@ pub const TTFBytes = struct {
     //pub const OpenDyslexicBdIt = @embedFile("fonts/OpenDyslexic/compiled/OpenDyslexic-Bold-Italic.otf");
 };
 
-pub fn initTTFBytesDatabase(allocator: std.mem.Allocator) !std.StringHashMap(dvui.FontBytesEntry) {
+pub fn initTTFBytesDatabase(allocator: std.mem.Allocator) std.mem.Allocator.Error!std.StringHashMap(dvui.FontBytesEntry) {
     var result = std.StringHashMap(dvui.FontBytesEntry).init(allocator);
     inline for (@typeInfo(TTFBytes).@"struct".decls) |decl| {
         try result.put(decl.name, dvui.FontBytesEntry{ .ttf_bytes = @field(TTFBytes, decl.name), .allocator = null });

--- a/src/Rect.zig
+++ b/src/Rect.zig
@@ -200,7 +200,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
         /// - h is bottom-left corner
         ///
         /// Only valid between dvui.Window.begin() and end().
-        pub fn stroke(self: Rect.Physical, radius: Rect.Physical, opts: dvui.Path.StrokeOptions) std.mem.Allocator.Error!void {
+        pub fn stroke(self: Rect.Physical, radius: Rect.Physical, opts: dvui.Path.StrokeOptions) dvui.Backend.GenericError!void {
             var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
             defer path.deinit();
 
@@ -219,7 +219,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
         /// - h is bottom-left corner
         ///
         /// Only valid between dvui.Window.begin() and end().
-        pub fn fill(self: Rect.Physical, radius: Rect.Physical, opts: dvui.Path.FillConvexOptions) std.mem.Allocator.Error!void {
+        pub fn fill(self: Rect.Physical, radius: Rect.Physical, opts: dvui.Path.FillConvexOptions) dvui.Backend.GenericError!void {
             var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
             defer path.deinit();
 

--- a/src/Rect.zig
+++ b/src/Rect.zig
@@ -200,7 +200,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
         /// - h is bottom-left corner
         ///
         /// Only valid between dvui.Window.begin() and end().
-        pub fn stroke(self: Rect.Physical, radius: Rect.Physical, opts: dvui.Path.StrokeOptions) !void {
+        pub fn stroke(self: Rect.Physical, radius: Rect.Physical, opts: dvui.Path.StrokeOptions) std.mem.Allocator.Error!void {
             var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
             defer path.deinit();
 
@@ -219,7 +219,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
         /// - h is bottom-left corner
         ///
         /// Only valid between dvui.Window.begin() and end().
-        pub fn fill(self: Rect.Physical, radius: Rect.Physical, opts: dvui.Path.FillConvexOptions) !void {
+        pub fn fill(self: Rect.Physical, radius: Rect.Physical, opts: dvui.Path.FillConvexOptions) std.mem.Allocator.Error!void {
             var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
             defer path.deinit();
 

--- a/src/Theme.zig
+++ b/src/Theme.zig
@@ -194,7 +194,7 @@ pub const QuickTheme = struct {
         );
     }
 
-    pub fn toTheme(self: @This(), gpa: std.mem.Allocator) !Theme {
+    pub fn toTheme(self: @This(), gpa: std.mem.Allocator) (std.mem.Allocator.Error || Color.FromHexError)!Theme {
         const color_accent = try Color.tryFromHex(self.color_focus);
         const color_err = try Color.tryFromHex("#ffaaaa");
         const color_text = try Color.tryFromHex(self.color_text);

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -61,7 +61,7 @@ pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Op
     return self;
 }
 
-pub fn register(self: *WidgetData) !void {
+pub fn register(self: *WidgetData) std.mem.Allocator.Error!void {
     self.rect_scale_cache = self.rectScale();
 
     // for normal widgets this is fine, but subwindows have to take care to
@@ -155,7 +155,9 @@ pub fn register(self: *WidgetData) !void {
                 outline_rect.y = @ceil(outline_rect.y) - 0.5;
             }
 
-            try outline_rect.stroke(.{}, .{ .thickness = 1 * rs.s, .color = dvui.themeGet().color_err, .after = true });
+            outline_rect.stroke(.{}, .{ .thickness = 1 * rs.s, .color = dvui.themeGet().color_err, .after = true }) catch {
+                dvui.log.err("Could not outline debug widget ({s}) {x}, at {}", .{ name, self.id, outline_rect });
+            };
 
             dvui.clipSet(clipr);
 
@@ -168,7 +170,7 @@ pub fn visible(self: *const WidgetData) bool {
     return !dvui.clipGet().intersect(self.borderRectScale().r).empty();
 }
 
-pub fn borderAndBackground(self: *const WidgetData, opts: struct { fill_color: ?Color = null }) !void {
+pub fn borderAndBackground(self: *const WidgetData, opts: struct { fill_color: ?Color = null }) std.mem.Allocator.Error!void {
     if (!self.visible()) {
         return;
     }
@@ -213,7 +215,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct { fill_color: ?
     }
 }
 
-pub fn focusBorder(self: *const WidgetData) !void {
+pub fn focusBorder(self: *const WidgetData) std.mem.Allocator.Error!void {
     if (self.visible()) {
         const rs = self.borderRectScale();
         const thick = 2 * rs.s;

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -61,7 +61,7 @@ pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Op
     return self;
 }
 
-pub fn register(self: *WidgetData) std.mem.Allocator.Error!void {
+pub fn register(self: *WidgetData) void {
     self.rect_scale_cache = self.rectScale();
 
     // for normal widgets this is fine, but subwindows have to take care to

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -170,7 +170,7 @@ pub fn visible(self: *const WidgetData) bool {
     return !dvui.clipGet().intersect(self.borderRectScale().r).empty();
 }
 
-pub fn borderAndBackground(self: *const WidgetData, opts: struct { fill_color: ?Color = null }) std.mem.Allocator.Error!void {
+pub fn borderAndBackground(self: *const WidgetData, opts: struct { fill_color: ?Color = null }) dvui.Backend.GenericError!void {
     if (!self.visible()) {
         return;
     }
@@ -215,7 +215,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct { fill_color: ?
     }
 }
 
-pub fn focusBorder(self: *const WidgetData) std.mem.Allocator.Error!void {
+pub fn focusBorder(self: *const WidgetData) dvui.Backend.GenericError!void {
     if (self.visible()) {
         const rs = self.borderRectScale();
         const thick = 2 * rs.s;

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1083,7 +1083,7 @@ pub fn begin(
 
     // Window's wd is kept frame to frame, so manually reset the cache.
     self.wd.rect_scale_cache = null;
-    try self.wd.register();
+    self.wd.register();
 
     self.layout = .{};
 

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -516,7 +516,7 @@ pub fn focusRemainingEventsInternal(self: *Self, event_num: u16, focusWindowId: 
 /// This can be called outside begin/end.  You should add all the events
 /// for a frame either before begin() or just after begin() and before
 /// calling normal dvui widgets.  end() clears the event list.
-pub fn addEventKey(self: *Self, event: Event.Key) !bool {
+pub fn addEventKey(self: *Self, event: Event.Key) std.mem.Allocator.Error!bool {
     if (self.debug_under_mouse and self.debug_under_mouse_esc_needed and event.action == .down and event.code == .escape) {
         // an escape will stop the debug stuff from following the mouse,
         // but need to stop it at the end of the frame when we've gotten
@@ -547,11 +547,11 @@ pub fn addEventKey(self: *Self, event: Event.Key) !bool {
 /// This can be called outside begin/end.  You should add all the events
 /// for a frame either before begin() or just after begin() and before
 /// calling normal dvui widgets.  end() clears the event list.
-pub fn addEventText(self: *Self, text: []const u8) !bool {
+pub fn addEventText(self: *Self, text: []const u8) std.mem.Allocator.Error!bool {
     return try self.addEventTextEx(text, false);
 }
 
-pub fn addEventTextEx(self: *Self, text: []const u8, selected: bool) !bool {
+pub fn addEventTextEx(self: *Self, text: []const u8, selected: bool) std.mem.Allocator.Error!bool {
     self.positionMouseEventRemove();
 
     self.event_num += 1;
@@ -575,7 +575,7 @@ pub fn addEventTextEx(self: *Self, text: []const u8, selected: bool) !bool {
 /// This can be called outside begin/end.  You should add all the events
 /// for a frame either before begin() or just after begin() and before
 /// calling normal dvui widgets.  end() clears the event list.
-pub fn addEventMouseMotion(self: *Self, pt: Point.Natural) !bool {
+pub fn addEventMouseMotion(self: *Self, pt: Point.Natural) std.mem.Allocator.Error!bool {
     const newpt = pt.scale(self.natural_scale / self.content_scale, Point.Physical);
     return try self.addEventMouseMotionPhysical(newpt);
 }
@@ -588,7 +588,7 @@ pub fn addEventMouseMotion(self: *Self, pt: Point.Natural) !bool {
 /// This can be called outside begin/end.  You should add all the events
 /// for a frame either before begin() or just after begin() and before
 /// calling normal dvui widgets.  end() clears the event list.
-pub fn addEventMouseMotionPhysical(self: *Self, newpt: Point.Physical) !bool {
+pub fn addEventMouseMotionPhysical(self: *Self, newpt: Point.Physical) std.mem.Allocator.Error!bool {
     self.positionMouseEventRemove();
 
     //log.debug("mouse motion {d} {d} -> {d} {d}", .{ x, y, newpt.x, newpt.y });
@@ -620,7 +620,7 @@ pub fn addEventMouseMotionPhysical(self: *Self, newpt: Point.Physical) !bool {
 /// This can be called outside begin/end.  You should add all the events
 /// for a frame either before begin() or just after begin() and before
 /// calling normal dvui widgets.  end() clears the event list.
-pub fn addEventMouseButton(self: *Self, b: dvui.enums.Button, action: Event.Mouse.Action) !bool {
+pub fn addEventMouseButton(self: *Self, b: dvui.enums.Button, action: Event.Mouse.Action) std.mem.Allocator.Error!bool {
     return addEventPointer(self, b, action, null);
 }
 
@@ -630,7 +630,7 @@ pub fn addEventMouseButton(self: *Self, b: dvui.enums.Button, action: Event.Mous
 /// This can be called outside begin/end.  You should add all the events
 /// for a frame either before begin() or just after begin() and before
 /// calling normal dvui widgets.  end() clears the event list.
-pub fn addEventPointer(self: *Self, b: dvui.enums.Button, action: Event.Mouse.Action, xynorm: ?Point) !bool {
+pub fn addEventPointer(self: *Self, b: dvui.enums.Button, action: Event.Mouse.Action, xynorm: ?Point) std.mem.Allocator.Error!bool {
     if (self.debug_under_mouse and !self.debug_under_mouse_esc_needed and action == .press and b.pointer()) {
         // a left click or touch will stop the debug stuff from following
         // the mouse, but need to stop it at the end of the frame when
@@ -699,7 +699,7 @@ pub fn addEventPointer(self: *Self, b: dvui.enums.Button, action: Event.Mouse.Ac
 /// This can be called outside begin/end.  You should add all the events
 /// for a frame either before begin() or just after begin() and before
 /// calling normal dvui widgets.  end() clears the event list.
-pub fn addEventMouseWheel(self: *Self, ticks: f32, dir: dvui.enums.Direction) !bool {
+pub fn addEventMouseWheel(self: *Self, ticks: f32, dir: dvui.enums.Direction) std.mem.Allocator.Error!bool {
     self.positionMouseEventRemove();
 
     const winId = self.windowFor(self.mouse_pt);
@@ -726,7 +726,7 @@ pub fn addEventMouseWheel(self: *Self, ticks: f32, dir: dvui.enums.Direction) !b
 /// This can be called outside begin/end.  You should add all the events
 /// for a frame either before begin() or just after begin() and before
 /// calling normal dvui widgets.  end() clears the event list.
-pub fn addEventTouchMotion(self: *Self, finger: dvui.enums.Button, xnorm: f32, ynorm: f32, dxnorm: f32, dynorm: f32) !bool {
+pub fn addEventTouchMotion(self: *Self, finger: dvui.enums.Button, xnorm: f32, ynorm: f32, dxnorm: f32, dynorm: f32) std.mem.Allocator.Error!bool {
     self.positionMouseEventRemove();
 
     const newpt = (Point{ .x = xnorm * self.wd.rect.w, .y = ynorm * self.wd.rect.h }).scale(self.natural_scale, Point.Physical);
@@ -914,7 +914,7 @@ pub fn waitTime(self: *Self, end_micros: ?u32, maxFPS: ?f32) u32 {
 pub fn begin(
     self: *Self,
     time_ns: i128,
-) !void {
+) std.mem.Allocator.Error!void {
     const larena = self._arena.allocator();
 
     var micros_since_last: u32 = 1;
@@ -1090,7 +1090,7 @@ pub fn begin(
     self.backend.begin(larena);
 }
 
-fn positionMouseEventAdd(self: *Self) !void {
+fn positionMouseEventAdd(self: *Self) std.mem.Allocator.Error!void {
     try self.events.append(self.arena(), .{ .evt = .{ .mouse = .{
         .action = .position,
         .button = .none,
@@ -1318,7 +1318,7 @@ pub fn dataRemove(self: *Self, id: WidgetId, key: []const u8) void {
 ///
 ///  If calling from a non-GUI thread, do any dataSet() calls before unlocking the
 ///  mutex to ensure that data is available before the dialog is displayed.
-pub fn dialogAdd(self: *Self, id: WidgetId, display: dvui.DialogDisplayFn) !*std.Thread.Mutex {
+pub fn dialogAdd(self: *Self, id: WidgetId, display: dvui.DialogDisplayFn) std.mem.Allocator.Error!*std.Thread.Mutex {
     self.dialog_mutex.lock();
 
     for (self.dialogs.items) |*d| {
@@ -1374,7 +1374,7 @@ fn dialogsShow(self: *Self) !void {
     }
 }
 
-pub fn timer(self: *Self, id: WidgetId, micros: i32) !void {
+pub fn timer(self: *Self, id: WidgetId, micros: i32) std.mem.Allocator.Error!void {
     // when start_time is in the future, we won't spam frames, so this will
     // cause a single frame and then expire
     const a = Animation{ .start_time = micros, .end_time = micros };
@@ -1392,7 +1392,7 @@ pub fn timerRemove(self: *Self, id: WidgetId) void {
 /// calling from a non-GUI thread, do any `dvui.dataSet` calls before unlocking
 /// the mutex to ensure that data is available before the dialog is
 /// displayed.
-pub fn toastAdd(self: *Self, id: WidgetId, subwindow_id: ?WidgetId, display: dvui.DialogDisplayFn, timeout: ?i32) !*std.Thread.Mutex {
+pub fn toastAdd(self: *Self, id: WidgetId, subwindow_id: ?WidgetId, display: dvui.DialogDisplayFn, timeout: ?i32) std.mem.Allocator.Error!*std.Thread.Mutex {
     self.dialog_mutex.lock();
 
     for (self.toasts.items) |*t| {
@@ -1693,7 +1693,7 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
     return ret;
 }
 
-fn initEvents(self: *Self) !void {
+fn initEvents(self: *Self) std.mem.Allocator.Error!void {
     self.events = .{};
     self.event_num = 0;
 

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -318,9 +318,9 @@ pub fn init(
         },
     }
 
-    const winSize = try self.backend.windowSize();
-    const pxSize = try self.backend.pixelSize();
-    self.content_scale = try self.backend.contentScale();
+    const winSize = self.backend.windowSize();
+    const pxSize = self.backend.pixelSize();
+    self.content_scale = self.backend.contentScale();
 
     // Even on hidpi screens I see slight flattening of the sides of glyphs
     // when snap_to_pixels is false, so we are going to default on for now.
@@ -480,7 +480,7 @@ pub fn refreshBackend(self: *Self, src: std.builtin.SourceLocation, id: ?WidgetI
     if (self.debugRefresh(null)) {
         log.debug("{s}:{d} refreshBackend {?x}", .{ src.file, src.line, id });
     }
-    self.backend.refresh() catch |err| log.warn("Backend refresh failed {!}, trace {?!}", .{ err, @errorReturnTrace() });
+    self.backend.refresh();
 }
 
 pub fn focusSubwindowInternal(self: *Self, subwindow_id: ?WidgetId, event_num: ?u16) void {
@@ -1015,10 +1015,10 @@ pub fn begin(
     self.tab_index_prev = self.tab_index;
     self.tab_index = @TypeOf(self.tab_index).init(self.tab_index.allocator);
 
-    self.rect_pixels = .fromSize(try self.backend.pixelSize());
+    self.rect_pixels = .fromSize(self.backend.pixelSize());
     dvui.clipSet(self.rect_pixels);
 
-    self.wd.rect = Rect.Natural.fromSize(try self.backend.windowSize()).scale(1.0 / self.content_scale, Rect);
+    self.wd.rect = Rect.Natural.fromSize(self.backend.windowSize()).scale(1.0 / self.content_scale, Rect);
     self.natural_scale = if (self.wd.rect.w == 0) 1.0 else self.rect_pixels.w / self.wd.rect.w;
 
     //dvui.log.debug("window size {d} x {d} renderer size {d} x {d} scale {d}", .{ self.wd.rect.w, self.wd.rect.h, self.rect_pixels.w, self.rect_pixels.h, self.natural_scale });

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -318,9 +318,9 @@ pub fn init(
         },
     }
 
-    const winSize = self.backend.windowSize();
-    const pxSize = self.backend.pixelSize();
-    self.content_scale = self.backend.contentScale();
+    const winSize = try self.backend.windowSize();
+    const pxSize = try self.backend.pixelSize();
+    self.content_scale = try self.backend.contentScale();
 
     // Even on hidpi screens I see slight flattening of the sides of glyphs
     // when snap_to_pixels is false, so we are going to default on for now.
@@ -480,7 +480,7 @@ pub fn refreshBackend(self: *Self, src: std.builtin.SourceLocation, id: ?WidgetI
     if (self.debugRefresh(null)) {
         log.debug("{s}:{d} refreshBackend {?x}", .{ src.file, src.line, id });
     }
-    self.backend.refresh();
+    self.backend.refresh() catch |err| log.warn("Backend refresh failed {!}, trace {?!}", .{ err, @errorReturnTrace() });
 }
 
 pub fn focusSubwindowInternal(self: *Self, subwindow_id: ?WidgetId, event_num: ?u16) void {
@@ -914,7 +914,7 @@ pub fn waitTime(self: *Self, end_micros: ?u32, maxFPS: ?f32) u32 {
 pub fn begin(
     self: *Self,
     time_ns: i128,
-) std.mem.Allocator.Error!void {
+) dvui.Backend.GenericError!void {
     const larena = self._arena.allocator();
 
     var micros_since_last: u32 = 1;
@@ -1015,10 +1015,10 @@ pub fn begin(
     self.tab_index_prev = self.tab_index;
     self.tab_index = @TypeOf(self.tab_index).init(self.tab_index.allocator);
 
-    self.rect_pixels = .fromSize(self.backend.pixelSize());
+    self.rect_pixels = .fromSize(try self.backend.pixelSize());
     dvui.clipSet(self.rect_pixels);
 
-    self.wd.rect = Rect.Natural.fromSize(self.backend.windowSize()).scale(1.0 / self.content_scale, Rect);
+    self.wd.rect = Rect.Natural.fromSize(try self.backend.windowSize()).scale(1.0 / self.content_scale, Rect);
     self.natural_scale = if (self.wd.rect.w == 0) 1.0 else self.rect_pixels.w / self.wd.rect.w;
 
     //dvui.log.debug("window size {d} x {d} renderer size {d} x {d} scale {d}", .{ self.wd.rect.w, self.wd.rect.h, self.rect_pixels.w, self.rect_pixels.h, self.natural_scale });
@@ -1087,7 +1087,7 @@ pub fn begin(
 
     self.layout = .{};
 
-    self.backend.begin(larena);
+    try self.backend.begin(larena);
 }
 
 fn positionMouseEventAdd(self: *Self) std.mem.Allocator.Error!void {
@@ -1581,7 +1581,7 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
     }
 
     // Call this before freeing data so backend can use data allocated during frame.
-    self.backend.end();
+    try self.backend.end();
 
     for (self.datas_trash.items) |sd| {
         sd.free(self.gpa);

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -960,7 +960,7 @@ pub fn hasEvent(_: Context) bool {
 }
 
 pub fn backend(self: Context) dvui.Backend {
-    return dvui.Backend.init(self, @This());
+    return dvui.Backend.init(self);
 }
 
 pub fn nanoTime(self: Context) i128 {

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -305,15 +305,16 @@ pub fn initWindow(window_state: *WindowState, options: InitOptions) !Context {
                 ),
                 else => unreachable,
             },
-            else => {
+            else => |win32Err| {
                 if (create_args.err) |err| return err;
-                win32.panicWin32("CreateWindow", win32.GetLastError());
+                win32.panicWin32("CreateWindow", win32Err);
             },
         };
     };
 
     if (options.size) |size| {
-        const dpi = win32.dpiFromHwnd(hwnd);
+        const dpi = win32.GetDpiForWindow(hwnd);
+        try toLastErr(@intCast(dpi), "GetDpiForWindow in initWindow");
         const screen_width = win32.GetSystemMetricsForDpi(@intFromEnum(win32.SM_CXSCREEN), dpi);
         const screen_height = win32.GetSystemMetricsForDpi(@intFromEnum(win32.SM_CYSCREEN), dpi);
         var wnd_size: win32.RECT = .{
@@ -322,11 +323,14 @@ pub fn initWindow(window_state: *WindowState, options: InitOptions) !Context {
             .right = @min(screen_width, @as(i32, @intFromFloat(@round(win32.scaleDpi(f32, size.w, dpi))))),
             .bottom = @min(screen_height, @as(i32, @intFromFloat(@round(win32.scaleDpi(f32, size.h, dpi))))),
         };
-        _ = win32.AdjustWindowRectEx(&wnd_size, style, 0, style_ex);
+        try toLastErr(
+            win32.AdjustWindowRectEx(&wnd_size, style, 0, style_ex),
+            "AdjustWindowRectEx in initWindow",
+        );
 
         const wnd_width = wnd_size.right - wnd_size.left;
         const wnd_height = wnd_size.bottom - wnd_size.top;
-        _ = win32.SetWindowPos(
+        try toLastErr(win32.SetWindowPos(
             hwnd,
             null,
             @divFloor(screen_width - wnd_width, 2),
@@ -334,10 +338,10 @@ pub fn initWindow(window_state: *WindowState, options: InitOptions) !Context {
             wnd_width,
             wnd_height,
             win32.SWP_NOCOPYBITS,
-        );
+        ), "SetWindowPos in initWindow");
     }
-    _ = win32.ShowWindow(hwnd, .{ .SHOWNORMAL = 1 });
-    _ = win32.UpdateWindow(hwnd);
+    try toLastErr(win32.ShowWindow(hwnd, .{ .SHOWNORMAL = 1 }), "ShowWindow in initWindow");
+    try toLastErr(win32.UpdateWindow(hwnd), "UpdateWindow in initWindow");
     return contextFromHwnd(hwnd);
 }
 
@@ -351,7 +355,10 @@ pub fn deinit(self: Context) void {
 pub fn handleSwapChainResizing(self: Context, width: c_uint, height: c_uint) !void {
     const state = stateFromHwnd(hwndFromContext(self));
     cleanupRenderTarget(state);
-    _ = state.swap_chain.ResizeBuffers(0, width, height, win32.DXGI_FORMAT_UNKNOWN, 0);
+    try toErr(
+        state.swap_chain.ResizeBuffers(0, width, height, win32.DXGI_FORMAT_UNKNOWN, 0),
+        "ResizeBuffers in handleSwapChainResizing",
+    );
     try createRenderTarget(state);
 }
 
@@ -364,8 +371,10 @@ pub const ServiceResult = union(enum) {
 /// queue is empty or WM_QUIT/WM_CLOSE are encountered.
 pub fn serviceMessageQueue() ServiceResult {
     var msg: win32.MSG = undefined;
+    // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-peekmessagea#return-value
     while (win32.PeekMessageA(&msg, null, 0, 0, win32.PM_REMOVE) != 0) {
         _ = win32.TranslateMessage(&msg);
+        // ignore return value, https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-dispatchmessagew#return-value
         _ = win32.DispatchMessageW(&msg);
         if (msg.message == win32.WM_QUIT) {
             @branchHint(.unlikely);
@@ -380,8 +389,23 @@ pub fn serviceMessageQueue() ServiceResult {
     return .queue_empty;
 }
 
-fn isOk(res: win32.HRESULT) bool {
-    return res >= 0;
+fn toErr(res: win32.HRESULT, what: []const u8) !void {
+    if (win32.SUCCEEDED(res)) return;
+    std.log.err("{s} failed, hresult=0x{x}", .{ what, res });
+    return dvui.Backend.GenericError.BackendError;
+}
+
+/// Check the return value and prints `win32.GetLastError()` on failure
+fn toLastErr(res: win32.BOOL, what: []const u8) !void {
+    if (res != win32.FALSE) return;
+    return lastErr(what);
+}
+
+/// prints `win32.GetLastError()`
+fn lastErr(what: []const u8) !void {
+    const err = win32.GetLastError();
+    if (err == win32.NO_ERROR) return std.log.err("{s} failed, error={}", .{ what, err });
+    return dvui.Backend.GenericError.BackendError;
 }
 
 fn initShader(state: *WindowState) !void {
@@ -401,16 +425,20 @@ fn initShader(state: *WindowState) !void {
         &vs_blob,
         &error_message,
     );
-    if (!isOk(compile_shader)) {
-        if (error_message == null) {
-            log.err("hresult of error message was skewed: {x}", .{compile_shader});
-            return error.VertexShaderInitFailed;
+    if (win32.FAILED(compile_shader)) {
+        if (error_message) |msg| {
+            defer _ = msg.IUnknown.Release();
+            const as_str: [*:0]const u8 = @ptrCast(msg.vtable.GetBufferPointer(error_message.?));
+            log.err("vertex shader compilation failed with:\n{s}", .{as_str});
         }
-
-        defer _ = error_message.?.IUnknown.Release();
-        const as_str: [*:0]const u8 = @ptrCast(error_message.?.vtable.GetBufferPointer(error_message.?));
-        log.err("vertex shader compilation failed with:\n{s}", .{as_str});
-        return error.VertexShaderInitFailed;
+        try toErr(compile_shader, "vertex shader compilation");
+        unreachable;
+    }
+    state.dx_options.vertex_bytes = vs_blob.?;
+    errdefer {
+        // TODO: Can this always be freed?
+        _ = vs_blob.?.IUnknown.Release();
+        state.dx_options.vertex_bytes = null;
     }
 
     var ps_blob: ?*win32.ID3DBlob = null;
@@ -427,45 +455,39 @@ fn initShader(state: *WindowState) !void {
         &ps_blob,
         &error_message,
     );
-    if (!isOk(ps_res)) {
-        if (error_message == null) {
-            log.err("hresult of error message was skewed: {x}", .{compile_shader});
-            return error.PixelShaderInitFailed;
+    if (win32.FAILED(ps_res)) {
+        if (error_message) |msg| {
+            defer _ = msg.IUnknown.Release();
+            const as_str: [*:0]const u8 = @ptrCast(msg.vtable.GetBufferPointer(error_message.?));
+            log.err("pixel shader compilation failed with:\n{s}", .{as_str});
         }
-
-        defer _ = error_message.?.IUnknown.Release();
-        const as_str: [*:0]const u8 = @ptrCast(error_message.?.vtable.GetBufferPointer(error_message.?));
-        log.err("pixel shader compilation failed with: {s}", .{as_str});
-        return error.PixelShaderInitFailed;
+        try toErr(ps_res, "pixel shader compile");
+        unreachable;
+    }
+    state.dx_options.pixel_bytes = ps_blob.?;
+    errdefer {
+        // TODO: Can this always be freed?
+        _ = ps_blob.?.IUnknown.Release();
+        state.dx_options.pixel_bytes = null;
     }
 
-    state.dx_options.vertex_bytes = vs_blob.?;
     var vertex_shader_result: @TypeOf(state.dx_options.vertex_shader.?) = undefined;
-    const create_vs = state.device.CreateVertexShader(
+    try toErr(state.device.CreateVertexShader(
         @ptrCast(state.dx_options.vertex_bytes.?.GetBufferPointer()),
         state.dx_options.vertex_bytes.?.GetBufferSize(),
         null,
         &vertex_shader_result,
-    );
+    ), "CreateVertexShader");
     state.dx_options.vertex_shader = vertex_shader_result;
 
-    if (!isOk(create_vs)) {
-        return error.CreateVertexShaderFailed;
-    }
-
-    state.dx_options.pixel_bytes = ps_blob.?;
     var pixel_shader_result: @TypeOf(state.dx_options.pixel_shader.?) = undefined;
-    const create_ps = state.device.CreatePixelShader(
+    try toErr(state.device.CreatePixelShader(
         @ptrCast(state.dx_options.pixel_bytes.?.GetBufferPointer()),
         state.dx_options.pixel_bytes.?.GetBufferSize(),
         null,
         &pixel_shader_result,
-    );
+    ), "CreatePixelShader");
     state.dx_options.pixel_shader = pixel_shader_result;
-
-    if (!isOk(create_ps)) {
-        return error.CreatePixelShaderFailed;
-    }
 }
 
 fn createRasterizerState(state: *WindowState) !void {
@@ -476,12 +498,13 @@ fn createRasterizerState(state: *WindowState) !void {
     raster_desc.DepthClipEnable = 0;
     raster_desc.ScissorEnable = 1;
 
+    // TODO: is this variable needed?
     var rasterizer_result: @TypeOf(state.dx_options.rasterizer.?) = undefined;
-    const rasterizer_res = state.device.CreateRasterizerState(&raster_desc, &rasterizer_result);
+    try toErr(
+        state.device.CreateRasterizerState(&raster_desc, &rasterizer_result),
+        "CreateRasterizerState in createRasterizerState",
+    );
     state.dx_options.rasterizer = rasterizer_result;
-    if (!isOk(rasterizer_res)) {
-        return error.RasterizerInitFailed;
-    }
 
     state.device_context.RSSetState(state.dx_options.rasterizer);
 }
@@ -489,15 +512,18 @@ fn createRasterizerState(state: *WindowState) !void {
 fn createRenderTarget(state: *WindowState) !void {
     var back_buffer: ?*win32.ID3D11Texture2D = null;
 
-    _ = state.swap_chain.GetBuffer(0, win32.IID_ID3D11Texture2D, @ptrCast(&back_buffer));
+    try toErr(
+        state.swap_chain.GetBuffer(0, win32.IID_ID3D11Texture2D, @ptrCast(&back_buffer)),
+        "GetBuffer in createRenderTarget",
+    );
     defer _ = back_buffer.?.IUnknown.Release();
 
     var render_target_result: @TypeOf(state.render_target.?) = undefined;
-    _ = state.device.CreateRenderTargetView(
+    try toErr(state.device.CreateRenderTargetView(
         @ptrCast(back_buffer),
         null,
         &render_target_result,
-    );
+    ), "CreateRenderTargetView in createRenderTarget");
     state.render_target = render_target_result;
 }
 
@@ -518,23 +544,19 @@ fn createInputLayout(state: *WindowState) !void {
     const num_elements = input_layout_desc.len;
 
     var vertex_layout_result: @TypeOf(state.dx_options.vertex_layout.?) = undefined;
-    const res = state.device.CreateInputLayout(
+    try toErr(state.device.CreateInputLayout(
         input_layout_desc,
         num_elements,
         @ptrCast(state.dx_options.vertex_bytes.?.GetBufferPointer()),
         state.dx_options.vertex_bytes.?.GetBufferSize(),
         &vertex_layout_result,
-    );
+    ), "CreateInputLayout in createInputLayout");
     state.dx_options.vertex_layout = vertex_layout_result;
-
-    if (!isOk(res)) {
-        return error.VertexLayoutCreationFailed;
-    }
 
     state.device_context.IASetInputLayout(state.dx_options.vertex_layout);
 }
 
-fn recreateShaderView(state: *WindowState, texture: *anyopaque) void {
+fn recreateShaderView(state: *WindowState, texture: *anyopaque) !void {
     const tex: *win32.ID3D11Texture2D = @ptrCast(@alignCast(texture));
 
     const rvd = win32.D3D11_SHADER_RESOURCE_VIEW_DESC{
@@ -553,17 +575,12 @@ fn recreateShaderView(state: *WindowState, texture: *anyopaque) void {
     }
 
     var texture_view_result: @TypeOf(state.dx_options.texture_view.?) = undefined;
-    const rv_result = state.device.CreateShaderResourceView(
+    try toErr(state.device.CreateShaderResourceView(
         &tex.ID3D11Resource,
         &rvd,
         &texture_view_result,
-    );
+    ), "CreateShaderResourceView in recreateShaderView");
     state.dx_options.texture_view = texture_view_result;
-
-    if (!isOk(rv_result)) {
-        log.err("Texture View creation failed", .{});
-        @panic("couldn't create texture view");
-    }
 }
 
 fn createSampler(state: *WindowState, interpolation: dvui.enums.TextureInterpolation) !void {
@@ -588,20 +605,15 @@ fn createSampler(state: *WindowState, interpolation: dvui.enums.TextureInterpola
 
     // TODO: Handle errors better
     var blend_state_result: @TypeOf(state.dx_options.blend_state.?) = undefined;
-    _ = state.device.CreateBlendState(&blend_desc, &blend_state_result);
+    try toErr(state.device.CreateBlendState(&blend_desc, &blend_state_result), "CreateBlendState in createSampler");
     state.dx_options.blend_state = blend_state_result;
-    _ = state.device_context.OMSetBlendState(state.dx_options.blend_state, null, 0xffffffff);
+    state.device_context.OMSetBlendState(state.dx_options.blend_state, null, 0xffffffff);
 
     var sampler_result: *win32.ID3D11SamplerState = undefined;
-    const sampler = state.device.CreateSamplerState(&samp_desc, &sampler_result);
+    try toErr(state.device.CreateSamplerState(&samp_desc, &sampler_result), "CreateSamplerState in createSampler");
     switch (interpolation) {
         .linear => state.dx_options.sampler_linear = sampler_result,
         .nearest => state.dx_options.sampler_nearest = sampler_result,
-    }
-
-    if (!isOk(sampler)) {
-        log.err("sampler state could not be iniitialized", .{});
-        return error.SamplerStateUninitialized;
     }
 }
 
@@ -617,7 +629,7 @@ fn createBuffer(state: *WindowState, bind_type: anytype, comptime InitialType: t
     data.pSysMem = @ptrCast(initial_data.ptr);
 
     var buffer: *win32.ID3D11Buffer = undefined;
-    _ = state.device.CreateBuffer(&bd, &data, &buffer);
+    try toErr(state.device.CreateBuffer(&bd, &data, &buffer), "CreateBuffer in createBuffer");
 
     // argument no longer pointer-to-optional since zigwin32 update - 2025-01-10
     //if (buffer) |buf| {
@@ -628,7 +640,7 @@ fn createBuffer(state: *WindowState, bind_type: anytype, comptime InitialType: t
 }
 
 // ############ Satisfy DVUI interfaces ############
-pub fn textureCreate(self: Context, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) dvui.Texture {
+pub fn textureCreate(self: Context, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.Texture {
     const state = stateFromHwnd(hwndFromContext(self));
 
     var texture: *win32.ID3D11Texture2D = undefined;
@@ -652,18 +664,13 @@ pub fn textureCreate(self: Context, pixels: [*]u8, width: u32, height: u32, inte
     resource_data.pSysMem = pixels;
     resource_data.SysMemPitch = width * 4; // 4 byte per pixel (RGBA)
 
-    const tex_creation = state.device.CreateTexture2D(
-        &tex_desc,
-        &resource_data,
-        &texture,
-    );
+    toErr(
+        state.device.CreateTexture2D(&tex_desc, &resource_data, &texture),
+        "CreateTexture2D in textureCreate",
+    ) catch return dvui.Backend.TextureError.TextureCreate;
+    errdefer _ = texture.IUnknown.Release();
 
-    if (!isOk(tex_creation)) {
-        log.err("Texture creation failed.", .{});
-        @panic("couldn't create texture");
-    }
-
-    state.texture_interpolation.put(texture, interpolation) catch @panic("texture interpolation map OOM");
+    try state.texture_interpolation.put(texture, interpolation);
 
     return dvui.Texture{ .ptr = texture, .width = width, .height = height };
 }
@@ -687,16 +694,17 @@ pub fn textureCreateTarget(self: Context, width: u32, height: u32, interpolation
         .MiscFlags = .{},
     };
     var texture: *win32.ID3D11Texture2D = undefined;
-    const texture_result = state.device.CreateTexture2D(&texture_desc, null, &texture);
-    if (!isOk(texture_result)) {
-        log.err("Texture for render target creation failed", .{});
-        return error.TextureCreate;
-    }
-    state.texture_interpolation.put(texture, interpolation) catch @panic("texture interpolation map OOM");
+    toErr(
+        state.device.CreateTexture2D(&texture_desc, null, &texture),
+        "CreateTexture2D target",
+    ) catch return dvui.Backend.TextureError.TextureCreate;
+    errdefer _ = texture.IUnknown.Release();
+
+    try state.texture_interpolation.put(texture, interpolation);
     return .{ .ptr = @ptrCast(texture), .width = width, .height = height };
 }
 
-pub fn textureReadTarget(self: Context, texture: dvui.TextureTarget, pixels_out: [*]u8) error{TextureRead}!void {
+pub fn textureReadTarget(self: Context, texture: dvui.TextureTarget, pixels_out: [*]u8) !void {
     const state = stateFromHwnd(hwndFromContext(self));
     const tex: *win32.ID3D11Texture2D = @ptrCast(@alignCast(texture.ptr));
 
@@ -716,18 +724,20 @@ pub fn textureReadTarget(self: Context, texture: dvui.TextureTarget, pixels_out:
         .MiscFlags = .{},
     };
     var staging: *win32.ID3D11Texture2D = undefined;
-    const texture_result = state.device.CreateTexture2D(&texture_desc, null, &staging);
-    if (!isOk(texture_result)) {
-        log.err("Texture creation for read failed", .{});
-        return error.TextureRead;
-    }
+    toErr(
+        state.device.CreateTexture2D(&texture_desc, null, &staging),
+        "CreateTexture2D in textureReadTarget",
+    ) catch return dvui.Backend.TextureError.TextureCreate;
     defer _ = staging.IUnknown.Release();
 
     state.device_context.CopyResource(&staging.ID3D11Resource, &tex.ID3D11Resource);
     defer state.device_context.Unmap(&staging.ID3D11Resource, 0);
 
     var mapped: win32.D3D11_MAPPED_SUBRESOURCE = undefined;
-    _ = state.device_context.Map(&staging.ID3D11Resource, 0, win32.D3D11_MAP.READ, 0, &mapped);
+    toErr(
+        state.device_context.Map(&staging.ID3D11Resource, 0, win32.D3D11_MAP.READ, 0, &mapped),
+        "Map in textureReadTarget",
+    ) catch return dvui.Backend.TextureError.TextureRead;
 
     if (mapped.pData) |data_ptr| {
         const data: [*]const u8 = @ptrCast(data_ptr);
@@ -749,14 +759,14 @@ pub fn textureDestroy(self: Context, texture: dvui.Texture) void {
     _ = tex.IUnknown.Release();
 }
 
-pub fn textureFromTarget(self: Context, texture: dvui.TextureTarget) dvui.Texture {
+pub fn textureFromTarget(self: Context, texture: dvui.TextureTarget) !dvui.Texture {
     const state = stateFromHwnd(hwndFromContext(self));
 
     // DX11 can't draw target textures, so read all the pixels and make a new texture
 
-    const pixels = state.arena.alloc(u8, texture.width * texture.height * 4) catch unreachable;
+    const pixels = try state.arena.alloc(u8, texture.width * texture.height * 4);
     defer state.arena.free(pixels);
-    self.textureReadTarget(texture, pixels.ptr) catch unreachable;
+    try self.textureReadTarget(texture, pixels.ptr);
 
     const tex: *win32.ID3D11Texture2D = @ptrCast(@alignCast(texture.ptr));
     const interpolation = if (state.texture_interpolation.fetchRemove(texture.ptr)) |kv| kv.value else blk: {
@@ -768,22 +778,18 @@ pub fn textureFromTarget(self: Context, texture: dvui.TextureTarget) dvui.Textur
     return self.textureCreate(pixels.ptr, texture.width, texture.height, interpolation);
 }
 
-pub fn renderTarget(self: Context, texture: ?dvui.TextureTarget) void {
+pub fn renderTarget(self: Context, texture: ?dvui.TextureTarget) !void {
     const state = stateFromHwnd(hwndFromContext(self));
     cleanupRenderTarget(state);
     if (texture) |tex| {
         const target: *win32.ID3D11Texture2D = @ptrCast(@alignCast(tex.ptr));
         var render_target: @TypeOf(state.render_target.?) = undefined;
-        const target_result = state.device.CreateRenderTargetView(
+        errdefer state.render_target = null;
+        try toErr(state.device.CreateRenderTargetView(
             @ptrCast(&target.ID3D11Resource),
             null,
             &render_target,
-        );
-        if (!isOk(target_result)) {
-            log.err("Render target creation failed", .{});
-            state.render_target = null;
-            return;
-        }
+        ), "CreateRenderTargetView in renderTarget");
         state.device_context.ClearRenderTargetView(render_target, @ptrCast(&[4]f32{ 0, 0, 0, 0 }));
         state.render_target = render_target;
     } else {
@@ -797,57 +803,24 @@ pub fn drawClippedTriangles(
     vtx: []const dvui.Vertex,
     idx: []const u16,
     clipr: ?dvui.Rect.Physical,
-) void {
+) !void {
     const state = stateFromHwnd(hwndFromContext(self));
     const client_size = win32.getClientSize(hwndFromContext(self));
     setViewport(state, @floatFromInt(client_size.cx), @floatFromInt(client_size.cy));
 
-    if (state.render_target == null) {
-        createRenderTarget(state) catch |err| {
-            log.err("render target could not be initialized: {}", .{err});
-            return;
-        };
-    }
-
-    if (state.dx_options.vertex_shader == null or state.dx_options.pixel_shader == null) {
-        initShader(state) catch |err| {
-            log.err("shaders could not be initialized: {}", .{err});
-            return;
-        };
-    }
-
-    if (state.dx_options.vertex_layout == null) {
-        createInputLayout(state) catch |err| {
-            log.err("Failed to create vertex layout: {}", .{err});
-            return;
-        };
-    }
-
-    if (state.dx_options.sampler_linear == null) {
-        createSampler(state, .linear) catch |err| {
-            log.err("linear sampler could not be initialized: {}", .{err});
-            return;
-        };
-    }
-    if (state.dx_options.sampler_nearest == null) {
-        createSampler(state, .nearest) catch |err| {
-            log.err("nearest sampler could not be initialized: {}", .{err});
-            return;
-        };
-    }
-
-    if (state.dx_options.rasterizer == null) {
-        createRasterizerState(state) catch |err| {
-            log.err("Creating rasterizer failed: {}", .{err});
-        };
-    }
+    if (state.render_target == null) try createRenderTarget(state);
+    if (state.dx_options.vertex_shader == null or state.dx_options.pixel_shader == null) try initShader(state);
+    if (state.dx_options.vertex_layout == null) try createInputLayout(state);
+    if (state.dx_options.sampler_linear == null) try createSampler(state, .linear);
+    if (state.dx_options.sampler_nearest == null) try createSampler(state, .nearest);
+    if (state.dx_options.rasterizer == null) try createRasterizerState(state);
 
     var stride: usize = @sizeOf(SimpleVertex);
     var offset: usize = 0;
-    const converted_vtx = convertVertices(state.arena, .{
+    const converted_vtx = try convertVertices(state.arena, .{
         .w = @floatFromInt(client_size.cx),
         .h = @floatFromInt(client_size.cy),
-    }, vtx, texture == null) catch @panic("OOM");
+    }, vtx, texture == null);
     defer state.arena.free(converted_vtx);
 
     // Do yourself a favour and don't touch it.
@@ -855,24 +828,18 @@ pub fn drawClippedTriangles(
     if (state.dx_options.vertex_buffer) |vb| {
         _ = vb.IUnknown.Release();
     }
-    state.dx_options.vertex_buffer = createBuffer(state, win32.D3D11_BIND_VERTEX_BUFFER, SimpleVertex, converted_vtx) catch {
-        log.err("no vertex buffer created", .{});
-        return;
-    };
+    state.dx_options.vertex_buffer = try createBuffer(state, win32.D3D11_BIND_VERTEX_BUFFER, SimpleVertex, converted_vtx);
 
     // Do yourself a favour and don't touch it.
     // End() isn't being called all the time, so it's kind of futile.
     if (state.dx_options.index_buffer) |ib| {
         _ = ib.IUnknown.Release();
     }
-    state.dx_options.index_buffer = createBuffer(state, win32.D3D11_BIND_INDEX_BUFFER, u16, idx) catch {
-        log.err("no index buffer created", .{});
-        return;
-    };
+    state.dx_options.index_buffer = try createBuffer(state, win32.D3D11_BIND_INDEX_BUFFER, u16, idx);
 
     setViewport(state, @floatFromInt(client_size.cx), @floatFromInt(client_size.cy));
 
-    if (texture) |tex| recreateShaderView(state, tex.ptr);
+    if (texture) |tex| try recreateShaderView(state, tex.ptr);
     const interpolation = if (texture) |tex| state.texture_interpolation.get(tex.ptr) orelse .linear else .linear;
 
     var scissor_rect: ?win32.RECT = std.mem.zeroes(win32.RECT);
@@ -908,11 +875,11 @@ pub fn drawClippedTriangles(
     if (scissor_rect) |srect| state.device_context.RSSetScissorRects(nums, @ptrCast(&srect));
 }
 
-pub fn begin(self: Context, arena: std.mem.Allocator) void {
+pub fn begin(self: Context, arena: std.mem.Allocator) !void {
     const state = stateFromHwnd(hwndFromContext(self));
     state.arena = arena;
 
-    const pixel_size = self.pixelSize();
+    const pixel_size = try self.pixelSize();
     var scissor_rect: win32.RECT = .{
         .left = 0,
         .top = 0,
@@ -925,32 +892,35 @@ pub fn begin(self: Context, arena: std.mem.Allocator) void {
     state.device_context.ClearRenderTargetView(state.render_target orelse return, @ptrCast((&clear_color).ptr));
 }
 
-pub fn end(self: Context) void {
+pub fn end(self: Context) !void {
     const state = stateFromHwnd(hwndFromContext(self));
-    _ = state.swap_chain.Present(if (state.vsync) 1 else 0, 0);
+    try toErr(state.swap_chain.Present(if (state.vsync) 1 else 0, 0), "Present in end");
 }
 
-pub fn pixelSize(self: Context) dvui.Size.Physical {
-    const client_size = win32.getClientSize(hwndFromContext(self));
+pub fn pixelSize(self: Context) !dvui.Size.Physical {
+    var rect: win32.RECT = undefined;
+    try toErr(win32.GetClientRect(hwndFromContext(self), &rect), "GetClientRect in pixelSize");
+    std.debug.assert(rect.left == 0);
+    std.debug.assert(rect.top == 0);
     return .{
-        .w = @floatFromInt(client_size.cx),
-        .h = @floatFromInt(client_size.cy),
+        .w = @floatFromInt(rect.right),
+        .h = @floatFromInt(rect.bottom),
     };
 }
 
-pub fn windowSize(self: Context) dvui.Size.Natural {
-    const size = self.pixelSize();
+pub fn windowSize(self: Context) !dvui.Size.Natural {
+    const size = try self.pixelSize();
     // apply dpi scaling manually as there is no convenient api to get the window
     // size of the client size. `win32.GetWindowRect` includes window decorations
-    const dpi = win32.dpiFromHwnd(hwndFromContext(self));
+    const dpi = win32.GetDpiForWindow(hwndFromContext(self));
+    try toLastErr(@intCast(dpi), "GetDpiForWindow in windowSize");
     return .{
         .w = size.w / win32.scaleFromDpi(f32, dpi),
         .h = size.h / win32.scaleFromDpi(f32, dpi),
     };
 }
 
-pub fn contentScale(self: Context) f32 {
-    _ = self;
+pub fn contentScale(_: Context) !f32 {
     return 1.0;
     //return @as(f32, @floatFromInt(win32.dpiFromHwnd(hwndFromContext(self)))) / 96.0;
 }
@@ -963,36 +933,36 @@ pub fn backend(self: Context) dvui.Backend {
     return dvui.Backend.init(self);
 }
 
-pub fn nanoTime(self: Context) i128 {
-    _ = self;
+pub fn nanoTime(_: Context) i128 {
     return std.time.nanoTimestamp();
 }
 
-pub fn sleep(self: Context, ns: u64) void {
-    _ = self;
+pub fn sleep(_: Context, ns: u64) void {
     std.time.sleep(ns);
 }
 
 pub fn clipboardText(self: Context) ![]const u8 {
     const state = stateFromHwnd(hwndFromContext(self));
-    const opened = win32.OpenClipboard(hwndFromContext(self)) == win32.zig.TRUE;
-    defer _ = win32.CloseClipboard();
-    if (!opened) {
-        return "";
-    }
+    toLastErr(win32.OpenClipboard(hwndFromContext(self)), "OpenClipboard in clipboardText") catch return "";
+    defer toLastErr(win32.CloseClipboard(), "CloseClipboard in clipboardText") catch {};
 
     // istg, windows. why. why utf16.
-    const data_handle = win32.GetClipboardData(@intFromEnum(win32.CF_UNICODETEXT)) orelse return "";
+    const data_handle = win32.GetClipboardData(@intFromEnum(win32.CF_UNICODETEXT)) orelse {
+        lastErr("GetClipboardData in clipboardText") catch {};
+        return "";
+    };
 
     var res: []u8 = undefined;
     {
         const handle: isize = @intCast(@intFromPtr(data_handle));
         const data: [*:0]u16 = @ptrCast(@alignCast(win32.GlobalLock(handle) orelse return ""));
-        defer _ = win32.GlobalUnlock(handle);
+        defer toLastErr(win32.GlobalUnlock(handle), "GlobalUnlock in clipboardText") catch {};
 
         // we want this to be a sane format.
-        const len = std.mem.indexOfSentinel(u16, 0, data);
-        res = std.unicode.utf16LeToUtf8Alloc(state.arena, data[0..len]) catch return error.OutOfMemory;
+        res = std.unicode.utf16LeToUtf8Alloc(state.arena, std.mem.span(data)) catch |err| switch (err) {
+            error.OutOfMemory => |e| return e,
+            else => return dvui.Backend.GenericError.BackendError,
+        };
     }
 
     return res;
@@ -1000,30 +970,28 @@ pub fn clipboardText(self: Context) ![]const u8 {
 
 pub fn clipboardTextSet(self: Context, text: []const u8) !void {
     const state = stateFromHwnd(hwndFromContext(self));
-    const opened = win32.OpenClipboard(hwndFromContext(self)) == win32.zig.TRUE;
-    defer _ = win32.CloseClipboard();
-    if (!opened) {
-        return;
-    }
+    toLastErr(win32.OpenClipboard(hwndFromContext(self)), "OpenClipboard in clipboardTextSet") catch return;
+    defer toLastErr(win32.CloseClipboard(), "CloseClipboard in clipboardTextSet") catch {};
 
     const handle = win32.GlobalAlloc(win32.GMEM_MOVEABLE, text.len * @sizeOf(u16) + 1); // don't forget the nullbyte
-    if (handle != 0x0) {
-        const as_utf16 = std.unicode.utf8ToUtf16LeAlloc(state.arena, text) catch return error.OutOfMemory;
-        defer state.arena.free(as_utf16);
+    if (handle == 0) return std.mem.Allocator.Error.OutOfMemory;
 
-        const data: [*:0]u16 = @ptrCast(@alignCast(win32.GlobalLock(handle) orelse return));
-        defer _ = win32.GlobalUnlock(handle);
+    const as_utf16 = std.unicode.utf8ToUtf16LeAlloc(state.arena, text) catch |err| switch (err) {
+        error.OutOfMemory => |e| return e,
+        else => return dvui.Backend.GenericError.BackendError,
+    };
+    defer state.arena.free(as_utf16);
 
-        for (as_utf16, 0..) |wide, i| {
-            data[i] = wide;
-        }
-    } else {
-        return error.OutOfMemory;
+    const data: [*:0]u16 = @ptrCast(@alignCast(win32.GlobalLock(handle) orelse return));
+    defer toLastErr(win32.GlobalUnlock(handle), "GlobalUnlock in clipboardTextSet") catch {};
+
+    for (as_utf16, 0..) |wide, i| {
+        data[i] = wide;
     }
 
-    _ = win32.EmptyClipboard();
+    try toLastErr(win32.EmptyClipboard(), "EmptyClipboard in clipboardTextSet");
     const handle_usize: usize = @intCast(handle);
-    _ = win32.SetClipboardData(@intFromEnum(win32.CF_UNICODETEXT), @ptrFromInt(handle_usize));
+    _ = win32.SetClipboardData(@intFromEnum(win32.CF_UNICODETEXT), @ptrFromInt(handle_usize)) orelse try lastErr("SetClipboardData in clipboardTextSet");
 }
 
 pub fn openURL(self: Context, url: []const u8) !void {
@@ -1031,9 +999,7 @@ pub fn openURL(self: Context, url: []const u8) !void {
     _ = url;
 }
 
-pub fn refresh(self: Context) void {
-    _ = self;
-}
+pub fn refresh(_: Context) void {}
 
 fn addEvent(_: Context, window: *dvui.Window, key_event: KeyEvent) !bool {
     const event = key_event.target;
@@ -1059,9 +1025,7 @@ fn addEvent(_: Context, window: *dvui.Window, key_event: KeyEvent) !bool {
     }
 }
 
-pub fn addAllEvents(self: Context, window: *dvui.Window) !bool {
-    _ = self;
-    _ = window;
+pub fn addAllEvents(_: Context, _: *dvui.Window) !bool {
     return false;
 }
 
@@ -1177,8 +1141,8 @@ pub fn wndProc(
         },
         win32.WM_PAINT => {
             var ps: win32.PAINTSTRUCT = undefined;
-            _ = win32.BeginPaint(hwnd, &ps) orelse return win32.panicWin32("BeginPaint", win32.GetLastError());
-            defer if (0 == win32.EndPaint(hwnd, &ps)) win32.panicWin32("EndPaint", win32.GetLastError());
+            if (win32.BeginPaint(hwnd, &ps) == null) lastErr("BeginPaint") catch return -1;
+            toLastErr(win32.EndPaint(hwnd, &ps), "EndPaint") catch return -1;
             return 0;
         },
         win32.WM_SIZE => {
@@ -1410,7 +1374,7 @@ fn createDeviceD3D(hwnd: win32.HWND) ?Directx11Options {
     var device_context: *win32.ID3D11DeviceContext = undefined;
     var swap_chain: *win32.IDXGISwapChain = undefined;
 
-    var res: win32.HRESULT = win32.D3D11CreateDeviceAndSwapChain(
+    toErr(switch (win32.D3D11CreateDeviceAndSwapChain(
         null,
         win32.D3D_DRIVER_TYPE_HARDWARE,
         null,
@@ -1423,10 +1387,8 @@ fn createDeviceD3D(hwnd: win32.HWND) ?Directx11Options {
         &device,
         &featureLevel,
         &device_context,
-    );
-
-    if (res == win32.DXGI_ERROR_UNSUPPORTED) {
-        res = win32.D3D11CreateDeviceAndSwapChain(
+    )) {
+        win32.DXGI_ERROR_UNSUPPORTED => win32.D3D11CreateDeviceAndSwapChain(
             null,
             win32.D3D_DRIVER_TYPE_WARP,
             null,
@@ -1439,10 +1401,9 @@ fn createDeviceD3D(hwnd: win32.HWND) ?Directx11Options {
             &device,
             &featureLevel,
             &device_context,
-        );
-    }
-    if (!isOk(res))
-        return null;
+        ),
+        else => |res| res,
+    }, "D3D11CreateDeviceAndSwapChain in createDeviceD3D") catch return null;
 
     return Directx11Options{
         .device = device,

--- a/src/backends/raylib.zig
+++ b/src/backends/raylib.zig
@@ -175,19 +175,19 @@ pub fn sleep(_: *RaylibBackend, ns: u64) void {
     std.time.sleep(ns);
 }
 
-pub fn pixelSize(_: *RaylibBackend) !dvui.Size.Physical {
+pub fn pixelSize(_: *RaylibBackend) dvui.Size.Physical {
     const w = c.GetRenderWidth();
     const h = c.GetRenderHeight();
     return .{ .w = @floatFromInt(w), .h = @floatFromInt(h) };
 }
 
-pub fn windowSize(_: *RaylibBackend) !dvui.Size.Natural {
+pub fn windowSize(_: *RaylibBackend) dvui.Size.Natural {
     const w = c.GetScreenWidth();
     const h = c.GetScreenHeight();
     return .{ .w = @floatFromInt(w), .h = @floatFromInt(h) };
 }
 
-pub fn contentScale(_: *RaylibBackend) !f32 {
+pub fn contentScale(_: *RaylibBackend) f32 {
     return 1.0;
 }
 
@@ -461,7 +461,7 @@ pub fn setCursor(self: *RaylibBackend, cursor: dvui.enums.Cursor) void {
 }
 
 //TODO implement this function
-pub fn refresh(_: *RaylibBackend) !void {}
+pub fn refresh(_: *RaylibBackend) void {}
 
 pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !bool {
     var disable_raylib_input: bool = false;

--- a/src/backends/raylib.zig
+++ b/src/backends/raylib.zig
@@ -163,7 +163,7 @@ pub fn deinit(self: *RaylibBackend) void {
 }
 
 pub fn backend(self: *RaylibBackend) dvui.Backend {
-    return dvui.Backend.init(self, @This());
+    return dvui.Backend.init(self);
 }
 
 pub fn nanoTime(self: *RaylibBackend) i128 {

--- a/src/backends/raylib.zig
+++ b/src/backends/raylib.zig
@@ -175,23 +175,23 @@ pub fn sleep(_: *RaylibBackend, ns: u64) void {
     std.time.sleep(ns);
 }
 
-pub fn pixelSize(_: *RaylibBackend) dvui.Size.Physical {
+pub fn pixelSize(_: *RaylibBackend) !dvui.Size.Physical {
     const w = c.GetRenderWidth();
     const h = c.GetRenderHeight();
     return .{ .w = @floatFromInt(w), .h = @floatFromInt(h) };
 }
 
-pub fn windowSize(_: *RaylibBackend) dvui.Size.Natural {
+pub fn windowSize(_: *RaylibBackend) !dvui.Size.Natural {
     const w = c.GetScreenWidth();
     const h = c.GetScreenHeight();
     return .{ .w = @floatFromInt(w), .h = @floatFromInt(h) };
 }
 
-pub fn contentScale(_: *RaylibBackend) f32 {
+pub fn contentScale(_: *RaylibBackend) !f32 {
     return 1.0;
 }
 
-pub fn drawClippedTriangles(self: *RaylibBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const u16, clipr_in: ?dvui.Rect.Physical) void {
+pub fn drawClippedTriangles(self: *RaylibBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const u16, clipr_in: ?dvui.Rect.Physical) !void {
 
     //make sure all raylib draw calls are rendered
     //before rendering dvui elements
@@ -290,8 +290,9 @@ pub fn drawClippedTriangles(self: *RaylibBackend, texture: ?dvui.Texture, vtx: [
     }
 }
 
-pub fn textureCreate(_: *RaylibBackend, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) dvui.Texture {
+pub fn textureCreate(_: *RaylibBackend, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.Texture {
     const texid = c.rlLoadTexture(pixels, @intCast(width), @intCast(height), c.PIXELFORMAT_UNCOMPRESSED_R8G8B8A8, 1);
+    if (texid <= 0) return dvui.Backend.TextureError.TextureCreate;
 
     switch (interpolation) {
         .nearest => {
@@ -312,9 +313,9 @@ pub fn textureCreate(_: *RaylibBackend, pixels: [*]u8, width: u32, height: u32, 
 
 pub fn textureCreateTarget(self: *RaylibBackend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.TextureTarget {
     const id = c.rlLoadFramebuffer(); // Load an empty framebuffer
-    if (id == 0) {
+    if (id <= 0) {
         log.debug("textureCreateTarget: rlLoadFramebuffer() failed\n", .{});
-        return error.TextureCreate;
+        return dvui.Backend.TextureError.TextureCreate;
     }
 
     c.rlEnableFramebuffer(id);
@@ -322,6 +323,7 @@ pub fn textureCreateTarget(self: *RaylibBackend, width: u32, height: u32, interp
 
     // Create color texture (default to RGBA)
     const texid = c.rlLoadTexture(null, @intCast(width), @intCast(height), c.PIXELFORMAT_UNCOMPRESSED_R8G8B8A8, 1);
+    if (texid <= 0) return dvui.Backend.TextureError.TextureCreate;
     switch (interpolation) {
         .nearest => {
             c.rlTextureParameters(texid, c.RL_TEXTURE_MIN_FILTER, c.RL_TEXTURE_FILTER_NEAREST);
@@ -341,16 +343,16 @@ pub fn textureCreateTarget(self: *RaylibBackend, width: u32, height: u32, interp
     // Check if fbo is complete with attachments (valid)
     if (!c.rlFramebufferComplete(id)) {
         log.debug("textureCreateTarget: rlFramebufferComplete() false\n", .{});
-        return error.TextureCreate;
+        return dvui.Backend.TextureError.TextureCreate;
     }
 
     try self.frame_buffers.put(texid, id);
 
     const ret = dvui.TextureTarget{ .ptr = @ptrFromInt(texid), .width = width, .height = height };
 
-    self.renderTarget(ret);
+    try self.renderTarget(ret);
     c.ClearBackground(c.BLANK);
-    self.renderTarget(null);
+    try self.renderTarget(null);
 
     return ret;
 }
@@ -361,14 +363,17 @@ pub fn textureFromTarget(_: *RaylibBackend, texture: dvui.TextureTarget) dvui.Te
 
 /// Render future drawClippedTriangles() to the passed texture (or screen
 /// if null).
-pub fn renderTarget(self: *RaylibBackend, texture: ?dvui.TextureTarget) void {
+pub fn renderTarget(self: *RaylibBackend, texture: ?dvui.TextureTarget) !void {
     if (texture) |tex| {
         const texid = @intFromPtr(tex.ptr);
-        var target: c.RenderTexture2D = undefined;
-        target.id = self.frame_buffers.get(@intCast(texid)) orelse unreachable;
-        target.texture.id = @intCast(texid);
-        target.texture.width = @intCast(tex.width);
-        target.texture.height = @intCast(tex.height);
+        const target: c.RenderTexture2D = .{
+            .id = self.frame_buffers.get(@intCast(texid)) orelse return dvui.Backend.GenericError.BackendError,
+            .texture = .{
+                .id = @intCast(texid),
+                .width = @intCast(tex.width),
+                .height = @intCast(tex.height),
+            },
+        };
         self.fb_width = target.texture.width;
         self.fb_height = target.texture.height;
 
@@ -388,16 +393,18 @@ pub fn renderTarget(self: *RaylibBackend, texture: ?dvui.TextureTarget) void {
     }
 }
 
-pub fn textureReadTarget(_: *RaylibBackend, texture: dvui.TextureTarget, pixels_out: [*]u8) error{TextureRead}!void {
-    var t: c.Texture2D = undefined;
-    t.id = @intCast(@intFromPtr(texture.ptr));
-    t.width = @intCast(texture.width);
-    t.height = @intCast(texture.height);
-    t.mipmaps = 1;
-    t.format = c.PIXELFORMAT_UNCOMPRESSED_R8G8B8A8;
+pub fn textureReadTarget(_: *RaylibBackend, texture: dvui.TextureTarget, pixels_out: [*]u8) !void {
+    const t: c.Texture2D = .{
+        .id = @intCast(@intFromPtr(texture.ptr)),
+        .width = @intCast(texture.width),
+        .height = @intCast(texture.height),
+        .mipmaps = 1,
+        .format = c.PIXELFORMAT_UNCOMPRESSED_R8G8B8A8,
+    };
 
     const img = c.LoadImageFromTexture(t);
     defer c.UnloadImage(img);
+    if (c.IsImageValid(img)) return dvui.Backend.TextureError.TextureRead;
 
     const imgData: [*]u8 = @ptrCast(img.data.?);
     for (0..@intCast(t.width * t.height * 4)) |i| {
@@ -415,7 +422,7 @@ pub fn textureDestroy(self: *RaylibBackend, texture: dvui.Texture) void {
 }
 
 pub fn clipboardText(_: *RaylibBackend) ![]const u8 {
-    return std.mem.sliceTo(c.GetClipboardText(), 0);
+    return std.mem.span(c.GetClipboardText());
 }
 
 pub fn clipboardTextSet(self: *RaylibBackend, text: []const u8) !void {
@@ -454,7 +461,7 @@ pub fn setCursor(self: *RaylibBackend, cursor: dvui.enums.Cursor) void {
 }
 
 //TODO implement this function
-pub fn refresh(_: *RaylibBackend) void {}
+pub fn refresh(_: *RaylibBackend) !void {}
 
 pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !bool {
     var disable_raylib_input: bool = false;

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -71,64 +71,71 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
     // if (options.hidden) _ = c.SDL_SetHint(c.SDL_HINT_VIDEODRIVER, "offscreen");
 
     // use the string version instead of the #define so we compile with SDL < 2.24
+
     _ = c.SDL_SetHint("SDL_HINT_WINDOWS_DPI_SCALING", "1");
 
-    if (c.SDL_Init(c.SDL_INIT_VIDEO) != if (sdl3) true else 0) {
-        log.err("Couldn't initialize SDL: {s}", .{c.SDL_GetError()});
-        return error.BackendError;
-    }
+    try toErr(c.SDL_Init(c.SDL_INIT_VIDEO), "SDL_Init in initWindow");
 
     const hidden_flag = if (options.hidden) c.SDL_WINDOW_HIDDEN else 0;
-    var window: *c.SDL_Window = undefined;
-    if (sdl3) {
-        window = c.SDL_CreateWindow(options.title, @as(c_int, @intFromFloat(options.size.w)), @as(c_int, @intFromFloat(options.size.h)), @intCast(c.SDL_WINDOW_HIGH_PIXEL_DENSITY | c.SDL_WINDOW_RESIZABLE | hidden_flag)) orelse {
-            log.err("Failed to open window: {s}", .{c.SDL_GetError()});
-            return error.BackendError;
-        };
-    } else {
-        window = c.SDL_CreateWindow(options.title, c.SDL_WINDOWPOS_UNDEFINED, c.SDL_WINDOWPOS_UNDEFINED, @as(c_int, @intFromFloat(options.size.w)), @as(c_int, @intFromFloat(options.size.h)), @intCast(c.SDL_WINDOW_ALLOW_HIGHDPI | c.SDL_WINDOW_RESIZABLE | hidden_flag)) orelse {
-            log.err("Failed to open window: {s}", .{c.SDL_GetError()});
-            return error.BackendError;
-        };
-    }
+    const window: *c.SDL_Window = if (sdl3)
+        c.SDL_CreateWindow(
+            options.title,
+            @as(c_int, @intFromFloat(options.size.w)),
+            @as(c_int, @intFromFloat(options.size.h)),
+            @intCast(c.SDL_WINDOW_HIGH_PIXEL_DENSITY | c.SDL_WINDOW_RESIZABLE | hidden_flag),
+        ) orelse return logErr("SDL_CreateWindow in initWindow")
+    else
+        c.SDL_CreateWindow(
+            options.title,
+            c.SDL_WINDOWPOS_UNDEFINED,
+            c.SDL_WINDOWPOS_UNDEFINED,
+            @as(c_int, @intFromFloat(options.size.w)),
+            @as(c_int, @intFromFloat(options.size.h)),
+            @intCast(c.SDL_WINDOW_ALLOW_HIGHDPI | c.SDL_WINDOW_RESIZABLE | hidden_flag),
+        ) orelse return logErr("SDL_CreateWindow in initWindow");
 
-    var renderer: *c.SDL_Renderer = undefined;
-    if (sdl3) {
+    errdefer c.SDL_DestroyWindow(window);
+
+    const renderer: *c.SDL_Renderer = if (!sdl3)
+        c.SDL_CreateRenderer(window, -1, @intCast(
+            c.SDL_RENDERER_TARGETTEXTURE | (if (options.vsync) c.SDL_RENDERER_PRESENTVSYNC else 0),
+        )) orelse return logErr("SDL_CreateRenderer in initWindow")
+    else blk: {
         const props = c.SDL_CreateProperties();
         defer c.SDL_DestroyProperties(props);
 
-        _ = c.SDL_SetPointerProperty(props, c.SDL_PROP_RENDERER_CREATE_WINDOW_POINTER, window);
+        try toErr(
+            c.SDL_SetPointerProperty(props, c.SDL_PROP_RENDERER_CREATE_WINDOW_POINTER, window),
+            "SDL_SetPointerProperty in initWindow",
+        );
 
         if (options.vsync) {
-            _ = c.SDL_SetNumberProperty(props, c.SDL_PROP_RENDERER_CREATE_PRESENT_VSYNC_NUMBER, 1);
+            try toErr(
+                c.SDL_SetNumberProperty(props, c.SDL_PROP_RENDERER_CREATE_PRESENT_VSYNC_NUMBER, 1),
+                "SDL_SetNumberProperty in initWindow",
+            );
         }
 
-        renderer = c.SDL_CreateRendererWithProperties(props) orelse {
-            log.err("Failed to create renderer: {s}", .{c.SDL_GetError()});
-            return error.BackendError;
-        };
-    } else {
-        renderer = c.SDL_CreateRenderer(window, -1, @intCast(c.SDL_RENDERER_TARGETTEXTURE | (if (options.vsync) c.SDL_RENDERER_PRESENTVSYNC else 0))) orelse {
-            log.err("Failed to create renderer: {s}", .{c.SDL_GetError()});
-            return error.BackendError;
-        };
-    }
+        break :blk c.SDL_CreateRendererWithProperties(props) orelse return logErr("SDL_CreateRendererWithProperties in initWindow");
+    };
+    errdefer c.SDL_DestroyRenderer(renderer);
 
     // do premultiplied alpha blending:
     // * rendering to a texture and then rendering the texture works the same
     // * any filtering happening across pixels won't bleed in transparent rgb values
     const pma_blend = c.SDL_ComposeCustomBlendMode(c.SDL_BLENDFACTOR_ONE, c.SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA, c.SDL_BLENDOPERATION_ADD, c.SDL_BLENDFACTOR_ONE, c.SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA, c.SDL_BLENDOPERATION_ADD);
-    _ = c.SDL_SetRenderDrawBlendMode(renderer, pma_blend);
+    try toErr(c.SDL_SetRenderDrawBlendMode(renderer, pma_blend), "SDL_SetRenderDrawBlendMode in initWindow");
 
     var back = init(window, renderer);
     back.we_own_window = true;
 
     if (sdl3) {
         back.initial_scale = c.SDL_GetDisplayContentScale(c.SDL_GetDisplayForWindow(window));
+        if (back.initial_scale == 0) return logErr("SDL_GetDisplayContentScale in initWindow");
         log.info("SDL3 backend scale {d}", .{back.initial_scale});
     } else {
-        const winSize = back.windowSize();
-        const pxSize = back.pixelSize();
+        const winSize = try back.windowSize();
+        const pxSize = try back.pixelSize();
         const nat_scale = pxSize.w / winSize.w;
         if (nat_scale == 1.0) {
             var guess_from_dpi = true;
@@ -207,9 +214,10 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
                 if (mdpi == null and builtin.os.tag == .windows) {
                     // see if we can guess correctly based on the dpi from SDL2
                     const display_num = c.SDL_GetWindowDisplayIndex(window);
+                    if (display_num < 0) return logErr("SDL_GetWindowDisplayIndex in initWindow");
                     var hdpi: f32 = undefined;
                     var vdpi: f32 = undefined;
-                    _ = c.SDL_GetDisplayDPI(display_num, null, &hdpi, &vdpi);
+                    try toErr(c.SDL_GetDisplayDPI(display_num, null, &hdpi, &vdpi), "SDL_GetDisplayDPI in initWindow");
                     mdpi = @max(hdpi, vdpi);
                     log.info("dpi {d} from SDL_GetDisplayDPI\n", .{mdpi.?});
                 }
@@ -237,19 +245,33 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
     }
 
     if (back.initial_scale != 1.0) {
-        _ = c.SDL_SetWindowSize(window, @as(c_int, @intFromFloat(back.initial_scale * options.size.w)), @as(c_int, @intFromFloat(back.initial_scale * options.size.h)));
+        _ = c.SDL_SetWindowSize(
+            window,
+            @as(c_int, @intFromFloat(back.initial_scale * options.size.w)),
+            @as(c_int, @intFromFloat(back.initial_scale * options.size.h)),
+        );
     }
 
     if (options.icon) |bytes| {
-        back.setIconFromFileContent(bytes);
+        try back.setIconFromFileContent(bytes);
     }
 
     if (options.min_size) |size| {
-        _ = c.SDL_SetWindowMinimumSize(window, @as(c_int, @intFromFloat(back.initial_scale * size.w)), @as(c_int, @intFromFloat(back.initial_scale * size.h)));
+        const ret = c.SDL_SetWindowMinimumSize(
+            window,
+            @as(c_int, @intFromFloat(back.initial_scale * size.w)),
+            @as(c_int, @intFromFloat(back.initial_scale * size.h)),
+        );
+        if (sdl3) try toErr(ret, "SDL_SetWindowMinimumSize in initWindow");
     }
 
     if (options.max_size) |size| {
-        _ = c.SDL_SetWindowMaximumSize(window, @as(c_int, @intFromFloat(back.initial_scale * size.w)), @as(c_int, @intFromFloat(back.initial_scale * size.h)));
+        const ret = c.SDL_SetWindowMaximumSize(
+            window,
+            @as(c_int, @intFromFloat(back.initial_scale * size.w)),
+            @as(c_int, @intFromFloat(back.initial_scale * size.h)),
+        );
+        if (sdl3) try toErr(ret, "SDL_SetWindowMaximumSize in initWindow");
     }
 
     return back;
@@ -259,32 +281,61 @@ pub fn init(window: *c.SDL_Window, renderer: *c.SDL_Renderer) SDLBackend {
     return SDLBackend{ .window = window, .renderer = renderer };
 }
 
-pub fn setIconFromFileContent(self: *SDLBackend, file_content: []const u8) void {
+const SDL_ERROR = if (sdl3) bool else c_int;
+const SDL_SUCCESS: SDL_ERROR = if (sdl3) true else 0;
+inline fn toErr(res: SDL_ERROR, what: []const u8) !void {
+    if (res == SDL_SUCCESS) return;
+    return logErr(what);
+}
+
+inline fn logErr(what: []const u8) dvui.Backend.GenericError {
+    std.log.err("{s} failed, error={s}", .{ what, c.SDL_GetError() });
+    return dvui.Backend.GenericError.BackendError;
+}
+
+pub fn setIconFromFileContent(self: *SDLBackend, file_content: []const u8) !void {
     var icon_w: c_int = undefined;
     var icon_h: c_int = undefined;
     var channels_in_file: c_int = undefined;
     const data = dvui.c.stbi_load_from_memory(file_content.ptr, @as(c_int, @intCast(file_content.len)), &icon_w, &icon_h, &channels_in_file, 4);
     if (data == null) {
         log.warn("when setting icon, stbi_load error: {s}", .{dvui.c.stbi_failure_reason()});
-        return;
+        return dvui.StbImageError.stbImageError;
     }
     defer dvui.c.stbi_image_free(data);
-    self.setIconFromABGR8888(data, icon_w, icon_h);
+    try self.setIconFromABGR8888(data, icon_w, icon_h);
 }
 
-pub fn setIconFromABGR8888(self: *SDLBackend, data: [*]const u8, icon_w: c_int, icon_h: c_int) void {
+pub fn setIconFromABGR8888(self: *SDLBackend, data: [*]const u8, icon_w: c_int, icon_h: c_int) !void {
     const surface = if (sdl3)
-        c.SDL_CreateSurfaceFrom(icon_w, icon_h, c.SDL_PIXELFORMAT_ABGR8888, @ptrCast(@constCast(data)), 4 * icon_w)
+        c.SDL_CreateSurfaceFrom(
+            icon_w,
+            icon_h,
+            c.SDL_PIXELFORMAT_ABGR8888,
+            @ptrCast(@constCast(data)),
+            4 * icon_w,
+        ) orelse return logErr("SDL_CreateSurfaceFrom in setIconFromABGR8888")
     else
-        c.SDL_CreateRGBSurfaceWithFormatFrom(@ptrCast(@constCast(data)), icon_w, icon_h, 32, 4 * icon_w, c.SDL_PIXELFORMAT_ABGR8888);
+        c.SDL_CreateRGBSurfaceWithFormatFrom(
+            @ptrCast(@constCast(data)),
+            icon_w,
+            icon_h,
+            32,
+            4 * icon_w,
+            c.SDL_PIXELFORMAT_ABGR8888,
+        ) orelse return logErr("SDL_CreateRGBSurfaceWithFormatFrom in setIconFromABGR8888");
 
     defer if (sdl3) c.SDL_DestroySurface(surface) else c.SDL_FreeSurface(surface);
 
-    _ = c.SDL_SetWindowIcon(self.window, surface);
+    if (sdl3) {
+        try toErr(c.SDL_SetWindowIcon(self.window, surface), "SDL_SetWindowIcon in setIconFromABGR8888");
+    } else {
+        c.SDL_SetWindowIcon(self.window, surface);
+    }
 }
 
 /// Return true if interrupted by event
-pub fn waitEventTimeout(_: *SDLBackend, timeout_micros: u32) bool {
+pub fn waitEventTimeout(_: *SDLBackend, timeout_micros: u32) !bool {
     if (timeout_micros == std.math.maxInt(u32)) {
         // wait no timeout
         _ = c.SDL_WaitEvent(null);
@@ -313,11 +364,11 @@ pub fn waitEventTimeout(_: *SDLBackend, timeout_micros: u32) bool {
     return false;
 }
 
-pub fn refresh(self: *SDLBackend) void {
+pub fn refresh(self: *SDLBackend) !void {
     _ = self;
     var ue = std.mem.zeroes(c.SDL_Event);
     ue.type = if (sdl3) c.SDL_EVENT_USER else c.SDL_USEREVENT;
-    _ = c.SDL_PushEvent(&ue);
+    try toErr(c.SDL_PushEvent(&ue), "SDL_PushEvent in refresh");
 }
 
 pub fn addAllEvents(self: *SDLBackend, win: *dvui.Window) !bool {
@@ -347,7 +398,7 @@ pub fn addAllEvents(self: *SDLBackend, win: *dvui.Window) !bool {
     return false;
 }
 
-pub fn setCursor(self: *SDLBackend, cursor: dvui.enums.Cursor) void {
+pub fn setCursor(self: *SDLBackend, cursor: dvui.enums.Cursor) !void {
     if (cursor != self.cursor_last) {
         self.cursor_last = cursor;
 
@@ -373,17 +424,18 @@ pub fn setCursor(self: *SDLBackend, cursor: dvui.enums.Cursor) void {
 
         if (self.cursor_backing[enum_int]) |cur| {
             if (sdl3) {
-                _ = c.SDL_SetCursor(cur);
+                try toErr(c.SDL_SetCursor(cur), "SDL_SetCursor in setCursor");
             } else {
                 c.SDL_SetCursor(cur);
             }
         } else {
-            log.err("SDL_CreateSystemCursor \"{s}\" failed", .{@tagName(cursor)});
+            log.err("setCursor \"{s}\" failed", .{@tagName(cursor)});
+            return logErr("SDL_CreateSystemCursor in setCursor");
         }
     }
 }
 
-pub fn textInputRect(self: *SDLBackend, rect: ?dvui.Rect.Natural) void {
+pub fn textInputRect(self: *SDLBackend, rect: ?dvui.Rect.Natural) !void {
     if (rect) |r| {
         if (sdl3) {
             // This is the offset from r.x in window coords, supposed to be the
@@ -393,11 +445,33 @@ pub fn textInputRect(self: *SDLBackend, rect: ?dvui.Rect.Natural) void {
             // text entries).
             const cursor = 0;
 
-            _ = c.SDL_SetTextInputArea(self.window, &c.SDL_Rect{ .x = @intFromFloat(r.x), .y = @intFromFloat(r.y), .w = @intFromFloat(r.w), .h = @intFromFloat(r.h) }, cursor);
-        } else c.SDL_SetTextInputRect(&c.SDL_Rect{ .x = @intFromFloat(r.x), .y = @intFromFloat(r.y), .w = @intFromFloat(r.w), .h = @intFromFloat(r.h) });
-        _ = if (sdl3) c.SDL_StartTextInput(self.window) else c.SDL_StartTextInput();
+            try toErr(c.SDL_SetTextInputArea(
+                self.window,
+                &c.SDL_Rect{
+                    .x = @intFromFloat(r.x),
+                    .y = @intFromFloat(r.y),
+                    .w = @intFromFloat(r.w),
+                    .h = @intFromFloat(r.h),
+                },
+                cursor,
+            ), "SDL_SetTextInputArea in textInputRect");
+        } else c.SDL_SetTextInputRect(&c.SDL_Rect{
+            .x = @intFromFloat(r.x),
+            .y = @intFromFloat(r.y),
+            .w = @intFromFloat(r.w),
+            .h = @intFromFloat(r.h),
+        });
+        if (sdl3) {
+            try toErr(c.SDL_StartTextInput(self.window), "SDL_StartTextInput in textInputRect");
+        } else {
+            c.SDL_StartTextInput();
+        }
     } else {
-        _ = if (sdl3) c.SDL_StopTextInput(self.window) else c.SDL_StopTextInput();
+        if (sdl3) {
+            try toErr(c.SDL_StopTextInput(self.window), "SDL_StopTextInput in textInputRect");
+        } else {
+            c.SDL_StopTextInput();
+        }
     }
 }
 
@@ -419,9 +493,9 @@ pub fn deinit(self: *SDLBackend) void {
     }
 }
 
-pub fn renderPresent(self: *SDLBackend) void {
+pub fn renderPresent(self: *SDLBackend) !void {
     if (sdl3) {
-        _ = c.SDL_RenderPresent(self.renderer);
+        try toErr(c.SDL_RenderPresent(self.renderer), "SDL_RenderPresent in renderPresent");
     } else {
         c.SDL_RenderPresent(self.renderer);
     }
@@ -431,66 +505,93 @@ pub fn backend(self: *SDLBackend) dvui.Backend {
     return dvui.Backend.init(self);
 }
 
-pub fn nanoTime(self: *SDLBackend) i128 {
-    _ = self;
+pub fn nanoTime(_: *SDLBackend) i128 {
     return std.time.nanoTimestamp();
 }
 
-pub fn sleep(self: *SDLBackend, ns: u64) void {
-    _ = self;
+pub fn sleep(_: *SDLBackend, ns: u64) void {
     std.time.sleep(ns);
 }
 
 pub fn clipboardText(self: *SDLBackend) ![]const u8 {
     const p = c.SDL_GetClipboardText();
-    defer c.SDL_free(p);
-    return try self.arena.dupe(u8, std.mem.sliceTo(p, 0));
+    defer c.SDL_free(p); // must free even on error
+
+    const str = std.mem.span(p);
+    // Log error, but don't fail the application
+    if (str.len == 0) logErr("SDL_GetClipboardText in clipboardText") catch {};
+
+    return try self.arena.dupe(u8, str);
 }
 
 pub fn clipboardTextSet(self: *SDLBackend, text: []const u8) !void {
     if (text.len == 0) return;
     const c_text = try self.arena.dupeZ(u8, text);
     defer self.arena.free(c_text);
-    _ = c.SDL_SetClipboardText(c_text.ptr);
+    try toErr(c.SDL_SetClipboardText(c_text.ptr), "SDL_SetClipboardText in clipboardTextSet");
 }
 
 pub fn openURL(self: *SDLBackend, url: []const u8) !void {
     const c_url = try self.arena.dupeZ(u8, url);
     defer self.arena.free(c_url);
-    _ = c.SDL_OpenURL(c_url.ptr);
+    try toErr(c.SDL_OpenURL(c_url.ptr), "SDL_OpenURL in openURL");
 }
 
-pub fn begin(self: *SDLBackend, arena: std.mem.Allocator) void {
+pub fn begin(self: *SDLBackend, arena: std.mem.Allocator) !void {
     self.arena = arena;
-    const size = self.pixelSize();
-    _ = if (sdl3) c.SDL_SetRenderClipRect(self.renderer, &c.SDL_Rect{ .x = 0, .y = 0, .w = @intFromFloat(size.w), .h = @intFromFloat(size.h) }) else c.SDL_RenderSetClipRect(self.renderer, &c.SDL_Rect{ .x = 0, .y = 0, .w = @intFromFloat(size.w), .h = @intFromFloat(size.h) });
+    const size = try self.pixelSize();
+    if (sdl3) {
+        try toErr(c.SDL_SetRenderClipRect(self.renderer, &c.SDL_Rect{
+            .x = 0,
+            .y = 0,
+            .w = @intFromFloat(size.w),
+            .h = @intFromFloat(size.h),
+        }), "SDL_SetRenderClipRect in begin");
+    } else {
+        try toErr(c.SDL_RenderSetClipRect(self.renderer, &c.SDL_Rect{
+            .x = 0,
+            .y = 0,
+            .w = @intFromFloat(size.w),
+            .h = @intFromFloat(size.h),
+        }), "SDL_SetRenderClipRect in begin");
+    }
 }
 
-pub fn end(_: *SDLBackend) void {}
+pub fn end(_: *SDLBackend) !void {}
 
-pub fn pixelSize(self: *SDLBackend) dvui.Size.Physical {
+pub fn pixelSize(self: *SDLBackend) !dvui.Size.Physical {
     var w: i32 = undefined;
     var h: i32 = undefined;
     if (sdl3) {
-        _ = c.SDL_GetCurrentRenderOutputSize(self.renderer, &w, &h);
+        try toErr(
+            c.SDL_GetCurrentRenderOutputSize(self.renderer, &w, &h),
+            "SDL_GetCurrentRenderOutputSize in pixelSize",
+        );
     } else {
-        _ = c.SDL_GetRendererOutputSize(self.renderer, &w, &h);
+        try toErr(
+            c.SDL_GetRendererOutputSize(self.renderer, &w, &h),
+            "SDL_GetRendererOutputSize in pixelSize",
+        );
     }
     return .{ .w = @as(f32, @floatFromInt(w)), .h = @as(f32, @floatFromInt(h)) };
 }
 
-pub fn windowSize(self: *SDLBackend) dvui.Size.Natural {
+pub fn windowSize(self: *SDLBackend) !dvui.Size.Natural {
     var w: i32 = undefined;
     var h: i32 = undefined;
-    _ = c.SDL_GetWindowSize(self.window, &w, &h);
+    if (sdl3) {
+        try toErr(c.SDL_GetWindowSize(self.window, &w, &h), "SDL_GetWindowSize in windowSize");
+    } else {
+        c.SDL_GetWindowSize(self.window, &w, &h);
+    }
     return .{ .w = @as(f32, @floatFromInt(w)), .h = @as(f32, @floatFromInt(h)) };
 }
 
-pub fn contentScale(self: *SDLBackend) f32 {
+pub fn contentScale(self: *SDLBackend) !f32 {
     return self.initial_scale;
 }
 
-pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const u16, maybe_clipr: ?dvui.Rect.Physical) void {
+pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const u16, maybe_clipr: ?dvui.Rect.Physical) !void {
     //std.debug.print("drawClippedTriangles:\n", .{});
     //for (vtx) |v, i| {
     //  std.debug.print("  {d} vertex {}\n", .{i, v});
@@ -503,9 +604,12 @@ pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []co
 
     if (maybe_clipr) |clipr| {
         if (sdl3) {
-            _ = c.SDL_GetRenderClipRect(self.renderer, &oldclip);
+            try toErr(
+                c.SDL_GetRenderClipRect(self.renderer, &oldclip),
+                "SDL_GetRenderClipRect in drawClippedTriangles",
+            );
         } else {
-            _ = c.SDL_RenderGetClipRect(self.renderer, &oldclip);
+            c.SDL_RenderGetClipRect(self.renderer, &oldclip);
         }
 
         // figure out how much we are losing by truncating x and y, need to add that back to w and h
@@ -514,9 +618,15 @@ pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []co
 
         //std.debug.print("SDL clip {} -> SDL_Rect{{ .x = {d}, .y = {d}, .w = {d}, .h = {d} }}\n", .{ clipr, clip.x, clip.y, clip.w, clip.h });
         if (sdl3) {
-            _ = c.SDL_SetRenderClipRect(self.renderer, &clip);
+            try toErr(
+                c.SDL_SetRenderClipRect(self.renderer, &clip),
+                "SDL_SetRenderClipRect in drawClippedTriangles",
+            );
         } else {
-            _ = c.SDL_RenderSetClipRect(self.renderer, &clip);
+            try toErr(
+                c.SDL_RenderSetClipRect(self.renderer, &clip),
+                "SDL_RenderSetClipRect in drawClippedTriangles",
+            );
         }
     }
 
@@ -528,7 +638,7 @@ pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []co
     if (sdl3) {
         // not great, but seems sdl3 strictly accepts color only in floats
         // TODO: review if better solution is possible
-        const vcols = self.arena.alloc(c.SDL_FColor, vtx.len) catch return;
+        const vcols = try self.arena.alloc(c.SDL_FColor, vtx.len);
         defer self.arena.free(vcols);
         for (vcols, 0..) |*col, i| {
             col.r = @as(f32, @floatFromInt(vtx[i].col.r)) / 255.0;
@@ -537,7 +647,7 @@ pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []co
             col.a = @as(f32, @floatFromInt(vtx[i].col.a)) / 255.0;
         }
 
-        _ = c.SDL_RenderGeometryRaw(
+        try toErr(c.SDL_RenderGeometryRaw(
             self.renderer,
             tex,
             @as(*const f32, @ptrCast(&vtx[0].pos)),
@@ -550,9 +660,9 @@ pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []co
             idx.ptr,
             @as(c_int, @intCast(idx.len)),
             @sizeOf(u16),
-        );
+        ), "SDL_RenderGeometryRaw, in drawClippedTriangles");
     } else {
-        _ = c.SDL_RenderGeometryRaw(
+        try toErr(c.SDL_RenderGeometryRaw(
             self.renderer,
             tex,
             @as(*const f32, @ptrCast(&vtx[0].pos)),
@@ -565,109 +675,156 @@ pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []co
             idx.ptr,
             @as(c_int, @intCast(idx.len)),
             @sizeOf(u16),
-        );
+        ), "SDL_RenderGeometryRaw in drawClippedTriangles");
     }
 
     if (maybe_clipr) |_| {
         if (sdl3) {
-            _ = c.SDL_SetRenderClipRect(self.renderer, &oldclip);
+            try toErr(
+                c.SDL_SetRenderClipRect(self.renderer, &oldclip),
+                "SDL_SetRenderClipRect in drawClippedTriangles reset clip",
+            );
         } else {
-            _ = c.SDL_RenderSetClipRect(self.renderer, &oldclip);
+            try toErr(
+                c.SDL_RenderSetClipRect(self.renderer, &oldclip),
+                "SDL_RenderSetClipRect in drawClippedTriangles reset clip",
+            );
         }
     }
 }
 
-pub fn textureCreate(self: *SDLBackend, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) dvui.Texture {
+pub fn textureCreate(self: *SDLBackend, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.Texture {
     if (!sdl3) switch (interpolation) {
         .nearest => _ = c.SDL_SetHint(c.SDL_HINT_RENDER_SCALE_QUALITY, "nearest"),
         .linear => _ = c.SDL_SetHint(c.SDL_HINT_RENDER_SCALE_QUALITY, "linear"),
     };
 
-    var surface: *c.SDL_Surface = undefined;
-    if (sdl3) {
-        surface = c.SDL_CreateSurfaceFrom(@as(c_int, @intCast(width)), @as(c_int, @intCast(height)), c.SDL_PIXELFORMAT_ABGR8888, pixels, @as(c_int, @intCast(4 * width)));
-    } else {
-        surface = c.SDL_CreateRGBSurfaceWithFormatFrom(pixels, @as(c_int, @intCast(width)), @as(c_int, @intCast(height)), 32, @as(c_int, @intCast(4 * width)), c.SDL_PIXELFORMAT_ABGR8888);
-    }
-    defer {
-        if (sdl3) {
-            c.SDL_DestroySurface(surface);
-        } else {
-            c.SDL_FreeSurface(surface);
-        }
-    }
+    const surface = if (sdl3)
+        c.SDL_CreateSurfaceFrom(
+            @as(c_int, @intCast(width)),
+            @as(c_int, @intCast(height)),
+            c.SDL_PIXELFORMAT_ABGR8888,
+            pixels,
+            @as(c_int, @intCast(4 * width)),
+        ) orelse return logErr("SDL_CreateSurfaceFrom in textureCreate")
+    else
+        c.SDL_CreateRGBSurfaceWithFormatFrom(
+            pixels,
+            @as(c_int, @intCast(width)),
+            @as(c_int, @intCast(height)),
+            32,
+            @as(c_int, @intCast(4 * width)),
+            c.SDL_PIXELFORMAT_ABGR8888,
+        ) orelse return logErr("SDL_CreateRGBSurfaceWithFormatFrom in textureCreate");
 
-    const texture = c.SDL_CreateTextureFromSurface(self.renderer, surface) orelse unreachable;
+    defer if (sdl3) c.SDL_DestroySurface(surface) else c.SDL_FreeSurface(surface);
 
-    if (sdl3) {
-        switch (interpolation) {
-            .nearest => _ = c.SDL_SetTextureScaleMode(texture, c.SDL_SCALEMODE_NEAREST),
-            .linear => _ = c.SDL_SetTextureScaleMode(texture, c.SDL_SCALEMODE_LINEAR),
-        }
-    }
+    const texture = c.SDL_CreateTextureFromSurface(self.renderer, surface) orelse return logErr("SDL_CreateTextureFromSurface in textureCreate");
+    errdefer c.SDL_DestroyTexture(texture);
+
+    if (sdl3) try toErr(switch (interpolation) {
+        .nearest => c.SDL_SetTextureScaleMode(texture, c.SDL_SCALEMODE_NEAREST),
+        .linear => c.SDL_SetTextureScaleMode(texture, c.SDL_SCALEMODE_LINEAR),
+    }, "SDL_SetTextureScaleMode in textureCreates");
 
     const pma_blend = c.SDL_ComposeCustomBlendMode(c.SDL_BLENDFACTOR_ONE, c.SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA, c.SDL_BLENDOPERATION_ADD, c.SDL_BLENDFACTOR_ONE, c.SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA, c.SDL_BLENDOPERATION_ADD);
-    _ = c.SDL_SetTextureBlendMode(texture, pma_blend);
+    try toErr(c.SDL_SetTextureBlendMode(texture, pma_blend), "SDL_SetTextureBlendMode in textureCreate");
     return dvui.Texture{ .ptr = texture, .width = width, .height = height };
 }
 
 pub fn textureCreateTarget(self: *SDLBackend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.TextureTarget {
-    if (!sdl3) {
-        switch (interpolation) {
-            .nearest => _ = c.SDL_SetHint(c.SDL_HINT_RENDER_SCALE_QUALITY, "nearest"),
-            .linear => _ = c.SDL_SetHint(c.SDL_HINT_RENDER_SCALE_QUALITY, "linear"),
-        }
-    }
+    if (!sdl3) switch (interpolation) {
+        .nearest => _ = c.SDL_SetHint(c.SDL_HINT_RENDER_SCALE_QUALITY, "nearest"),
+        .linear => _ = c.SDL_SetHint(c.SDL_HINT_RENDER_SCALE_QUALITY, "linear"),
+    };
 
-    const texture = c.SDL_CreateTexture(self.renderer, c.SDL_PIXELFORMAT_ABGR8888, c.SDL_TEXTUREACCESS_TARGET, @intCast(width), @intCast(height)) orelse unreachable;
+    const texture = c.SDL_CreateTexture(
+        self.renderer,
+        c.SDL_PIXELFORMAT_ABGR8888,
+        c.SDL_TEXTUREACCESS_TARGET,
+        @intCast(width),
+        @intCast(height),
+    ) orelse return logErr("SDL_CreateTexture in textureCreateTarget");
+    errdefer c.SDL_DestroyTexture(texture);
 
-    if (sdl3) {
-        switch (interpolation) {
-            .nearest => _ = c.SDL_SetTextureScaleMode(texture, c.SDL_SCALEMODE_NEAREST),
-            .linear => _ = c.SDL_SetTextureScaleMode(texture, c.SDL_SCALEMODE_LINEAR),
-        }
-    }
+    if (sdl3) try toErr(switch (interpolation) {
+        .nearest => c.SDL_SetTextureScaleMode(texture, c.SDL_SCALEMODE_NEAREST),
+        .linear => c.SDL_SetTextureScaleMode(texture, c.SDL_SCALEMODE_LINEAR),
+    }, "SDL_SetTextureScaleMode in textureCreates");
 
     const pma_blend = c.SDL_ComposeCustomBlendMode(c.SDL_BLENDFACTOR_ONE, c.SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA, c.SDL_BLENDOPERATION_ADD, c.SDL_BLENDFACTOR_ONE, c.SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA, c.SDL_BLENDOPERATION_ADD);
-    _ = c.SDL_SetTextureBlendMode(texture, pma_blend);
-    //_ = c.SDL_SetTextureBlendMode(texture, c.SDL_BLENDMODE_BLEND);
+    try toErr(
+        c.SDL_SetTextureBlendMode(texture, pma_blend),
+        "SDL_SetTextureBlendMode in textureCreateTarget",
+    );
+    //try toErr(c.SDL_SetTextureBlendMode(texture, c.SDL_BLENDMODE_BLEND), "SDL_SetTextureBlendMode in textureCreateTarget",);
 
     // make sure texture starts out transparent
+    // null is the default render target
     const old = c.SDL_GetRenderTarget(self.renderer);
-    defer _ = c.SDL_SetRenderTarget(self.renderer, old);
+    defer toErr(
+        c.SDL_SetRenderTarget(self.renderer, old),
+        "SDL_SetRenderTarget in textureCreateTarget",
+    ) catch log.err("Could not reset render target", .{});
 
-    var oldBlend: [1]c_uint = undefined;
-    _ = c.SDL_GetRenderDrawBlendMode(self.renderer, &oldBlend);
-    defer _ = c.SDL_SetRenderDrawBlendMode(self.renderer, oldBlend[0]);
+    var oldBlend: c_uint = undefined;
+    try toErr(
+        c.SDL_GetRenderDrawBlendMode(self.renderer, &oldBlend),
+        "SDL_GetRenderDrawBlendMode in textureCreateTarget",
+    );
+    defer toErr(
+        c.SDL_SetRenderDrawBlendMode(self.renderer, oldBlend),
+        "SDL_SetRenderDrawBlendMode in textureCreateTarget",
+    ) catch log.err("Could not reset render blend mode", .{});
 
-    _ = c.SDL_SetRenderTarget(self.renderer, texture);
-    _ = c.SDL_SetRenderDrawBlendMode(self.renderer, c.SDL_BLENDMODE_NONE);
-    _ = c.SDL_SetRenderDrawColor(self.renderer, 0, 0, 0, 0);
-    _ = c.SDL_RenderFillRect(self.renderer, null);
+    try toErr(
+        c.SDL_SetRenderTarget(self.renderer, texture),
+        "SDL_SetRenderTarget in textureCreateTarget",
+    );
+    try toErr(
+        c.SDL_SetRenderDrawBlendMode(self.renderer, c.SDL_BLENDMODE_NONE),
+        "SDL_SetRenderDrawBlendMode in textureCreateTarget",
+    );
+    try toErr(
+        c.SDL_SetRenderDrawColor(self.renderer, 0, 0, 0, 0),
+        "SDL_SetRenderDrawColor in textureCreateTarget",
+    );
+    try toErr(
+        c.SDL_RenderFillRect(self.renderer, null),
+        "SDL_RenderFillRect in textureCreateTarget",
+    );
 
     return dvui.TextureTarget{ .ptr = texture, .width = width, .height = height };
 }
 
-pub fn textureReadTarget(self: *SDLBackend, texture: dvui.TextureTarget, pixels_out: [*]u8) error{TextureRead}!void {
+pub fn textureReadTarget(self: *SDLBackend, texture: dvui.TextureTarget, pixels_out: [*]u8) !void {
     if (sdl3) {
+        // null is the default target
         const orig_target = c.SDL_GetRenderTarget(self.renderer);
-        const r = c.SDL_SetRenderTarget(self.renderer, @ptrCast(@alignCast(texture.ptr)));
-        defer _ = c.SDL_SetRenderTarget(self.renderer, orig_target);
+        try toErr(c.SDL_SetRenderTarget(self.renderer, @alignCast(@ptrCast(texture.ptr))), "SDL_SetRenderTarget in textureReadTarget");
+        defer toErr(
+            c.SDL_SetRenderTarget(self.renderer, orig_target),
+            "SDL_SetRenderTarget in textureReadTarget",
+        ) catch log.err("Could not reset render target", .{});
 
-        if (!r) {
-            std.debug.print("setRenderTarget Error: {s}", .{c.SDL_GetError()});
-            return error.TextureRead;
-        }
-
-        var surface: *c.SDL_Surface = c.SDL_RenderReadPixels(self.renderer, null) orelse return error.TextureRead;
+        var surface: *c.SDL_Surface = c.SDL_RenderReadPixels(self.renderer, null) orelse
+            logErr("SDL_RenderReadPixels in textureReadTarget") catch
+            return dvui.Backend.TextureError.TextureRead;
         defer c.SDL_DestroySurface(surface);
+
         if (texture.width * texture.height != surface.*.w * surface.*.h) {
-            std.debug.print("texture {d} {d} surface {d} {d}\n", .{ texture.width, texture.height, surface.*.w, surface.*.h });
-            return error.TextureRead;
+            log.err(
+                "texture and target surface sizes did not match: texture {d} {d} surface {d} {d}\n",
+                .{ texture.width, texture.height, surface.*.w, surface.*.h },
+            );
+            return dvui.Backend.TextureError.TextureRead;
         }
+
         // TODO: most common format is RGBA8888, doing conversion during copy to pixels_out should be faster
         if (surface.*.format != c.SDL_PIXELFORMAT_ABGR8888) {
-            surface = c.SDL_ConvertSurface(surface, c.SDL_PIXELFORMAT_ABGR8888) orelse return error.TextureRead;
+            surface = c.SDL_ConvertSurface(surface, c.SDL_PIXELFORMAT_ABGR8888) orelse
+                logErr("SDL_ConvertSurface in textureReadTarget") catch
+                return dvui.Backend.TextureError.TextureRead;
         }
         @memcpy(pixels_out[0 .. texture.width * texture.height * 4], @as(?[*]u8, @ptrCast(surface.*.pixels)).?[0 .. texture.width * texture.height * 4]);
         return;
@@ -678,7 +835,7 @@ pub fn textureReadTarget(self: *SDLBackend, texture: dvui.TextureTarget, pixels_
     // crashes if we ask it to do the conversion for us.
     var swap_rb = true;
     var info: c.SDL_RendererInfo = undefined;
-    _ = c.SDL_GetRendererInfo(self.renderer, &info);
+    try toErr(c.SDL_GetRendererInfo(self.renderer, &info), "SDL_GetRendererInfo in textureReadTarget");
     //std.debug.print("renderer name {s} formats:\n", .{info.name});
     for (0..info.num_texture_formats) |i| {
         //std.debug.print("  {s}\n", .{c.SDL_GetPixelFormatName(info.texture_formats[i])});
@@ -687,18 +844,23 @@ pub fn textureReadTarget(self: *SDLBackend, texture: dvui.TextureTarget, pixels_
         }
     }
 
-    //var format: u32 = undefined;
-    //var access: c_int = undefined;
-    //var w: c_int = undefined;
-    //var h: c_int = undefined;
-    //_ = c.SDL_QueryTexture(@ptrCast(texture), &format, &access, &w, &h);
-    //std.debug.print("query texture: {s} {d} {d} {d} width {d}\n", .{c.SDL_GetPixelFormatName(format), access, w, h, width});
-
     const orig_target = c.SDL_GetRenderTarget(self.renderer);
-    _ = c.SDL_SetRenderTarget(self.renderer, @ptrCast(texture.ptr));
-    defer _ = c.SDL_SetRenderTarget(self.renderer, orig_target);
+    try toErr(c.SDL_SetRenderTarget(self.renderer, @ptrCast(texture.ptr)), "SDL_SetRenderTarget in textureReadTarget");
+    defer toErr(
+        c.SDL_SetRenderTarget(self.renderer, orig_target),
+        "SDL_SetRenderTarget in textureReadTarget",
+    ) catch log.err("Could not reset render target", .{});
 
-    _ = c.SDL_RenderReadPixels(self.renderer, null, if (swap_rb) c.SDL_PIXELFORMAT_ARGB8888 else c.SDL_PIXELFORMAT_ABGR8888, pixels_out, @intCast(texture.width * 4));
+    toErr(
+        c.SDL_RenderReadPixels(
+            self.renderer,
+            null,
+            if (swap_rb) c.SDL_PIXELFORMAT_ARGB8888 else c.SDL_PIXELFORMAT_ABGR8888,
+            pixels_out,
+            @intCast(texture.width * 4),
+        ),
+        "SDL_RenderReadPixels in textureReadTarget",
+    ) catch return dvui.Backend.TextureError.TextureRead;
 
     if (swap_rb) {
         for (0..texture.width * texture.height) |i| {
@@ -714,27 +876,33 @@ pub fn textureDestroy(_: *SDLBackend, texture: dvui.Texture) void {
     c.SDL_DestroyTexture(@as(*c.SDL_Texture, @ptrCast(@alignCast(texture.ptr))));
 }
 
-pub fn textureFromTarget(self: *SDLBackend, texture: dvui.TextureTarget) dvui.Texture {
+pub fn textureFromTarget(self: *SDLBackend, texture: dvui.TextureTarget) !dvui.Texture {
     // SDL can't read from non-target textures, so read all the pixels and make a new texture
-    const pixels = self.arena.alloc(u8, texture.width * texture.height * 4) catch unreachable;
+    const pixels = try self.arena.alloc(u8, texture.width * texture.height * 4);
     defer self.arena.free(pixels);
-    self.textureReadTarget(texture, pixels.ptr) catch unreachable;
+    try self.textureReadTarget(texture, pixels.ptr);
 
     c.SDL_DestroyTexture(@as(*c.SDL_Texture, @ptrCast(@alignCast(texture.ptr))));
 
     return self.textureCreate(pixels.ptr, texture.width, texture.height, .linear);
 }
 
-pub fn renderTarget(self: *SDLBackend, texture: ?dvui.TextureTarget) void {
+pub fn renderTarget(self: *SDLBackend, texture: ?dvui.TextureTarget) !void {
     const ptr: ?*anyopaque = if (texture) |tex| tex.ptr else null;
-    _ = c.SDL_SetRenderTarget(self.renderer, @ptrCast(@alignCast(ptr)));
+    try toErr(c.SDL_SetRenderTarget(self.renderer, @ptrCast(@alignCast(ptr))), "SDL_SetRenderTarget in renderTarget");
 
     // by default sdl sets an empty clip, let's ensure it is the full texture/screen
     if (sdl3) {
         // sdl3 crashes if w/h are too big, this seems to work
-        _ = c.SDL_SetRenderClipRect(self.renderer, &c.SDL_Rect{ .x = 0, .y = 0, .w = 65536, .h = 65536 });
+        try toErr(
+            c.SDL_SetRenderClipRect(self.renderer, &c.SDL_Rect{ .x = 0, .y = 0, .w = 65536, .h = 65536 }),
+            "SDL_SetRenderClipRect in renderTarget",
+        );
     } else {
-        _ = c.SDL_RenderSetClipRect(self.renderer, &c.SDL_Rect{ .x = 0, .y = 0, .w = std.math.maxInt(c_int), .h = std.math.maxInt(c_int) });
+        try toErr(
+            c.SDL_RenderSetClipRect(self.renderer, &c.SDL_Rect{ .x = 0, .y = 0, .w = std.math.maxInt(c_int), .h = std.math.maxInt(c_int) }),
+            "SDL_RenderSetClipRect in renderTarget",
+        );
     }
 }
 
@@ -1103,7 +1271,11 @@ pub fn main() !u8 {
     });
     defer back.deinit();
 
-    _ = c.SDL_EnableScreenSaver();
+    if (sdl3) {
+        toErr(c.SDL_EnableScreenSaver(), "SDL_EnableScreenSaver in sdl main") catch {};
+    } else {
+        c.SDL_EnableScreenSaver();
+    }
 
     //// init dvui Window (maps onto a single OS window)
     var win = try dvui.Window.init(@src(), gpa, back.backend(), .{});
@@ -1132,22 +1304,22 @@ pub fn main() !u8 {
 
         // if dvui widgets might not cover the whole window, then need to clear
         // the previous frame's render
-        _ = c.SDL_SetRenderDrawColor(back.renderer, 0, 0, 0, 255);
-        _ = c.SDL_RenderClear(back.renderer);
+        try toErr(c.SDL_SetRenderDrawColor(back.renderer, 0, 0, 0, 255), "SDL_SetRenderDrawColor in sdl main");
+        try toErr(c.SDL_RenderClear(back.renderer), "SDL_RenderClear in sdl main");
 
         const res = try app.frameFn();
 
         const end_micros = try win.end(.{});
 
-        back.setCursor(win.cursorRequested());
-        back.textInputRect(win.textInputRequested());
+        try back.setCursor(win.cursorRequested());
+        try back.textInputRect(win.textInputRequested());
 
-        back.renderPresent();
+        try back.renderPresent();
 
         if (res != .ok) break :main_loop;
 
         const wait_event_micros = win.waitTime(end_micros, null);
-        interrupted = back.waitEventTimeout(wait_event_micros);
+        interrupted = try back.waitEventTimeout(wait_event_micros);
     }
 
     return 0;
@@ -1183,7 +1355,11 @@ fn appInit(appstate: ?*?*anyopaque, argc: c_int, argv: ?[*:null]?[*:0]u8) callco
         return c.SDL_APP_FAILURE;
     };
 
-    _ = c.SDL_EnableScreenSaver();
+    if (sdl3) {
+        toErr(c.SDL_EnableScreenSaver(), "SDL_EnableScreenSaver in sdl main") catch {};
+    } else {
+        c.SDL_EnableScreenSaver();
+    }
 
     //// init dvui Window (maps onto a single OS window)
     gwin = dvui.Window.init(@src(), gpa, gback.backend(), .{}) catch |err| {
@@ -1262,8 +1438,8 @@ fn appIterate(_: ?*anyopaque) callconv(.c) c.SDL_AppResult {
 
     // if dvui widgets might not cover the whole window, then need to clear
     // the previous frame's render
-    _ = c.SDL_SetRenderDrawColor(gback.renderer, 0, 0, 0, 255);
-    _ = c.SDL_RenderClear(gback.renderer);
+    toErr(c.SDL_SetRenderDrawColor(gback.renderer, 0, 0, 0, 255), "SDL_SetRenderDrawColor in sdl main") catch return c.SDL_APP_FAILURE;
+    toErr(c.SDL_RenderClear(gback.renderer), "SDL_RenderClear in sdl main") catch return c.SDL_APP_FAILURE;
 
     const app = dvui.App.get() orelse unreachable;
     const res = app.frameFn() catch |err| {
@@ -1276,10 +1452,10 @@ fn appIterate(_: ?*anyopaque) callconv(.c) c.SDL_AppResult {
         return c.SDL_APP_FAILURE;
     };
 
-    gback.setCursor(gwin.cursorRequested());
-    gback.textInputRect(gwin.textInputRequested());
+    gback.setCursor(gwin.cursorRequested()) catch return c.SDL_APP_FAILURE;
+    gback.textInputRect(gwin.textInputRequested()) catch return c.SDL_APP_FAILURE;
 
-    gback.renderPresent();
+    gback.renderPresent() catch return c.SDL_APP_FAILURE;
 
     if (res != .ok) return c.SDL_APP_SUCCESS;
 
@@ -1300,7 +1476,7 @@ fn appIterate(_: ?*anyopaque) callconv(.c) c.SDL_AppResult {
     }
 
     gno_wait = true;
-    ginterrupted = gback.waitEventTimeout(wait_event_micros);
+    ginterrupted = gback.waitEventTimeout(wait_event_micros) catch return c.SDL_APP_FAILURE;
     gno_wait = false;
 
     return c.SDL_APP_CONTINUE;

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -428,7 +428,7 @@ pub fn renderPresent(self: *SDLBackend) void {
 }
 
 pub fn backend(self: *SDLBackend) dvui.Backend {
-    return dvui.Backend.init(self, @This());
+    return dvui.Backend.init(self);
 }
 
 pub fn nanoTime(self: *SDLBackend) i128 {

--- a/src/backends/testing.zig
+++ b/src/backends/testing.zig
@@ -58,13 +58,13 @@ pub fn end(_: *TestingBackend) !void {}
 
 /// Return size of the window in physical pixels.  For a 300x200 retina
 /// window (so actually 600x400), this should return 600x400.
-pub fn pixelSize(self: *TestingBackend) !dvui.Size.Physical {
+pub fn pixelSize(self: *TestingBackend) dvui.Size.Physical {
     return self.size_pixels;
 }
 
 /// Return size of the window in logical pixels.  For a 300x200 retina
 /// window (so actually 600x400), this should return 300x200.
-pub fn windowSize(self: *TestingBackend) !dvui.Size.Natural {
+pub fn windowSize(self: *TestingBackend) dvui.Size.Natural {
     return self.size;
 }
 
@@ -72,7 +72,7 @@ pub fn windowSize(self: *TestingBackend) !dvui.Size.Natural {
 /// additional display scaling (usually set in their window system's
 /// settings).  Currently only called during Window.init(), so currently
 /// this sets the initial content scale.
-pub fn contentScale(_: *TestingBackend) !f32 {
+pub fn contentScale(_: *TestingBackend) f32 {
     return 1;
 }
 
@@ -145,7 +145,7 @@ pub fn openURL(_: *TestingBackend, _: []const u8) std.mem.Allocator.Error!void {
 /// thread.  Used to wake up the gui thread.  It only has effect if you
 /// are using waitTime() or some other method of waiting until a new
 /// event comes in.
-pub fn refresh(_: *TestingBackend) !void {}
+pub fn refresh(_: *TestingBackend) void {}
 
 pub fn backend(self: *TestingBackend) dvui.Backend {
     return dvui.Backend.init(self);

--- a/src/backends/testing.zig
+++ b/src/backends/testing.zig
@@ -122,7 +122,7 @@ pub fn textureFromTarget(_: *TestingBackend, texture: dvui.TextureTarget) dvui.T
 pub fn renderTarget(_: *TestingBackend, _: ?dvui.TextureTarget) void {}
 
 /// Get clipboard content (text only)
-pub fn clipboardText(self: *TestingBackend) error{OutOfMemory}![]const u8 {
+pub fn clipboardText(self: *TestingBackend) std.mem.Allocator.Error![]const u8 {
     if (self.clipboard) |text| {
         return try self.arena.dupe(u8, text);
     } else {
@@ -131,7 +131,7 @@ pub fn clipboardText(self: *TestingBackend) error{OutOfMemory}![]const u8 {
 }
 
 /// Set clipboard content (text only)
-pub fn clipboardTextSet(self: *TestingBackend, text: []const u8) error{OutOfMemory}!void {
+pub fn clipboardTextSet(self: *TestingBackend, text: []const u8) std.mem.Allocator.Error!void {
     if (self.clipboard) |prev_text| {
         self.allocator.free(prev_text);
     }
@@ -139,7 +139,7 @@ pub fn clipboardTextSet(self: *TestingBackend, text: []const u8) error{OutOfMemo
 }
 
 /// Open URL in system browser
-pub fn openURL(_: *TestingBackend, _: []const u8) error{OutOfMemory}!void {}
+pub fn openURL(_: *TestingBackend, _: []const u8) std.mem.Allocator.Error!void {}
 
 /// Called by dvui.refresh() when it is called from a background
 /// thread.  Used to wake up the gui thread.  It only has effect if you

--- a/src/backends/testing.zig
+++ b/src/backends/testing.zig
@@ -148,7 +148,7 @@ pub fn openURL(_: *TestingBackend, _: []const u8) std.mem.Allocator.Error!void {
 pub fn refresh(_: *TestingBackend) void {}
 
 pub fn backend(self: *TestingBackend) dvui.Backend {
-    return dvui.Backend.init(self, TestingBackend);
+    return dvui.Backend.init(self);
 }
 
 test {

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -560,15 +560,15 @@ pub fn end(_: *WebBackend) !void {
     have_event = false;
 }
 
-pub fn pixelSize(_: *WebBackend) !dvui.Size.Physical {
+pub fn pixelSize(_: *WebBackend) dvui.Size.Physical {
     return .{ .w = wasm.wasm_pixel_width(), .h = wasm.wasm_pixel_height() };
 }
 
-pub fn windowSize(_: *WebBackend) !dvui.Size.Natural {
+pub fn windowSize(_: *WebBackend) dvui.Size.Natural {
     return .{ .w = wasm.wasm_canvas_width(), .h = wasm.wasm_canvas_height() };
 }
 
-pub fn contentScale(_: *WebBackend) !f32 {
+pub fn contentScale(_: *WebBackend) f32 {
     return 1.0;
 }
 
@@ -692,7 +692,7 @@ pub fn downloadData(name: []const u8, data: []const u8) !void {
     wasm.wasm_download_data(name.ptr, name.len, data.ptr, data.len);
 }
 
-pub fn refresh(_: *WebBackend) !void {}
+pub fn refresh(_: *WebBackend) void {}
 
 pub fn setCursor(self: *WebBackend, cursor: dvui.enums.Cursor) void {
     if (cursor != self.cursor_last) {

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -538,46 +538,41 @@ pub fn init() !WebBackend {
     return ret;
 }
 
-pub fn deinit(self: *WebBackend) void {
-    _ = self;
-}
+pub fn deinit(_: *WebBackend) void {}
 
 pub fn backend(self: *WebBackend) dvui.Backend {
     return dvui.Backend.init(self);
 }
 
-pub fn nanoTime(self: *WebBackend) i128 {
-    _ = self;
+pub fn nanoTime(_: *WebBackend) i128 {
     return @as(i128, @intFromFloat(wasm.wasm_now())) * 1_000_000;
 }
 
-pub fn sleep(self: *WebBackend, ns: u64) void {
-    _ = self;
+pub fn sleep(_: *WebBackend, ns: u64) void {
     wasm.wasm_sleep(@intCast(@divTrunc(ns, 1_000_000)));
 }
 
-pub fn begin(self: *WebBackend, arena_in: std.mem.Allocator) void {
-    _ = self;
+pub fn begin(_: *WebBackend, arena_in: std.mem.Allocator) !void {
     arena = arena_in;
 }
 
-pub fn end(_: *WebBackend) void {
+pub fn end(_: *WebBackend) !void {
     have_event = false;
 }
 
-pub fn pixelSize(_: *WebBackend) dvui.Size.Physical {
+pub fn pixelSize(_: *WebBackend) !dvui.Size.Physical {
     return .{ .w = wasm.wasm_pixel_width(), .h = wasm.wasm_pixel_height() };
 }
 
-pub fn windowSize(_: *WebBackend) dvui.Size.Natural {
+pub fn windowSize(_: *WebBackend) !dvui.Size.Natural {
     return .{ .w = wasm.wasm_canvas_width(), .h = wasm.wasm_canvas_height() };
 }
 
-pub fn contentScale(_: *WebBackend) f32 {
+pub fn contentScale(_: *WebBackend) !f32 {
     return 1.0;
 }
 
-pub fn drawClippedTriangles(_: *WebBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const u16, maybe_clipr: ?dvui.Rect.Physical) void {
+pub fn drawClippedTriangles(_: *WebBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const u16, maybe_clipr: ?dvui.Rect.Physical) !void {
     var x: i32 = std.math.maxInt(i32);
     var w: i32 = std.math.maxInt(i32);
     var y: i32 = std.math.maxInt(i32);
@@ -622,9 +617,7 @@ pub fn drawClippedTriangles(_: *WebBackend, texture: ?dvui.Texture, vtx: []const
     );
 }
 
-pub fn textureCreate(self: *WebBackend, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) dvui.Texture {
-    _ = self;
-
+pub fn textureCreate(_: *WebBackend, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.Texture {
     const wasm_interp: u8 = switch (interpolation) {
         .nearest => 0,
         .linear => 1,
@@ -634,8 +627,7 @@ pub fn textureCreate(self: *WebBackend, pixels: [*]u8, width: u32, height: u32, 
     return dvui.Texture{ .ptr = @ptrFromInt(id), .width = width, .height = height };
 }
 
-pub fn textureCreateTarget(self: *WebBackend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.TextureTarget {
-    _ = self;
+pub fn textureCreateTarget(_: *WebBackend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.TextureTarget {
     const wasm_interp: u8 = switch (interpolation) {
         .nearest => 0,
         .linear => 1,
@@ -645,12 +637,11 @@ pub fn textureCreateTarget(self: *WebBackend, width: u32, height: u32, interpola
     return dvui.TextureTarget{ .ptr = @ptrFromInt(id), .width = width, .height = height };
 }
 
-pub fn textureFromTarget(_: *WebBackend, texture: dvui.TextureTarget) dvui.Texture {
+pub fn textureFromTarget(_: *WebBackend, texture: dvui.TextureTarget) !dvui.Texture {
     return .{ .ptr = texture.ptr, .width = texture.width, .height = texture.height };
 }
 
-pub fn renderTarget(self: *WebBackend, texture: ?dvui.TextureTarget) void {
-    _ = self;
+pub fn renderTarget(_: *WebBackend, texture: ?dvui.TextureTarget) !void {
     if (texture) |tex| {
         wasm.wasm_renderTarget(@intCast(@intFromPtr(tex.ptr)));
     } else {
@@ -658,7 +649,7 @@ pub fn renderTarget(self: *WebBackend, texture: ?dvui.TextureTarget) void {
     }
 }
 
-pub fn textureReadTarget(_: *WebBackend, texture: dvui.TextureTarget, pixels_out: [*]u8) error{TextureRead}!void {
+pub fn textureReadTarget(_: *WebBackend, texture: dvui.TextureTarget, pixels_out: [*]u8) !void {
     wasm.wasm_textureRead(@intCast(@intFromPtr(texture.ptr)), pixels_out, texture.width, texture.height);
 }
 
@@ -674,8 +665,7 @@ pub fn textInputRect(_: *WebBackend, rect: ?dvui.Rect.Natural) void {
     }
 }
 
-pub fn clipboardText(self: *WebBackend) std.mem.Allocator.Error![]const u8 {
-    _ = self;
+pub fn clipboardText(_: *WebBackend) ![]const u8 {
     // Current strategy is to return nothing:
     // - let the browser continue with the paste operation
     // - puts the text into the hidden_input
@@ -689,24 +679,20 @@ pub fn clipboardText(self: *WebBackend) std.mem.Allocator.Error![]const u8 {
     return "";
 }
 
-pub fn clipboardTextSet(self: *WebBackend, text: []const u8) !void {
-    _ = self;
+pub fn clipboardTextSet(_: *WebBackend, text: []const u8) !void {
     wasm.wasm_clipboardTextSet(text.ptr, text.len);
     return;
 }
 
-pub fn openURL(self: *WebBackend, url: []const u8) !void {
+pub fn openURL(_: *WebBackend, url: []const u8) !void {
     wasm.wasm_open_url(url.ptr, url.len);
-    _ = self;
 }
 
 pub fn downloadData(name: []const u8, data: []const u8) !void {
     wasm.wasm_download_data(name.ptr, name.len, data.ptr, data.len);
 }
 
-pub fn refresh(self: *WebBackend) void {
-    _ = self;
-}
+pub fn refresh(_: *WebBackend) !void {}
 
 pub fn setCursor(self: *WebBackend, cursor: dvui.enums.Cursor) void {
     if (cursor != self.cursor_last) {

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -674,7 +674,7 @@ pub fn textInputRect(_: *WebBackend, rect: ?dvui.Rect.Natural) void {
     }
 }
 
-pub fn clipboardText(self: *WebBackend) error{OutOfMemory}![]const u8 {
+pub fn clipboardText(self: *WebBackend) std.mem.Allocator.Error![]const u8 {
     _ = self;
     // Current strategy is to return nothing:
     // - let the browser continue with the paste operation

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -543,7 +543,7 @@ pub fn deinit(self: *WebBackend) void {
 }
 
 pub fn backend(self: *WebBackend) dvui.Backend {
-    return dvui.Backend.init(self, @This());
+    return dvui.Backend.init(self);
 }
 
 pub fn nanoTime(self: *WebBackend) i128 {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -256,7 +256,7 @@ pub const Alignment = struct {
     }
 
     /// Add spacer with margin.x so they all end at the same edge.
-    pub fn spacer(self: *Alignment, src: std.builtin.SourceLocation, id_extra: usize) !void {
+    pub fn spacer(self: *Alignment, src: std.builtin.SourceLocation, id_extra: usize) std.mem.Allocator.Error!void {
         const uniqueId = dvui.parentGet().extendId(src, id_extra);
         var wd = try dvui.spacer(src, .{}, .{ .margin = self.margin(uniqueId), .id_extra = id_extra });
         self.record(uniqueId, &wd);
@@ -1219,7 +1219,7 @@ pub const Path = struct {
         /// - h is bottom-left corner
         ///
         /// Only valid between `Window.begin`and `Window.end`.
-        pub fn addRect(path: *Builder, r: Rect.Physical, radius: Rect.Physical) !void {
+        pub fn addRect(path: *Builder, r: Rect.Physical, radius: Rect.Physical) std.mem.Allocator.Error!void {
             var rad = radius;
             const maxrad = @min(r.w, r.h) / 2;
             rad.x = @min(rad.x, maxrad);
@@ -1244,7 +1244,7 @@ pub const Path = struct {
         /// addition to path would duplicate the end of the arc.
         ///
         /// Only valid between `Window.begin`and `Window.end`.
-        pub fn addArc(path: *Builder, center: Point.Physical, radius: f32, start: f32, end: f32, skip_end: bool) !void {
+        pub fn addArc(path: *Builder, center: Point.Physical, radius: f32, start: f32, end: f32, skip_end: bool) std.mem.Allocator.Error!void {
             if (radius == 0) {
                 try path.points.append(center);
                 return;
@@ -1299,7 +1299,7 @@ pub const Path = struct {
         try std.testing.expectApproxEqRel(40, triangles.bounds.h, 0.05);
     }
 
-    pub fn dupe(path: Path, allocator: std.mem.Allocator) !Path {
+    pub fn dupe(path: Path, allocator: std.mem.Allocator) std.mem.Allocator.Error!Path {
         return .{ .points = try allocator.dupe(Point.Physical, path.points) };
     }
 
@@ -1312,7 +1312,7 @@ pub const Path = struct {
     /// Fill path (must be convex) with `color` (or `Theme.color_fill`).  See `Rect.fill`.
     ///
     /// Only valid between `Window.begin`and `Window.end`.
-    pub fn fillConvex(path: Path, opts: FillConvexOptions) !void {
+    pub fn fillConvex(path: Path, opts: FillConvexOptions) std.mem.Allocator.Error!void {
         if (path.points.len < 3) {
             return;
         }
@@ -1350,7 +1350,7 @@ pub const Path = struct {
     /// pixel inside. Currently blur < 1 is treated as 1, but might change.
     ///
     /// Only valid between `Window.begin`and `Window.end`.
-    pub fn fillConvexTriangles(path: Path, opts: FillConvexOptions) !Triangles {
+    pub fn fillConvexTriangles(path: Path, opts: FillConvexOptions) std.mem.Allocator.Error!Triangles {
         if (path.points.len < 3) {
             return .empty;
         }
@@ -1472,7 +1472,7 @@ pub const Path = struct {
     /// Stroke path as a series of line segments.  See `Rect.stroke`.
     ///
     /// Only valid between `Window.begin`and `Window.end`.
-    pub fn stroke(path: Path, opts: StrokeOptions) !void {
+    pub fn stroke(path: Path, opts: StrokeOptions) std.mem.Allocator.Error!void {
         if (path.points.len == 0) {
             return;
         }
@@ -1503,7 +1503,7 @@ pub const Path = struct {
     /// transparent at the edge.
     ///
     /// Only valid between `Window.begin`and `Window.end`.
-    pub fn strokeTriangles(path: Path, opts: StrokeOptions) !Triangles {
+    pub fn strokeTriangles(path: Path, opts: StrokeOptions) std.mem.Allocator.Error!Triangles {
         if (dvui.clipGet().empty()) {
             return .empty;
         }
@@ -1739,7 +1739,7 @@ pub const Triangles = struct {
             .h = -math.floatMax(f32),
         },
 
-        pub fn init(allocator: std.mem.Allocator, vtx_count: usize, idx_count: usize) !Builder {
+        pub fn init(allocator: std.mem.Allocator, vtx_count: usize, idx_count: usize) std.mem.Allocator.Error!Builder {
             std.debug.assert(vtx_count >= 3);
             std.debug.assert(idx_count % 3 == 0);
             return .{
@@ -1801,7 +1801,7 @@ pub const Triangles = struct {
         }
     };
 
-    pub fn dupe(self: *const Triangles, allocator: std.mem.Allocator) !Triangles {
+    pub fn dupe(self: *const Triangles, allocator: std.mem.Allocator) std.mem.Allocator.Error!Triangles {
         return .{
             .vertexes = try allocator.dupe(Vertex, self.vertexes),
             .indices = try allocator.dupe(u16, self.indices),
@@ -1888,7 +1888,7 @@ pub const Triangles = struct {
     }
 };
 
-pub fn renderTriangles(triangles: Triangles, tex: ?Texture) !void {
+pub fn renderTriangles(triangles: Triangles, tex: ?Texture) std.mem.Allocator.Error!void {
     if (triangles.vertexes.len == 0) {
         return;
     }
@@ -1925,7 +1925,7 @@ pub fn renderTriangles(triangles: Triangles, tex: ?Texture) !void {
 /// tagged with.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn subwindowAdd(id: WidgetId, rect: Rect, rect_pixels: Rect.Physical, modal: bool, stay_above_parent_window: ?WidgetId) !void {
+pub fn subwindowAdd(id: WidgetId, rect: Rect, rect_pixels: Rect.Physical, modal: bool, stay_above_parent_window: ?WidgetId) std.mem.Allocator.Error!void {
     const cw = currentWindow();
     const arena = cw.arena();
 
@@ -2292,7 +2292,7 @@ pub fn refresh(win: ?*Window, src: std.builtin.SourceLocation, id: ?WidgetId) vo
 /// Get the textual content of the system clipboard.  Caller must copy.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn clipboardText() error{OutOfMemory}![]const u8 {
+pub fn clipboardText() std.mem.Allocator.Error![]const u8 {
     const cw = currentWindow();
     return cw.backend.clipboardText();
 }
@@ -2300,7 +2300,7 @@ pub fn clipboardText() error{OutOfMemory}![]const u8 {
 /// Set the textual content of the system clipboard.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn clipboardTextSet(text: []const u8) error{OutOfMemory}!void {
+pub fn clipboardTextSet(text: []const u8) std.mem.Allocator.Error!void {
     const cw = currentWindow();
     try cw.backend.clipboardTextSet(text);
 }
@@ -2308,7 +2308,7 @@ pub fn clipboardTextSet(text: []const u8) error{OutOfMemory}!void {
 /// Ask the system to open the given url.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn openURL(url: []const u8) !void {
+pub fn openURL(url: []const u8) std.mem.Allocator.Error!void {
     const cw = currentWindow();
     try cw.backend.openURL(url);
 }
@@ -2989,7 +2989,7 @@ pub fn animationGet(id: WidgetId, key: []const u8) ?Animation {
 /// has passed.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn timer(id: WidgetId, micros: i32) !void {
+pub fn timer(id: WidgetId, micros: i32) std.mem.Allocator.Error!void {
     try currentWindow().timer(id, micros);
 }
 
@@ -3043,7 +3043,7 @@ pub const TabIndex = struct {
 /// null widgets are visited in order of calling `tabIndexSet`.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn tabIndexSet(widget_id: WidgetId, tab_index: ?u16) !void {
+pub fn tabIndexSet(widget_id: WidgetId, tab_index: ?u16) std.mem.Allocator.Error!void {
     if (tab_index != null and tab_index.? == 0)
         return;
 
@@ -3157,14 +3157,14 @@ pub fn wantTextInput(r: Rect.Natural) void {
     cw.text_input_rect = r;
 }
 
-pub fn floatingMenu(src: std.builtin.SourceLocation, init_opts: FloatingMenuWidget.InitOptions, opts: Options) !*FloatingMenuWidget {
+pub fn floatingMenu(src: std.builtin.SourceLocation, init_opts: FloatingMenuWidget.InitOptions, opts: Options) std.mem.Allocator.Error!*FloatingMenuWidget {
     var ret = try currentWindow().arena().create(FloatingMenuWidget);
     ret.* = FloatingMenuWidget.init(src, init_opts, opts);
     try ret.install();
     return ret;
 }
 
-pub fn floatingWindow(src: std.builtin.SourceLocation, floating_opts: FloatingWindowWidget.InitOptions, opts: Options) !*FloatingWindowWidget {
+pub fn floatingWindow(src: std.builtin.SourceLocation, floating_opts: FloatingWindowWidget.InitOptions, opts: Options) std.mem.Allocator.Error!*FloatingWindowWidget {
     var ret = try currentWindow().arena().create(FloatingWindowWidget);
     ret.* = FloatingWindowWidget.init(src, floating_opts, opts);
     try ret.install();
@@ -3242,7 +3242,7 @@ pub const IdMutex = struct {
 ///
 /// If called from non-GUI thread or outside `Window.begin`/`Window.end`, you
 /// **must** pass a pointer to the Window you want to add the dialog to.
-pub fn dialogAdd(win: ?*Window, src: std.builtin.SourceLocation, id_extra: usize, display: DialogDisplayFn) !IdMutex {
+pub fn dialogAdd(win: ?*Window, src: std.builtin.SourceLocation, id_extra: usize, display: DialogDisplayFn) std.mem.Allocator.Error!IdMutex {
     if (win) |w| {
         // we are being called from non gui thread
         const id = hashSrc(null, src, id_extra);
@@ -3290,7 +3290,7 @@ pub const DialogOptions = struct {
 ///
 /// Can be called from any thread, but if calling from a non-GUI thread or
 /// outside `Window.begin`/`Window.end` you must set opts.window.
-pub fn dialog(src: std.builtin.SourceLocation, user_struct: anytype, opts: DialogOptions) !void {
+pub fn dialog(src: std.builtin.SourceLocation, user_struct: anytype, opts: DialogOptions) std.mem.Allocator.Error!void {
     const id_mutex = try dialogAdd(opts.window, src, opts.id_extra, opts.displayFn);
     const id = id_mutex.id;
     dataSet(opts.window, id, "_modal", opts.modal);
@@ -3433,7 +3433,7 @@ const WasmFile = struct {
     /// The filename of the uploaded file. Does not include the path of the file
     name: [:0]const u8,
 
-    pub fn readData(self: *WasmFile, allocator: std.mem.Allocator) ![]u8 {
+    pub fn readData(self: *WasmFile, allocator: std.mem.Allocator) std.mem.Allocator.Error![]u8 {
         std.debug.assert(wasm); // WasmFile shouldn't be used outside wasm builds
         const data = try allocator.alloc(u8, self.size);
         dvui.backend.readFileData(self.id, self.index, data.ptr);
@@ -3530,7 +3530,7 @@ pub const DialogNativeFileOptions = struct {
 /// Not thread safe, but can be used from any thread.
 ///
 /// Returned string is created by passed allocator.  Not implemented for web (returns null).
-pub fn dialogNativeFileOpen(alloc: std.mem.Allocator, opts: DialogNativeFileOptions) !?[:0]const u8 {
+pub fn dialogNativeFileOpen(alloc: std.mem.Allocator, opts: DialogNativeFileOptions) std.mem.Allocator.Error!?[:0]const u8 {
     if (wasm) {
         return null;
     }
@@ -3544,7 +3544,7 @@ pub fn dialogNativeFileOpen(alloc: std.mem.Allocator, opts: DialogNativeFileOpti
 /// Not thread safe, but can be used from any thread.
 ///
 /// Returned slice and strings are created by passed allocator.  Not implemented for web (returns null).
-pub fn dialogNativeFileOpenMultiple(alloc: std.mem.Allocator, opts: DialogNativeFileOptions) !?[][:0]const u8 {
+pub fn dialogNativeFileOpenMultiple(alloc: std.mem.Allocator, opts: DialogNativeFileOptions) std.mem.Allocator.Error!?[][:0]const u8 {
     if (wasm) {
         return null;
     }
@@ -3558,7 +3558,7 @@ pub fn dialogNativeFileOpenMultiple(alloc: std.mem.Allocator, opts: DialogNative
 /// Not thread safe, but can be used from any thread.
 ///
 /// Returned string is created by passed allocator.  Not implemented for web (returns null).
-pub fn dialogNativeFileSave(alloc: std.mem.Allocator, opts: DialogNativeFileOptions) !?[:0]const u8 {
+pub fn dialogNativeFileSave(alloc: std.mem.Allocator, opts: DialogNativeFileOptions) std.mem.Allocator.Error!?[:0]const u8 {
     if (wasm) {
         return null;
     }
@@ -3566,7 +3566,7 @@ pub fn dialogNativeFileSave(alloc: std.mem.Allocator, opts: DialogNativeFileOpti
     return dialogNativeFileInternal(false, false, alloc, opts);
 }
 
-fn dialogNativeFileInternal(comptime open: bool, comptime multiple: bool, alloc: std.mem.Allocator, opts: DialogNativeFileOptions) if (multiple) error{OutOfMemory}!?[][:0]const u8 else error{OutOfMemory}!?[:0]const u8 {
+fn dialogNativeFileInternal(comptime open: bool, comptime multiple: bool, alloc: std.mem.Allocator, opts: DialogNativeFileOptions) if (multiple) std.mem.Allocator.Error!?[][:0]const u8 else std.mem.Allocator.Error!?[:0]const u8 {
     var backing: [500]u8 = undefined;
     var buf: []u8 = &backing;
 
@@ -3662,7 +3662,7 @@ pub const DialogNativeFolderSelectOptions = struct {
 /// Not thread safe, but can be used from any thread.
 ///
 /// Returned string is created by passed allocator.  Not implemented for web (returns null).
-pub fn dialogNativeFolderSelect(alloc: std.mem.Allocator, opts: DialogNativeFolderSelectOptions) error{OutOfMemory}!?[]const u8 {
+pub fn dialogNativeFolderSelect(alloc: std.mem.Allocator, opts: DialogNativeFolderSelectOptions) std.mem.Allocator.Error!?[]const u8 {
     if (wasm) {
         return null;
     }
@@ -3718,7 +3718,7 @@ pub const Toast = struct {
 ///
 /// If called from non-GUI thread or outside `Window.begin`/`Window.end`, you must
 /// pass a pointer to the Window you want to add the toast to.
-pub fn toastAdd(win: ?*Window, src: std.builtin.SourceLocation, id_extra: usize, subwindow_id: ?WidgetId, display: DialogDisplayFn, timeout: ?i32) !IdMutex {
+pub fn toastAdd(win: ?*Window, src: std.builtin.SourceLocation, id_extra: usize, subwindow_id: ?WidgetId, display: DialogDisplayFn, timeout: ?i32) std.mem.Allocator.Error!IdMutex {
     if (win) |w| {
         // we are being called from non gui thread
         const id = hashSrc(null, src, id_extra);
@@ -3811,7 +3811,7 @@ pub const ToastOptions = struct {
 ///
 /// Can be called from any thread, but if called from a non-GUI thread or
 /// outside `Window.begin`/`Window.end`, you must set `opts.window`.
-pub fn toast(src: std.builtin.SourceLocation, opts: ToastOptions) !void {
+pub fn toast(src: std.builtin.SourceLocation, opts: ToastOptions) std.mem.Allocator.Error!void {
     const id_mutex = try dvui.toastAdd(opts.window, src, opts.id_extra, opts.subwindow_id, opts.displayFn, opts.timeout);
     const id = id_mutex.id;
     dvui.dataSetSlice(opts.window, id, "_message", opts.message);
@@ -3865,7 +3865,7 @@ pub fn toastsShow(floating_window_data: ?*WidgetData) !void {
     }
 }
 
-pub fn animate(src: std.builtin.SourceLocation, init_opts: AnimateWidget.InitOptions, opts: Options) !*AnimateWidget {
+pub fn animate(src: std.builtin.SourceLocation, init_opts: AnimateWidget.InitOptions, opts: Options) std.mem.Allocator.Error!*AnimateWidget {
     var ret = try currentWindow().arena().create(AnimateWidget);
     ret.* = AnimateWidget.init(src, init_opts, opts);
     try ret.install();
@@ -4089,7 +4089,7 @@ pub fn expander(src: std.builtin.SourceLocation, label_str: []const u8, init_opt
 /// than init_opts.collapsed_size space.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn paned(src: std.builtin.SourceLocation, init_opts: PanedWidget.InitOptions, opts: Options) !*PanedWidget {
+pub fn paned(src: std.builtin.SourceLocation, init_opts: PanedWidget.InitOptions, opts: Options) std.mem.Allocator.Error!*PanedWidget {
     var ret = try currentWindow().arena().create(PanedWidget);
     ret.* = PanedWidget.init(src, init_opts, opts);
     try ret.install();
@@ -4127,7 +4127,7 @@ pub fn textLayout(src: std.builtin.SourceLocation, init_opts: TextLayoutWidget.I
 /// directly inside Context.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn context(src: std.builtin.SourceLocation, init_opts: ContextWidget.InitOptions, opts: Options) !*ContextWidget {
+pub fn context(src: std.builtin.SourceLocation, init_opts: ContextWidget.InitOptions, opts: Options) std.mem.Allocator.Error!*ContextWidget {
     var ret = try currentWindow().arena().create(ContextWidget);
     ret.* = ContextWidget.init(src, init_opts, opts);
     try ret.install();
@@ -4151,7 +4151,7 @@ pub fn tooltip(src: std.builtin.SourceLocation, init_opts: FloatingTooltipWidget
 /// not have a parent widget.  See makeLabels() in src/Examples.zig
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn virtualParent(src: std.builtin.SourceLocation, opts: Options) !*VirtualParentWidget {
+pub fn virtualParent(src: std.builtin.SourceLocation, opts: Options) std.mem.Allocator.Error!*VirtualParentWidget {
     var ret = try currentWindow().arena().create(VirtualParentWidget);
     ret.* = VirtualParentWidget.init(src, opts);
     try ret.install();
@@ -4164,7 +4164,7 @@ pub fn virtualParent(src: std.builtin.SourceLocation, opts: Options) !*VirtualPa
 /// See `box`.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn overlay(src: std.builtin.SourceLocation, opts: Options) !*OverlayWidget {
+pub fn overlay(src: std.builtin.SourceLocation, opts: Options) std.mem.Allocator.Error!*OverlayWidget {
     var ret = try currentWindow().arena().create(OverlayWidget);
     ret.* = OverlayWidget.init(src, opts);
     try ret.install();
@@ -4187,7 +4187,7 @@ pub fn overlay(src: std.builtin.SourceLocation, opts: Options) !*OverlayWidget {
 /// See `boxEqual` and `flexbox`.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn box(src: std.builtin.SourceLocation, dir: enums.Direction, opts: Options) !*BoxWidget {
+pub fn box(src: std.builtin.SourceLocation, dir: enums.Direction, opts: Options) std.mem.Allocator.Error!*BoxWidget {
     var ret = try currentWindow().arena().create(BoxWidget);
     ret.* = BoxWidget.init(src, dir, false, opts);
     try ret.install();
@@ -4200,7 +4200,7 @@ pub fn box(src: std.builtin.SourceLocation, dir: enums.Direction, opts: Options)
 /// See `box` and `flexbox`.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn boxEqual(src: std.builtin.SourceLocation, dir: enums.Direction, opts: Options) !*BoxWidget {
+pub fn boxEqual(src: std.builtin.SourceLocation, dir: enums.Direction, opts: Options) std.mem.Allocator.Error!*BoxWidget {
     var ret = try currentWindow().arena().create(BoxWidget);
     ret.* = BoxWidget.init(src, dir, true, opts);
     try ret.install();
@@ -4213,7 +4213,7 @@ pub fn boxEqual(src: std.builtin.SourceLocation, dir: enums.Direction, opts: Opt
 /// See `box` and `boxEqual`.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn flexbox(src: std.builtin.SourceLocation, init_opts: FlexBoxWidget.InitOptions, opts: Options) !*FlexBoxWidget {
+pub fn flexbox(src: std.builtin.SourceLocation, init_opts: FlexBoxWidget.InitOptions, opts: Options) std.mem.Allocator.Error!*FlexBoxWidget {
     var ret = try currentWindow().arena().create(FlexBoxWidget);
     ret.* = FlexBoxWidget.init(src, init_opts, opts);
     try ret.install();
@@ -4221,7 +4221,7 @@ pub fn flexbox(src: std.builtin.SourceLocation, init_opts: FlexBoxWidget.InitOpt
     return ret;
 }
 
-pub fn cache(src: std.builtin.SourceLocation, init_opts: CacheWidget.InitOptions, opts: Options) !*CacheWidget {
+pub fn cache(src: std.builtin.SourceLocation, init_opts: CacheWidget.InitOptions, opts: Options) std.mem.Allocator.Error!*CacheWidget {
     var ret = try currentWindow().arena().create(CacheWidget);
     ret.* = CacheWidget.init(src, init_opts, opts);
     if (init_opts.invalidate) {
@@ -4231,7 +4231,7 @@ pub fn cache(src: std.builtin.SourceLocation, init_opts: CacheWidget.InitOptions
     return ret;
 }
 
-pub fn reorder(src: std.builtin.SourceLocation, opts: Options) !*ReorderWidget {
+pub fn reorder(src: std.builtin.SourceLocation, opts: Options) std.mem.Allocator.Error!*ReorderWidget {
     var ret = try currentWindow().arena().create(ReorderWidget);
     ret.* = ReorderWidget.init(src, opts);
     try ret.install();
@@ -4239,16 +4239,16 @@ pub fn reorder(src: std.builtin.SourceLocation, opts: Options) !*ReorderWidget {
     return ret;
 }
 
-pub fn scrollArea(src: std.builtin.SourceLocation, init_opts: ScrollAreaWidget.InitOpts, opts: Options) !*ScrollAreaWidget {
+pub fn scrollArea(src: std.builtin.SourceLocation, init_opts: ScrollAreaWidget.InitOpts, opts: Options) std.mem.Allocator.Error!*ScrollAreaWidget {
     var ret = try currentWindow().arena().create(ScrollAreaWidget);
     ret.* = ScrollAreaWidget.init(src, init_opts, opts);
     try ret.install();
     return ret;
 }
 
-pub fn grid(src: std.builtin.SourceLocation, init_opts: GridWidget.InitOpts, opts: Options) !*GridWidget {
+pub fn grid(src: std.builtin.SourceLocation, init_opts: GridWidget.InitOpts, opts: Options) std.mem.Allocator.Error!*GridWidget {
     const ret = try currentWindow().arena().create(GridWidget);
-    ret.* = try GridWidget.init(src, init_opts, opts);
+    ret.* = GridWidget.init(src, init_opts, opts);
     try ret.install();
     return ret;
 }
@@ -4597,7 +4597,7 @@ pub fn columnLayoutProportional(ratio_widths: []const f32, col_widths: []f32, co
     }
 }
 
-pub fn separator(src: std.builtin.SourceLocation, opts: Options) !WidgetData {
+pub fn separator(src: std.builtin.SourceLocation, opts: Options) std.mem.Allocator.Error!WidgetData {
     const defaults: Options = .{
         .name = "Separator",
         .background = true, // TODO: remove this when border and background are no longer coupled
@@ -4613,7 +4613,7 @@ pub fn separator(src: std.builtin.SourceLocation, opts: Options) !WidgetData {
     return wd;
 }
 
-pub fn spacer(src: std.builtin.SourceLocation, size: Size, opts: Options) !WidgetData {
+pub fn spacer(src: std.builtin.SourceLocation, size: Size, opts: Options) std.mem.Allocator.Error!WidgetData {
     if (opts.min_size_content != null) {
         log.debug("spacer options had min_size but is being overwritten\n", .{});
     }
@@ -4626,7 +4626,7 @@ pub fn spacer(src: std.builtin.SourceLocation, size: Size, opts: Options) !Widge
     return wd;
 }
 
-pub fn spinner(src: std.builtin.SourceLocation, opts: Options) !void {
+pub fn spinner(src: std.builtin.SourceLocation, opts: Options) std.mem.Allocator.Error!void {
     var defaults: Options = .{
         .name = "Spinner",
         .min_size_content = .{ .w = 50, .h = 50 },
@@ -4675,7 +4675,7 @@ pub fn spinner(src: std.builtin.SourceLocation, opts: Options) !void {
     try path.build().stroke(.{ .thickness = 3.0 * rs.s, .color = options.color(.text) });
 }
 
-pub fn scale(src: std.builtin.SourceLocation, init_opts: ScaleWidget.InitOptions, opts: Options) !*ScaleWidget {
+pub fn scale(src: std.builtin.SourceLocation, init_opts: ScaleWidget.InitOptions, opts: Options) std.mem.Allocator.Error!*ScaleWidget {
     var ret = try currentWindow().arena().create(ScaleWidget);
     ret.* = ScaleWidget.init(src, init_opts, opts);
     try ret.install();
@@ -4683,7 +4683,7 @@ pub fn scale(src: std.builtin.SourceLocation, init_opts: ScaleWidget.InitOptions
     return ret;
 }
 
-pub fn menu(src: std.builtin.SourceLocation, dir: enums.Direction, opts: Options) !*MenuWidget {
+pub fn menu(src: std.builtin.SourceLocation, dir: enums.Direction, opts: Options) std.mem.Allocator.Error!*MenuWidget {
     var ret = try currentWindow().arena().create(MenuWidget);
     ret.* = MenuWidget.init(src, .{ .dir = dir }, opts);
     try ret.install();
@@ -4734,7 +4734,7 @@ pub fn menuItemIcon(src: std.builtin.SourceLocation, name: []const u8, tvg_bytes
     return ret;
 }
 
-pub fn menuItem(src: std.builtin.SourceLocation, init_opts: MenuItemWidget.InitOptions, opts: Options) !*MenuItemWidget {
+pub fn menuItem(src: std.builtin.SourceLocation, init_opts: MenuItemWidget.InitOptions, opts: Options) std.mem.Allocator.Error!*MenuItemWidget {
     var ret = try currentWindow().arena().create(MenuItemWidget);
     ret.* = MenuItemWidget.init(src, init_opts, opts);
     try ret.install();
@@ -4906,7 +4906,7 @@ pub const ImageInitOptions = struct {
 /// Show raster image.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn image(src: std.builtin.SourceLocation, init_opts: ImageInitOptions, opts: Options) !WidgetData {
+pub fn image(src: std.builtin.SourceLocation, init_opts: ImageInitOptions, opts: Options) std.mem.Allocator.Error!WidgetData {
     const options = (Options{ .name = init_opts.name }).override(opts);
 
     var size = Size{};
@@ -5110,7 +5110,7 @@ pub var slider_defaults: Options = .{
 };
 
 // returns true if fraction (0-1) was changed
-pub fn slider(src: std.builtin.SourceLocation, dir: enums.Direction, fraction: *f32, opts: Options) !bool {
+pub fn slider(src: std.builtin.SourceLocation, dir: enums.Direction, fraction: *f32, opts: Options) std.mem.Allocator.Error!bool {
     std.debug.assert(fraction.* >= 0);
     std.debug.assert(fraction.* <= 1);
 
@@ -5679,7 +5679,7 @@ pub const Progress_InitOptions = struct {
     percent: f32,
 };
 
-pub fn progress(src: std.builtin.SourceLocation, init_opts: Progress_InitOptions, opts: Options) !void {
+pub fn progress(src: std.builtin.SourceLocation, init_opts: Progress_InitOptions, opts: Options) std.mem.Allocator.Error!void {
     const options = progress_defaults.override(opts);
 
     var b = try box(src, init_opts.dir, options);
@@ -5749,7 +5749,7 @@ pub fn checkbox(src: std.builtin.SourceLocation, target: *bool, label_str: ?[]co
     return ret;
 }
 
-pub fn checkmark(checked: bool, focused: bool, rs: RectScale, pressed: bool, hovered: bool, opts: Options) !void {
+pub fn checkmark(checked: bool, focused: bool, rs: RectScale, pressed: bool, hovered: bool, opts: Options) std.mem.Allocator.Error!void {
     const cornerRad = opts.corner_radiusGet().scale(rs.s, Rect.Physical);
     try rs.r.fill(cornerRad, .{ .color = opts.color(.border) });
 
@@ -5835,7 +5835,7 @@ pub fn radio(src: std.builtin.SourceLocation, active: bool, label_str: ?[]const 
     return ret;
 }
 
-pub fn radioCircle(active: bool, focused: bool, rs: RectScale, pressed: bool, hovered: bool, opts: Options) !void {
+pub fn radioCircle(active: bool, focused: bool, rs: RectScale, pressed: bool, hovered: bool, opts: Options) std.mem.Allocator.Error!void {
     const cornerRad = Rect.Physical.all(1000);
     const r = rs.r;
     try r.fill(cornerRad, .{ .color = opts.color(.border) });
@@ -6067,7 +6067,7 @@ pub fn textEntryColor(src: std.builtin.SourceLocation, init_opts: TextEntryColor
                 _ = try std.fmt.bufPrint(buffer, "#{x:0>2}{x:0>2}{x:0>2}{x:0>2}", .{ v.r, v.g, v.b, v.a });
                 te.len = 9;
             } else {
-                te.textSet(&(v.toHexString() catch unreachable), false);
+                te.textSet(&(v.toHexString()), false);
             }
         }
     }
@@ -6641,7 +6641,7 @@ pub const RenderTextureOptions = struct {
     debug: bool = false,
 };
 
-pub fn renderTexture(tex: Texture, rs: RectScale, opts: RenderTextureOptions) !void {
+pub fn renderTexture(tex: Texture, rs: RectScale, opts: RenderTextureOptions) std.mem.Allocator.Error!void {
     if (rs.s == 0) return;
     if (clipGet().intersect(rs.r).empty()) return;
 
@@ -6677,7 +6677,7 @@ pub fn renderTexture(tex: Texture, rs: RectScale, opts: RenderTextureOptions) !v
     try renderTriangles(triangles, tex);
 }
 
-pub fn renderIcon(name: []const u8, tvg_bytes: []const u8, rs: RectScale, opts: RenderTextureOptions, icon_opts: IconRenderOptions) !void {
+pub fn renderIcon(name: []const u8, tvg_bytes: []const u8, rs: RectScale, opts: RenderTextureOptions, icon_opts: IconRenderOptions) std.mem.Allocator.Error!void {
     if (rs.s == 0) return;
     if (clipGet().intersect(rs.r).empty()) return;
 
@@ -6734,7 +6734,7 @@ pub fn imageTexture(name: []const u8, image_bytes: []const u8) !TextureCacheEntr
     return entry;
 }
 
-pub fn renderImage(name: []const u8, image_bytes: []const u8, rs: RectScale, opts: RenderTextureOptions) !void {
+pub fn renderImage(name: []const u8, image_bytes: []const u8, rs: RectScale, opts: RenderTextureOptions) std.mem.Allocator.Error!void {
     if (rs.s == 0) return;
     if (clipGet().intersect(rs.r).empty()) return;
 
@@ -6809,7 +6809,7 @@ pub const pngEncodeOptions = struct {
 /// Make a png encoded image from RGBA pixels.
 ///
 /// Gives bytes of a png file (allocated by arena).
-pub fn pngEncode(arena: std.mem.Allocator, pixels: []u8, width: u32, height: u32, opts: pngEncodeOptions) ![]u8 {
+pub fn pngEncode(arena: std.mem.Allocator, pixels: []u8, width: u32, height: u32, opts: pngEncodeOptions) std.mem.Allocator.Error![]u8 {
     var len: c_int = undefined;
     const png_bytes = c.stbi_write_png_to_mem(pixels.ptr, @intCast(width * 4), @intCast(width), @intCast(height), 4, &len);
     defer {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -4606,7 +4606,7 @@ pub fn separator(src: std.builtin.SourceLocation, opts: Options) std.mem.Allocat
     };
 
     var wd = WidgetData.init(src, .{}, defaults.override(opts));
-    try wd.register();
+    wd.register();
     try wd.borderAndBackground(.{});
     wd.minSizeSetAndRefresh();
     wd.minSizeReportToParent();
@@ -4619,7 +4619,7 @@ pub fn spacer(src: std.builtin.SourceLocation, size: Size, opts: Options) std.me
     }
     const defaults: Options = .{ .name = "Spacer" };
     var wd = WidgetData.init(src, .{}, defaults.override(opts).override(.{ .min_size_content = size }));
-    try wd.register();
+    wd.register();
     try wd.borderAndBackground(.{});
     wd.minSizeSetAndRefresh();
     wd.minSizeReportToParent();
@@ -4633,7 +4633,7 @@ pub fn spinner(src: std.builtin.SourceLocation, opts: Options) std.mem.Allocator
     };
     const options = defaults.override(opts);
     var wd = WidgetData.init(src, .{}, options);
-    try wd.register();
+    wd.register();
     wd.minSizeSetAndRefresh();
     wd.minSizeReportToParent();
 
@@ -4919,7 +4919,7 @@ pub fn image(src: std.builtin.SourceLocation, init_opts: ImageInitOptions, opts:
     }
 
     var wd = WidgetData.init(src, .{}, options.override(.{ .min_size_content = size }));
-    try wd.register();
+    wd.register();
 
     const cr = wd.contentRect();
     const ms = wd.options.min_size_contentGet();
@@ -4987,7 +4987,7 @@ pub fn debugFontAtlases(src: std.builtin.SourceLocation, opts: Options) !void {
     const size = sizePhys.scale(1.0 / ss, Size);
 
     var wd = WidgetData.init(src, .{}, opts.override(.{ .name = "debugFontAtlases", .min_size_content = size }));
-    try wd.register();
+    wd.register();
 
     try wd.borderAndBackground(.{});
 

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -76,33 +76,36 @@ pub const Keybind = struct {
     key: ?Key = null,
     also: ?[]const u8 = null,
 
-    pub fn format(self: Keybind, arena: std.mem.Allocator) ![]u8 {
-        var ctrl_str: []const u8 = "";
+    pub fn format(self: *const Keybind, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+        var needs_space = false;
         if (self.control) |ctrl| {
-            ctrl_str = if (ctrl) "ctrl " else "!ctrl ";
+            if (needs_space) try writer.writeByte(' ') else needs_space = true;
+            if (!ctrl) try writer.writeByte('!');
+            try writer.writeAll("ctrl");
         }
 
-        var cmd_str: []const u8 = "";
         if (self.command) |cmd| {
-            cmd_str = if (cmd) "cmd " else "!cmd ";
+            if (needs_space) try writer.writeByte(' ') else needs_space = true;
+            if (!cmd) try writer.writeByte('!');
+            try writer.writeAll("cmd");
         }
 
-        var alt_str: []const u8 = "";
         if (self.alt) |alt| {
-            alt_str = if (alt) "alt " else "!alt ";
+            if (needs_space) try writer.writeByte(' ') else needs_space = true;
+            if (!alt) try writer.writeByte('!');
+            try writer.writeAll("alt");
         }
 
-        var shift_str: []const u8 = "";
         if (self.shift) |shift| {
-            shift_str = if (shift) "shift " else "!shift ";
+            if (needs_space) try writer.writeByte(' ') else needs_space = true;
+            if (!shift) try writer.writeByte('!');
+            try writer.writeAll("shift");
         }
 
-        var key_str: []const u8 = "";
         if (self.key) |key| {
-            key_str = @tagName(key);
+            if (needs_space) try writer.writeByte(' ') else needs_space = true;
+            try writer.writeAll(@tagName(key));
         }
-
-        return try std.fmt.allocPrint(arena, "{s}{s}{s}{s}{s}", .{ ctrl_str, cmd_str, alt_str, shift_str, key_str });
     }
 };
 

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -186,7 +186,7 @@ pub fn capturePng(self: *Self, frame: dvui.App.frameFunction, rect: ?dvui.Rect.P
     // render the retained dialogs and deferred renders
     _ = try dvui.currentWindow().endRendering(.{});
 
-    picture.stop();
+    try picture.stop();
 
     // texture will be destroyed in picture.deinit() so grab pixels now
     const png_data = try picture.png(self.allocator);

--- a/src/tracking_hash_map.zig
+++ b/src/tracking_hash_map.zig
@@ -153,7 +153,7 @@ pub fn TrackingAutoHashMap(
         }
 
         /// Returns all keys that had not been used since the last call to this function
-        pub fn reset(self: *Self, allocator: std.mem.Allocator) ![]const K {
+        pub fn reset(self: *Self, allocator: std.mem.Allocator) std.mem.Allocator.Error![]const K {
             var unused = std.ArrayListUnmanaged(K).empty;
             var map_it = self.map.iterator();
             while (map_it.next()) |entry| {

--- a/src/widgets/AnimateWidget.zig
+++ b/src/widgets/AnimateWidget.zig
@@ -78,7 +78,7 @@ pub fn install(self: *AnimateWidget) std.mem.Allocator.Error!void {
     }
 
     dvui.parentSet(self.widget());
-    try self.wd.register();
+    self.wd.register();
     try self.wd.borderAndBackground(.{});
 }
 

--- a/src/widgets/AnimateWidget.zig
+++ b/src/widgets/AnimateWidget.zig
@@ -35,7 +35,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return AnimateWidget{ .wd = WidgetData.init(src, .{}, defaults.override(opts)), .init_opts = init_opts };
 }
 
-pub fn install(self: *AnimateWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *AnimateWidget) !void {
     if (dvui.firstFrame(self.wd.id)) {
         // start begin animation
         self.start();

--- a/src/widgets/AnimateWidget.zig
+++ b/src/widgets/AnimateWidget.zig
@@ -35,7 +35,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return AnimateWidget{ .wd = WidgetData.init(src, .{}, defaults.override(opts)), .init_opts = init_opts };
 }
 
-pub fn install(self: *AnimateWidget) !void {
+pub fn install(self: *AnimateWidget) std.mem.Allocator.Error!void {
     if (dvui.firstFrame(self.wd.id)) {
         // start begin animation
         self.start();

--- a/src/widgets/BoxWidget.zig
+++ b/src/widgets/BoxWidget.zig
@@ -43,7 +43,7 @@ pub fn init(src: std.builtin.SourceLocation, dir: enums.Direction, equal_space: 
     return self;
 }
 
-pub fn install(self: *BoxWidget) !void {
+pub fn install(self: *BoxWidget) std.mem.Allocator.Error!void {
     try self.wd.register();
 
     // our rect for children has to start at 0,0
@@ -66,7 +66,7 @@ pub fn install(self: *BoxWidget) !void {
     dvui.parentSet(self.widget());
 }
 
-pub fn drawBackground(self: *BoxWidget) !void {
+pub fn drawBackground(self: *BoxWidget) std.mem.Allocator.Error!void {
     try self.wd.borderAndBackground(.{});
 }
 

--- a/src/widgets/BoxWidget.zig
+++ b/src/widgets/BoxWidget.zig
@@ -43,7 +43,7 @@ pub fn init(src: std.builtin.SourceLocation, dir: enums.Direction, equal_space: 
     return self;
 }
 
-pub fn install(self: *BoxWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *BoxWidget) !void {
     self.wd.register();
 
     // our rect for children has to start at 0,0
@@ -66,7 +66,7 @@ pub fn install(self: *BoxWidget) std.mem.Allocator.Error!void {
     dvui.parentSet(self.widget());
 }
 
-pub fn drawBackground(self: *BoxWidget) std.mem.Allocator.Error!void {
+pub fn drawBackground(self: *BoxWidget) !void {
     try self.wd.borderAndBackground(.{});
 }
 

--- a/src/widgets/BoxWidget.zig
+++ b/src/widgets/BoxWidget.zig
@@ -44,7 +44,7 @@ pub fn init(src: std.builtin.SourceLocation, dir: enums.Direction, equal_space: 
 }
 
 pub fn install(self: *BoxWidget) std.mem.Allocator.Error!void {
-    try self.wd.register();
+    self.wd.register();
 
     // our rect for children has to start at 0,0
     self.child_rect = self.wd.contentRect().justSize();

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -40,7 +40,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *ButtonWidget) std.mem.Allocator.Error!void {
-    try self.wd.register();
+    self.wd.register();
     dvui.parentSet(self.widget());
 
     if (self.wd.visible()) {

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -39,7 +39,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *ButtonWidget) !void {
+pub fn install(self: *ButtonWidget) std.mem.Allocator.Error!void {
     try self.wd.register();
     dvui.parentSet(self.widget());
 
@@ -62,7 +62,7 @@ pub fn processEvents(self: *ButtonWidget) void {
     }
 }
 
-pub fn drawBackground(self: *ButtonWidget) !void {
+pub fn drawBackground(self: *ButtonWidget) std.mem.Allocator.Error!void {
     var fill_color: ?Color = null;
     if (dvui.captured(self.wd.id)) {
         fill_color = self.wd.options.color(.fill_press);
@@ -73,7 +73,7 @@ pub fn drawBackground(self: *ButtonWidget) !void {
     try self.wd.borderAndBackground(.{ .fill_color = fill_color });
 }
 
-pub fn drawFocus(self: *ButtonWidget) !void {
+pub fn drawFocus(self: *ButtonWidget) std.mem.Allocator.Error!void {
     if (self.init_options.draw_focus and self.focused()) {
         try self.wd.focusBorder();
     }

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -39,7 +39,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *ButtonWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *ButtonWidget) !void {
     self.wd.register();
     dvui.parentSet(self.widget());
 
@@ -62,7 +62,7 @@ pub fn processEvents(self: *ButtonWidget) void {
     }
 }
 
-pub fn drawBackground(self: *ButtonWidget) std.mem.Allocator.Error!void {
+pub fn drawBackground(self: *ButtonWidget) !void {
     var fill_color: ?Color = null;
     if (dvui.captured(self.wd.id)) {
         fill_color = self.wd.options.color(.fill_press);
@@ -73,7 +73,7 @@ pub fn drawBackground(self: *ButtonWidget) std.mem.Allocator.Error!void {
     try self.wd.borderAndBackground(.{ .fill_color = fill_color });
 }
 
-pub fn drawFocus(self: *ButtonWidget) std.mem.Allocator.Error!void {
+pub fn drawFocus(self: *ButtonWidget) !void {
     if (self.init_options.draw_focus and self.focused()) {
         try self.wd.focusBorder();
     }

--- a/src/widgets/CacheWidget.zig
+++ b/src/widgets/CacheWidget.zig
@@ -41,7 +41,7 @@ fn tce(self: *CacheWidget) ?*dvui.TextureCacheEntry {
     return dvui.currentWindow().texture_cache.getPtr(self.hash);
 }
 
-fn drawTce(self: *CacheWidget, t: *const dvui.TextureCacheEntry) !void {
+fn drawTce(self: *CacheWidget, t: *const dvui.TextureCacheEntry) std.mem.Allocator.Error!void {
     const rs = self.wd.contentRectScale();
 
     try dvui.renderTexture(t.texture, rs, .{ .uv = (Rect{}).toSize(self.tex_uv), .debug = self.wd.options.debugGet() });
@@ -51,7 +51,7 @@ fn drawTce(self: *CacheWidget, t: *const dvui.TextureCacheEntry) !void {
 }
 
 /// Must be called before install().
-pub fn invalidate(self: *CacheWidget) !void {
+pub fn invalidate(self: *CacheWidget) std.mem.Allocator.Error!void {
     if (self.tce()) |t| {
         // if we had a texture, show it this frame because our contents needs a frame to get sizing
         try self.drawTce(t);
@@ -65,7 +65,7 @@ pub fn invalidate(self: *CacheWidget) !void {
     }
 }
 
-pub fn install(self: *CacheWidget) !void {
+pub fn install(self: *CacheWidget) std.mem.Allocator.Error!void {
     dvui.parentSet(self.widget());
     try self.wd.register();
     try self.wd.borderAndBackground(.{});

--- a/src/widgets/CacheWidget.zig
+++ b/src/widgets/CacheWidget.zig
@@ -17,9 +17,8 @@ pub const InitOptions = struct {
 wd: WidgetData = undefined,
 hash: u64 = undefined,
 refresh_prev_value: u8 = undefined,
-caching: bool = false,
-caching_tex: dvui.TextureTarget = undefined,
-texture_create_error: bool = false,
+state: enum { ok, texture_create_error, unsupported } = .ok,
+caching_tex: ?dvui.TextureTarget = null,
 tex_uv: Size = undefined,
 old_target: dvui.RenderTarget = undefined,
 old_clip: ?Rect.Physical = null,
@@ -31,32 +30,35 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     self.wd = WidgetData.init(src, .{}, defaults.override(opts));
 
     self.hash = dvui.hashIdKey(self.wd.id, "_tex");
+    if (dvui.dataGet(null, self.wd.id, "_tex_uv", Size)) |uv| self.tex_uv = uv;
+    if (dvui.dataGet(null, self.wd.id, "_unsupported", bool) orelse false) self.state = .unsupported;
     self.tex_uv = dvui.dataGet(null, self.wd.id, "_tex_uv", Size) orelse .{};
     self.refresh_prev_value = dvui.currentWindow().extra_frames_needed;
     dvui.currentWindow().extra_frames_needed = 0;
     return self;
 }
 
-fn tce(self: *CacheWidget) ?*dvui.TextureCacheEntry {
-    return dvui.currentWindow().texture_cache.getPtr(self.hash);
+fn getCachedTexture(self: *CacheWidget) ?dvui.Texture {
+    const entry = dvui.currentWindow().texture_cache.getPtr(self.hash) orelse return null;
+    return entry.texture;
 }
 
-fn drawTce(self: *CacheWidget, t: *const dvui.TextureCacheEntry) std.mem.Allocator.Error!void {
+fn drawCachedTexture(self: *CacheWidget, t: dvui.Texture) !void {
     const rs = self.wd.contentRectScale();
 
-    try dvui.renderTexture(t.texture, rs, .{ .uv = (Rect{}).toSize(self.tex_uv), .debug = self.wd.options.debugGet() });
+    try dvui.renderTexture(t, rs, .{ .uv = (Rect{}).toSize(self.tex_uv), .debug = self.wd.options.debugGet() });
     //if (self.wd.options.debugGet()) {
     //    dvui.log.debug("drawing {d} {d} {d}x{d} {d}x{d} {d} {d}", .{ rs.r.x, rs.r.y, rs.r.w, rs.r.h, t.texture.width, t.texture.height, self.tex_uv.w, self.tex_uv.h });
     //}
 }
 
 /// Must be called before install().
-pub fn invalidate(self: *CacheWidget) std.mem.Allocator.Error!void {
-    if (self.tce()) |t| {
+pub fn invalidate(self: *CacheWidget) !void {
+    if (self.getCachedTexture()) |t| {
         // if we had a texture, show it this frame because our contents needs a frame to get sizing
-        try self.drawTce(t);
+        try self.drawCachedTexture(t);
 
-        dvui.textureDestroyLater(t.texture);
+        dvui.textureDestroyLater(t);
         _ = dvui.currentWindow().texture_cache.remove(self.hash);
 
         // now we've shown the texture, so prevent any widgets from drawing on top of it this frame
@@ -65,53 +67,57 @@ pub fn invalidate(self: *CacheWidget) std.mem.Allocator.Error!void {
     }
 }
 
-pub fn install(self: *CacheWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *CacheWidget) !void {
     dvui.parentSet(self.widget());
     self.wd.register();
     try self.wd.borderAndBackground(.{});
 
-    if (self.tce()) |t| {
+    if (self.state != .ok) return;
+
+    if (self.getCachedTexture()) |t| {
         // successful cache, draw texture and enforce min size
-        try self.drawTce(t);
+        try self.drawCachedTexture(t);
         self.wd.minSizeMax(self.wd.rect.size());
     } else {
 
         // we need to cache, but only do it if we didn't have any refreshes from last frame
         if (dvui.dataGet(null, self.wd.id, "_cache_now", bool) orelse false) {
-            self.caching = true;
-        }
-
-        if (self.caching) {
             const rs = self.wd.contentRectScale();
             const w: u32 = @intFromFloat(@ceil(rs.r.w));
             const h: u32 = @intFromFloat(@ceil(rs.r.h));
             self.tex_uv = .{ .w = rs.r.w / @ceil(rs.r.w), .h = rs.r.h / @ceil(rs.r.h) };
 
-            if (self.caching) {
-                self.caching_tex = dvui.textureCreateTarget(w, h, .linear) catch |err| blk: {
-                    if (err == error.TextureCreate) {
-                        self.texture_create_error = dvui.dataGet(null, self.wd.id, "_texture_create_error", bool) orelse false;
-                        if (!self.texture_create_error) {
-                            // indicate that texture failed last frame to prevent backends that always return errors from forever refreshing
-                            dvui.dataSet(null, self.wd.id, "_texture_create_error", true);
-                        }
+            self.caching_tex = dvui.textureCreateTarget(w, h, .linear) catch |err| switch (err) {
+                error.TextureCreate => blk: {
+                    self.state = .texture_create_error;
+                    if (dvui.dataGet(null, self.wd.id, "_texture_create_error", bool) orelse false) {
+                        // indicate that texture failed last frame to prevent backends that always return errors from forever refreshing
+                        dvui.dataSet(null, self.wd.id, "_texture_create_error", true);
                     }
-                    self.caching = false;
-                    break :blk undefined;
-                };
-            }
+                    break :blk null;
+                },
+                else => |e| return e,
+            };
+            errdefer if (self.caching_tex) |cache_tex| {
+                // There is no destroy for targets so this will do
+                if (dvui.textureFromTarget(cache_tex) catch null) |tex| dvui.textureDestroyLater(tex);
+                self.caching_tex = null;
+            };
 
-            if (self.caching) {
+            if (self.caching_tex) |tex| {
                 var offset = rs.r.topLeft();
                 if (dvui.snapToPixels()) {
                     offset.x = @round(offset.x);
                     offset.y = @round(offset.y);
                 }
-                self.old_target = dvui.renderTarget(.{ .texture = self.caching_tex, .offset = offset });
+                self.old_target = try dvui.renderTarget(.{ .texture = tex, .offset = offset });
 
                 // clip to just us, even if we are off screen
                 self.old_clip = dvui.clipGet();
                 dvui.clipSet(rs.r);
+            } else if (self.state != .texture_create_error) {
+                // `textureCreateTarget` returned null, indicating render target are unsupported
+                dvui.dataSet(null, self.wd.id, "_unsupported", true);
             }
         }
     }
@@ -119,7 +125,7 @@ pub fn install(self: *CacheWidget) std.mem.Allocator.Error!void {
 
 /// Must be called after install().
 pub fn uncached(self: *CacheWidget) bool {
-    return (self.caching or self.tce() == null);
+    return (self.caching_tex != null or self.getCachedTexture() == null);
 }
 
 pub fn widget(self: *CacheWidget) Widget {
@@ -150,9 +156,11 @@ pub fn processEvent(self: *CacheWidget, e: *dvui.Event, bubbling: bool) void {
     }
 }
 
-pub fn deinit(self: *CacheWidget) void {
+/// This deinit function returns an error because of the additional
+/// texture handling it requires.
+pub fn deinit(self: *CacheWidget) !void {
     const cw = dvui.currentWindow();
-    if (!self.texture_create_error and self.uncached()) {
+    if (self.state == .ok and self.uncached()) {
         if (dvui.currentWindow().extra_frames_needed == 0) {
             dvui.dataSet(null, self.wd.id, "_cache_now", true);
             dvui.refresh(null, @src(), self.wd.id);
@@ -163,17 +171,15 @@ pub fn deinit(self: *CacheWidget) void {
     if (self.old_clip) |clip| {
         dvui.clipSet(clip);
     }
-    if (self.caching) {
-        _ = dvui.renderTarget(self.old_target);
+    if (self.caching_tex) |tex| {
+        _ = try dvui.renderTarget(self.old_target);
 
-        // convert texture target to normal texture
-        const entry = dvui.TextureCacheEntry{ .texture = dvui.textureFromTarget(self.caching_tex) }; // destroys self.caching_tex
-        cw.texture_cache.put(cw.gpa, self.hash, entry) catch @panic("OOM");
+        // convert texture target to normal texture, destroys self.caching_tex
+        const texture = try dvui.textureFromTarget(tex);
+        try cw.texture_cache.put(cw.gpa, self.hash, .{ .texture = texture });
 
         // draw texture so we see it this frame
-        self.drawTce(&entry) catch {
-            dvui.log.debug("{x} CacheWidget.deinit failed to render texture\n", .{self.wd.id});
-        };
+        try self.drawCachedTexture(texture);
 
         dvui.dataSet(null, self.wd.id, "_tex_uv", self.tex_uv);
         dvui.dataRemove(null, self.wd.id, "_cache_now");

--- a/src/widgets/CacheWidget.zig
+++ b/src/widgets/CacheWidget.zig
@@ -67,7 +67,7 @@ pub fn invalidate(self: *CacheWidget) std.mem.Allocator.Error!void {
 
 pub fn install(self: *CacheWidget) std.mem.Allocator.Error!void {
     dvui.parentSet(self.widget());
-    try self.wd.register();
+    self.wd.register();
     try self.wd.borderAndBackground(.{});
 
     if (self.tce()) |t| {

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -31,7 +31,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *ColorPickerWidget) !void {
+pub fn install(self: *ColorPickerWidget) std.mem.Allocator.Error!void {
     self.box = try dvui.box(self.src, self.init_opts.dir, self.opts);
 
     if (try valueSaturationBox(@src(), self.init_opts.hsv, .{})) {
@@ -55,7 +55,7 @@ pub const value_saturation_box_defaults = Options{
 };
 
 /// Returns true if the color was changed
-pub fn valueSaturationBox(src: std.builtin.SourceLocation, hsv: *Color.HSV, opts: Options) !bool {
+pub fn valueSaturationBox(src: std.builtin.SourceLocation, hsv: *Color.HSV, opts: Options) std.mem.Allocator.Error!bool {
     const options = value_saturation_box_defaults.override(opts);
 
     var b = try dvui.box(src, .horizontal, options);
@@ -175,7 +175,7 @@ pub var hue_slider_defaults: Options = .{
 /// Returns true if the hue was changed
 ///
 /// `hue` >= 0 and `hue` < 360
-pub fn hueSlider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hue: *f32, opts: Options) !bool {
+pub fn hueSlider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hue: *f32, opts: Options) std.mem.Allocator.Error!bool {
     var fraction = std.math.clamp(hue.* / 360, 0, 1);
     std.debug.assert(fraction >= 0);
     std.debug.assert(fraction <= 1);
@@ -304,7 +304,7 @@ pub fn hueSlider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hue
     return ret;
 }
 
-pub fn getHueSelectorTexture(dir: dvui.enums.Direction) !dvui.Texture {
+pub fn getHueSelectorTexture(dir: dvui.enums.Direction) std.mem.Allocator.Error!dvui.Texture {
     const hue_texture_id = dvui.hashIdKey(@enumFromInt(@as(u64, @intFromEnum(dir))), "hue_selector_texture");
     const cw = dvui.currentWindow();
     const res = try cw.texture_cache.getOrPut(cw.gpa, hue_texture_id);
@@ -319,7 +319,7 @@ pub fn getHueSelectorTexture(dir: dvui.enums.Direction) !dvui.Texture {
     return res.value_ptr.texture;
 }
 
-pub fn getValueSaturationTexture(hue: f32) !dvui.Texture {
+pub fn getValueSaturationTexture(hue: f32) std.mem.Allocator.Error!dvui.Texture {
     const hue_texture_id = dvui.hashIdKey(@enumFromInt(@as(u64, @intFromFloat(hue * 10000))), "value_saturation_texture");
     const cw = dvui.currentWindow();
     const res = try cw.texture_cache.getOrPut(cw.gpa, hue_texture_id);

--- a/src/widgets/ContextWidget.zig
+++ b/src/widgets/ContextWidget.zig
@@ -43,7 +43,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *ContextWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *ContextWidget) !void {
     dvui.parentSet(self.widget());
     self.wd.register();
     try self.wd.borderAndBackground(.{});

--- a/src/widgets/ContextWidget.zig
+++ b/src/widgets/ContextWidget.zig
@@ -43,7 +43,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *ContextWidget) !void {
+pub fn install(self: *ContextWidget) std.mem.Allocator.Error!void {
     dvui.parentSet(self.widget());
     try self.wd.register();
     try self.wd.borderAndBackground(.{});

--- a/src/widgets/ContextWidget.zig
+++ b/src/widgets/ContextWidget.zig
@@ -45,7 +45,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 
 pub fn install(self: *ContextWidget) std.mem.Allocator.Error!void {
     dvui.parentSet(self.widget());
-    try self.wd.register();
+    self.wd.register();
     try self.wd.borderAndBackground(.{});
 }
 

--- a/src/widgets/FlexBoxWidget.zig
+++ b/src/widgets/FlexBoxWidget.zig
@@ -35,14 +35,14 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *FlexBoxWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *FlexBoxWidget) !void {
     self.wd.register();
     dvui.parentSet(self.widget());
 
     self.prevClip = dvui.clip(self.wd.contentRectScale().r);
 }
 
-pub fn drawBackground(self: *FlexBoxWidget) std.mem.Allocator.Error!void {
+pub fn drawBackground(self: *FlexBoxWidget) !void {
     const clip = dvui.clipGet();
     dvui.clipSet(self.prevClip);
     try self.wd.borderAndBackground(.{});

--- a/src/widgets/FlexBoxWidget.zig
+++ b/src/widgets/FlexBoxWidget.zig
@@ -35,14 +35,14 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *FlexBoxWidget) !void {
+pub fn install(self: *FlexBoxWidget) std.mem.Allocator.Error!void {
     try self.wd.register();
     dvui.parentSet(self.widget());
 
     self.prevClip = dvui.clip(self.wd.contentRectScale().r);
 }
 
-pub fn drawBackground(self: *FlexBoxWidget) !void {
+pub fn drawBackground(self: *FlexBoxWidget) std.mem.Allocator.Error!void {
     const clip = dvui.clipGet();
     dvui.clipSet(self.prevClip);
     try self.wd.borderAndBackground(.{});

--- a/src/widgets/FlexBoxWidget.zig
+++ b/src/widgets/FlexBoxWidget.zig
@@ -36,7 +36,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *FlexBoxWidget) std.mem.Allocator.Error!void {
-    try self.wd.register();
+    self.wd.register();
     dvui.parentSet(self.widget());
 
     self.prevClip = dvui.clip(self.wd.contentRectScale().r);

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -124,7 +124,7 @@ pub fn install(self: *FloatingMenuWidget) std.mem.Allocator.Error!void {
 
     try dvui.subwindowAdd(self.wd.id, self.wd.rect, rs.r, false, null);
     dvui.captureMouseMaintain(.{ .id = self.wd.id, .rect = rs.r, .subwindow_id = self.wd.id });
-    try self.wd.register();
+    self.wd.register();
 
     // first break out of whatever clip we were in (so box shadows work, since
     // they are outside our window)

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -91,7 +91,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *FloatingMenuWidget) !void {
+pub fn install(self: *FloatingMenuWidget) std.mem.Allocator.Error!void {
     self.prev_rendering = dvui.renderingSet(false);
 
     dvui.parentSet(self.widget());

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -91,7 +91,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *FloatingMenuWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *FloatingMenuWidget) !void {
     self.prev_rendering = dvui.renderingSet(false);
 
     dvui.parentSet(self.widget());

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -178,7 +178,7 @@ pub fn install(self: *FloatingTooltipWidget) !void {
 
     try dvui.subwindowAdd(self.wd.id, self.wd.rect, rs.r, false, self.prev_windowId);
     dvui.captureMouseMaintain(.{ .id = self.wd.id, .rect = rs.r, .subwindow_id = self.wd.id });
-    try self.wd.register();
+    self.wd.register();
 
     // first clip to the whole window to break out of whatever clipping we
     // might have been in (example: might be nested inside another tooltip)

--- a/src/widgets/FloatingWidget.zig
+++ b/src/widgets/FloatingWidget.zig
@@ -49,7 +49,7 @@ pub fn init(src: std.builtin.SourceLocation, opts_in: Options) FloatingWidget {
     return self;
 }
 
-pub fn install(self: *FloatingWidget) !void {
+pub fn install(self: *FloatingWidget) std.mem.Allocator.Error!void {
     self.prev_rendering = dvui.renderingSet(false);
 
     dvui.parentSet(self.widget());

--- a/src/widgets/FloatingWidget.zig
+++ b/src/widgets/FloatingWidget.zig
@@ -49,7 +49,7 @@ pub fn init(src: std.builtin.SourceLocation, opts_in: Options) FloatingWidget {
     return self;
 }
 
-pub fn install(self: *FloatingWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *FloatingWidget) !void {
     self.prev_rendering = dvui.renderingSet(false);
 
     dvui.parentSet(self.widget());

--- a/src/widgets/FloatingWidget.zig
+++ b/src/widgets/FloatingWidget.zig
@@ -60,7 +60,7 @@ pub fn install(self: *FloatingWidget) std.mem.Allocator.Error!void {
 
     try dvui.subwindowAdd(self.wd.id, self.wd.rect, rs.r, false, self.prev_windowId);
     dvui.captureMouseMaintain(.{ .id = self.wd.id, .rect = rs.r, .subwindow_id = self.wd.id });
-    try self.wd.register();
+    self.wd.register();
 
     // first break out of whatever clipping we were in
     self.prevClip = dvui.clipGet();

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -239,7 +239,7 @@ pub fn install(self: *FloatingWindowWidget) !void {
     dvui.clipSet(dvui.windowRectPixels());
 }
 
-pub fn drawBackground(self: *FloatingWindowWidget) !void {
+pub fn drawBackground(self: *FloatingWindowWidget) std.mem.Allocator.Error!void {
     const rs = self.wd.rectScale();
     try dvui.subwindowAdd(self.wd.id, self.wd.rect, rs.r, self.init_options.modal, if (self.init_options.stay_above_parent_window) self.prev_windowInfo.id else null);
     dvui.captureMouseMaintain(.{ .id = self.wd.id, .rect = rs.r, .subwindow_id = self.wd.id });

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -243,7 +243,7 @@ pub fn drawBackground(self: *FloatingWindowWidget) std.mem.Allocator.Error!void 
     const rs = self.wd.rectScale();
     try dvui.subwindowAdd(self.wd.id, self.wd.rect, rs.r, self.init_options.modal, if (self.init_options.stay_above_parent_window) self.prev_windowInfo.id else null);
     dvui.captureMouseMaintain(.{ .id = self.wd.id, .rect = rs.r, .subwindow_id = self.wd.id });
-    try self.wd.register();
+    self.wd.register();
 
     if (self.init_options.modal) {
         // paint over everything below

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -239,7 +239,7 @@ pub fn install(self: *FloatingWindowWidget) !void {
     dvui.clipSet(dvui.windowRectPixels());
 }
 
-pub fn drawBackground(self: *FloatingWindowWidget) std.mem.Allocator.Error!void {
+pub fn drawBackground(self: *FloatingWindowWidget) !void {
     const rs = self.wd.rectScale();
     try dvui.subwindowAdd(self.wd.id, self.wd.rect, rs.r, self.init_options.modal, if (self.init_options.stay_above_parent_window) self.prev_windowInfo.id else null);
     dvui.captureMouseMaintain(.{ .id = self.wd.id, .rect = rs.r, .subwindow_id = self.wd.id });

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -106,7 +106,7 @@ saved_clip_rect: ?Rect.Physical = null,
 resizing: bool = false,
 rows_y_offset: f32 = 0,
 
-pub fn init(src: std.builtin.SourceLocation, init_opts: InitOpts, opts: Options) !GridWidget {
+pub fn init(src: std.builtin.SourceLocation, init_opts: InitOpts, opts: Options) GridWidget {
     var self = GridWidget{};
     self.init_opts = init_opts;
     const options = defaults.override(opts);
@@ -142,7 +142,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOpts, opts: Options)
     return self;
 }
 
-pub fn install(self: *GridWidget) !void {
+pub fn install(self: *GridWidget) std.mem.Allocator.Error!void {
     try self.vbox.install();
     try self.vbox.drawBackground();
 
@@ -190,7 +190,7 @@ pub fn data(self: *GridWidget) *WidgetData {
 /// 2) opts.width if supplied
 /// 3) Otherewise column will expand to the available space.
 /// It is recommended that widths are provided for all columns.
-pub fn column(self: *GridWidget, src: std.builtin.SourceLocation, opts: ColOptions) !*BoxWidget {
+pub fn column(self: *GridWidget, src: std.builtin.SourceLocation, opts: ColOptions) std.mem.Allocator.Error!*BoxWidget {
     self.clipReset();
     self.current_col = null;
 
@@ -246,7 +246,7 @@ fn clipReset(self: *GridWidget) void {
 /// Returns a hbox. deinit() must be called on this hbox before creating a new cell.
 /// Only one header cell is allowed per column.
 /// Height is taken from opts.height if provided, otherwise height is automatically determined.
-pub fn headerCell(self: *GridWidget, src: std.builtin.SourceLocation, opts: CellOptions) !*BoxWidget {
+pub fn headerCell(self: *GridWidget, src: std.builtin.SourceLocation, opts: CellOptions) std.mem.Allocator.Error!*BoxWidget {
     const y: f32 = self.scroll.si.viewport.y;
     const parent_rect = self.current_col.?.data().contentRect();
 
@@ -278,7 +278,7 @@ pub fn headerCell(self: *GridWidget, src: std.builtin.SourceLocation, opts: Cell
 /// Create a new body cell within a column
 /// Returns a hbox. deinit() must be called on this hbox before creating a new cell.
 /// Height is taken from opts.height if provided, otherwise height is automatically determined.
-pub fn bodyCell(self: *GridWidget, src: std.builtin.SourceLocation, row_num: usize, opts: CellOptions) !*BoxWidget {
+pub fn bodyCell(self: *GridWidget, src: std.builtin.SourceLocation, row_num: usize, opts: CellOptions) std.mem.Allocator.Error!*BoxWidget {
     const parent_rect = self.current_col.?.data().contentRect();
 
     const cell_height: f32 = height: {

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -142,7 +142,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOpts, opts: Options)
     return self;
 }
 
-pub fn install(self: *GridWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *GridWidget) !void {
     try self.vbox.install();
     try self.vbox.drawBackground();
 
@@ -190,7 +190,7 @@ pub fn data(self: *GridWidget) *WidgetData {
 /// 2) opts.width if supplied
 /// 3) Otherewise column will expand to the available space.
 /// It is recommended that widths are provided for all columns.
-pub fn column(self: *GridWidget, src: std.builtin.SourceLocation, opts: ColOptions) std.mem.Allocator.Error!*BoxWidget {
+pub fn column(self: *GridWidget, src: std.builtin.SourceLocation, opts: ColOptions) !*BoxWidget {
     self.clipReset();
     self.current_col = null;
 
@@ -246,7 +246,7 @@ fn clipReset(self: *GridWidget) void {
 /// Returns a hbox. deinit() must be called on this hbox before creating a new cell.
 /// Only one header cell is allowed per column.
 /// Height is taken from opts.height if provided, otherwise height is automatically determined.
-pub fn headerCell(self: *GridWidget, src: std.builtin.SourceLocation, opts: CellOptions) std.mem.Allocator.Error!*BoxWidget {
+pub fn headerCell(self: *GridWidget, src: std.builtin.SourceLocation, opts: CellOptions) !*BoxWidget {
     const y: f32 = self.scroll.si.viewport.y;
     const parent_rect = self.current_col.?.data().contentRect();
 
@@ -278,7 +278,7 @@ pub fn headerCell(self: *GridWidget, src: std.builtin.SourceLocation, opts: Cell
 /// Create a new body cell within a column
 /// Returns a hbox. deinit() must be called on this hbox before creating a new cell.
 /// Height is taken from opts.height if provided, otherwise height is automatically determined.
-pub fn bodyCell(self: *GridWidget, src: std.builtin.SourceLocation, row_num: usize, opts: CellOptions) std.mem.Allocator.Error!*BoxWidget {
+pub fn bodyCell(self: *GridWidget, src: std.builtin.SourceLocation, row_num: usize, opts: CellOptions) !*BoxWidget {
     const parent_rect = self.current_col.?.data().contentRect();
 
     const cell_height: f32 = height: {

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -482,7 +482,7 @@ pub const HeaderResizeWidget = struct {
     }
 
     pub fn install(self: *HeaderResizeWidget) !void {
-        try self.wd.register();
+        self.wd.register();
         try self.wd.borderAndBackground(.{});
     }
 

--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -34,7 +34,7 @@ pub fn init(src: std.builtin.SourceLocation, name: []const u8, tvg_bytes: []cons
     return self;
 }
 
-pub fn install(self: *IconWidget) !void {
+pub fn install(self: *IconWidget) std.mem.Allocator.Error!void {
     try self.wd.register();
     try self.wd.borderAndBackground(.{});
 }

--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -34,7 +34,7 @@ pub fn init(src: std.builtin.SourceLocation, name: []const u8, tvg_bytes: []cons
     return self;
 }
 
-pub fn install(self: *IconWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *IconWidget) !void {
     self.wd.register();
     try self.wd.borderAndBackground(.{});
 }

--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -35,7 +35,7 @@ pub fn init(src: std.builtin.SourceLocation, name: []const u8, tvg_bytes: []cons
 }
 
 pub fn install(self: *IconWidget) std.mem.Allocator.Error!void {
-    try self.wd.register();
+    self.wd.register();
     try self.wd.borderAndBackground(.{});
 }
 

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -46,7 +46,7 @@ pub fn data(self: *LabelWidget) *WidgetData {
 }
 
 pub fn install(self: *LabelWidget) std.mem.Allocator.Error!void {
-    try self.wd.register();
+    self.wd.register();
     try self.wd.borderAndBackground(.{});
 }
 

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -45,7 +45,7 @@ pub fn data(self: *LabelWidget) *WidgetData {
     return &self.wd;
 }
 
-pub fn install(self: *LabelWidget) !void {
+pub fn install(self: *LabelWidget) std.mem.Allocator.Error!void {
     try self.wd.register();
     try self.wd.borderAndBackground(.{});
 }

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -48,7 +48,7 @@ pub fn data(self: *LabelWidget) *WidgetData {
     return &self.wd;
 }
 
-pub fn install(self: *LabelWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *LabelWidget) !void {
     self.wd.register();
     try self.wd.borderAndBackground(.{});
 }

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -15,9 +15,10 @@ pub var defaults: Options = .{
 };
 
 wd: WidgetData = undefined,
-label_str: []const u8 = undefined,
+label_str: []const u8,
 
 pub fn init(src: std.builtin.SourceLocation, comptime fmt: []const u8, args: anytype, opts: Options) LabelWidget {
+    comptime if (!std.unicode.utf8ValidateSlice(fmt)) @compileError("Format strings must be valid utf-8");
     const l = std.fmt.allocPrint(dvui.currentWindow().arena(), fmt, args) catch |err| blk: {
         const newid = dvui.parentGet().extendId(src, opts.idExtra());
         dvui.currentWindow().debug_widget_id = newid;
@@ -29,9 +30,11 @@ pub fn init(src: std.builtin.SourceLocation, comptime fmt: []const u8, args: any
 }
 
 pub fn initNoFmt(src: std.builtin.SourceLocation, label_str: []const u8, opts: Options) LabelWidget {
-    var self = LabelWidget{};
+    var self = LabelWidget{
+        .label_str = dvui.toUtf8(dvui.currentWindow().arena(), label_str) catch label_str,
+    };
+
     const options = defaults.override(opts);
-    self.label_str = label_str;
 
     var size = options.fontGet().textSize(self.label_str);
     size = Size.max(size, options.min_size_contentGet());

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -53,7 +53,7 @@ pub fn install(self: *MenuItemWidget) !void {
     dvui.parentSet(self.widget());
 }
 
-pub fn drawBackground(self: *MenuItemWidget, opts: struct { focus_as_outline: bool = false }) std.mem.Allocator.Error!void {
+pub fn drawBackground(self: *MenuItemWidget, opts: struct { focus_as_outline: bool = false }) !void {
     var focused: bool = false;
     if (self.wd.id == dvui.focusedWidgetId()) {
         focused = true;

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -53,7 +53,7 @@ pub fn install(self: *MenuItemWidget) !void {
     dvui.parentSet(self.widget());
 }
 
-pub fn drawBackground(self: *MenuItemWidget, opts: struct { focus_as_outline: bool = false }) !void {
+pub fn drawBackground(self: *MenuItemWidget, opts: struct { focus_as_outline: bool = false }) std.mem.Allocator.Error!void {
     var focused: bool = false;
     if (self.wd.id == dvui.focusedWidgetId()) {
         focused = true;

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -40,7 +40,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *MenuItemWidget) !void {
-    try self.wd.register();
+    self.wd.register();
 
     // For most widgets we only tabIndexSet if they are visible, but menu
     // items are often in large dropdowns that are scrollable, plus the

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -80,7 +80,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 pub fn install(self: *MenuWidget) std.mem.Allocator.Error!void {
     dvui.parentSet(self.widget());
     self.parentMenu = menuSet(self);
-    try self.wd.register();
+    self.wd.register();
     try self.wd.borderAndBackground(.{});
 
     const evts = dvui.events();

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -77,7 +77,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *MenuWidget) !void {
+pub fn install(self: *MenuWidget) std.mem.Allocator.Error!void {
     dvui.parentSet(self.widget());
     self.parentMenu = menuSet(self);
     try self.wd.register();

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -77,7 +77,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *MenuWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *MenuWidget) !void {
     dvui.parentSet(self.widget());
     self.parentMenu = menuSet(self);
     self.wd.register();

--- a/src/widgets/OverlayWidget.zig
+++ b/src/widgets/OverlayWidget.zig
@@ -18,12 +18,12 @@ pub fn init(src: std.builtin.SourceLocation, opts: Options) OverlayWidget {
     return OverlayWidget{ .wd = WidgetData.init(src, .{}, defaults.override(opts)) };
 }
 
-pub fn install(self: *OverlayWidget) !void {
+pub fn install(self: *OverlayWidget) std.mem.Allocator.Error!void {
     dvui.parentSet(self.widget());
     try self.wd.register();
 }
 
-pub fn drawBackground(self: *OverlayWidget) !void {
+pub fn drawBackground(self: *OverlayWidget) std.mem.Allocator.Error!void {
     try self.wd.borderAndBackground(.{});
 }
 

--- a/src/widgets/OverlayWidget.zig
+++ b/src/widgets/OverlayWidget.zig
@@ -18,12 +18,12 @@ pub fn init(src: std.builtin.SourceLocation, opts: Options) OverlayWidget {
     return OverlayWidget{ .wd = WidgetData.init(src, .{}, defaults.override(opts)) };
 }
 
-pub fn install(self: *OverlayWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *OverlayWidget) !void {
     dvui.parentSet(self.widget());
     self.wd.register();
 }
 
-pub fn drawBackground(self: *OverlayWidget) std.mem.Allocator.Error!void {
+pub fn drawBackground(self: *OverlayWidget) !void {
     try self.wd.borderAndBackground(.{});
 }
 

--- a/src/widgets/OverlayWidget.zig
+++ b/src/widgets/OverlayWidget.zig
@@ -20,7 +20,7 @@ pub fn init(src: std.builtin.SourceLocation, opts: Options) OverlayWidget {
 
 pub fn install(self: *OverlayWidget) std.mem.Allocator.Error!void {
     dvui.parentSet(self.widget());
-    try self.wd.register();
+    self.wd.register();
 }
 
 pub fn drawBackground(self: *OverlayWidget) std.mem.Allocator.Error!void {

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -114,7 +114,7 @@ pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Op
     return self;
 }
 
-pub fn install(self: *PanedWidget) !void {
+pub fn install(self: *PanedWidget) std.mem.Allocator.Error!void {
     try self.wd.register();
 
     try self.wd.borderAndBackground(.{});
@@ -137,7 +137,7 @@ pub fn processEvents(self: *PanedWidget) void {
     }
 }
 
-pub fn draw(self: *PanedWidget) !void {
+pub fn draw(self: *PanedWidget) std.mem.Allocator.Error!void {
     if (self.collapsed()) return;
 
     if (dvui.captured(self.wd.id)) {

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -115,7 +115,7 @@ pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Op
 }
 
 pub fn install(self: *PanedWidget) std.mem.Allocator.Error!void {
-    try self.wd.register();
+    self.wd.register();
 
     try self.wd.borderAndBackground(.{});
     self.prevClip = dvui.clip(self.wd.contentRectScale().r);

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -114,7 +114,7 @@ pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Op
     return self;
 }
 
-pub fn install(self: *PanedWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *PanedWidget) !void {
     self.wd.register();
 
     try self.wd.borderAndBackground(.{});
@@ -137,7 +137,7 @@ pub fn processEvents(self: *PanedWidget) void {
     }
 }
 
-pub fn draw(self: *PanedWidget) std.mem.Allocator.Error!void {
+pub fn draw(self: *PanedWidget) !void {
     if (self.collapsed()) return;
 
     if (dvui.captured(self.wd.id)) {

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -27,7 +27,7 @@ pub fn init(src: std.builtin.SourceLocation, opts: Options) ReorderWidget {
     return self;
 }
 
-pub fn install(self: *ReorderWidget) !void {
+pub fn install(self: *ReorderWidget) std.mem.Allocator.Error!void {
     try self.wd.register();
     try self.wd.borderAndBackground(.{});
 
@@ -192,7 +192,7 @@ pub fn draggable(src: std.builtin.SourceLocation, init_opts: draggableInitOption
     return ret;
 }
 
-pub fn reorderable(self: *ReorderWidget, src: std.builtin.SourceLocation, init_opts: Reorderable.InitOptions, opts: Options) !*Reorderable {
+pub fn reorderable(self: *ReorderWidget, src: std.builtin.SourceLocation, init_opts: Reorderable.InitOptions, opts: Options) std.mem.Allocator.Error!*Reorderable {
     const ret = try dvui.currentWindow().arena().create(Reorderable);
     ret.* = Reorderable.init(src, self, init_opts, opts);
     try ret.install();
@@ -246,7 +246,7 @@ pub const Reorderable = struct {
         return false;
     }
 
-    pub fn install(self: *Reorderable) !void {
+    pub fn install(self: *Reorderable) std.mem.Allocator.Error!void {
         self.installed = true;
         if (self.reorder.drag_point) |dp| {
             const topleft = dp.plus(dvui.dragOffset());
@@ -321,7 +321,7 @@ pub const Reorderable = struct {
         return false;
     }
 
-    pub fn reinstall(self: *Reorderable) !void {
+    pub fn reinstall(self: *Reorderable) std.mem.Allocator.Error!void {
         // send our target rect to the parent for sizing
         self.wd.minSizeMax(self.wd.rect.size());
         self.wd.minSizeReportToParent();

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -28,7 +28,7 @@ pub fn init(src: std.builtin.SourceLocation, opts: Options) ReorderWidget {
 }
 
 pub fn install(self: *ReorderWidget) std.mem.Allocator.Error!void {
-    try self.wd.register();
+    self.wd.register();
     try self.wd.borderAndBackground(.{});
 
     dvui.parentSet(self.widget());
@@ -252,7 +252,7 @@ pub const Reorderable = struct {
             const topleft = dp.plus(dvui.dragOffset());
             if (self.reorder.id_reorderable.? == (self.init_options.reorder_id orelse self.wd.id.asUsize())) {
                 // we are being dragged - put in floating widget
-                try self.wd.register();
+                self.wd.register();
                 dvui.parentSet(self.widget());
 
                 self.floating_widget = dvui.FloatingWidget.init(@src(), .{ .rect = Rect.fromPoint(.cast(topleft.toNatural())), .min_size_content = self.reorder.reorderable_size });
@@ -281,7 +281,7 @@ pub const Reorderable = struct {
                 }
 
                 if (self.target_rs == null or self.init_options.last_slot) {
-                    try self.wd.register();
+                    self.wd.register();
                     dvui.parentSet(self.widget());
                 }
             }
@@ -289,7 +289,7 @@ pub const Reorderable = struct {
             self.wd = WidgetData.init(self.wd.src, .{}, self.options);
             self.reorder.reorderable_size = self.wd.rect.size();
 
-            try self.wd.register();
+            self.wd.register();
             dvui.parentSet(self.widget());
         }
     }
@@ -328,7 +328,7 @@ pub const Reorderable = struct {
 
         // reinstall ourselves getting the next rect from parent
         self.wd = WidgetData.init(self.wd.src, .{}, self.options);
-        try self.wd.register();
+        self.wd.register();
         dvui.parentSet(self.widget());
     }
 

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -27,7 +27,7 @@ pub fn init(src: std.builtin.SourceLocation, opts: Options) ReorderWidget {
     return self;
 }
 
-pub fn install(self: *ReorderWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *ReorderWidget) !void {
     self.wd.register();
     try self.wd.borderAndBackground(.{});
 
@@ -192,7 +192,7 @@ pub fn draggable(src: std.builtin.SourceLocation, init_opts: draggableInitOption
     return ret;
 }
 
-pub fn reorderable(self: *ReorderWidget, src: std.builtin.SourceLocation, init_opts: Reorderable.InitOptions, opts: Options) std.mem.Allocator.Error!*Reorderable {
+pub fn reorderable(self: *ReorderWidget, src: std.builtin.SourceLocation, init_opts: Reorderable.InitOptions, opts: Options) !*Reorderable {
     const ret = try dvui.currentWindow().arena().create(Reorderable);
     ret.* = Reorderable.init(src, self, init_opts, opts);
     try ret.install();
@@ -246,7 +246,7 @@ pub const Reorderable = struct {
         return false;
     }
 
-    pub fn install(self: *Reorderable) std.mem.Allocator.Error!void {
+    pub fn install(self: *Reorderable) !void {
         self.installed = true;
         if (self.reorder.drag_point) |dp| {
             const topleft = dp.plus(dvui.dragOffset());
@@ -276,7 +276,7 @@ pub const Reorderable = struct {
                     }
 
                     if (self.init_options.reinstall and !self.init_options.last_slot) {
-                        try self.reinstall();
+                        self.reinstall();
                     }
                 }
 
@@ -321,7 +321,7 @@ pub const Reorderable = struct {
         return false;
     }
 
-    pub fn reinstall(self: *Reorderable) std.mem.Allocator.Error!void {
+    pub fn reinstall(self: *Reorderable) void {
         // send our target rect to the parent for sizing
         self.wd.minSizeMax(self.wd.rect.size());
         self.wd.minSizeReportToParent();

--- a/src/widgets/ScaleWidget.zig
+++ b/src/widgets/ScaleWidget.zig
@@ -54,7 +54,7 @@ pub fn install(self: *ScaleWidget) std.mem.Allocator.Error!void {
     }
 
     dvui.parentSet(self.widget());
-    try self.wd.register();
+    self.wd.register();
     try self.wd.borderAndBackground(.{});
 }
 

--- a/src/widgets/ScaleWidget.zig
+++ b/src/widgets/ScaleWidget.zig
@@ -46,7 +46,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *ScaleWidget) !void {
+pub fn install(self: *ScaleWidget) std.mem.Allocator.Error!void {
     if (self.init_options.scale) |init_s| {
         self.scale = init_s;
     } else {

--- a/src/widgets/ScaleWidget.zig
+++ b/src/widgets/ScaleWidget.zig
@@ -46,7 +46,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *ScaleWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *ScaleWidget) !void {
     if (self.init_options.scale) |init_s| {
         self.scale = init_s;
     } else {

--- a/src/widgets/ScrollAreaWidget.zig
+++ b/src/widgets/ScrollAreaWidget.zig
@@ -53,7 +53,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOpts, opts: Options)
     return self;
 }
 
-pub fn install(self: *ScrollAreaWidget) !void {
+pub fn install(self: *ScrollAreaWidget) std.mem.Allocator.Error!void {
     if (self.init_opts.scroll_info) |si| {
         self.si = si;
         if (self.init_opts.vertical != null) {

--- a/src/widgets/ScrollAreaWidget.zig
+++ b/src/widgets/ScrollAreaWidget.zig
@@ -53,7 +53,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOpts, opts: Options)
     return self;
 }
 
-pub fn install(self: *ScrollAreaWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *ScrollAreaWidget) !void {
     if (self.init_opts.scroll_info) |si| {
         self.si = si;
         if (self.init_opts.vertical != null) {

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -50,7 +50,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *ScrollBarWidget) !void {
+pub fn install(self: *ScrollBarWidget) std.mem.Allocator.Error!void {
     try self.wd.register();
     try self.wd.borderAndBackground(.{});
 

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -50,7 +50,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *ScrollBarWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *ScrollBarWidget) !void {
     self.wd.register();
     try self.wd.borderAndBackground(.{});
 

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -51,7 +51,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *ScrollBarWidget) std.mem.Allocator.Error!void {
-    try self.wd.register();
+    self.wd.register();
     try self.wd.borderAndBackground(.{});
 
     self.grabRect = self.wd.contentRect();

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -60,7 +60,7 @@ pub fn init(src: std.builtin.SourceLocation, io_scroll_info: *ScrollInfo, opts: 
 }
 
 pub fn install(self: *ScrollContainerWidget) std.mem.Allocator.Error!void {
-    try self.wd.register();
+    self.wd.register();
 
     // user code might have changed our rect
     const crect = self.wd.contentRect();

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -59,7 +59,7 @@ pub fn init(src: std.builtin.SourceLocation, io_scroll_info: *ScrollInfo, opts: 
     return self;
 }
 
-pub fn install(self: *ScrollContainerWidget) !void {
+pub fn install(self: *ScrollContainerWidget) std.mem.Allocator.Error!void {
     try self.wd.register();
 
     // user code might have changed our rect

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -59,7 +59,7 @@ pub fn init(src: std.builtin.SourceLocation, io_scroll_info: *ScrollInfo, opts: 
     return self;
 }
 
-pub fn install(self: *ScrollContainerWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *ScrollContainerWidget) !void {
     self.wd.register();
 
     // user code might have changed our rect

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -125,7 +125,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *TextEntryWidget) !void {
-    try self.wd.register();
+    self.wd.register();
 
     if (self.wd.visible()) {
         try dvui.tabIndexSet(self.wd.id, self.wd.options.tab_index);

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -224,7 +224,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, show_touch_draggables: bool = true }) std.mem.Allocator.Error!void {
+pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, show_touch_draggables: bool = true }) !void {
     self.focus_at_start = opts.focused orelse (self.wd.id == dvui.focusedWidgetId());
 
     self.wd.register();

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -227,7 +227,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, show_touch_draggables: bool = true }) std.mem.Allocator.Error!void {
     self.focus_at_start = opts.focused orelse (self.wd.id == dvui.focusedWidgetId());
 
-    try self.wd.register();
+    self.wd.register();
     dvui.parentSet(self.widget());
 
     if (self.selection_in) |sel| {

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -224,7 +224,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     return self;
 }
 
-pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, show_touch_draggables: bool = true }) !void {
+pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, show_touch_draggables: bool = true }) std.mem.Allocator.Error!void {
     self.focus_at_start = opts.focused orelse (self.wd.id == dvui.focusedWidgetId());
 
     try self.wd.register();

--- a/src/widgets/VirtualParentWidget.zig
+++ b/src/widgets/VirtualParentWidget.zig
@@ -23,7 +23,7 @@ pub fn init(src: std.builtin.SourceLocation, opts: Options) VirtualParentWidget 
     return VirtualParentWidget{ .wd = WidgetData.init(src, .{}, defaults.override(opts)) };
 }
 
-pub fn install(self: *VirtualParentWidget) std.mem.Allocator.Error!void {
+pub fn install(self: *VirtualParentWidget) !void {
     dvui.parentSet(self.widget());
     self.wd.register();
 }

--- a/src/widgets/VirtualParentWidget.zig
+++ b/src/widgets/VirtualParentWidget.zig
@@ -23,7 +23,7 @@ pub fn init(src: std.builtin.SourceLocation, opts: Options) VirtualParentWidget 
     return VirtualParentWidget{ .wd = WidgetData.init(src, .{}, defaults.override(opts)) };
 }
 
-pub fn install(self: *VirtualParentWidget) !void {
+pub fn install(self: *VirtualParentWidget) std.mem.Allocator.Error!void {
     dvui.parentSet(self.widget());
     try self.wd.register();
 }

--- a/src/widgets/VirtualParentWidget.zig
+++ b/src/widgets/VirtualParentWidget.zig
@@ -25,7 +25,7 @@ pub fn init(src: std.builtin.SourceLocation, opts: Options) VirtualParentWidget 
 
 pub fn install(self: *VirtualParentWidget) std.mem.Allocator.Error!void {
     dvui.parentSet(self.widget());
-    try self.wd.register();
+    self.wd.register();
 }
 
 pub fn widget(self: *VirtualParentWidget) Widget {


### PR DESCRIPTION
Relates to #192

This overhauls the error handing of dvui, specifying possible error return types and applies resonable fallback to avoid returning errors. My main idea here is that errors are ok, but they should be as limited as possible, allowing user code to specify `fn frame() error{OutOfMemory}!void { ... }` and all other errors to be handled with compiler guarantees.

This will allow most functions to only return `error.OutOfMemory`. I think not panicking on OOM is preferable because by keeping the `try`s everywhere, we can catch the OOM error in the main loop and attempt to run the next frame until the error hopefully goes away, or some max attempts is reached. Panicking would stop any user deinit code from running, which isn't very nice for a library.

The other main source of errors is text rendering needing to recreate its font atlas and getting glyphs. This has been addressed by falling back to `std.unicode.replacement_character`, which we reasonably could assume to exist (or not, I'm not sure about fonts).

## TODO

- [x] Specify/extend backend errors to surface them reasonably
- [ ] ~~Specify errors on widget functions~~