### PR TITLE
Dx11 dpi scaling issues

### DIFF
--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -1035,8 +1035,7 @@ pub fn refresh(self: Context) void {
     _ = self;
 }
 
-fn addEvent(self: Context, window: *dvui.Window, key_event: KeyEvent) !bool {
-    _ = self;
+fn addEvent(_: Context, window: *dvui.Window, key_event: KeyEvent) !bool {
     const event = key_event.target;
     const action = key_event.action;
     switch (event) {
@@ -1051,7 +1050,7 @@ fn addEvent(self: Context, window: *dvui.Window, key_event: KeyEvent) !bool {
             return window.addEventMouseButton(ev, if (action == .up) .release else .press);
         },
         .mouse_event => |ev| {
-            return window.addEventMouseMotion(.{ .x = @floatFromInt(ev.x), .y = @floatFromInt(ev.y) });
+            return window.addEventMouseMotionPhysical(.{ .x = @floatFromInt(ev.x), .y = @floatFromInt(ev.y) });
         },
         .wheel_event => |ev| {
             return window.addEventMouseWheel(@floatFromInt(ev), .vertical);


### PR DESCRIPTION
There were some odd behaviours for the dx11 scaling were the mouse position was *slightly* off towards the bottom right of the window. Turns out `win32.GetWindowRect` includes the title bar and other things in the window rect, messing up the natural scale factor.

To fix this issue, the dpi scaling is manually applied to the pixel window size. Also turns out dx11 gives the mouse position in out Physical coordinates, so we have to unapply the Natural to Physical scaling. I left a todo about changing the parameter type for mouse events at comptime.