### PR TITLE
IconWidget: Initial color set to white 

### DIFF
--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -49,7 +49,7 @@ pub fn matchEvent(self: *IconWidget, e: *dvui.Event) bool {
 
 pub fn draw(self: *IconWidget) !void {
     const rs = self.wd.parent.screenRectScale(self.wd.contentRect());
-    try dvui.renderIcon(self.name, self.tvg_bytes, rs, .{ .rotation = self.wd.options.rotationGet(), .colormod = self.wd.options.color(.text) }, self.icon_opts);
+    try dvui.renderIcon(self.name, self.tvg_bytes, rs, .{ .rotation = self.wd.options.rotationGet(), .colormod = .white }, self.icon_opts);
 }
 
 pub fn deinit(self: *IconWidget) void {


### PR DESCRIPTION
...to prevent final fill color being multiplied with text color.

When using the IconWidget, it seems that the color is defaulted to be the theme's text color, which is fine except when setting the fill color of the icon, the final color seems to be multiplied with the text color, meaning you can't set the icon fill to the color you want. 

I believe we just need to set that `color_mod` to white to prevent that behavior, but please let me know if this is wrong, we may need to also set the fill color to .text by default?