### PR TITLE
set self to undefined in deinits

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -3559,7 +3559,7 @@ pub fn debuggingErrors() !void {
             try dvui.label(@src(), " - fix by passing .id_extra = <loop index>", .{}, .{ .id_extra = i });
         }
 
-        if (try dvui.labelClick(@src(), "See https://github.com/david-vanderson/dvui/blob/master/readme-implementation.md#widget-ids", .{}, .{ .gravity_y = 0.5, .color_text = .{ .color = .{ .r = 0x35, .g = 0x84, .b = 0xe4 } } })) {
+        if (try dvui.labelClick(@src(), "See https://github.com/david-vanderson/dvui/blob/master/readme-implementation.md#widget-ids", .{}, .{ .color_text = .{ .color = .{ .r = 0x35, .g = 0x84, .b = 0xe4 } } })) {
             try dvui.openURL("https://github.com/david-vanderson/dvui/blob/master/readme-implementation.md#widget-ids");
         }
     }

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -2498,6 +2498,7 @@ pub fn focus() !void {
         tl.deinit();
 
         var te = try dvui.textEntry(@src(), .{}, .{});
+        const teId = te.data().id;
 
         // firstFrame must be called before te.deinit()
         if (dvui.firstFrame(te.data().id)) {
@@ -2521,7 +2522,7 @@ pub fn focus() !void {
             }
 
             if (try dvui.button(@src(), "Focus Prev textEntry", .{}, .{})) {
-                dvui.focusWidget(te.data().id, null, null);
+                dvui.focusWidget(teId, null, null);
             }
         }
 

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -119,6 +119,7 @@ const AnimatingDialog = struct {
         }
 
         try win.install();
+        defer win.deinit();
         win.processEventsBefore();
         try win.drawBackground();
 
@@ -144,8 +145,6 @@ const AnimatingDialog = struct {
         if (winHeight_changed) {
             win.data().rect.h = winHeight;
         }
-
-        win.deinit();
 
         if (closing) {
             dvui.animation(win.wd.id, "rect_percent", .{ .start_val = 1.0, .end_val = 0.0, .end_time = duration, .easing = easing });

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -4637,6 +4637,7 @@ pub const StrokeTest = struct {
         self.wd.minSizeReportToParent();
 
         dvui.parentReset(self.wd.id, self.wd.parent);
+        self.* = undefined;
     }
 };
 

--- a/src/Theme.zig
+++ b/src/Theme.zig
@@ -71,6 +71,7 @@ pub fn deinit(self: *Theme, gpa: std.mem.Allocator) void {
         gpa.free(self.font_title_3.name);
         gpa.free(self.font_title_4.name);
     }
+    self.* = undefined;
 }
 
 pub fn fontSizeAdd(self: *Theme, delta: f32) Theme {

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -422,6 +422,7 @@ pub fn deinit(self: *Self) void {
         }
     }
     self.themes.deinit();
+    self.* = undefined;
 }
 
 pub fn arena(self: *Self) std.mem.Allocator {

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -52,6 +52,7 @@ pub const WindowState = struct {
         _ = state.device_context.IUnknown.Release();
         _ = state.swap_chain.IUnknown.Release();
         state.dx_options.deinit();
+        state.* = undefined;
     }
 };
 

--- a/src/backends/raylib.zig
+++ b/src/backends/raylib.zig
@@ -160,6 +160,7 @@ pub fn deinit(self: *RaylibBackend) void {
     if (self.we_own_window) {
         c.CloseWindow();
     }
+    self.* = undefined;
 }
 
 pub fn backend(self: *RaylibBackend) dvui.Backend {

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -417,6 +417,7 @@ pub fn deinit(self: *SDLBackend) void {
         c.SDL_DestroyWindow(self.window);
         c.SDL_Quit();
     }
+    self.* = undefined;
 }
 
 pub fn renderPresent(self: *SDLBackend) void {

--- a/src/backends/testing.zig
+++ b/src/backends/testing.zig
@@ -33,6 +33,7 @@ pub fn deinit(self: *TestingBackend) void {
     if (self.clipboard) |text| {
         self.allocator.free(text);
     }
+    self.* = undefined;
 }
 
 /// Get monotonic nanosecond timestamp. Doesn't have to be system time.

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -539,7 +539,7 @@ pub fn init() !WebBackend {
 }
 
 pub fn deinit(self: *WebBackend) void {
-    _ = self;
+    self.* = undefined;
 }
 
 pub fn backend(self: *WebBackend) dvui.Backend {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -288,6 +288,7 @@ pub const Alignment = struct {
                 refresh(null, @src(), self.id);
             }
         }
+        self.* = undefined;
     }
 };
 
@@ -459,6 +460,7 @@ pub const FontCacheEntry = struct {
             _ = c.FT_Done_Face(self.face);
         }
         win.backend.textureDestroy(self.texture_atlas);
+        self.* = undefined;
     }
 
     pub const OpenFlags = packed struct(c_int) {
@@ -4015,6 +4017,7 @@ pub const ComboBox = struct {
     pub fn deinit(self: *ComboBox) void {
         self.sug.deinit();
         self.te.deinit();
+        self.* = undefined;
     }
 };
 
@@ -6795,6 +6798,7 @@ pub const Picture = struct {
         const texture = dvui.textureFromTarget(self.texture); // destroys self.texture
         dvui.renderTexture(texture, .{ .r = self.r }, .{}) catch {};
         dvui.textureDestroyLater(texture);
+        self.* = undefined;
     }
 };
 

--- a/src/tracking_hash_map.zig
+++ b/src/tracking_hash_map.zig
@@ -79,6 +79,7 @@ pub fn TrackingAutoHashMap(
         /// See `HashMap.deinit`
         pub fn deinit(self: *Self, allocator: Allocator) void {
             self.map.deinit(allocator);
+            self.* = undefined;
         }
 
         /// See `HashMap.count`

--- a/src/widgets/AnimateWidget.zig
+++ b/src/widgets/AnimateWidget.zig
@@ -156,6 +156,7 @@ pub fn deinit(self: *AnimateWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/BoxWidget.zig
+++ b/src/widgets/BoxWidget.zig
@@ -280,6 +280,7 @@ pub fn deinit(self: *BoxWidget) void {
     dvui.dataSet(null, self.wd.id, "_data", Data{ .total_weight = self.total_weight, .min_space_taken = self.min_space_taken });
 
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -173,6 +173,7 @@ pub fn deinit(self: *ButtonWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/CacheWidget.zig
+++ b/src/widgets/CacheWidget.zig
@@ -181,6 +181,7 @@ pub fn deinit(self: *CacheWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -45,6 +45,7 @@ pub fn install(self: *ColorPickerWidget) !void {
 
 pub fn deinit(self: *ColorPickerWidget) void {
     self.box.deinit();
+    self.* = undefined;
 }
 
 pub const value_saturation_box_defaults = Options{

--- a/src/widgets/ContextWidget.zig
+++ b/src/widgets/ContextWidget.zig
@@ -136,6 +136,7 @@ pub fn deinit(self: *ContextWidget) void {
     //self.wd.minSizeReportToParent();
 
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -199,6 +199,7 @@ pub fn deinit(self: *DropdownWidget) void {
     }
     self.menuItem.deinit();
     self.menu.deinit();
+    self.* = undefined;
 }
 
 const Options = dvui.Options;

--- a/src/widgets/FlexBoxWidget.zig
+++ b/src/widgets/FlexBoxWidget.zig
@@ -119,6 +119,7 @@ pub fn deinit(self: *FlexBoxWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -285,6 +285,7 @@ pub fn deinit(self: *FloatingMenuWidget) void {
     _ = dvui.subwindowCurrentSet(self.prev_windowId, null);
     dvui.clipSet(self.prevClip);
     _ = dvui.renderingSet(self.prev_rendering);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -250,6 +250,7 @@ pub fn deinit(self: *FloatingTooltipWidget) void {
     _ = dvui.subwindowCurrentSet(self.prev_windowId, null);
     dvui.clipSet(self.prevClip);
     _ = dvui.renderingSet(self.prev_rendering);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/FloatingWidget.zig
+++ b/src/widgets/FloatingWidget.zig
@@ -119,6 +119,7 @@ pub fn deinit(self: *FloatingWidget) void {
     _ = dvui.subwindowCurrentSet(self.prev_windowId, null);
     dvui.clipSet(self.prevClip);
     _ = dvui.renderingSet(self.prev_rendering);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -580,6 +580,7 @@ pub fn deinit(self: *FloatingWindowWidget) void {
     _ = dvui.subwindowCurrentSet(self.prev_windowInfo.id, self.prev_windowInfo.rect);
     dvui.clipSet(self.prevClip);
     _ = dvui.renderingSet(self.prev_rendering);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -176,6 +176,7 @@ pub fn deinit(self: *GridWidget) void {
     self.scroll.deinit();
 
     self.vbox.deinit();
+    self.* = undefined;
 }
 
 pub fn data(self: *GridWidget) *WidgetData {
@@ -579,6 +580,7 @@ pub const HeaderResizeWidget = struct {
         dvui.dataSet(null, self.wd.id, "_offset", self.offset);
         self.wd.minSizeSetAndRefresh();
         self.wd.minSizeReportToParent();
+        self.* = undefined;
     }
 };
 test {

--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -55,6 +55,7 @@ pub fn draw(self: *IconWidget) !void {
 pub fn deinit(self: *IconWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -107,6 +107,7 @@ pub fn processEvent(self: *LabelWidget, e: *Event, bubbling: bool) void {
 pub fn deinit(self: *LabelWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -261,6 +261,7 @@ pub fn deinit(self: *MenuItemWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -227,6 +227,7 @@ pub fn deinit(self: *MenuWidget) void {
     self.wd.minSizeReportToParent();
     _ = menuSet(self.parentMenu);
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/OverlayWidget.zig
+++ b/src/widgets/OverlayWidget.zig
@@ -59,6 +59,7 @@ pub fn deinit(self: *OverlayWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -336,6 +336,7 @@ pub fn deinit(self: *PanedWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/PlotWidget.zig
+++ b/src/widgets/PlotWidget.zig
@@ -68,6 +68,7 @@ pub const Line = struct {
 
     pub fn deinit(self: *Line) void {
         self.path.deinit();
+        self.* = undefined;
     }
 };
 
@@ -299,6 +300,7 @@ pub fn deinit(self: *PlotWidget) void {
     }
 
     self.box.deinit();
+    self.* = undefined;
 }
 
 const Options = dvui.Options;

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -140,6 +140,7 @@ pub fn deinit(self: *ReorderWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 pub fn dragStart(self: *ReorderWidget, reorder_id: usize, p: dvui.Point.Physical) void {
@@ -371,6 +372,7 @@ pub const Reorderable = struct {
         self.wd.minSizeReportToParent();
 
         dvui.parentReset(self.wd.id, self.wd.parent);
+        self.* = undefined;
     }
 };
 

--- a/src/widgets/ScaleWidget.zig
+++ b/src/widgets/ScaleWidget.zig
@@ -170,6 +170,7 @@ pub fn deinit(self: *ScaleWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/ScrollAreaWidget.zig
+++ b/src/widgets/ScrollAreaWidget.zig
@@ -164,6 +164,7 @@ pub fn deinit(self: *ScrollAreaWidget) void {
     dvui.dataSet(null, self.hbox.data().id, "_scroll_info", self.si.*);
 
     self.hbox.deinit();
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -192,6 +192,7 @@ pub fn drawGrab(self: *ScrollBarWidget) !void {
 pub fn deinit(self: *ScrollBarWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -586,6 +586,7 @@ pub fn deinit(self: *ScrollContainerWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/SuggestionWidget.zig
+++ b/src/widgets/SuggestionWidget.zig
@@ -118,6 +118,7 @@ pub fn deinit(self: *SuggestionWidget) void {
         self.drop = null;
     }
     self.menu.deinit();
+    self.* = undefined;
 }
 
 const Options = dvui.Options;

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -157,6 +157,7 @@ pub fn addTab(self: *TabsWidget, selected: bool, opts: Options) !*ButtonWidget {
 pub fn deinit(self: *TabsWidget) void {
     self.box.deinit();
     self.scroll.deinit();
+    self.* = undefined;
 }
 
 const Options = dvui.Options;

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -903,6 +903,7 @@ pub fn deinit(self: *TextEntryWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -1827,6 +1827,7 @@ pub fn deinit(self: *TextLayoutWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 test {

--- a/src/widgets/VirtualParentWidget.zig
+++ b/src/widgets/VirtualParentWidget.zig
@@ -66,6 +66,7 @@ pub fn deinit(self: *VirtualParentWidget) void {
         dvui.dataSet(null, self.wd.id, "_rect", u);
     }
     dvui.parentReset(self.wd.id, self.wd.parent);
+    self.* = undefined;
 }
 
 test {


### PR DESCRIPTION
The zig std library commonly sets self to undefined on deinit() to help detect use after deinit() errors. While I think use after deinit() is fairly unlikely the way DVUI is commonly used, it is trivial to implement and gives some extra protection.

This PR sets self.* = undefined in all deinit()s where self is a non-const pointer.
This operation becomes a noop in release fast and release small builds, but fills the struct with all 0xAA in debug and release safe builds.
