### PR TITLE
Split arenas and add widget stack

### DIFF
--- a/src/Rect.zig
+++ b/src/Rect.zig
@@ -201,7 +201,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
         ///
         /// Only valid between dvui.Window.begin() and end().
         pub fn stroke(self: Rect.Physical, radius: Rect.Physical, opts: dvui.Path.StrokeOptions) dvui.Backend.GenericError!void {
-            var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
+            var path: dvui.Path.Builder = .init(dvui.currentWindow().lifo());
             defer path.deinit();
 
             try path.addRect(self, radius);
@@ -220,7 +220,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
         ///
         /// Only valid between dvui.Window.begin() and end().
         pub fn fill(self: Rect.Physical, radius: Rect.Physical, opts: dvui.Path.FillConvexOptions) dvui.Backend.GenericError!void {
-            var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
+            var path: dvui.Path.Builder = .init(dvui.currentWindow().lifo());
             defer path.deinit();
 
             try path.addRect(self, radius);

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -127,7 +127,7 @@ pub fn register(self: *WidgetData) void {
             if (dvui.minSizeGet(self.id)) |ms| {
                 min_size = ms;
             }
-            cw.debug_info_name_rect = std.fmt.allocPrint(cw.long_term_arena(), "{x} {s}\n\n{}\nmin {}\n{}\nscale {d}\npadding {}\nborder {}\nmargin {}", .{
+            cw.debug_info_name_rect = std.fmt.allocPrint(cw.arena(), "{x} {s}\n\n{}\nmin {}\n{}\nscale {d}\npadding {}\nborder {}\nmargin {}", .{
                 self.id,
                 name,
                 rs.r,
@@ -161,7 +161,7 @@ pub fn register(self: *WidgetData) void {
 
             dvui.clipSet(clipr);
 
-            cw.debug_info_src_id_extra = std.fmt.allocPrint(cw.long_term_arena(), "{s}:{d}\nid_extra {d}", .{ self.src.file, self.src.line, self.options.idExtra() }) catch "ERROR allocPrint";
+            cw.debug_info_src_id_extra = std.fmt.allocPrint(cw.arena(), "{s}:{d}\nid_extra {d}", .{ self.src.file, self.src.line, self.options.idExtra() }) catch "ERROR allocPrint";
         }
     }
 }

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -127,7 +127,7 @@ pub fn register(self: *WidgetData) void {
             if (dvui.minSizeGet(self.id)) |ms| {
                 min_size = ms;
             }
-            cw.debug_info_name_rect = std.fmt.allocPrint(cw.arena(), "{x} {s}\n\n{}\nmin {}\n{}\nscale {d}\npadding {}\nborder {}\nmargin {}", .{
+            cw.debug_info_name_rect = std.fmt.allocPrint(cw.long_term_arena(), "{x} {s}\n\n{}\nmin {}\n{}\nscale {d}\npadding {}\nborder {}\nmargin {}", .{
                 self.id,
                 name,
                 rs.r,
@@ -161,7 +161,7 @@ pub fn register(self: *WidgetData) void {
 
             dvui.clipSet(clipr);
 
-            cw.debug_info_src_id_extra = std.fmt.allocPrint(cw.arena(), "{s}:{d}\nid_extra {d}", .{ self.src.file, self.src.line, self.options.idExtra() }) catch "ERROR allocPrint";
+            cw.debug_info_src_id_extra = std.fmt.allocPrint(cw.long_term_arena(), "{s}:{d}\nid_extra {d}", .{ self.src.file, self.src.line, self.options.idExtra() }) catch "ERROR allocPrint";
         }
     }
 }

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -448,7 +448,7 @@ pub fn deinit(self: *Self) void {
 /// If you want the memory to be automatically freed at the end
 /// of the frame, use `Window.long_term_arena`
 pub fn arena(self: *Self) std.mem.Allocator {
-    return self._temp_arena.allocator();
+    return self._temp_arena.allocatorFIFO();
 }
 
 /// A general allocator for using during a frame. All allocations

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1698,7 +1698,8 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
     // std.log.debug("peak long term arena {d} (0x{0x})", .{self._long_term_arena.peak_usage});
     // std.log.debug("peak widget stack {d} (0x{0x})", .{self.peak_widget_stack});
 
-    _ = self._long_term_arena.reset();
+    // self._long_term_arena.debug_log();
+    _ = self._long_term_arena.reset(.retain_capacity);
     if (self._temp_arena.current_usage != 0 and
         // If we have more than one buffer, we increased in size this frame, ignore errors
         self._temp_arena.arena.state.buffer_list.len() == 1)
@@ -1707,7 +1708,8 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
         // const buf: [*]u8 = @ptrCast(self._temp_arena.arena.state.buffer_list.first.?);
         // std.log.debug("Arena content {s}", .{buf[@sizeOf(usize) .. self._temp_arena.current_usage]});
     }
-    _ = self._temp_arena.reset();
+    // self._temp_arena.debug_log();
+    _ = self._temp_arena.reset(.retain_capacity);
 
     // Widget stack
     if (self._widget_stack.end_index != 0) {

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -224,8 +224,8 @@ export fn dvui_c_memcpy(dest: [*c]u8, src: [*c]const u8, n: usize) [*c]u8 {
 
 export fn dvui_c_memmove(dest: [*c]u8, src: [*c]const u8, n: usize) [*c]u8 {
     //log.debug("dvui_c_memmove dest {*} src {*} {d}", .{ dest, src, n });
-    const buf = dvui.currentWindow().long_term_arena().alloc(u8, n) catch unreachable;
-    defer dvui.currentWindow().long_term_arena().free(buf);
+    const buf = dvui.currentWindow().arena().alloc(u8, n) catch unreachable;
+    defer dvui.currentWindow().arena().free(buf);
     @memcpy(buf, src[0..n]);
     @memcpy(dest[0..n], buf);
     return dest;

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -224,8 +224,8 @@ export fn dvui_c_memcpy(dest: [*c]u8, src: [*c]const u8, n: usize) [*c]u8 {
 
 export fn dvui_c_memmove(dest: [*c]u8, src: [*c]const u8, n: usize) [*c]u8 {
     //log.debug("dvui_c_memmove dest {*} src {*} {d}", .{ dest, src, n });
-    const buf = dvui.currentWindow().arena().alloc(u8, n) catch unreachable;
-    defer dvui.currentWindow().arena().free(buf);
+    const buf = dvui.currentWindow().long_term_arena().alloc(u8, n) catch unreachable;
+    defer dvui.currentWindow().long_term_arena().free(buf);
     @memcpy(buf, src[0..n]);
     @memcpy(dest[0..n], buf);
     return dest;

--- a/src/widgets/AnimateWidget.zig
+++ b/src/widgets/AnimateWidget.zig
@@ -137,6 +137,7 @@ pub fn processEvent(self: *AnimateWidget, e: *Event, bubbling: bool) void {
 }
 
 pub fn deinit(self: *AnimateWidget) void {
+    defer dvui.widgetFree(self);
     if (self.val) |v| {
         switch (self.init_opts.kind) {
             .alpha => {

--- a/src/widgets/BoxWidget.zig
+++ b/src/widgets/BoxWidget.zig
@@ -246,6 +246,7 @@ pub fn processEvent(self: *BoxWidget, e: *Event, bubbling: bool) void {
 }
 
 pub fn deinit(self: *BoxWidget) void {
+    defer dvui.widgetFree(self);
     var ms: Size = undefined;
     var extra_space = false;
     if (self.init_opts.dir == .horizontal) {

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -170,6 +170,7 @@ pub fn processEvent(self: *ButtonWidget, e: *Event, bubbling: bool) void {
 }
 
 pub fn deinit(self: *ButtonWidget) void {
+    defer dvui.widgetFree(self);
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);

--- a/src/widgets/CacheWidget.zig
+++ b/src/widgets/CacheWidget.zig
@@ -159,6 +159,7 @@ pub fn processEvent(self: *CacheWidget, e: *dvui.Event, bubbling: bool) void {
 /// This deinit function returns an error because of the additional
 /// texture handling it requires.
 pub fn deinit(self: *CacheWidget) !void {
+    defer dvui.widgetFree(self);
     const cw = dvui.currentWindow();
     if (self.state == .ok and self.uncached()) {
         if (dvui.currentWindow().extra_frames_needed == 0) {

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -44,6 +44,7 @@ pub fn install(self: *ColorPickerWidget) dvui.Backend.TextureError!void {
 }
 
 pub fn deinit(self: *ColorPickerWidget) void {
+    defer dvui.widgetFree(self);
     self.box.deinit();
     self.* = undefined;
 }

--- a/src/widgets/ContextWidget.zig
+++ b/src/widgets/ContextWidget.zig
@@ -127,6 +127,7 @@ pub fn processEvent(self: *ContextWidget, e: *Event, bubbling: bool) void {
 }
 
 pub fn deinit(self: *ContextWidget) void {
+    defer dvui.widgetFree(self);
     if (self.focused) {
         dvui.dataSet(null, self.wd.id, "_activePt", self.activePt);
     }

--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -193,6 +193,7 @@ pub fn addChoice(self: *DropdownWidget) !*MenuItemWidget {
 }
 
 pub fn deinit(self: *DropdownWidget) void {
+    defer dvui.widgetFree(self);
     if (self.drop != null) {
         self.drop.?.deinit();
         self.drop = null;

--- a/src/widgets/FlexBoxWidget.zig
+++ b/src/widgets/FlexBoxWidget.zig
@@ -114,6 +114,7 @@ pub fn processEvent(self: *FlexBoxWidget, e: *dvui.Event, bubbling: bool) void {
 }
 
 pub fn deinit(self: *FlexBoxWidget) void {
+    defer dvui.widgetFree(self);
     dvui.dataSet(null, self.wd.id, "_mrw", self.max_row_width);
     dvui.clipSet(self.prevClip);
     self.wd.minSizeSetAndRefresh();

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -224,6 +224,7 @@ pub fn chainFocused(self: *FloatingMenuWidget, self_call: bool) bool {
 }
 
 pub fn deinit(self: *FloatingMenuWidget) void {
+    defer dvui.widgetFree(self);
     self.menu.deinit();
     self.scroll.deinit();
     self.scaler.deinit();

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -222,6 +222,7 @@ pub fn processEvent(self: *FloatingTooltipWidget, e: *Event, bubbling: bool) voi
 }
 
 pub fn deinit(self: *FloatingTooltipWidget) void {
+    defer dvui.widgetFree(self);
     if (!self.installed) {
         return;
     }

--- a/src/widgets/FloatingWidget.zig
+++ b/src/widgets/FloatingWidget.zig
@@ -110,6 +110,7 @@ pub fn processEvent(self: *FloatingWidget, e: *Event, bubbling: bool) void {
 }
 
 pub fn deinit(self: *FloatingWidget) void {
+    defer dvui.widgetFree(self);
     self.scaler.deinit();
     self.wd.minSizeSetAndRefresh();
 

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -544,6 +544,7 @@ pub fn processEvent(self: *FloatingWindowWidget, e: *Event, bubbling: bool) void
 }
 
 pub fn deinit(self: *FloatingWindowWidget) void {
+    defer dvui.widgetFree(self);
     self.layout.deinit();
 
     if (self.auto_size_refresh_prev_value) |pv| {

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -158,6 +158,7 @@ pub fn install(self: *GridWidget) !void {
 }
 
 pub fn deinit(self: *GridWidget) void {
+    defer dvui.widgetFree(self);
     self.clipReset();
 
     // resizing if row heights changed or a resize was requested via init options.
@@ -227,7 +228,7 @@ pub fn column(self: *GridWidget, src: std.builtin.SourceLocation, opts: ColOptio
     col_opts.min_size_content = .{ .w = w, .h = self.last_height };
     col_opts.max_size_content = if (w > 0) .width(w) else null;
 
-    var col = try dvui.currentWindow().arena().create(BoxWidget);
+    var col = dvui.widgetAlloc(BoxWidget);
     col.* = BoxWidget.init(src, .{ .dir = .vertical }, col_opts);
     try col.install();
     try col.drawBackground();
@@ -262,7 +263,7 @@ pub fn headerCell(self: *GridWidget, src: std.builtin.SourceLocation, opts: Cell
     cell_opts.rect = .{ .x = 0, .y = y, .w = parent_rect.w, .h = header_height };
 
     // Create the cell and install as parent.
-    var cell = try dvui.currentWindow().arena().create(BoxWidget);
+    var cell = dvui.widgetAlloc(BoxWidget);
     cell.* = BoxWidget.init(src, .{ .dir = .horizontal }, cell_opts);
     try cell.install();
     try cell.drawBackground();
@@ -306,7 +307,7 @@ pub fn bodyCell(self: *GridWidget, src: std.builtin.SourceLocation, row_num: usi
     cell_opts.rect = .{ .x = 0, .y = self.next_row_y, .w = parent_rect.w, .h = cell_height };
     cell_opts.id_extra = row_num;
 
-    var cell = try dvui.currentWindow().arena().create(BoxWidget);
+    var cell = dvui.widgetAlloc(BoxWidget);
     cell.* = BoxWidget.init(src, .{ .dir = .horizontal }, cell_opts);
     try cell.install();
     try cell.drawBackground();

--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -53,6 +53,7 @@ pub fn draw(self: *IconWidget) !void {
 }
 
 pub fn deinit(self: *IconWidget) void {
+    defer dvui.widgetFree(self);
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     self.* = undefined;

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -19,7 +19,7 @@ label_str: []const u8,
 
 pub fn init(src: std.builtin.SourceLocation, comptime fmt: []const u8, args: anytype, opts: Options) LabelWidget {
     comptime if (!std.unicode.utf8ValidateSlice(fmt)) @compileError("Format strings must be valid utf-8");
-    const l = std.fmt.allocPrint(dvui.currentWindow().arena(), fmt, args) catch |err| blk: {
+    const l = std.fmt.allocPrint(dvui.currentWindow().long_term_arena(), fmt, args) catch |err| blk: {
         const newid = dvui.parentGet().extendId(src, opts.idExtra());
         dvui.currentWindow().debug_widget_id = newid;
         dvui.log.err("{s}:{d} LabelWidget id {x} (highlighted in red) init() got {!}", .{ src.file, src.line, newid, err });
@@ -31,7 +31,7 @@ pub fn init(src: std.builtin.SourceLocation, comptime fmt: []const u8, args: any
 
 pub fn initNoFmt(src: std.builtin.SourceLocation, label_str: []const u8, opts: Options) LabelWidget {
     var self = LabelWidget{
-        .label_str = dvui.toUtf8(dvui.currentWindow().arena(), label_str) catch label_str,
+        .label_str = dvui.toUtf8(dvui.currentWindow().long_term_arena(), label_str) catch label_str,
     };
 
     const options = defaults.override(opts);

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -108,6 +108,7 @@ pub fn processEvent(self: *LabelWidget, e: *Event, bubbling: bool) void {
 }
 
 pub fn deinit(self: *LabelWidget) void {
+    defer dvui.widgetFree(self);
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     self.* = undefined;

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -16,32 +16,64 @@ pub var defaults: Options = .{
 
 wd: WidgetData = undefined,
 label_str: []const u8,
+/// An allocator to free `label_str` on `deinit`
+allocator: ?std.mem.Allocator,
 
 pub fn init(src: std.builtin.SourceLocation, comptime fmt: []const u8, args: anytype, opts: Options) LabelWidget {
     comptime if (!std.unicode.utf8ValidateSlice(fmt)) @compileError("Format strings must be valid utf-8");
-    const l = std.fmt.allocPrint(dvui.currentWindow().long_term_arena(), fmt, args) catch |err| blk: {
-        const newid = dvui.parentGet().extendId(src, opts.idExtra());
-        dvui.currentWindow().debug_widget_id = newid;
-        dvui.log.err("{s}:{d} LabelWidget id {x} (highlighted in red) init() got {!}", .{ src.file, src.line, newid, err });
-        break :blk "<Error OutOfMemory>";
-    };
 
-    return LabelWidget.initNoFmt(src, l, opts);
+    const cw = dvui.currentWindow();
+    // Validate utf8 formatting
+    const str, const alloc = blk: {
+        const str = std.fmt.allocPrint(cw.arena(), fmt, args) catch |err| {
+            logAndHighlight(src, opts, err);
+            break :blk .{ fmt, null };
+        };
+        // We need to use `long_term_arena` because otherwise we
+        // will not be able to free the memory of the allocPrint
+        const utf8 = dvui.toUtf8(cw.long_term_arena(), str) catch |err| {
+            logAndHighlight(src, opts, err);
+            // We contained invalid utf8, so textSize will fail later
+            break :blk .{ str, cw.arena() };
+        };
+        if (str.ptr == utf8.ptr) break :blk .{ str, cw.arena() };
+        cw.arena().free(str);
+        dvui.log.debug("{s}:{d}: LabelWidget format output was invalid utf8 for '{s}'.", .{ src.file, src.line, str });
+        break :blk .{ utf8, null };
+    };
+    return initNoFmtAllocator(src, str, alloc, opts);
 }
 
 pub fn initNoFmt(src: std.builtin.SourceLocation, label_str: []const u8, opts: Options) LabelWidget {
-    var self = LabelWidget{
-        .label_str = dvui.toUtf8(dvui.currentWindow().long_term_arena(), label_str) catch label_str,
+    const arena = dvui.currentWindow().arena();
+    // If the allocation fails, the textSize will be incorrect
+    // later because of invalid utf8
+    const str = dvui.toUtf8(arena, label_str) catch |err| blk: {
+        logAndHighlight(src, opts, err);
+        break :blk label_str;
     };
+    return initNoFmtAllocator(src, str, if (str.ptr != label_str.ptr) arena else null, opts);
+}
 
+/// The `allocator` argument will be used to deallocator `label_str` on
+/// when `deinit` is called.
+///
+/// Assumes the label_str is valid utf8
+pub fn initNoFmtAllocator(src: std.builtin.SourceLocation, label_str: []const u8, allocator: ?std.mem.Allocator, opts: Options) LabelWidget {
     const options = defaults.override(opts);
-
-    var size = options.fontGet().textSize(self.label_str);
+    var size = options.fontGet().textSize(label_str);
     size = Size.max(size, options.min_size_contentGet());
+    return .{
+        .wd = .init(src, .{}, options.override(.{ .min_size_content = size })),
+        .label_str = label_str,
+        .allocator = allocator,
+    };
+}
 
-    self.wd = WidgetData.init(src, .{}, options.override(.{ .min_size_content = size }));
-
-    return self;
+fn logAndHighlight(src: std.builtin.SourceLocation, opts: Options, err: anyerror) void {
+    const newid = dvui.parentGet().extendId(src, opts.idExtra());
+    dvui.currentWindow().debug_widget_id = newid;
+    dvui.log.err("{s}:{d} LabelWidget id {x} (highlighted in red) init() got {!}", .{ src.file, src.line, newid, err });
 }
 
 pub fn data(self: *LabelWidget) *WidgetData {
@@ -109,6 +141,7 @@ pub fn processEvent(self: *LabelWidget, e: *Event, bubbling: bool) void {
 
 pub fn deinit(self: *LabelWidget) void {
     defer dvui.widgetFree(self);
+    if (self.allocator) |alloc| alloc.free(self.label_str);
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     self.* = undefined;

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -257,6 +257,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event, bubbling: bool) void {
 }
 
 pub fn deinit(self: *MenuItemWidget) void {
+    defer dvui.widgetFree(self);
     dvui.dataSet(null, self.wd.id, "_focus_last", self.focused_last_frame);
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -217,6 +217,7 @@ pub fn processEvent(self: *MenuWidget, e: *Event, bubbling: bool) void {
 }
 
 pub fn deinit(self: *MenuWidget) void {
+    defer dvui.widgetFree(self);
     self.box.deinit();
     dvui.dataSet(null, self.wd.id, "_mouse_mode", self.mouse_mode);
     dvui.dataSet(null, self.wd.id, "_sub_act", self.submenus_activated);

--- a/src/widgets/OverlayWidget.zig
+++ b/src/widgets/OverlayWidget.zig
@@ -56,6 +56,7 @@ pub fn processEvent(self: *OverlayWidget, e: *Event, bubbling: bool) void {
 }
 
 pub fn deinit(self: *OverlayWidget) void {
+    defer dvui.widgetFree(self);
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     dvui.parentReset(self.wd.id, self.wd.parent);

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -329,6 +329,7 @@ pub fn processEvent(self: *PanedWidget, e: *Event, bubbling: bool) void {
 }
 
 pub fn deinit(self: *PanedWidget) void {
+    defer dvui.widgetFree(self);
     dvui.clipSet(self.prevClip);
     dvui.dataSet(null, self.wd.id, "_collapsing", self.collapsing);
     dvui.dataSet(null, self.wd.id, "_collapsed", self.collapsed_state);

--- a/src/widgets/PlotWidget.zig
+++ b/src/widgets/PlotWidget.zig
@@ -132,8 +132,8 @@ pub fn install(self: *PlotWidget) !void {
     if (self.y_axis.name) |_| {
         for (yticks) |m_ytick| {
             if (m_ytick) |ytick| {
-                const tick_str = try std.fmt.allocPrint(dvui.currentWindow().arena(), "{d}", .{ytick});
-                defer dvui.currentWindow().arena().free(tick_str);
+                const tick_str = try std.fmt.allocPrint(dvui.currentWindow().lifo(), "{d}", .{ytick});
+                defer dvui.currentWindow().lifo().free(tick_str);
                 tick_width = @max(tick_width, tick_font.textSize(tick_str).w);
             }
         }
@@ -218,8 +218,8 @@ pub fn install(self: *PlotWidget) !void {
         for (yticks) |m_ytick| {
             if (m_ytick) |ytick| {
                 const tick: Data = .{ .x = self.x_axis.min orelse 0, .y = ytick };
-                const tick_str = try std.fmt.allocPrint(dvui.currentWindow().arena(), "{d}", .{ytick});
-                defer dvui.currentWindow().arena().free(tick_str);
+                const tick_str = try std.fmt.allocPrint(dvui.currentWindow().lifo(), "{d}", .{ytick});
+                defer dvui.currentWindow().lifo().free(tick_str);
                 const tick_str_size = tick_font.textSize(tick_str).scale(self.data_rs.s, Size.Physical);
                 var tick_p = self.dataToScreen(tick);
                 tick_p.x -= tick_str_size.w + pad;
@@ -239,8 +239,8 @@ pub fn install(self: *PlotWidget) !void {
         for (xticks) |m_xtick| {
             if (m_xtick) |xtick| {
                 const tick: Data = .{ .x = xtick, .y = self.y_axis.min orelse 0 };
-                const tick_str = try std.fmt.allocPrint(dvui.currentWindow().arena(), "{d}", .{xtick});
-                defer dvui.currentWindow().arena().free(tick_str);
+                const tick_str = try std.fmt.allocPrint(dvui.currentWindow().lifo(), "{d}", .{xtick});
+                defer dvui.currentWindow().lifo().free(tick_str);
                 const tick_str_size = tick_font.textSize(tick_str).scale(self.data_rs.s, Size.Physical);
                 var tick_p = self.dataToScreen(tick);
                 tick_p.x = @max(tick_p.x, self.data_rs.r.x);
@@ -260,7 +260,7 @@ pub fn install(self: *PlotWidget) !void {
 pub fn line(self: *PlotWidget) Line {
     return .{
         .plot = self,
-        .path = .init(dvui.currentWindow().arena()),
+        .path = .init(dvui.currentWindow().lifo()),
     };
 }
 
@@ -291,9 +291,9 @@ pub fn deinit(self: *PlotWidget) void {
 
     if (self.hover_data) |hd| {
         var p = self.box.data().contentRectScale().pointFromPhysical(self.mouse_point.?);
-        const str = std.fmt.allocPrint(dvui.currentWindow().arena(), "{d}, {d}", .{ hd.x, hd.y }) catch "";
+        const str = std.fmt.allocPrint(dvui.currentWindow().lifo(), "{d}, {d}", .{ hd.x, hd.y }) catch "";
         // NOTE: Always calling free is safe because fallback is a 0 len slice, which is ignored
-        defer dvui.currentWindow().arena().free(str);
+        defer dvui.currentWindow().lifo().free(str);
         const size: Size = (dvui.Options{}).fontGet().textSize(str);
         p.x -= size.w / 2;
         const padding = dvui.LabelWidget.defaults.paddingGet();

--- a/src/widgets/PlotWidget.zig
+++ b/src/widgets/PlotWidget.zig
@@ -67,6 +67,7 @@ pub const Line = struct {
     }
 
     pub fn deinit(self: *Line) void {
+        defer dvui.widgetFree(self);
         self.path.deinit();
         self.* = undefined;
     }
@@ -264,6 +265,7 @@ pub fn line(self: *PlotWidget) Line {
 }
 
 pub fn deinit(self: *PlotWidget) void {
+    defer dvui.widgetFree(self);
     dvui.clipSet(self.old_clip);
 
     // maybe we got no data

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -118,6 +118,7 @@ pub fn processEvent(self: *ReorderWidget, e: *dvui.Event, bubbling: bool) void {
 }
 
 pub fn deinit(self: *ReorderWidget) void {
+    defer dvui.widgetFree(self);
     if (self.drag_ending) {
         self.id_reorderable = null;
         self.drag_point = null;
@@ -194,7 +195,7 @@ pub fn draggable(src: std.builtin.SourceLocation, init_opts: draggableInitOption
 }
 
 pub fn reorderable(self: *ReorderWidget, src: std.builtin.SourceLocation, init_opts: Reorderable.InitOptions, opts: Options) !*Reorderable {
-    const ret = try dvui.currentWindow().arena().create(Reorderable);
+    const ret = dvui.widgetAlloc(Reorderable);
     ret.* = Reorderable.init(src, self, init_opts, opts);
     try ret.install();
     return ret;
@@ -363,6 +364,7 @@ pub const Reorderable = struct {
     }
 
     pub fn deinit(self: *Reorderable) void {
+        defer dvui.widgetFree(self);
         if (self.floating_widget) |*fw| {
             self.wd.minSizeMax(fw.wd.min_size);
             fw.deinit();

--- a/src/widgets/ScaleWidget.zig
+++ b/src/widgets/ScaleWidget.zig
@@ -166,6 +166,7 @@ pub fn minSizeForChild(self: *ScaleWidget, s: Size) void {
 }
 
 pub fn deinit(self: *ScaleWidget) void {
+    defer dvui.widgetFree(self);
     dvui.dataSet(null, self.wd.id, "_scale", self.scale.*);
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();

--- a/src/widgets/ScrollAreaWidget.zig
+++ b/src/widgets/ScrollAreaWidget.zig
@@ -148,6 +148,7 @@ pub fn data(self: *ScrollAreaWidget) *WidgetData {
 }
 
 pub fn deinit(self: *ScrollAreaWidget) void {
+    defer dvui.widgetFree(self);
     dvui.dataSet(null, self.hbox.data().id, "_scroll_id", self.scroll.wd.id);
     self.scroll.deinit();
 

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -190,6 +190,7 @@ pub fn drawGrab(self: *ScrollBarWidget) !void {
 }
 
 pub fn deinit(self: *ScrollBarWidget) void {
+    defer dvui.widgetFree(self);
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     self.* = undefined;

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -539,6 +539,7 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
 }
 
 pub fn deinit(self: *ScrollContainerWidget) void {
+    // defer dvui.widgetFree(self);
     self.processEventsAfter();
 
     dvui.dataSet(null, self.wd.id, "_fv_id", self.first_visible_id);

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -539,7 +539,7 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
 }
 
 pub fn deinit(self: *ScrollContainerWidget) void {
-    // defer dvui.widgetFree(self);
+    defer dvui.widgetFree(self);
     self.processEventsAfter();
 
     dvui.dataSet(null, self.wd.id, "_fv_id", self.first_visible_id);

--- a/src/widgets/SuggestionWidget.zig
+++ b/src/widgets/SuggestionWidget.zig
@@ -108,6 +108,7 @@ pub fn addChoice(self: *SuggestionWidget) !*MenuItemWidget {
 }
 
 pub fn deinit(self: *SuggestionWidget) void {
+    defer dvui.widgetFree(self);
     if (self.selected_index > (self.drop_mi_index -| 1)) {
         self.selected_index = self.drop_mi_index -| 1;
         dvui.refresh(null, @src(), self.id);

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -117,7 +117,7 @@ pub fn addTab(self: *TabsWidget, selected: bool, opts: Options) !*ButtonWidget {
 
         switch (self.init_options.dir) {
             .horizontal => {
-                var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
+                var path: dvui.Path.Builder = .init(dvui.currentWindow().lifo());
                 defer path.deinit();
 
                 try path.points.append(r.bottomRight());
@@ -133,7 +133,7 @@ pub fn addTab(self: *TabsWidget, selected: bool, opts: Options) !*ButtonWidget {
                 try path.build().stroke(.{ .thickness = 2 * rs.s, .color = dvui.themeGet().color_accent, .after = true });
             },
             .vertical => {
-                var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
+                var path: dvui.Path.Builder = .init(dvui.currentWindow().lifo());
                 defer path.deinit();
 
                 try path.points.append(r.topRight());

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -155,6 +155,7 @@ pub fn addTab(self: *TabsWidget, selected: bool, opts: Options) !*ButtonWidget {
 }
 
 pub fn deinit(self: *TabsWidget) void {
+    defer dvui.widgetFree(self);
     self.box.deinit();
     self.scroll.deinit();
     self.* = undefined;

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -872,6 +872,7 @@ pub fn getText(self: *const TextEntryWidget) []u8 {
 }
 
 pub fn deinit(self: *TextEntryWidget) void {
+    defer dvui.widgetFree(self);
     if (self.len == 0 or self.len + realloc_bin_size + @divTrunc(realloc_bin_size, 2) <= self.text.len) {
         // we want to shrink the allocation
         const new_len = if (self.len == 0) 0 else realloc_bin_size * (@divTrunc(self.len, realloc_bin_size) + 1);

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -274,8 +274,8 @@ pub fn draw(self: *TextEntryWidget) !void {
         sel.start = sstart.?;
         sel.cursor = scursor.?;
         sel.end = send.?;
-        var password_str: []u8 = try dvui.currentWindow().arena().alloc(u8, count * pc.len);
-        defer dvui.currentWindow().arena().free(password_str);
+        var password_str: []u8 = try dvui.currentWindow().lifo().alloc(u8, count * pc.len);
+        defer dvui.currentWindow().lifo().free(password_str);
         for (0..count) |i| {
             for (0..pc.len) |pci| {
                 password_str[i * pc.len + pci] = pc[pci];

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -1774,6 +1774,7 @@ pub fn copy(self: *TextLayoutWidget) void {
 }
 
 pub fn deinit(self: *TextLayoutWidget) void {
+    defer dvui.widgetFree(self);
     if (!self.add_text_done) {
         self.addTextDone(.{}) catch |err| {
             dvui.log.err("TextLayoutWidget.deinit addTextDone got {!}\n", .{err});

--- a/src/widgets/VirtualParentWidget.zig
+++ b/src/widgets/VirtualParentWidget.zig
@@ -62,6 +62,7 @@ pub fn processEvent(self: *VirtualParentWidget, e: *Event, bubbling: bool) void 
 }
 
 pub fn deinit(self: *VirtualParentWidget) void {
+    defer dvui.widgetFree(self);
     if (self.child_rect_union) |u| {
         dvui.dataSet(null, self.wd.id, "_rect", u);
     }


### PR DESCRIPTION
Relates to #335

Dvui applications should mostly be able to work on one large stack of data, reusing it as it goes since all widgets are immediate. Some reasons the arena used as this stack could not free its memory was because items with "frame lifetime" got allocated along side it.

Widgets enforce this stacking behaviour with `parentReset` already, which we can leverage for a separate widget stack were functions needing to return a pointer to a widget can use. `widgetAlloc` will allocate a widget on this "fixed" stack, falling back to the arena. All widgets should now call `widgetFree` in its `deinit` to remove itself from that stack, if it was allocated there. `widgetAlloc` keeps track of the total space used so the stack can be reallocated if it overflows.

We also want to be able to ignore or panic on OOM errors, which in turn means we should aim to reduce the number of points were allocation are performed. `ShrinkingArenaAllocator` have been changed to not free like the previous behaviour for this purpose. We can think about maybe only shrinking at some time/frame interval to not leak memory but still limit reallocations.

This also changes the `ShrinkingArenaAllocator` to check for alignment padding and still free items in those cases. It is unlikely that a value of < 8 bytes gets allocated and not freed correctly, so this change should be safe.

All of these changes reduces the total amount of allocations performed by the arenas/widget stack during a frame as well as reducing the peak total arenas/widget stack memory use of the app example from ~1800KB to ~950KB.

A followup to this will begin handling errors, probably by logging returning early or perhaps `catch @panic("OOM")` if needed.