### PR TITLE
Lifo free account for the alignment of memory pointer

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -1514,7 +1514,7 @@ pub fn styling() !void {
             defer drawBox.deinit();
             const rs = drawBox.data().contentRectScale();
 
-            var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
+            var path: dvui.Path.Builder = .init(dvui.currentWindow().lifo());
             defer path.deinit();
             try path.addRect(rs.r, dvui.Rect.Physical.all(5));
 

--- a/src/Rect.zig
+++ b/src/Rect.zig
@@ -201,7 +201,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
         ///
         /// Only valid between dvui.Window.begin() and end().
         pub fn stroke(self: Rect.Physical, radius: Rect.Physical, opts: dvui.Path.StrokeOptions) dvui.Backend.GenericError!void {
-            var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
+            var path: dvui.Path.Builder = .init(dvui.currentWindow().lifo());
             defer path.deinit();
 
             try path.addRect(self, radius);
@@ -220,7 +220,7 @@ pub fn RectType(comptime units: dvui.enums.Units) type {
         ///
         /// Only valid between dvui.Window.begin() and end().
         pub fn fill(self: Rect.Physical, radius: Rect.Physical, opts: dvui.Path.FillConvexOptions) dvui.Backend.GenericError!void {
-            var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
+            var path: dvui.Path.Builder = .init(dvui.currentWindow().lifo());
             defer path.deinit();
 
             try path.addRect(self, radius);

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1706,13 +1706,10 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
 
     // self._arena.debug_log();
     _ = self._arena.reset(.retain_capacity);
-    if (self._lifo_arena.current_usage != 0 and
-        // If we have more than one buffer, we increased in size this frame, ignore errors
-        self._lifo_arena.arena.state.buffer_list.len() == 1)
-    {
+    if (self._lifo_arena.current_usage != 0 and !self._lifo_arena.has_expanded()) {
         log.warn("Arena was not empty at the end of the frame, {d} byte left. Did you forget to free memory somewhere?", .{self._lifo_arena.current_usage});
         // const buf: [*]u8 = @ptrCast(self._lifo_arena.arena.state.buffer_list.first.?);
-        // std.log.debug("Arena content {s}", .{buf[@sizeOf(usize) .. self._lifo_arena.current_usage]});
+        // std.log.debug("Arena content {s}", .{buf[@sizeOf(usize)..self._lifo_arena.current_usage]});
     }
     // self._lifo_arena.debug_log();
     _ = self._lifo_arena.reset(.retain_capacity);

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -4904,7 +4904,7 @@ pub fn menuItem(src: std.builtin.SourceLocation, init_opts: MenuItemWidget.InitO
 pub fn labelClick(src: std.builtin.SourceLocation, comptime fmt: []const u8, args: anytype, opts: Options) !bool {
     var ret = false;
 
-    var lw = LabelWidget.init(src, fmt, args, (Options{ .name = "LabelClick" }).override(opts));
+    var lw = LabelWidget.init(src, fmt, args, opts.override(.{ .name = "LabelClick" }));
     // now lw has a Rect from its parent but hasn't processed events or drawn
 
     const lwid = lw.data().id;

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1692,7 +1692,7 @@ pub const Path = struct {
             const center = path.points[0];
 
             const other_allocator = if (current_window) |cw|
-                if (cw.lifo().ptr != allocator.ptr) cw.arena() else cw.arena()
+                if (cw.lifo().ptr != allocator.ptr) cw.lifo() else cw.arena()
             else
                 // Using the same allocator will "leak" the tempPath on
                 // arena allocators because it can only free the last allocation
@@ -4818,7 +4818,7 @@ pub fn spinner(src: std.builtin.SourceLocation, opts: Options) !void {
         animation(wd.id, "_t", anim);
     }
 
-    var path: Path.Builder = .init(dvui.currentWindow().arena());
+    var path: Path.Builder = .init(dvui.currentWindow().lifo());
     defer path.deinit();
 
     const full_circle = 2 * std.math.pi;
@@ -6727,7 +6727,7 @@ pub fn renderTexture(tex: Texture, rs: RectScale, opts: RenderTextureOptions) Ba
         return;
     }
 
-    var path: Path.Builder = .init(dvui.currentWindow().arena());
+    var path: Path.Builder = .init(dvui.currentWindow().lifo());
     defer path.deinit();
 
     try path.addRect(rs.r, opts.corner_radius.scale(rs.s, Rect.Physical));

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -37,8 +37,8 @@ pub fn init(src: std.builtin.SourceLocation, comptime fmt: []const u8, args: any
             break :blk .{ str, cw.lifo() };
         };
         if (str.ptr == utf8.ptr) break :blk .{ str, cw.lifo() };
-        dvui.log.debug("{s}:{d}: LabelWidget format output was invalid utf8 for '{s}'.", .{ src.file, src.line, str });
         cw.lifo().free(str);
+        dvui.log.debug("{s}:{d}: LabelWidget format output was invalid utf8 for '{s}'.", .{ src.file, src.line, str });
         break :blk .{ utf8, null };
     };
     return initNoFmtAllocator(src, str, alloc, opts);
@@ -140,15 +140,11 @@ pub fn processEvent(self: *LabelWidget, e: *Event, bubbling: bool) void {
 }
 
 pub fn deinit(self: *LabelWidget) void {
+    defer dvui.widgetFree(self);
+    if (self.allocator) |alloc| alloc.free(self.label_str);
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
-
-    // need to free label_str after widget
-    const allocator = self.allocator;
-    const label_str = self.label_str;
     self.* = undefined;
-    dvui.widgetFree(self);
-    if (allocator) |alloc| alloc.free(label_str);
 }
 
 test {

--- a/src/widgets/PlotWidget.zig
+++ b/src/widgets/PlotWidget.zig
@@ -260,7 +260,7 @@ pub fn install(self: *PlotWidget) !void {
 pub fn line(self: *PlotWidget) Line {
     return .{
         .plot = self,
-        .path = .init(dvui.currentWindow().arena()),
+        .path = .init(dvui.currentWindow().lifo()),
     };
 }
 

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -117,7 +117,7 @@ pub fn addTab(self: *TabsWidget, selected: bool, opts: Options) !*ButtonWidget {
 
         switch (self.init_options.dir) {
             .horizontal => {
-                var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
+                var path: dvui.Path.Builder = .init(dvui.currentWindow().lifo());
                 defer path.deinit();
 
                 try path.points.append(r.bottomRight());
@@ -133,7 +133,7 @@ pub fn addTab(self: *TabsWidget, selected: bool, opts: Options) !*ButtonWidget {
                 try path.build().stroke(.{ .thickness = 2 * rs.s, .color = dvui.themeGet().color_accent, .after = true });
             },
             .vertical => {
-                var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
+                var path: dvui.Path.Builder = .init(dvui.currentWindow().lifo());
                 defer path.deinit();
 
                 try path.points.append(r.topRight());

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -334,7 +334,7 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
             }
 
             if (visible) {
-                var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
+                var path: dvui.Path.Builder = .init(dvui.currentWindow().lifo());
                 defer path.deinit();
 
                 try path.points.append(.{ .x = fcrs.r.x + fcrs.r.w, .y = fcrs.r.y });
@@ -405,7 +405,7 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
             }
 
             if (visible) {
-                var path: dvui.Path.Builder = .init(dvui.currentWindow().arena());
+                var path: dvui.Path.Builder = .init(dvui.currentWindow().lifo());
                 defer path.deinit();
 
                 try path.points.append(.{ .x = fcrs.r.x, .y = fcrs.r.y });


### PR DESCRIPTION
Fixes #364

This was an oversight as the pointer of the memory doesn't necessarily have to be aligned to 8, like in `[]const u8` buffers were alignment is 1.

A note about lifo errors, the trace back given does not indicate that the code there as a fault. It indicates that somewhere between its allocation and free call, there is faulty handling.