### PR TITLE
SDL and raylib logs forwarded to std.log

### DIFF
--- a/src/backends/raylib.zig
+++ b/src/backends/raylib.zig
@@ -892,8 +892,18 @@ pub fn EndDrawingWaitEventTimeout(_: *RaylibBackend, timeout_micros: u32) void {
     return;
 }
 
+// Optional: windows os only
+const winapi = if (builtin.os.tag == .windows) struct {
+    extern "kernel32" fn AttachConsole(dwProcessId: std.os.windows.DWORD) std.os.windows.BOOL;
+} else struct {};
+
 pub fn main() !void {
     const app = dvui.App.get() orelse return error.DvuiAppNotDefined;
+
+    if (builtin.os.tag == .windows) { // optional
+        // on windows graphical apps have no console, so output goes to nowhere - attach it manually. related: https://github.com/ziglang/zig/issues/4196
+        _ = winapi.AttachConsole(0xFFFFFFFF);
+    }
 
     var gpa_instance = std.heap.GeneralPurposeAllocator(.{}){};
     const gpa = gpa_instance.allocator();


### PR DESCRIPTION
Mentioned this in https://github.com/david-vanderson/dvui/pull/336#issuecomment-2953203748

This forwards backend logs (from the external library) to std.log so that users can implement implement their own log functions to log to files for example. The scope is different for external library logs and logs from our backend implementation, allowing for filtering their levels separately.  