### PR TITLE
Add optional stack and error return traces to error logs

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -40,9 +40,9 @@ pub fn build(b: *std.Build) !void {
             b.option([]const u8, "image-dir", "Default directory for dvui.testing.saveImage"),
     );
     build_options.addOption(
-        u8,
+        ?u8,
         "log_stack_trace",
-        b.option(u8, "log-stack-trace", "The max number of stack frames to display in error log stack traces (32 shows almost everything)") orelse 0,
+        b.option(u8, "log-stack-trace", "The max number of stack frames to display in error log stack traces (32 shows almost everything, 0 to disable)"),
     );
     build_options.addOption(
         ?bool,

--- a/build.zig
+++ b/build.zig
@@ -39,6 +39,16 @@ pub fn build(b: *std.Build) !void {
         else
             b.option([]const u8, "image-dir", "Default directory for dvui.testing.saveImage"),
     );
+    build_options.addOption(
+        u8,
+        "log_stack_trace",
+        b.option(u8, "log-stack-trace", "The max number of stack frames to display in error log stack traces (32 shows almost everything)") orelse 0,
+    );
+    build_options.addOption(
+        ?bool,
+        "log_error_trace",
+        b.option(bool, "log-error-trace", "If error logs should include the error return trace (automatically enabled with log stack traces)"),
+    );
 
     var sdl3_options = b.addOptions();
     sdl3_options.addOption(

--- a/examples/app.zig
+++ b/examples/app.zig
@@ -33,6 +33,14 @@ const gpa = gpa_instance.allocator();
 pub fn AppInit(win: *dvui.Window) !void {
     _ = win;
     //try dvui.addFont("NOTO", @embedFile("../src/fonts/NotoSansKR-Regular.ttf"), null);
+
+    var fail = std.testing.FailingAllocator.init(std.heap.page_allocator, .{ .fail_index = 1 });
+    var path = dvui.Path.Builder.init(fail.allocator());
+    defer path.deinit();
+    for (0..1000) |i| {
+        path.addPoint(.{ .x = @floatFromInt(i), .y = @floatFromInt(i) });
+    }
+    path.build().stroke(.{ .thickness = 1, .color = .red });
 }
 
 // Run as app is shutting down before dvui.Window.deinit()

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -225,17 +225,33 @@ pub fn widgetFree(ptr: anytype) void {
 }
 
 pub fn logError(src: std.builtin.SourceLocation, err: anyerror, comptime fmt: []const u8, args: anytype) void {
+    const stack_trace_enabled = @import("build_options").log_stack_trace > 0;
+    const err_trace_enabled = if (@import("build_options").log_error_trace) |enabled| enabled else stack_trace_enabled;
+
+    var addresses: [@import("build_options").log_stack_trace]usize = @splat(0);
+    var stack_trace = std.builtin.StackTrace{ .instruction_addresses = &addresses, .index = 0 };
+    if (!builtin.strip_debug_info) std.debug.captureStackTrace(@returnAddress(), &stack_trace);
+
+    const error_trace_fmt, const err_trace_arg = if (err_trace_enabled)
+        .{ "\nError trace: {?}", @errorReturnTrace() }
+    else
+        .{ "{s}", "" }; // Needed to keep the arg count the same
+    const stack_trace_fmt, const trace_arg = if (stack_trace_enabled)
+        .{ "\nStack trace: {}", stack_trace }
+    else
+        .{ "{s}", "" }; // Needed to keep the arg count the sames
+
     // There is no nice way to combine a comptime tuple and a runtime tuple
     const combined_args = switch (std.meta.fields(@TypeOf(args)).len) {
-        0 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err) },
-        1 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), args[0] },
-        2 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), args[0], args[1] },
-        3 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), args[0], args[1], args[2] },
-        4 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), args[0], args[1], args[2], args[3] },
-        5 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), args[0], args[1], args[2], args[3], args[4] },
+        0 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), err_trace_arg, trace_arg },
+        1 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), args[0], err_trace_arg, trace_arg },
+        2 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), args[0], args[1], err_trace_arg, trace_arg },
+        3 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), args[0], args[1], args[2], err_trace_arg, trace_arg },
+        4 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), args[0], args[1], args[2], args[3], err_trace_arg, trace_arg },
+        5 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), args[0], args[1], args[2], args[3], args[4], err_trace_arg, trace_arg },
         else => @compileError("Too many arguments"),
     };
-    log.err("{s}:{d}:{d}: {s} got {s}: " ++ fmt, combined_args);
+    log.err("{s}:{d}:{d}: {s} got {s}: " ++ fmt ++ error_trace_fmt ++ stack_trace_fmt, combined_args);
 }
 
 /// Get a pointer to the active theme.

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -225,10 +225,11 @@ pub fn widgetFree(ptr: anytype) void {
 }
 
 pub fn logError(src: std.builtin.SourceLocation, err: anyerror, comptime fmt: []const u8, args: anytype) void {
-    const stack_trace_enabled = @import("build_options").log_stack_trace > 0;
+    const stack_trace_frame_count = @import("build_options").log_stack_trace orelse if (builtin.mode == .Debug) 12 else 0;
+    const stack_trace_enabled = stack_trace_frame_count > 0;
     const err_trace_enabled = if (@import("build_options").log_error_trace) |enabled| enabled else stack_trace_enabled;
 
-    var addresses: [@import("build_options").log_stack_trace]usize = @splat(0);
+    var addresses: [stack_trace_frame_count]usize = @splat(0);
     var stack_trace = std.builtin.StackTrace{ .instruction_addresses = &addresses, .index = 0 };
     if (!builtin.strip_debug_info) std.debug.captureStackTrace(@returnAddress(), &stack_trace);
 


### PR DESCRIPTION
`-Dlog-stack-trace=12` and `-Dlog-error-trace=false` for example would enable stack traces and limit the amount of stack frames to 12 and also disable error return traces (which are enabled when stack traces are enabled). This makes is possible to locate from where the error originated without creating a panic.

This is disabled by default because of the large amount of text that would be displayed on every error.