### PR TITLE
make text layout have the padding and margin the same as labels

### DIFF
--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -24,8 +24,7 @@ const TextLayoutWidget = @This();
 /// 500 if our min width is zero).
 pub var defaults: Options = .{
     .name = "TextLayout",
-    .margin = Rect.all(4),
-    .padding = Rect.all(4),
+    .padding = Rect.all(6),
     .background = true,
 };
 


### PR DESCRIPTION
Fixes #381 

TextLayout default margin is removed.
TextLayout default padding set to 6.