### PR TITLE
Mouse event mods and shift horizontal scroll

### DIFF
--- a/readme-implementation.md
+++ b/readme-implementation.md
@@ -53,7 +53,6 @@ See the code for [pub fn sliderEntry](https://github.com/david-vanderson/dvui/bl
 * tab index
 * storing data from frame to frame
 * intercepting events and forwarding to child widgets
-* tracking ctrl key for ctrl-click
 * drawing a rounded rect
 
 ### One Frame At a Time

--- a/src/Event.zig
+++ b/src/Event.zig
@@ -127,6 +127,8 @@ pub const Mouse = struct {
     // mouse motion will be a touch or .none
     button: enums.Button,
 
+    mod: enums.Mod,
+
     p: dvui.Point.Physical,
     floating_win: dvui.WidgetId,
 };

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -2991,17 +2991,12 @@ pub fn scrollCanvas(comptime data: u8) void {
         dragBox.deinit();
     }
 
-    var ctrl_down = dvui.dataGet(null, vbox.data().id, "_ctrl", bool) orelse false;
     var zoom: f32 = 1;
     var zoomP: Point.Physical = .{};
 
     // process scroll area events after boxes so the boxes get first pick (so
     // the button works)
     for (evts) |*e| {
-        if (e.evt == .key and e.evt.key.matchBind("ctrl/cmd")) {
-            ctrl_down = (e.evt.key.action == .down or e.evt.key.action == .repeat);
-        }
-
         if (!scroll.scroll.matchEvent(e))
             continue;
 
@@ -3031,7 +3026,7 @@ pub fn scrollCanvas(comptime data: u8) void {
                             dvui.refresh(null, @src(), scroll.scroll.data().id);
                         }
                     }
-                } else if (me.action == .wheel_y and ctrl_down) {
+                } else if (me.action == .wheel_y and me.mod.ctrlOrCommand()) {
                     e.handle(@src(), scroll.scroll.data());
                     const base: f32 = 1.01;
                     const zs = @exp(@log(base) * me.action.wheel_y);
@@ -3065,8 +3060,6 @@ pub fn scrollCanvas(comptime data: u8) void {
 
         dvui.refresh(null, @src(), scroll.scroll.data().id);
     }
-
-    dvui.dataSet(null, vbox.data().id, "_ctrl", ctrl_down);
 
     scaler.deinit();
 

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -745,6 +745,9 @@ pub fn addEventPointer(self: *Self, b: dvui.enums.Button, action: Event.Mouse.Ac
 
 /// Add a mouse wheel event.  Positive ticks means scrolling up / scrolling left.
 ///
+/// If the shift key is being held, any vertical scroll will be transformed to
+/// horizontal.
+///
 /// This can be called outside begin/end.  You should add all the events
 /// for a frame either before begin() or just after begin() and before
 /// calling normal dvui widgets.  end() clears the event list.
@@ -758,7 +761,7 @@ pub fn addEventMouseWheel(self: *Self, ticks: f32, dir: dvui.enums.Direction) st
     self.event_num += 1;
     try self.events.append(self.arena(), Event{ .num = self.event_num, .evt = .{
         .mouse = .{
-            .action = if (dir == .vertical) .{ .wheel_y = ticks } else .{ .wheel_x = ticks },
+            .action = if (dir == .vertical and !self.modifiers.shift()) .{ .wheel_y = ticks } else .{ .wheel_x = ticks },
             .button = .none,
             .mod = self.modifiers,
             .p = self.mouse_pt,

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -743,7 +743,7 @@ pub fn addEventPointer(self: *Self, b: dvui.enums.Button, action: Event.Mouse.Ac
     return ret;
 }
 
-/// Add a mouse wheel event.  Positive ticks means scrolling up / scrolling left.
+/// Add a mouse wheel event.  Positive ticks means scrolling up / scrolling right.
 ///
 /// If the shift key is being held, any vertical scroll will be transformed to
 /// horizontal.
@@ -759,15 +759,26 @@ pub fn addEventMouseWheel(self: *Self, ticks: f32, dir: dvui.enums.Direction) st
     //std.debug.print("mouse wheel {d}\n", .{ticks});
 
     self.event_num += 1;
-    try self.events.append(self.arena(), Event{ .num = self.event_num, .evt = .{
-        .mouse = .{
-            .action = if (dir == .vertical and !self.modifiers.shift()) .{ .wheel_y = ticks } else .{ .wheel_x = ticks },
-            .button = .none,
-            .mod = self.modifiers,
-            .p = self.mouse_pt,
-            .floating_win = winId,
+    try self.events.append(self.arena(), Event{
+        .num = self.event_num,
+        .evt = .{
+            .mouse = .{
+                .action = if (dir == .vertical)
+                    if (!self.modifiers.shift())
+                        .{ .wheel_y = ticks }
+                    else
+                        // Invert ticks so scrolling up takes you left
+                        // (matches behaviour of text editors and browsers)
+                        .{ .wheel_x = -ticks }
+                else
+                    .{ .wheel_x = ticks },
+                .button = .none,
+                .mod = self.modifiers,
+                .p = self.mouse_pt,
+                .floating_win = winId,
+            },
         },
-    } });
+    });
 
     const ret = (self.wd.id != winId);
     try self.positionMouseEventAdd();

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -47,6 +47,10 @@ event_num: u16 = 0,
 // Start off screen so nothing is highlighted on the first frame
 mouse_pt: Point.Physical = .{ .x = -1, .y = -1 },
 mouse_pt_prev: Point.Physical = .{ .x = -1, .y = -1 },
+/// Holds the current state of the modifiers from the most
+/// recently added key event. Used for adding modifiers to
+/// mouse events
+modifiers: dvui.enums.Mod = .none,
 inject_motion_event: bool = false,
 
 drag_state: enum {
@@ -567,6 +571,8 @@ pub fn addEventKey(self: *Self, event: Event.Key) std.mem.Allocator.Error!bool {
 
     self.positionMouseEventRemove();
 
+    self.modifiers = event.mod;
+
     self.event_num += 1;
     try self.events.append(self.arena(), Event{
         .num = self.event_num,
@@ -645,6 +651,7 @@ pub fn addEventMouseMotionPhysical(self: *Self, newpt: Point.Physical) std.mem.A
         .mouse = .{
             .action = .{ .motion = dp },
             .button = if (self.debug_touch_simulate_events and self.debug_touch_simulate_down) .touch0 else .none,
+            .mod = self.modifiers,
             .p = self.mouse_pt,
             .floating_win = winId,
         },
@@ -713,6 +720,7 @@ pub fn addEventPointer(self: *Self, b: dvui.enums.Button, action: Event.Mouse.Ac
             .mouse = .{
                 .action = .focus,
                 .button = bb,
+                .mod = self.modifiers,
                 .p = self.mouse_pt,
                 .floating_win = winId,
             },
@@ -724,6 +732,7 @@ pub fn addEventPointer(self: *Self, b: dvui.enums.Button, action: Event.Mouse.Ac
         .mouse = .{
             .action = action,
             .button = bb,
+            .mod = self.modifiers,
             .p = self.mouse_pt,
             .floating_win = winId,
         },
@@ -751,6 +760,7 @@ pub fn addEventMouseWheel(self: *Self, ticks: f32, dir: dvui.enums.Direction) st
         .mouse = .{
             .action = if (dir == .vertical) .{ .wheel_y = ticks } else .{ .wheel_x = ticks },
             .button = .none,
+            .mod = self.modifiers,
             .p = self.mouse_pt,
             .floating_win = winId,
         },
@@ -782,6 +792,7 @@ pub fn addEventTouchMotion(self: *Self, finger: dvui.enums.Button, xnorm: f32, y
         .mouse = .{
             .action = .{ .motion = dp },
             .button = finger,
+            .mod = self.modifiers,
             .p = self.mouse_pt,
             .floating_win = winId,
         },
@@ -1134,6 +1145,7 @@ fn positionMouseEventAdd(self: *Self) std.mem.Allocator.Error!void {
     try self.events.append(self.arena(), .{ .evt = .{ .mouse = .{
         .action = .position,
         .button = .none,
+        .mod = self.modifiers,
         .p = self.mouse_pt,
         .floating_win = self.windowFor(self.mouse_pt),
     } } });

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5604,7 +5604,6 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
     const rs = b.data().contentRectScale();
 
     var text_mode = dataGet(null, b.data().id, "_text_mode", bool) orelse false;
-    var ctrl_down = dataGet(null, b.data().id, "_ctrl", bool) orelse false;
 
     // must call dataGet/dataSet on these every frame to prevent them from
     // getting purged
@@ -5634,10 +5633,6 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
 
         const evts = events();
         for (evts) |*e| {
-            if (e.evt == .key and e.evt.key.matchBind("ctrl/cmd")) {
-                ctrl_down = (e.evt.key.action == .down or e.evt.key.action == .repeat);
-            }
-
             if (!text_mode) {
                 // if we are switching out of text mode, skip processing any
                 // remaining events
@@ -5706,10 +5701,6 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
 
         const evts = events();
         for (evts) |*e| {
-            if (e.evt == .key and e.evt.key.matchBind("ctrl/cmd")) {
-                ctrl_down = (e.evt.key.action == .down or e.evt.key.action == .repeat);
-            }
-
             if (!eventMatch(e, .{ .id = b.data().id, .r = rs.r }))
                 continue;
 
@@ -5721,7 +5712,7 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
                         focusWidget(b.data().id, null, e.num);
                     } else if (me.action == .press and me.button.pointer()) {
                         e.handle(@src(), b.data());
-                        if (ctrl_down) {
+                        if (me.mod.ctrlOrCommand()) {
                             text_mode = true;
                             refresh(null, @src(), b.data().id);
                         } else {
@@ -5874,7 +5865,6 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
     }
 
     dataSet(null, b.data().id, "_text_mode", text_mode);
-    dataSet(null, b.data().id, "_ctrl", ctrl_down);
 
     if (ret) {
         refresh(null, @src(), b.data().id);

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -158,6 +158,11 @@ pub const Mod = enum(u16) {
         return self.has(.lcommand) or self.has(.rcommand);
     }
 
+    /// This uses `command` on MacOS and `control` otherwise
+    pub fn ctrlOrCommand(self: Mod) bool {
+        return if (builtin.target.os.tag == .macos) self.command() else self.control();
+    }
+
     ///combine two modifiers
     pub fn combine(self: *Mod, other: Mod) void {
         const s: u16 = @intFromEnum(self.*);


### PR DESCRIPTION
This started of by adding a way for mouse events to also have access for the current modifiers, for `ctrl+click` for example. The motivating reason was that I wanted to add `shift+scroll` as horizontal scroll as it always annoyed me not to be able to horizontally scroll without using the scroll bar. Not the last received modifiers from key events is stored on the `Window`, similar to `mouse_pt` and used for `ctrl+click` and `shift+scroll`.

There was some confusion about the direction of scroll and positive and negative tick values. The docs stated that positive meant up/left but when using a horizontal scroll wheel, positive meant right. The docs have now been updated accordingly and all current code (that I found) seemed to already handle/expect this.

d59d419bf0ca6b344277d79f86101360d96cd4a2 was also found and fixed to enable this modifier caching for raylib.