### PR TITLE
save rect of the focused widget

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -143,6 +143,7 @@ pub const Subwindow = struct {
     rect: Rect = Rect{},
     rect_pixels: dvui.Rect.Physical = .{},
     focused_widgetId: ?WidgetId = null,
+    focused_widgetRect: Rect.Physical = .{},
     render_cmds: std.ArrayList(dvui.RenderCommand),
     render_cmds_after: std.ArrayList(dvui.RenderCommand),
     used: bool = true,

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1375,6 +1375,7 @@ pub fn focusWidget(id: ?WidgetId, subwindow_id: ?WidgetId, event_num: ?u16) void
         if (swid == sw.id) {
             if (sw.focused_widgetId != id) {
                 sw.focused_widgetId = id;
+                sw.focused_widgetRect = .{};
                 if (event_num) |en| {
                     focusRemainingEvents(en, sw.id, sw.focused_widgetId);
                 }
@@ -1390,6 +1391,7 @@ pub fn focusWidget(id: ?WidgetId, subwindow_id: ?WidgetId, event_num: ?u16) void
                         while (true) : (wd = wd.parent.data()) {
                             if (wd.id == wid) {
                                 cw.last_focused_id_this_frame = wid;
+                                sw.focused_widgetRect = wd.rectScale().r;
                                 break;
                             }
 


### PR DESCRIPTION
What do you think of something like this?

It allows me to write a generic action like below that scrolls the grid to show the currently focused widget, whenever the focused widget changes. 

So, the user would call init() before creating any columns to get the currently focused widget and then if the focus changes during any of the grid columns, scroll to the focused widget. (It probably needs some more checking that the focused widget is actually in the grid, but that is easy to add).

```
pub const ScrollToFocused = struct {
    focused_wid: ?dvui.WidgetId = null,

    pub fn init() ScrollToFocused {
        return .{ .focused_wid = dvui.focusedWidgetId() };
    }

    pub fn performAction(self: *ScrollToFocused, grid: *GridWidget) void {
        const current_focus_wid = dvui.focusedWidgetId();
        if (current_focus_wid != self.focused_wid) {
            self.focused_wid = current_focus_wid;
        } else {
            return;
        }
        const sw = dvui.currentWindow().subwindowFocused();
        if (sw.focused_widgetId != null) {
            var scroll_to: dvui.Event = .{ .evt = .{ .scroll_to = .{
                .screen_rect = sw.focused_widgetRect,
                .over_scroll = false,
            } } };
            // TODO: Add a grid.scrollTo()? Can't just take a row number as the column might not be scrolled to, so needs a rect?
            // Or a better way to bubble the event to the scroll container.
            grid.scroll.scroll.processEvent(&scroll_to, true);
        }
    }
};
```
I'm calling processEvent directly on the scroll container here, because I don't have a child widget I can bubble the event on. But I'll find a way to make that nicer.

Edit: Also add a dvui.focusedWidgetIdAndRect() or similar?
