### PR TITLE
PanedWidget: Add init option for the ratio to be set when the widget …

### DIFF
--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -24,6 +24,9 @@ pub const InitOptions = struct {
     /// Use to save/control the split externally.
     split_ratio: ?*f32 = null,
 
+    /// When uncollapsing, the split ratio will be set to this value.
+    uncollapse_ratio: ?f32 = null,
+
     /// Thickness (logical) of sash handle.  If handle_dynamic is not null,
     /// this is min handle size.
     handle_size: f32 = 4,
@@ -90,7 +93,9 @@ pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Op
         // expanding
         self.collapsing = false;
         self.collapsed_state = false;
-        if (self.split_ratio.* > 0.5) {
+        if (self.init_opts.uncollapse_ratio) |ratio| {
+            self.animateSplit(ratio);
+        } else if (self.split_ratio.* > 0.5) {
             self.animateSplit(0.5);
         } else {
             // we were on the second widget, this will


### PR DESCRIPTION
…un-collapses.

This is cool for anything that uses the paned widget and wants to remember the paned locations and have those persist when the widget uncollapses. In my app I can just read from settings for the split ratios and then set the uncollapse ratio to the settings, and then only set the settings value if the window isn't collapsing/collapsed and the behavior is really nice.

Simple change, let me know if you want me to redo this with different names or anything.

Thanks!