### PR TITLE
GridWidget: Extract headers from grid body plus other improvements

### DIFF
--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -4687,6 +4687,7 @@ pub fn gridHeading(
     src: std.builtin.SourceLocation,
     g: *GridWidget,
     heading: []const u8,
+    col_num: usize,
     resize_opts: ?GridWidget.HeaderResizeWidget.InitOptions,
     cell_style: anytype, // GridWidget.CellStyle
 ) void {
@@ -4700,8 +4701,8 @@ pub fn gridHeading(
     };
     const opts = if (@TypeOf(cell_style) == @TypeOf(.{})) GridWidget.CellStyle.none else cell_style;
 
-    const label_options = label_defaults.override(opts.options(g.col_num, 0));
-    var cell = g.headerCell(src, opts.cellOptions(g.col_num, 0));
+    const label_options = label_defaults.override(opts.options(col_num, 0));
+    var cell = g.headerCell(src, col_num, opts.cellOptions(col_num, 0));
     defer cell.deinit();
 
     labelNoFmt(@src(), heading, .{}, label_options);
@@ -4715,6 +4716,7 @@ pub fn gridHeading(
 pub fn gridHeadingSortable(
     src: std.builtin.SourceLocation,
     g: *GridWidget,
+    col_num: usize,
     heading: []const u8,
     dir: *GridWidget.SortDirection,
     resize_opts: ?GridWidget.HeaderResizeWidget.InitOptions,
@@ -4729,21 +4731,21 @@ pub fn gridHeadingSortable(
         .corner_radius = Rect.all(0),
     };
     const opts = if (@TypeOf(cell_style) == @TypeOf(.{})) GridWidget.CellStyle.none else cell_style;
-    const heading_opts = heading_defaults.override(opts.options(g.col_num, 0));
+    const heading_opts = heading_defaults.override(opts.options(col_num, 0));
 
-    var cell = g.headerCell(src, opts.cellOptions(g.col_num, 0));
+    var cell = g.headerCell(src, col_num, opts.cellOptions(col_num, 0));
     defer cell.deinit();
 
     gridHeadingSeparator(resize_opts);
 
-    const sort_changed = switch (g.colSortOrder()) {
+    const sort_changed = switch (g.colSortOrder(col_num)) {
         .unsorted => button(@src(), heading, .{ .draw_focus = false }, heading_opts),
         .ascending => buttonLabelAndIcon(@src(), heading, icon_ascending, .{ .draw_focus = false }, heading_opts),
         .descending => buttonLabelAndIcon(@src(), heading, icon_descending, .{ .draw_focus = false }, heading_opts),
     };
 
     if (sort_changed) {
-        g.sortChanged();
+        g.sortChanged(col_num);
     }
     dir.* = g.sort_direction;
     return sort_changed;
@@ -4758,6 +4760,7 @@ pub fn gridHeadingSortable(
 pub fn gridColumnFromSlice(
     src: std.builtin.SourceLocation,
     g: *GridWidget,
+    col_num: usize,
     comptime T: type,
     data: []const T,
     comptime field_name: ?[]const u8,
@@ -4791,8 +4794,9 @@ pub fn gridColumnFromSlice(
     for (data, 0..) |item, row_num| {
         var cell = g.bodyCell(
             src,
+            col_num,
             row_num,
-            opts.cellOptions(g.col_num, row_num),
+            opts.cellOptions(col_num, row_num),
         );
         defer cell.deinit();
         const cell_value = value: {
@@ -4816,7 +4820,7 @@ pub fn gridColumnFromSlice(
             @src(),
             fmt,
             .{cell_value},
-            opts.options(g.col_num, row_num),
+            opts.options(col_num, row_num),
         );
     }
 }
@@ -4834,6 +4838,7 @@ pub const GridColumnSelectAllState = enum {
 pub fn gridHeadingCheckbox(
     src: std.builtin.SourceLocation,
     g: *GridWidget,
+    col_num: usize,
     selection: *GridColumnSelectAllState,
     cell_style: anytype, // GridWidget.CellStyle
 ) bool {
@@ -4848,13 +4853,13 @@ pub fn gridHeadingCheckbox(
 
     const opts = if (@TypeOf(cell_style) == @TypeOf(.{})) GridWidget.CellStyle.none else cell_style;
 
-    const header_options = header_defaults.override(opts.options(g.col_num, 0));
+    const header_options = header_defaults.override(opts.options(col_num, 0));
     var checkbox_opts: Options = header_options.strip();
     checkbox_opts.padding = ButtonWidget.defaults.paddingGet();
     checkbox_opts.gravity_x = header_options.gravity_x;
     checkbox_opts.gravity_y = header_options.gravity_y;
 
-    var cell = g.headerCell(src, opts.cellOptions(g.col_num, 0));
+    var cell = g.headerCell(src, col_num, opts.cellOptions(col_num, 0));
     defer cell.deinit();
 
     var clicked = false;
@@ -4886,6 +4891,7 @@ pub fn gridHeadingCheckbox(
 pub fn gridColumnCheckbox(
     src: std.builtin.SourceLocation,
     g: *dvui.GridWidget,
+    col_num: usize,
     comptime T: type,
     data: []T,
     comptime field_name: ?[]const u8,
@@ -4914,8 +4920,9 @@ pub fn gridColumnCheckbox(
     for (data, 0..) |*item, row_num| {
         var cell = g.bodyCell(
             src,
+            col_num,
             row_num,
-            opts.cellOptions(g.col_num, row_num),
+            opts.cellOptions(col_num, row_num),
         );
         defer cell.deinit();
         const is_selected: *bool = if (T == bool) item else &@field(item, field_name.?);
@@ -4924,7 +4931,7 @@ pub fn gridColumnCheckbox(
             @src(),
             is_selected,
             null,
-            check_defaults.override(opts.options(g.col_num, row_num)),
+            check_defaults.override(opts.options(col_num, row_num)),
         );
         selection_changed = selection_changed or was_selected != is_selected.*;
     }

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -842,5 +842,6 @@ pub const HeaderResizeWidget = struct {
     }
 };
 test {
+    _ = @import("GridWidget/testing.zig");
     @import("std").testing.refAllDecls(@This());
 }

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -5,6 +5,14 @@
 // TODO: Fix issue where have to specify col width the the var row height demo. Not sure why that is needed?
 // TODO: Do we maintain the y-offset thing so that people with variable row heights can do their own virtual scrolling?
 //            - Maybe dump it unless someone actually needs it. It's pretty hard to virtual scroll with variable heights.
+// TODO: Fix error in demo when turning on horizontal scrolling
+// TODO: Used to be able to limit resizing to just withing the window, i.e. not start hscrolling. Can we still do that?
+// TODO: Resizable demo starts out hscrolling rather than fitting to window like previous. What should it be doing???
+// TODO: Tension between setting the min content width on bbox in the body scroll area and horizontal scrolling.
+//        - So if set min content size, then it will hscroll without asking. Maybe that is better.
+//        - But it also means that the grid won't be the first widget to collapse, even if another has a min content size.
+// What if we use a rect instead? - Nope.
+// TODO: Why do we need to subtract more scrollbar padding from the fit window layout?
 
 const std = @import("std");
 const dvui = @import("../dvui.zig");
@@ -298,7 +306,7 @@ fn headerScrollAreaCreate(self: *GridWidget) void {
             .expand = .horizontal,
             .min_size_content = .{
                 .h = self.header_height,
-                .w = self.totalWidth(),
+                //.w = self.totalWidth(),
             },
         });
         self.hscroll.?.install();
@@ -341,18 +349,28 @@ pub fn bodyScrollContainerCreate(self: *GridWidget, src: std.builtin.SourceLocat
         self.bscroll.?.install();
         self.bscroll.?.processEvents();
         self.bscroll.?.processVelocity();
+
+        // TODO: What is the proper way to do this?
+        // - Set the virtual size directly on hte scroll_containers scroll_info? This seems dangerous if they aren't using .given
+        // - Use the box to represent the area
+        // - Some other way?
+        //self.bsi.virtual_size.h = self.last_height;
+        //self.bsi.virtual_size.w = self.totalWidth();
         // Use this box to set the size of the scrollable area. Not sure why min/max size content on the scroll area doesn't work?
-        const w = self.totalWidth();
+        //const w = self.totalWidth();
         self.bbox = BoxWidget.init(
             @src(),
             .{ .dir = .horizontal },
             .{
-                .min_size_content = .{ .h = self.last_height, .w = w },
-                .max_size_content = .{ .h = self.last_height, .w = w },
-                .expand = .both,
+                //.rect = .{ .x = 0, .y = 0, .w = self.totalWidth(), .h = self.last_height },
+                .min_size_content = .{ .h = self.last_height, .w = self.totalWidth() },
+                //.max_size_content = .height(self.last_height),
+                //.expand = .both,
             },
         );
         self.bbox.install();
+        std.debug.print("min_size = {}\n", .{self.bbox.data().options.min_size_content orelse dvui.Size.zero});
+        //self.bbox.minSizeForChild(.{ .h = self.last_height, .w = self.totalWidth() });
     }
 }
 
@@ -409,7 +427,8 @@ pub fn headerCell(self: *GridWidget, src: std.builtin.SourceLocation, col_num: u
     // Determine heights for next frame.
     if (cell.data().contentRect().h > 0) {
         const cell_size = cell.data().rect.size();
-        self.colWidthSet(col_num, cell_size.w);
+        if (opts.width() > 0) // TODO: Can we clean this up somehow?
+            self.colWidthSet(col_num, cell_size.w);
         self.header_height = @max(self.header_height, cell_size.h);
     }
     return cell;
@@ -599,6 +618,8 @@ pub const HeaderResizeWidget = struct {
         min_size: ?f32 = null,
         // Will not resize to more than this value
         max_size: ?f32 = null,
+        // The total width of all columns will not exceed this value. // TODO:
+        total_size: ?f32 = null,
 
         pub const fixed: ?InitOptions = null;
     };

--- a/src/widgets/GridWidget/CellStyle.zig
+++ b/src/widgets/GridWidget/CellStyle.zig
@@ -176,3 +176,7 @@ pub const HoveredRow = struct {
         };
     }
 };
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/GridWidget/testing.zig
+++ b/src/widgets/GridWidget/testing.zig
@@ -1,0 +1,516 @@
+const std = @import("std");
+const dvui = @import("../../dvui.zig");
+const GridWidget = dvui.GridWidget;
+
+test "GridWidget: basic by col" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var box = dvui.box(@src(), .vertical, .{ .expand = .both, .background = true, .color_fill = .fill_window });
+            defer box.deinit();
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(10) }, .{ .expand = .both }); // TODO: .expand!
+            defer grid.deinit();
+            {
+                for (0..10) |col| {
+                    var cell = grid.headerCell(@src(), col, .{ .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}", .{col}, .{});
+                }
+                for (0..10) |col| {
+                    for (0..10) |row| {
+                        var cell = grid.bodyCell(@src(), col, row, .{});
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                    }
+                }
+            }
+
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-basic_by_col.png");
+}
+
+test "GridWidget: basic by row" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var box = dvui.box(@src(), .vertical, .{ .expand = .both, .background = true, .color_fill = .fill_window });
+            defer box.deinit();
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(10) }, .{ .expand = .both }); // TODO: .expand!
+            defer grid.deinit();
+            {
+                for (0..10) |col| {
+                    var cell = grid.headerCell(@src(), col, .{ .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}", .{col}, .{});
+                }
+                for (0..10) |row| {
+                    for (0..10) |col| {
+                        var cell = grid.bodyCell(@src(), col, row, .{});
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                    }
+                }
+            }
+
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-basic_by_row.png");
+}
+
+test "GridWidget: empty grid" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var box = dvui.box(@src(), .vertical, .{ .expand = .both, .background = true, .color_fill = .fill_window });
+            defer box.deinit();
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(0) }, .{});
+            defer grid.deinit();
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-empty.png");
+}
+
+test "GridWidget: one cell" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var box = dvui.box(@src(), .vertical, .{ .expand = .both, .background = true, .color_fill = .fill_window });
+            defer box.deinit();
+
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(1) }, .{ .expand = .both }); // TODO:
+            defer grid.deinit();
+            var cell = grid.bodyCell(@src(), 0, 0, .{});
+            defer cell.deinit();
+            dvui.labelNoFmt(@src(), "0:0", .{}, .{});
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-one_cell.png");
+}
+
+test "GridWidget: populate by col" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(10) }, .{}); // TODO:
+            defer grid.deinit();
+            for (0..10) |col| {
+                for (0..10) |row| {
+                    var cell = grid.bodyCell(@src(), col, row, .{});
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-by_col.png");
+}
+
+test "GridWidget: populate by col no expand" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(10) }, .{}); // TODO:
+            defer grid.deinit();
+            for (0..10) |col| {
+                for (0..10) |row| {
+                    var cell = grid.bodyCell(@src(), col, row, .{});
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-by_col_no_expand.png");
+}
+
+test "GridWidget: populate by row" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(10) }, .{}); // TODO:
+            defer grid.deinit();
+            for (0..10) |row| {
+                for (0..10) |col| {
+                    var cell = grid.bodyCell(@src(), col, row, .{});
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-by_row.png");
+}
+
+test "GridWidget: populate by reverse rol, col" {
+    // This should be the most difficult as the layout starts in the bottom right and moves to the top-left.
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(10) }, .{}); // TODO:
+            defer grid.deinit();
+            for (0..10) |row| {
+                for (0..10) |col| {
+                    var cell = grid.bodyCell(@src(), 9 - col, 9 - row, .{});
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ 9 - col, 9 - row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-by_reverse_row_col.png");
+}
+
+test "GridWidget: col out of bounds" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(5) }, .{});
+            defer grid.deinit();
+            for (0..10) |col| {
+                for (0..10) |row| {
+                    var cell = grid.bodyCell(@src(), col, row, .{});
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-col_out_of_bounds.png");
+}
+
+test "GridWidget: col widths" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        var col_widths: [10]f32 = @splat(50);
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .{ .cols = .colWidths(&col_widths) }, .{ .expand = .horizontal }); // TODO: No .expand
+            defer grid.deinit();
+            for (0..10) |col| {
+                for (0..10) |row| {
+                    var cell = grid.bodyCell(@src(), col, row, .{});
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-col_widths.png");
+}
+
+test "GridWidget: cell widths" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            // TODO: This should work without .expand
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(10) }, .{ .expand = .horizontal });
+            defer grid.deinit();
+            for (0..10) |col| {
+                for (0..10) |row| {
+                    var cell = grid.bodyCell(@src(), col, row, .{ .size = .{ .w = 50 } });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-cell_widths.png");
+}
+
+test "GridWidget: ignore cell_heights" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(10) }, .{});
+            defer grid.deinit();
+            for (0..10) |col| {
+                for (0..10) |row| {
+                    var cell = grid.bodyCell(@src(), col, row, .{ .size = .{ .h = 200 }, .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-ignore_cell_height.png");
+}
+
+test "GridWidget: variable cell_heights by col" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(10), .var_row_heights = true }, .{ .expand = .both });
+            defer grid.deinit();
+            for (0..10) |col| {
+                for (0..10) |row| {
+                    const row_f: f32 = @floatFromInt(row);
+                    var cell = grid.bodyCell(@src(), col, row, .{ .size = .{ .h = @abs(5 - row_f) * 15 + 30 }, .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-variable_cell_height_col.png");
+}
+
+test "GridWidget: variable cell_heights by row" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(10), .var_row_heights = true }, .{ .expand = .vertical }); // TODO: no expand
+            defer grid.deinit();
+            for (0..10) |row| {
+                for (0..10) |col| {
+                    const row_f: f32 = @floatFromInt(row);
+                    var cell = grid.bodyCell(@src(), col, row, .{ .size = .{ .h = @abs(5 - row_f) * 15 + 30 }, .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-variable_cell_height_row.png");
+}
+
+test "GridWidget: styling" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(10) }, .{ .expand = .both }); // TODO: no expand
+            defer grid.deinit();
+            for (0..10) |row| {
+                for (0..10) |col| {
+                    var cell = grid.bodyCell(@src(), col, row, .{
+                        .border = dvui.Rect.all(15),
+                        .padding = dvui.Rect.all(15),
+                        .margin = dvui.Rect.all(15),
+                    });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-styling.png");
+}
+
+test "GridWidget: styling empty" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(10) }, .{ .expand = .both }); // TODO: no expand
+            defer grid.deinit();
+            for (0..10) |row| {
+                for (0..10) |col| {
+                    var cell = grid.bodyCell(@src(), col, row, .{
+                        .border = dvui.Rect.all(15),
+                        .padding = dvui.Rect.all(15),
+                        .margin = dvui.Rect.all(15),
+                    });
+                    defer cell.deinit();
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-styling_empty.png");
+}
+
+test "GridWidget: heading only" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(10) }, .{ .expand = .both }); // TODO: no expand
+            defer grid.deinit();
+            for (0..10) |col| {
+                var cell = grid.headerCell(@src(), col, .{ .color_fill = .fill_control, .background = true });
+                defer cell.deinit();
+                dvui.label(@src(), "Col {}", .{col}, .{});
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-heading_only.png");
+}
+
+test "GridWidget: body then header" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(10) }, .{ .expand = .both }); // TODO: no expand
+            defer grid.deinit();
+            {
+                var cell = grid.bodyCell(@src(), 0, 0, .{});
+                defer cell.deinit();
+                dvui.labelNoFmt(@src(), "Body", .{}, .{});
+            }
+            {
+                var cell = grid.headerCell(@src(), 0, .{});
+                defer cell.deinit();
+                dvui.labelNoFmt(@src(), "Header", .{}, .{});
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-body_then_header.png");
+}
+
+test "GridWidget: vary header height" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var box = dvui.box(@src(), .vertical, .{ .expand = .both, .background = true, .color_fill = .fill_window });
+            defer box.deinit();
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(4) }, .{});
+            defer grid.deinit();
+            {
+                for (0..4) |col| {
+                    var cell = grid.headerCell(@src(), col, .{ .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}", .{col}, .{ .font_style = switch (col) {
+                        0 => .title_2,
+                        1 => .title_3,
+                        2 => .title_1,
+                        3 => .title_4,
+                        else => unreachable,
+                    } });
+                }
+                for (0..4) |col| {
+                    for (0..4) |row| {
+                        var cell = grid.bodyCell(@src(), col, row, .{});
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                    }
+                }
+            }
+
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-vary_header_height.png");
+}
+
+test "GridWidget: vary row height" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var box = dvui.box(@src(), .vertical, .{ .expand = .both, .background = true, .color_fill = .fill_window });
+            defer box.deinit();
+            var grid = dvui.grid(@src(), .{ .cols = .numCols(4) }, .{});
+            defer grid.deinit();
+            {
+                for (0..4) |col| {
+                    var cell = grid.headerCell(@src(), col, .{ .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}", .{col}, .{});
+                }
+                for (0..4) |col| {
+                    for (0..4) |row| {
+                        var cell = grid.bodyCell(@src(), col, row, .{
+                            .border = dvui.Rect.all(1),
+                        });
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{
+                            .font_style = switch (row) {
+                                0 => .title_2,
+                                1 => .title_3,
+                                2 => .title_1,
+                                3 => .title_4,
+                                else => unreachable,
+                            },
+                        });
+                    }
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-vary_row_height.png");
+}


### PR DESCRIPTION
As prophesized, I'm stuck on an issue with the fit to content, and I think it might be an issue with the display of scrollbars in the scroll area? 

The first thing I noticed is that the frame count was hitting 60fps with no input, which I tracked down to the width of the content rect for the grid changing by +/-10px per frame. i.e. a scroll-bar width.

Now this only happens on "Demo Window" screen where it shows mini versions of the demos. If I actually open the demo, the FPS drops back to normal.

I've had to put an extra -10px in the example for the "Styling and sorting" demo as below to stop it. Removing the -10 demonstrates the behaviour.
Setting the vertical scrollbar to always be shown also fixes the issue, no additional -10 is required.
```
        // TODO: Why does this need -10? The columnLayoutProportional is already subtracting the scrollbar width from the content width?
        dvui.columnLayoutProportional(&.{ -1, -1 }, &local.col_widths, outer_hbox.data().contentRect().w - grid_panel_size.w - 10);
        std.debug.print("hbox_ = {d}, grid_w = {d}, widths = {d}\n", .{ outer_hbox.data().contentRect().w, grid.data().contentRect().w, local.col_widths });
```
The -10 does need to happen, but columnLayoutProportional already subtracts that.

The reason I think it might be a scroll area issue is that I saw some strange behaviour when I was playing with different methods of setting the content size for the scroll rect. In cases where the hscroll bar or vscroll bar where not at the edges of the grid content area, I'd see the horizontal and vertical scroll-bars sometimes show and sometimes disappear as I moved the mouse in, out and around the demo windows (I don't remember exactly the scenario, sorry). If I recall correctly, they should not have been showing at all.

Anyway, this isn't holding me up and I can live with the work-around for now. I'll see if I can work out that previous scenario. But if you can find some time to have a look, it would be much appreciated. 

Outside of that the grid demos appear to be working 100%. More testing and a little cleanup required, but is close.

