### PR TITLE
Grid Widget: Remove headers from body and other improvements

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -4020,109 +4020,20 @@ fn gridStyling() void {
         var banding: Banding = .none;
         var margin: f32 = 0;
         var padding: f32 = 0;
-
+        var col_widths: [2]f32 = @splat(0);
         const Banding = enum { none, rows, cols };
     };
 
     var outer_hbox = dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
     defer outer_hbox.deinit();
-    const row_background = local.banding != .none or local.borders.nonZero();
 
-    {
-        var grid = dvui.grid(@src(), .{ .resize_rows = local.resize_rows }, .{
-            .expand = .both,
-            .background = true,
-            .border = Rect.all(1),
-        });
-        defer grid.deinit();
-        local.resize_rows = false; // Only resize rows when needed.
-
-        // Set start, end and interval based on sort direction.
-        const start_temp: i32, //
-        const end_temp: i32, //
-        const interval: i32 = switch (local.sort_dir) {
-            .ascending, .unsorted => .{ 0, 100, 5 },
-            .descending => .{ 100, 0, -5 },
-        };
-        std.debug.assert(@mod(end_temp - start_temp, interval) == 0); // Temperature range must be a multiple of interval
-
-        // Manually control sorting, so that sort direction is always reversed regardless of
-        // which column header is clicked.
-        const current_sort_dir = local.sort_dir;
-
-        const cell_opts: GridWidget.CellStyle.Banded = .{
-            .banding = switch (local.banding) {
-                .none, .rows => .rows,
-                .cols => .cols,
-            },
-
-            .cell_opts = .{
-                .border = local.borders,
-                .background = row_background,
-                .margin = Rect.all(local.margin),
-                .padding = Rect.all(local.padding),
-            },
-            .alt_cell_opts = .{
-                .border = local.borders,
-                .margin = Rect.all(local.margin),
-                .padding = Rect.all(local.padding),
-                .background = row_background,
-                // Only set the alternate fill colour if actually banding.
-                .color_fill = if (local.banding != .none) .fill_press else null,
-            },
-        };
-
-        // First column displays temperature in Celcius.
-        {
-            var col = grid.column(@src(), .{});
-            defer col.deinit();
-            // Set this column as the default sort
-            if (current_sort_dir == .unsorted) {
-                local.sort_dir = .ascending;
-                grid.colSortSet(local.sort_dir);
-            }
-
-            if (dvui.gridHeadingSortable(@src(), grid, "Celcius", &local.sort_dir, .fixed, .{})) {
-                grid.colSortSet(current_sort_dir.reverse());
-            }
-
-            var temp: i32 = start_temp;
-            var row_num: usize = 0;
-            while (temp != end_temp + interval) : ({
-                temp += interval;
-                row_num += 1;
-            }) {
-                var cell = grid.bodyCell(@src(), row_num, cell_opts.cellOptions(grid.col_num, row_num));
-                defer cell.deinit();
-                dvui.label(@src(), "{d}", .{temp}, .{ .gravity_x = 0.5, .expand = .horizontal });
-            }
-        }
-        // Second column displays temperature in Farenheight.
-        {
-            var col = grid.column(@src(), .{});
-            defer col.deinit();
-            if (dvui.gridHeadingSortable(@src(), grid, "Fahrenheit", &local.sort_dir, .fixed, .{})) {
-                grid.colSortSet(current_sort_dir.reverse());
-            }
-
-            var temp: i32 = start_temp;
-            var row_num: usize = 0;
-            while (temp != end_temp + interval) : ({
-                temp += interval;
-                row_num += 1;
-            }) {
-                var cell = grid.bodyCell(@src(), row_num, cell_opts.cellOptions(grid.col_num, row_num));
-                defer cell.deinit();
-                dvui.label(@src(), "{d}", .{@divFloor(temp * 9, 5) + 32}, .{ .gravity_x = 0.5, .expand = .horizontal });
-            }
-        }
-    }
     {
         var outer_vbox = dvui.box(@src(), .vertical, .{
             .min_size_content = grid_panel_size,
             .max_size_content = .size(grid_panel_size),
             .expand = .vertical,
             .border = Rect.all(1),
+            .gravity_x = 1.0,
         });
         defer outer_vbox.deinit();
 
@@ -4190,6 +4101,101 @@ fn gridStyling() void {
             }
         }
     }
+
+    const row_background = local.banding != .none or local.borders.nonZero();
+
+    {
+        var grid = dvui.grid(@src(), .colWidths(&local.col_widths), .{
+            .resize_rows = local.resize_rows,
+        }, .{
+            .expand = .both,
+            .background = true,
+            .border = Rect.all(1),
+        });
+        defer grid.deinit();
+
+        // Layout both columns equally, taking up the full width of the grid.
+        dvui.columnLayoutProportional(&.{ -1, -1 }, &local.col_widths, grid.data().contentRect().w);
+
+        local.resize_rows = false; // Only resize rows when needed.
+
+        // Set start, end and interval based on sort direction.
+        const start_temp: i32, //
+        const end_temp: i32, //
+        const interval: i32 = switch (local.sort_dir) {
+            .ascending, .unsorted => .{ 0, 100, 5 },
+            .descending => .{ 100, 0, -5 },
+        };
+
+        std.debug.assert(@mod(end_temp - start_temp, interval) == 0); // Temperature range must be a multiple of interval
+
+        // Manually control sorting, so that sort direction is always reversed regardless of
+        // which column header is clicked.
+        const current_sort_dir = local.sort_dir;
+
+        const cell_opts: GridWidget.CellStyle.Banded = .{
+            .banding = switch (local.banding) {
+                .none, .rows => .rows,
+                .cols => .cols,
+            },
+
+            .cell_opts = .{
+                .border = local.borders,
+                .background = row_background,
+                .margin = Rect.all(local.margin),
+                .padding = Rect.all(local.padding),
+            },
+            .alt_cell_opts = .{
+                .border = local.borders,
+                .margin = Rect.all(local.margin),
+                .padding = Rect.all(local.padding),
+                .background = row_background,
+                // Only set the alternate fill colour if actually banding.
+                .color_fill = if (local.banding != .none) .fill_press else null,
+            },
+        };
+
+        if (dvui.gridHeadingSortable(@src(), grid, 0, "Celcius", &local.sort_dir, .fixed, .{})) {
+            grid.colSortSet(0, current_sort_dir.reverse());
+        }
+
+        if (dvui.gridHeadingSortable(@src(), grid, 1, "Fahrenheit", &local.sort_dir, .fixed, .{})) {
+            grid.colSortSet(1, current_sort_dir.reverse());
+        }
+
+        // First column displays temperature in Celcius.
+        {
+            // Set this column as the default sort
+            if (current_sort_dir == .unsorted) {
+                local.sort_dir = .ascending;
+                grid.colSortSet(0, local.sort_dir);
+            }
+
+            var temp: i32 = start_temp;
+            var row_num: usize = 0;
+            while (temp != end_temp + interval) : ({
+                temp += interval;
+                row_num += 1;
+            }) {
+                var cell = grid.bodyCell(@src(), 0, row_num, cell_opts.cellOptions(0, row_num));
+                defer cell.deinit();
+                dvui.label(@src(), "{d}", .{temp}, .{ .gravity_x = 0.5, .expand = .horizontal });
+            }
+        }
+        // Second column displays temperature in Farenheight.
+        {
+            var temp: i32 = start_temp;
+            var row_num: usize = 0;
+            while (temp != end_temp + interval) : ({
+                temp += interval;
+                row_num += 1;
+            }) {
+                var cell = grid.bodyCell(@src(), 1, row_num, cell_opts.cellOptions(1, row_num));
+                defer cell.deinit();
+                dvui.label(@src(), "{d}", .{@divFloor(temp * 9, 5) + 32}, .{ .gravity_x = 0.5, .expand = .horizontal });
+            }
+        }
+    }
 }
 
 fn gridLayouts() void {
@@ -4221,6 +4227,7 @@ fn gridLayouts() void {
         const column_ratios = [num_cols]f32{ checkbox_w, -10, -10, -7, -15, -30 };
         const fixed_widths = [num_cols]f32{ checkbox_w, 80, 120, 80, 100, 300 };
         const equal_spacing = [num_cols]f32{ checkbox_w, -1, -1, -1, -1, -1 };
+        const fit_window = [num_cols]f32{ checkbox_w, 0, 0, 0, 0, 0 };
         var selection_state: dvui.GridColumnSelectAllState = .select_none;
         var sort_dir: GridWidget.SortDirection = .unsorted;
         var layout_style: Layout = .proportional;
@@ -4228,13 +4235,13 @@ fn gridLayouts() void {
         var resize_rows: bool = false;
 
         /// Create a textArea for the description so that the text can wrap.
-        fn customDescriptionColumn(src: std.builtin.SourceLocation, grid: *GridWidget, data: []Car, opts: *const GridWidget.CellStyle.Banded) void {
+        fn customDescriptionColumn(src: std.builtin.SourceLocation, grid: *GridWidget, col_num: usize, data: []Car, opts: *const GridWidget.CellStyle.Banded) void {
             for (data, 0..) |*car, row_num| {
-                var col = grid.bodyCell(src, row_num, opts.cellOptions(grid.col_num, row_num));
+                var col = grid.bodyCell(src, col_num, row_num, opts.cellOptions(col_num, row_num));
                 defer col.deinit();
                 var text = dvui.textLayout(@src(), .{ .break_lines = true }, .{ .expand = .both, .background = false });
                 defer text.deinit();
-                text.addText(car.description, opts.options(grid.col_num, row_num));
+                text.addText(car.description, opts.options(col_num, row_num));
             }
         }
 
@@ -4302,10 +4309,12 @@ fn gridLayouts() void {
 
         const resize_min = 80;
         const resize_max = 500;
-        fn headerResizeOptions(col_num: usize) ?GridWidget.HeaderResizeWidget.InitOptions {
+        fn headerResizeOptions(grid: *GridWidget, col_num: usize) ?GridWidget.HeaderResizeWidget.InitOptions {
+            _ = grid;
             if (layout_style != .user_resizable) return .fixed;
             return .{
-                .size = &col_widths[col_num],
+                .sizes = &col_widths,
+                .num = col_num,
                 .min_size = resize_min,
                 .max_size = resize_max,
             };
@@ -4358,13 +4367,7 @@ fn gridLayouts() void {
         else
             null;
 
-        const col_widths: ?[]f32 = switch (local.layout_style) {
-            .fit_window => null,
-            else => &local.col_widths,
-        };
-
-        var grid = dvui.grid(@src(), .{
-            .col_widths = col_widths,
+        var grid = dvui.grid(@src(), .colWidths(&local.col_widths), .{
             .scroll_opts = scroll_opts,
             .resize_rows = local.resize_rows,
         }, .{
@@ -4375,80 +4378,76 @@ fn gridLayouts() void {
             .max_size_content = .height(content_h),
         });
         defer grid.deinit();
+        local.resize_rows = false;
 
-        // Fit columns to the grid visible area, or to the virtual scroll area if horizontal scorlling is enabled.
-        const maybe_ratio = switch (local.layout_style) {
+        const col_widths_src: ?[]const f32 = switch (local.layout_style) {
             .equal_spacing => &local.equal_spacing,
             .fixed_width => &local.fixed_widths,
             .proportional => &local.column_ratios,
-            .fit_window => null,
+            .fit_window => &local.equal_spacing,
             .user_resizable => null,
         };
-        if (maybe_ratio) |ratio| {
-            dvui.columnLayoutProportional(ratio, &local.col_widths, if (local.h_scroll) 1024 else grid.data().contentRect().w);
+        if (col_widths_src) |col_widths| {
+            switch (local.layout_style) {
+                .fit_window => {
+                    dvui.columnLayoutProportional(col_widths, &local.col_widths, grid.data().contentRect().w);
+                },
+                else => {
+                    // Fit columns to the grid visible area, or to the virtual scroll area if horizontal scorlling is enabled.
+                    dvui.columnLayoutProportional(col_widths, &local.col_widths, if (local.h_scroll) 1024 else grid.data().contentRect().w);
+                },
+            }
         }
-        local.resize_rows = false;
+
+        if (dvui.gridHeadingCheckbox(@src(), grid, 0, &local.selection_state, .{})) {
+            for (all_cars) |*car| {
+                car.selected = switch (local.selection_state) {
+                    .select_all => true,
+                    .select_none => false,
+                    .unchanged => break,
+                };
+            }
+        }
+        if (dvui.gridHeadingSortable(@src(), grid, 1, "Make", &local.sort_dir, local.headerResizeOptions(grid, 1), .{})) {
+            local.sort("Make");
+        }
+        if (dvui.gridHeadingSortable(@src(), grid, 2, "Model", &local.sort_dir, local.headerResizeOptions(grid, 2), .{})) {
+            local.sort("Model");
+        }
+        if (dvui.gridHeadingSortable(@src(), grid, 3, "Year", &local.sort_dir, local.headerResizeOptions(grid, 3), .{})) {
+            local.sort("Year");
+        }
+        if (dvui.gridHeadingSortable(@src(), grid, 4, "Condition", &local.sort_dir, local.headerResizeOptions(grid, 4), .{})) {
+            local.sort("Condition");
+        }
+        if (dvui.gridHeadingSortable(@src(), grid, 5, "Description", &local.sort_dir, local.headerResizeOptions(grid, 5), .{})) {
+            local.sort("Description");
+        }
 
         // Selection
         {
             // Make the checkbox column fixed width. (This width is used if init_opts.col_widths is null)
-            var col = grid.column(@src(), .{ .width = local.checkbox_w });
-            defer col.deinit();
-            if (dvui.gridHeadingCheckbox(@src(), grid, &local.selection_state, .{})) {
-                for (all_cars) |*car| {
-                    car.selected = switch (local.selection_state) {
-                        .select_all => true,
-                        .select_none => false,
-                        .unchanged => break,
-                    };
-                }
-            }
-            _ = dvui.gridColumnCheckbox(@src(), grid, Car, all_cars[0..], "selected", banded.optionsOverride(.{ .gravity_y = 0 }));
+            _ = dvui.gridColumnCheckbox(@src(), grid, 0, Car, all_cars[0..], "selected", banded.optionsOverride(.{ .gravity_y = 0 }));
         }
         // Make
         {
-            var col = grid.column(@src(), .{});
-            defer col.deinit();
-            if (dvui.gridHeadingSortable(@src(), grid, "Make", &local.sort_dir, local.headerResizeOptions(1), .{})) {
-                local.sort("Make");
-            }
-            dvui.gridColumnFromSlice(@src(), grid, Car, all_cars[0..], "make", "{s}", banded);
+            dvui.gridColumnFromSlice(@src(), grid, 1, Car, all_cars[0..], "make", "{s}", banded);
         }
         // Model
         {
-            var col = grid.column(@src(), .{});
-            defer col.deinit();
-            if (dvui.gridHeadingSortable(@src(), grid, "Model", &local.sort_dir, local.headerResizeOptions(2), .{})) {
-                local.sort("Model");
-            }
-            dvui.gridColumnFromSlice(@src(), grid, Car, all_cars[0..], "model", "{s}", banded);
+            dvui.gridColumnFromSlice(@src(), grid, 2, Car, all_cars[0..], "model", "{s}", banded);
         }
         // Year
         {
-            var col = grid.column(@src(), .{});
-            defer col.deinit();
-            if (dvui.gridHeadingSortable(@src(), grid, "Year", &local.sort_dir, local.headerResizeOptions(3), .{})) {
-                local.sort("Year");
-            }
-            dvui.gridColumnFromSlice(@src(), grid, Car, all_cars[0..], "year", "{d}", banded);
+            dvui.gridColumnFromSlice(@src(), grid, 3, Car, all_cars[0..], "year", "{d}", banded);
         }
         // Condition
         {
-            var col = grid.column(@src(), .{});
-            defer col.deinit();
-            if (dvui.gridHeadingSortable(@src(), grid, "Condition", &local.sort_dir, local.headerResizeOptions(4), .{})) {
-                local.sort("Condition");
-            }
-            dvui.gridColumnFromSlice(@src(), grid, Car, all_cars[0..], "condition", "{s}", local.ConditionTextColor.init(&banded_centered));
+            dvui.gridColumnFromSlice(@src(), grid, 4, Car, all_cars[0..], "condition", "{s}", local.ConditionTextColor.init(&banded_centered));
         }
         // Description
         {
-            var col = grid.column(@src(), .{});
-            defer col.deinit();
-            if (dvui.gridHeadingSortable(@src(), grid, "Description", &local.sort_dir, local.headerResizeOptions(5), .{})) {
-                local.sort("Description");
-            }
-            local.customDescriptionColumn(@src(), grid, all_cars[0..], &banded);
+            local.customDescriptionColumn(@src(), grid, 5, all_cars[0..], &banded);
         }
     }
     {
@@ -4508,6 +4507,8 @@ fn gridVirtualScrolling() void {
         var primes: std.StaticBitSet(num_rows) = .initFull();
         var generated_primes: bool = false;
         var highlighted_row: ?usize = null;
+        var last_col_width: f32 = 0;
+        var resize_cols: bool = false;
 
         // Generate prime numbers using The Sieve of Eratosthenes.
         fn generatePrimes() void {
@@ -4538,12 +4539,25 @@ fn gridVirtualScrolling() void {
 
     var vbox = dvui.box(@src(), .vertical, .{ .expand = .both });
     defer vbox.deinit();
-    var grid = dvui.grid(@src(), .{ .scroll_opts = .{ .scroll_info = &local.scroll_info } }, .{
+    var grid = dvui.grid(@src(), .numCols(2), .{
+        .scroll_opts = .{ .scroll_info = &local.scroll_info },
+        .resize_cols = local.resize_cols,
+    }, .{
         .expand = .both,
         .background = true,
         .border = Rect.all(1),
     });
     defer grid.deinit();
+    local.resize_cols = false;
+
+    // dvui.columnLayoutProportional is normally used to calculate column sizes. This example is highlighting
+    // passing column widths though the cell options rather than using the col_widths slice.
+    // Note that if column widths change size, the resize_cols init option must be used.
+    const col_width = (grid.data().contentRect().w - GridWidget.scrollbar_padding_defaults.w) / 2.0;
+    if (col_width < local.last_col_width) {
+        local.resize_cols = true;
+    }
+    local.last_col_width = col_width;
 
     // Highlight hovered row.
     // Each column has slightly different border requirements, so create separate options for each.
@@ -4553,37 +4567,32 @@ fn gridVirtualScrolling() void {
             .border = .{ .x = 1, .w = 1, .h = 1 },
             .background = true,
             .color_fill_hover = .fill_hover,
+            .size = .{ .w = col_width },
         },
     };
     highlight_hovered_1.processEvents(grid, &local.scroll_info);
-    const highlight_hovered_2 = highlight_hovered_1.cellOptionsOverride(.{ .border = .{ .w = 1, .h = 1 } });
+    const highlight_hovered_2 = highlight_hovered_1.cellOptionsOverride(.{
+        .border = .{ .w = 1, .h = 1 },
+    });
 
     // Virtual scrolling
     const scroller: dvui.GridWidget.VirtualScroller = .init(grid, .{ .total_rows = num_rows, .scroll_info = &local.scroll_info });
     const first = scroller.startRow();
     const last = scroller.endRow(); // Note that endRow is exclusive, meaning it can be used as a slice end index.
+    const CellStyle = GridWidget.CellStyle;
+    dvui.gridHeading(@src(), grid, "Number", 0, .fixed, CellStyle{ .cell_opts = .{ .size = .{ .w = col_width } } });
+    dvui.gridHeading(@src(), grid, "Is prime?", 1, .fixed, CellStyle{ .cell_opts = .{ .size = .{ .w = col_width } } });
 
-    // Number column
-    {
-        var col = grid.column(@src(), .{});
-        defer col.deinit();
-        dvui.gridHeading(@src(), grid, "Number", .fixed, .{});
-
-        for (first..last) |num| {
-            var cell = grid.bodyCell(@src(), num, highlight_hovered_1.cellOptions(0, num));
+    for (first..last) |num| {
+        {
+            var cell = grid.bodyCell(@src(), 0, num, highlight_hovered_1.cellOptions(0, num));
             defer cell.deinit();
             dvui.label(@src(), "{d}", .{num}, .{});
         }
-    }
-    // Prime column
-    {
-        const check_img = @embedFile("icons/entypo/check.tvg");
-        var col = grid.column(@src(), .{});
-        defer col.deinit();
-        dvui.gridHeading(@src(), grid, "Is prime?", .fixed, .{});
+        {
+            const check_img = @embedFile("icons/entypo/check.tvg");
 
-        for (first..last) |num| {
-            var cell = grid.bodyCell(@src(), num, highlight_hovered_2.cellOptions(1, num));
+            var cell = grid.bodyCell(@src(), 1, num, highlight_hovered_2.cellOptions(1, num));
             defer cell.deinit();
             if (local.isPrime(num)) {
                 dvui.icon(@src(), "Check", check_img, .{}, .{ .gravity_x = 0.5, .gravity_y = 0.5, .background = false });
@@ -4593,7 +4602,7 @@ fn gridVirtualScrolling() void {
 }
 
 fn gridVariableRowHeights() void {
-    var grid = dvui.grid(@src(), .{}, .{
+    var grid = dvui.grid(@src(), .numCols(1), .{ .var_row_heights = true }, .{
         .expand = .both,
         .padding = Rect.all(0),
     });
@@ -4605,15 +4614,14 @@ fn gridVariableRowHeights() void {
         .cell_opts = .{ .border = Rect.all(1) },
         .opts = .{ .gravity_x = 0.5, .gravity_y = 0.5, .expand = .both },
     };
-    var col = grid.column(@src(), .{});
-    defer col.deinit();
     for (1..10) |row_num| {
         const row_num_i: i32 = @intCast(row_num);
         const row_height = 70 - (@abs(row_num_i - 5) * 10);
         var cell = grid.bodyCell(
             @src(),
+            0,
             row_num,
-            cell_style.cellOptions(0, row_num).override(.{ .height = @floatFromInt(row_height) }),
+            cell_style.cellOptions(0, row_num).override(.{ .size = .{ .h = @floatFromInt(row_height), .w = 500 } }),
         );
         defer cell.deinit();
         dvui.label(@src(), "h = {d}", .{row_height}, cell_style.options(0, row_num));

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -4657,9 +4657,9 @@ pub fn scrollArea(src: std.builtin.SourceLocation, init_opts: ScrollAreaWidget.I
     return ret;
 }
 
-pub fn grid(src: std.builtin.SourceLocation, init_opts: GridWidget.InitOpts, opts: Options) *GridWidget {
+pub fn grid(src: std.builtin.SourceLocation, cols: GridWidget.WidthsOrNum, init_opts: GridWidget.InitOpts, opts: Options) *GridWidget {
     const ret = widgetAlloc(GridWidget);
-    ret.* = GridWidget.init(src, init_opts, opts);
+    ret.* = GridWidget.init(src, cols, init_opts, opts);
     ret.install();
     return ret;
 }
@@ -4687,6 +4687,7 @@ pub fn gridHeading(
     src: std.builtin.SourceLocation,
     g: *GridWidget,
     heading: []const u8,
+    col_num: usize,
     resize_opts: ?GridWidget.HeaderResizeWidget.InitOptions,
     cell_style: anytype, // GridWidget.CellStyle
 ) void {
@@ -4700,8 +4701,8 @@ pub fn gridHeading(
     };
     const opts = if (@TypeOf(cell_style) == @TypeOf(.{})) GridWidget.CellStyle.none else cell_style;
 
-    const label_options = label_defaults.override(opts.options(g.col_num, 0));
-    var cell = g.headerCell(src, opts.cellOptions(g.col_num, 0));
+    const label_options = label_defaults.override(opts.options(col_num, 0));
+    var cell = g.headerCell(src, col_num, opts.cellOptions(col_num, 0));
     defer cell.deinit();
 
     labelNoFmt(@src(), heading, .{}, label_options);
@@ -4715,6 +4716,7 @@ pub fn gridHeading(
 pub fn gridHeadingSortable(
     src: std.builtin.SourceLocation,
     g: *GridWidget,
+    col_num: usize,
     heading: []const u8,
     dir: *GridWidget.SortDirection,
     resize_opts: ?GridWidget.HeaderResizeWidget.InitOptions,
@@ -4729,21 +4731,21 @@ pub fn gridHeadingSortable(
         .corner_radius = Rect.all(0),
     };
     const opts = if (@TypeOf(cell_style) == @TypeOf(.{})) GridWidget.CellStyle.none else cell_style;
-    const heading_opts = heading_defaults.override(opts.options(g.col_num, 0));
+    const heading_opts = heading_defaults.override(opts.options(col_num, 0));
 
-    var cell = g.headerCell(src, opts.cellOptions(g.col_num, 0));
+    var cell = g.headerCell(src, col_num, opts.cellOptions(col_num, 0));
     defer cell.deinit();
 
     gridHeadingSeparator(resize_opts);
 
-    const sort_changed = switch (g.colSortOrder()) {
+    const sort_changed = switch (g.colSortOrder(col_num)) {
         .unsorted => button(@src(), heading, .{ .draw_focus = false }, heading_opts),
         .ascending => buttonLabelAndIcon(@src(), heading, icon_ascending, .{ .draw_focus = false }, heading_opts),
         .descending => buttonLabelAndIcon(@src(), heading, icon_descending, .{ .draw_focus = false }, heading_opts),
     };
 
     if (sort_changed) {
-        g.sortChanged();
+        g.sortChanged(col_num);
     }
     dir.* = g.sort_direction;
     return sort_changed;
@@ -4758,6 +4760,7 @@ pub fn gridHeadingSortable(
 pub fn gridColumnFromSlice(
     src: std.builtin.SourceLocation,
     g: *GridWidget,
+    col_num: usize,
     comptime T: type,
     data: []const T,
     comptime field_name: ?[]const u8,
@@ -4791,8 +4794,9 @@ pub fn gridColumnFromSlice(
     for (data, 0..) |item, row_num| {
         var cell = g.bodyCell(
             src,
+            col_num,
             row_num,
-            opts.cellOptions(g.col_num, row_num),
+            opts.cellOptions(col_num, row_num),
         );
         defer cell.deinit();
         const cell_value = value: {
@@ -4816,7 +4820,7 @@ pub fn gridColumnFromSlice(
             @src(),
             fmt,
             .{cell_value},
-            opts.options(g.col_num, row_num),
+            opts.options(col_num, row_num),
         );
     }
 }
@@ -4834,6 +4838,7 @@ pub const GridColumnSelectAllState = enum {
 pub fn gridHeadingCheckbox(
     src: std.builtin.SourceLocation,
     g: *GridWidget,
+    col_num: usize,
     selection: *GridColumnSelectAllState,
     cell_style: anytype, // GridWidget.CellStyle
 ) bool {
@@ -4848,13 +4853,13 @@ pub fn gridHeadingCheckbox(
 
     const opts = if (@TypeOf(cell_style) == @TypeOf(.{})) GridWidget.CellStyle.none else cell_style;
 
-    const header_options = header_defaults.override(opts.options(g.col_num, 0));
+    const header_options = header_defaults.override(opts.options(col_num, 0));
     var checkbox_opts: Options = header_options.strip();
     checkbox_opts.padding = ButtonWidget.defaults.paddingGet();
     checkbox_opts.gravity_x = header_options.gravity_x;
     checkbox_opts.gravity_y = header_options.gravity_y;
 
-    var cell = g.headerCell(src, opts.cellOptions(g.col_num, 0));
+    var cell = g.headerCell(src, col_num, opts.cellOptions(col_num, 0));
     defer cell.deinit();
 
     var clicked = false;
@@ -4886,6 +4891,7 @@ pub fn gridHeadingCheckbox(
 pub fn gridColumnCheckbox(
     src: std.builtin.SourceLocation,
     g: *dvui.GridWidget,
+    col_num: usize,
     comptime T: type,
     data: []T,
     comptime field_name: ?[]const u8,
@@ -4914,8 +4920,9 @@ pub fn gridColumnCheckbox(
     for (data, 0..) |*item, row_num| {
         var cell = g.bodyCell(
             src,
+            col_num,
             row_num,
-            opts.cellOptions(g.col_num, row_num),
+            opts.cellOptions(col_num, row_num),
         );
         defer cell.deinit();
         const is_selected: *bool = if (T == bool) item else &@field(item, field_name.?);
@@ -4924,7 +4931,7 @@ pub fn gridColumnCheckbox(
             @src(),
             is_selected,
             null,
-            check_defaults.override(opts.options(g.col_num, row_num)),
+            check_defaults.override(opts.options(col_num, row_num)),
         );
         selection_changed = selection_changed or was_selected != is_selected.*;
     }

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -839,6 +839,6 @@ pub const HeaderResizeWidget = struct {
 };
 test {
     // TODO: Don't include grid tests yet.
-    _ = @import("GridWidget/testing.zig");
+    //_ = @import("GridWidget/testing.zig");
     @import("std").testing.refAllDecls(@This());
 }

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -570,6 +570,9 @@ fn headerScrollAreaCreate(self: *GridWidget) void {
             .min_size_content = .{ .h = if (self.header_height > 0) self.header_height else self.last_header_height, .w = self.totalWidth() },
         });
         self.hscroll.?.install();
+        if (!std.math.approxEqAbs(f32, self.header_height, self.last_header_height, 0.01)) {
+            self.resizing = true;
+        }
     }
 }
 

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -166,6 +166,7 @@ cur_row: usize = std.math.maxInt(usize), // current row being rendered
 rows_y_offset: f32 = 0, // y value to offset rendering of the first body cell
 next_row_y: f32 = 0, // Next y position for laying out rows with variable heights
 this_row_y: f32 = 0, // This y position for laying out rows with variable heights
+last_header_height: f32 = 0, // Height of header last frame
 
 // Options
 init_opts: InitOpts = undefined,
@@ -208,6 +209,8 @@ pub fn init(src: std.builtin.SourceLocation, cols: WidthsOrNum, init_opts: InitO
     if (dvui.firstFrame(self.data().id)) {
         self.resizing = true;
     }
+
+    self.last_header_height = self.header_height;
     if (init_opts.resize_rows or self.resizing) {
         self.row_height = 0;
         self.header_height = 0;
@@ -572,7 +575,7 @@ fn headerScrollAreaCreate(self: *GridWidget) void {
         }, .{
             .name = "GridWidgetHeaderScroll",
             .expand = .horizontal,
-            .min_size_content = .{ .h = self.header_height, .w = self.last_size.w },
+            .min_size_content = .{ .h = if (self.header_height > 0) self.header_height else self.last_header_height, .w = self.last_size.w },
         });
         self.hscroll.?.install();
     }

--- a/src/widgets/GridWidget/CellStyle.zig
+++ b/src/widgets/GridWidget/CellStyle.zig
@@ -176,3 +176,7 @@ pub const HoveredRow = struct {
         };
     }
 };
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/GridWidget/testing.zig
+++ b/src/widgets/GridWidget/testing.zig
@@ -260,7 +260,7 @@ test "cell widths" {
     try t.saveImage(frame, null, "GridWidget-cell_widths.png");
 }
 
-test "ignore cell_heights" {
+test "cell heights non variable" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
     const frame = struct {
@@ -269,7 +269,8 @@ test "ignore cell_heights" {
             defer grid.deinit();
             for (0..10) |col| {
                 for (0..10) |row| {
-                    var cell = grid.bodyCell(@src(), col, row, .{ .size = .{ .h = 200 }, .border = dvui.Rect.all(1) });
+                    const row_f: f32 = @floatFromInt(row);
+                    var cell = grid.bodyCell(@src(), col, row, .{ .size = .{ .h = 20 * row_f }, .border = dvui.Rect.all(1) });
                     defer cell.deinit();
                     dvui.label(@src(), "{}:{}", .{ col, row }, .{});
                 }
@@ -279,7 +280,31 @@ test "ignore cell_heights" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveImage(frame, null, "GridWidget-ignore_cell_height.png");
+    try t.saveImage(frame, null, "GridWidget-cell_height_nonvar.png");
+}
+
+test "cell heights non variable reverse" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            for (0..10) |col| {
+                for (0..10) |i| {
+                    const i_f: f32 = @floatFromInt(i);
+                    const row = 9 - i;
+                    var cell = grid.bodyCell(@src(), col, row, .{ .size = .{ .h = 20 * i_f }, .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-cell_height_nonvar_rev.png");
 }
 
 test "variable cell_heights by col" {
@@ -302,7 +327,7 @@ test "variable cell_heights by col" {
     }.frame;
 
     try dvui.testing.settle(frame);
-    try t.saveImage(frame, null, "GridWidget-variable_cell_height_col.png");
+    try t.saveImage(frame, null, "GridWidget-cell_height_var.png");
 }
 
 test "variable cell_heights by row" {

--- a/src/widgets/GridWidget/testing.zig
+++ b/src/widgets/GridWidget/testing.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const dvui = @import("../../dvui.zig");
 const GridWidget = dvui.GridWidget;
 
-test "GridWidget: basic by col" {
+test "basic by col" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -33,7 +33,7 @@ test "GridWidget: basic by col" {
     try t.saveImage(frame, null, "GridWidget-basic_by_col.png");
 }
 
-test "GridWidget: basic by row" {
+test "basic by row" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -64,7 +64,7 @@ test "GridWidget: basic by row" {
     try t.saveImage(frame, null, "GridWidget-basic_by_row.png");
 }
 
-test "GridWidget: empty grid" {
+test "empty grid" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -80,7 +80,7 @@ test "GridWidget: empty grid" {
     try t.saveImage(frame, null, "GridWidget-empty.png");
 }
 
-test "GridWidget: one cell" {
+test "one cell" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -99,7 +99,7 @@ test "GridWidget: one cell" {
     try t.saveImage(frame, null, "GridWidget-one_cell.png");
 }
 
-test "GridWidget: populate by col expand" {
+test "populate by col expand" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -122,7 +122,7 @@ test "GridWidget: populate by col expand" {
     try t.saveImage(frame, null, "GridWidget-by_col_expand.png");
 }
 
-test "GridWidget: populate by col no expand" {
+test "populate by col no expand" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -145,7 +145,7 @@ test "GridWidget: populate by col no expand" {
     try t.saveImage(frame, null, "GridWidget-by_col_no_expand.png");
 }
 
-test "GridWidget: populate by row" {
+test "populate by row" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -168,7 +168,7 @@ test "GridWidget: populate by row" {
     try t.saveImage(frame, null, "GridWidget-by_row.png");
 }
 
-test "GridWidget: populate by reverse rol, col" {
+test "populate by reverse rol, col" {
     // This should be the most difficult as the layout starts in the bottom right and moves to the top-left.
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
@@ -192,7 +192,7 @@ test "GridWidget: populate by reverse rol, col" {
     try t.saveImage(frame, null, "GridWidget-by_reverse_row_col.png");
 }
 
-test "GridWidget: col out of bounds" {
+test "col out of bounds" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -215,7 +215,7 @@ test "GridWidget: col out of bounds" {
     try t.saveImage(frame, null, "GridWidget-col_out_of_bounds.png");
 }
 
-test "GridWidget: col widths" {
+test "col widths" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
     const frame = struct {
@@ -238,7 +238,7 @@ test "GridWidget: col widths" {
     try t.saveImage(frame, null, "GridWidget-col_widths.png");
 }
 
-test "GridWidget: cell widths" {
+test "cell widths" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
     const frame = struct {
@@ -260,7 +260,7 @@ test "GridWidget: cell widths" {
     try t.saveImage(frame, null, "GridWidget-cell_widths.png");
 }
 
-test "GridWidget: ignore cell_heights" {
+test "ignore cell_heights" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
     const frame = struct {
@@ -282,7 +282,7 @@ test "GridWidget: ignore cell_heights" {
     try t.saveImage(frame, null, "GridWidget-ignore_cell_height.png");
 }
 
-test "GridWidget: variable cell_heights by col" {
+test "variable cell_heights by col" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
     const frame = struct {
@@ -305,7 +305,7 @@ test "GridWidget: variable cell_heights by col" {
     try t.saveImage(frame, null, "GridWidget-variable_cell_height_col.png");
 }
 
-test "GridWidget: variable cell_heights by row" {
+test "variable cell_heights by row" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
     const frame = struct {
@@ -328,7 +328,7 @@ test "GridWidget: variable cell_heights by row" {
     try t.saveImage(frame, null, "GridWidget-variable_cell_height_row.png");
 }
 
-test "GridWidget: styling" {
+test "styling" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
     const frame = struct {
@@ -354,7 +354,7 @@ test "GridWidget: styling" {
     try t.saveImage(frame, null, "GridWidget-styling.png");
 }
 
-test "GridWidget: styling empty" {
+test "styling empty" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
     const frame = struct {
@@ -379,7 +379,7 @@ test "GridWidget: styling empty" {
     try t.saveImage(frame, null, "GridWidget-styling_empty.png");
 }
 
-test "GridWidget: heading only" {
+test "heading only" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
     const frame = struct {
@@ -399,7 +399,7 @@ test "GridWidget: heading only" {
     try t.saveImage(frame, null, "GridWidget-heading_only.png");
 }
 
-test "GridWidget: body then header" {
+test "body then header" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
     const frame = struct {
@@ -424,7 +424,7 @@ test "GridWidget: body then header" {
     try t.saveImage(frame, null, "GridWidget-body_then_header.png");
 }
 
-test "GridWidget: vary header height" {
+test "vary header height" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -461,7 +461,7 @@ test "GridWidget: vary header height" {
     try t.saveImage(frame, null, "GridWidget-vary_header_height.png");
 }
 
-test "GridWidget: vary row height" {
+test "vary row height" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -501,7 +501,7 @@ test "GridWidget: vary row height" {
     try t.saveImage(frame, null, "GridWidget-vary_row_height.png");
 }
 
-test "GridWidget: sparse" {
+test "sparse" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -526,7 +526,7 @@ test "GridWidget: sparse" {
     try t.saveImage(frame, null, "GridWidget-sparse.png");
 }
 
-test "GridWidget: sparse reverse" {
+test "sparse reverse" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -552,7 +552,7 @@ test "GridWidget: sparse reverse" {
     try t.saveImage(frame, null, "GridWidget-sparse_reverse.png");
 }
 
-test "GridWidget: more header cells than body cells" {
+test "more header cells than body cells" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -584,7 +584,7 @@ test "GridWidget: more header cells than body cells" {
     try t.saveImage(frame, null, "GridWidget-more_headers_than_body.png");
 }
 
-test "GridWidget: more body cells than header cells" {
+test "more body cells than header cells" {
     var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
     defer t.deinit();
 
@@ -614,6 +614,87 @@ test "GridWidget: more body cells than header cells" {
 
     try dvui.testing.settle(frame);
     try t.saveImage(frame, null, "GridWidget-more_body_than_header.png");
+}
+
+test "resize cols" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        var action: enum { wide, resize, narrow } = .wide;
+        var frame_count: usize = 0;
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(4), .{ .resize_cols = action == .resize }, .{});
+            defer grid.deinit();
+            {
+                for (0..4) |col| {
+                    var cell = grid.headerCell(@src(), col, .{
+                        .border = dvui.Rect.all(1),
+                        .size = .{ .w = if (action == .wide) 100 else 50 },
+                    });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}", .{col}, .{});
+                }
+                for (0..4) |col| {
+                    for (0..4) |row| {
+                        var cell = grid.bodyCell(@src(), col, row, .{
+                            .border = dvui.Rect.all(1),
+                        });
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                    }
+                }
+            }
+            if (action == .resize) action = .narrow;
+            return .ok;
+        }
+    };
+    frame.action = .wide;
+    try dvui.testing.settle(frame.frame);
+    try t.saveImage(frame.frame, null, "GridWidget-resize_cols_wide.png");
+    frame.action = .resize;
+    try dvui.testing.settle(frame.frame);
+    try t.saveImage(frame.frame, null, "GridWidget-resize_cols_narrow.png");
+}
+
+test "resize rows" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        var action: enum { tall, resize, short } = .tall;
+        var frame_count: usize = 0;
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(4), .{ .resize_rows = action == .resize }, .{});
+            defer grid.deinit();
+            {
+                for (0..4) |col| {
+                    var cell = grid.headerCell(@src(), col, .{
+                        .border = dvui.Rect.all(1),
+                    });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}", .{col}, .{});
+                }
+                for (0..4) |col| {
+                    for (0..4) |row| {
+                        var cell = grid.bodyCell(@src(), col, row, .{
+                            .border = dvui.Rect.all(1),
+                        });
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{ .font_style = if (action == .tall) .title_1 else null });
+                    }
+                }
+            }
+            if (action == .resize) action = .short;
+            return .ok;
+        }
+    };
+    frame.action = .tall;
+    try dvui.testing.settle(frame.frame);
+    try t.saveImage(frame.frame, null, "GridWidget-resize_rows_tall.png");
+    frame.action = .resize;
+    try dvui.testing.settle(frame.frame);
+    try t.saveImage(frame.frame, null, "GridWidget-resize_rows_short.png");
 }
 
 test "add rows" {

--- a/src/widgets/GridWidget/testing.zig
+++ b/src/widgets/GridWidget/testing.zig
@@ -883,3 +883,32 @@ test "remove cols and shrink" {
     try dvui.testing.settle(frame.frame);
     try t.saveImage(frame.frame, null, "GridWidget-remove_cols_shrink.png");
 }
+
+test "header size and shrink" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        var action: enum { tall, resize, short } = .tall;
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{ .resize_rows = action == .resize }, .{});
+            defer grid.deinit();
+            {
+                for (0..10) |col| {
+                    var cell = grid.headerCell(@src(), col, .{
+                        .size = .{ .h = if (action == .tall) 100 else 50 },
+                        .border = dvui.Rect.all(1),
+                    });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}", .{col}, .{});
+                }
+            }
+            if (action == .resize) action = .short;
+            return .ok;
+        }
+    };
+    try dvui.testing.settle(frame.frame);
+    try t.saveImage(frame.frame, null, "GridWidget-reheader_pre_resize.png");
+    frame.action = .resize;
+    try dvui.testing.settle(frame.frame);
+    try t.saveImage(frame.frame, null, "GridWidget-header_post_resize.png");
+}

--- a/src/widgets/GridWidget/testing.zig
+++ b/src/widgets/GridWidget/testing.zig
@@ -1,0 +1,617 @@
+const std = @import("std");
+const dvui = @import("../../dvui.zig");
+const GridWidget = dvui.GridWidget;
+
+test "GridWidget: basic by col" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            {
+                for (0..10) |col| {
+                    var cell = grid.headerCell(@src(), col, .{ .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}", .{col}, .{});
+                }
+                for (0..10) |col| {
+                    for (0..10) |row| {
+                        var cell = grid.bodyCell(@src(), col, row, .{});
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                    }
+                }
+            }
+
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-basic_by_col.png");
+}
+
+test "GridWidget: basic by row" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            {
+                for (0..10) |col| {
+                    var cell = grid.headerCell(@src(), col, .{ .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}", .{col}, .{});
+                }
+                for (0..10) |row| {
+                    for (0..10) |col| {
+                        var cell = grid.bodyCell(@src(), col, row, .{});
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                    }
+                }
+            }
+
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-basic_by_row.png");
+}
+
+test "GridWidget: empty grid" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(0), .{}, .{});
+            defer grid.deinit();
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-empty.png");
+}
+
+test "GridWidget: one cell" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(1), .{}, .{});
+            defer grid.deinit();
+            var cell = grid.bodyCell(@src(), 0, 0, .{});
+            defer cell.deinit();
+            dvui.labelNoFmt(@src(), "0:0", .{}, .{});
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-one_cell.png");
+}
+
+test "GridWidget: populate by col expand" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{ .expand = .both });
+            defer grid.deinit();
+            for (0..10) |col| {
+                for (0..10) |row| {
+                    var cell = grid.bodyCell(@src(), col, row, .{});
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-by_col_expand.png");
+}
+
+test "GridWidget: populate by col no expand" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            for (0..10) |col| {
+                for (0..10) |row| {
+                    var cell = grid.bodyCell(@src(), col, row, .{});
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-by_col_no_expand.png");
+}
+
+test "GridWidget: populate by row" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            for (0..10) |row| {
+                for (0..10) |col| {
+                    var cell = grid.bodyCell(@src(), col, row, .{});
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-by_row.png");
+}
+
+test "GridWidget: populate by reverse rol, col" {
+    // This should be the most difficult as the layout starts in the bottom right and moves to the top-left.
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{}); // TODO:
+            defer grid.deinit();
+            for (0..10) |row| {
+                for (0..10) |col| {
+                    var cell = grid.bodyCell(@src(), 9 - col, 9 - row, .{});
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ 9 - col, 9 - row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-by_reverse_row_col.png");
+}
+
+test "GridWidget: col out of bounds" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(5), .{}, .{});
+            defer grid.deinit();
+            for (0..10) |col| {
+                for (0..10) |row| {
+                    var cell = grid.bodyCell(@src(), col, row, .{});
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-col_out_of_bounds.png");
+}
+
+test "GridWidget: col widths" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        var col_widths: [10]f32 = @splat(50);
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .colWidths(&col_widths), .{}, .{ .expand = .both }); // TODO: No .expand
+            defer grid.deinit();
+            for (0..10) |col| {
+                for (0..10) |row| {
+                    var cell = grid.bodyCell(@src(), col, row, .{});
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-col_widths.png");
+}
+
+test "GridWidget: cell widths" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            for (0..10) |col| {
+                for (0..10) |row| {
+                    var cell = grid.bodyCell(@src(), col, row, .{ .size = .{ .w = 50 } });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-cell_widths.png");
+}
+
+test "GridWidget: ignore cell_heights" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            for (0..10) |col| {
+                for (0..10) |row| {
+                    var cell = grid.bodyCell(@src(), col, row, .{ .size = .{ .h = 200 }, .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-ignore_cell_height.png");
+}
+
+test "GridWidget: variable cell_heights by col" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{ .var_row_heights = true }, .{});
+            defer grid.deinit();
+            for (0..10) |col| {
+                for (0..10) |row| {
+                    const row_f: f32 = @floatFromInt(row);
+                    var cell = grid.bodyCell(@src(), col, row, .{ .size = .{ .h = @abs(5 - row_f) * 15 + 30 }, .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-variable_cell_height_col.png");
+}
+
+test "GridWidget: variable cell_heights by row" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{ .var_row_heights = true }, .{});
+            defer grid.deinit();
+            for (0..10) |row| {
+                for (0..10) |col| {
+                    const row_f: f32 = @floatFromInt(row);
+                    var cell = grid.bodyCell(@src(), col, row, .{ .size = .{ .h = @abs(5 - row_f) * 15 + 30 }, .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-variable_cell_height_row.png");
+}
+
+test "GridWidget: styling" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            for (0..10) |row| {
+                for (0..10) |col| {
+                    var cell = grid.bodyCell(@src(), col, row, .{
+                        .border = dvui.Rect.all(15),
+                        .padding = dvui.Rect.all(15),
+                        .margin = dvui.Rect.all(15),
+                    });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-styling.png");
+}
+
+test "GridWidget: styling empty" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            for (0..10) |row| {
+                for (0..10) |col| {
+                    var cell = grid.bodyCell(@src(), col, row, .{
+                        .border = dvui.Rect.all(15),
+                        .padding = dvui.Rect.all(15),
+                        .margin = dvui.Rect.all(15),
+                    });
+                    defer cell.deinit();
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-styling_empty.png");
+}
+
+test "GridWidget: heading only" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            for (0..10) |col| {
+                var cell = grid.headerCell(@src(), col, .{ .color_fill = .fill_control, .background = true, .border = dvui.Rect.all(1) });
+                defer cell.deinit();
+                dvui.label(@src(), "Col {}", .{col}, .{});
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-heading_only.png");
+}
+
+test "GridWidget: body then header" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            {
+                var cell = grid.bodyCell(@src(), 0, 0, .{});
+                defer cell.deinit();
+                dvui.labelNoFmt(@src(), "Body", .{}, .{});
+            }
+            {
+                var cell = grid.headerCell(@src(), 0, .{});
+                defer cell.deinit();
+                dvui.labelNoFmt(@src(), "Header", .{}, .{});
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-body_then_header.png");
+}
+
+test "GridWidget: vary header height" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(4), .{}, .{});
+            defer grid.deinit();
+            {
+                for (0..4) |col| {
+                    var cell = grid.headerCell(@src(), col, .{ .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}", .{col}, .{ .font_style = switch (col) {
+                        0 => .title_2,
+                        1 => .title_3,
+                        2 => .title_1,
+                        3 => .title_4,
+                        else => unreachable,
+                    } });
+                }
+                for (0..4) |col| {
+                    for (0..4) |row| {
+                        var cell = grid.bodyCell(@src(), col, row, .{});
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                    }
+                }
+            }
+
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-vary_header_height.png");
+}
+
+test "GridWidget: vary row height" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(4), .{}, .{});
+            defer grid.deinit();
+            {
+                for (0..4) |col| {
+                    var cell = grid.headerCell(@src(), col, .{ .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}", .{col}, .{});
+                }
+                for (0..4) |col| {
+                    for (0..4) |row| {
+                        var cell = grid.bodyCell(@src(), col, row, .{
+                            .border = dvui.Rect.all(1),
+                        });
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{
+                            .font_style = switch (row) {
+                                0 => .title_2,
+                                1 => .title_3,
+                                2 => .title_1,
+                                3 => .title_4,
+                                else => unreachable,
+                            },
+                        });
+                    }
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-vary_row_height.png");
+}
+
+test "GridWidget: sparse" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            {
+                for (0..10) |col_row| {
+                    var cell = grid.bodyCell(@src(), col_row, col_row, .{
+                        .border = dvui.Rect.all(1),
+                    });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{[col_row]}:{[col_row]}", .{ .col_row = col_row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-sparse.png");
+}
+
+test "GridWidget: sparse reverse" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            {
+                for (0..10) |i| {
+                    const col_row = 9 - i;
+                    var cell = grid.bodyCell(@src(), col_row, col_row, .{
+                        .border = dvui.Rect.all(1),
+                    });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{[col_row]}:{[col_row]}", .{ .col_row = col_row }, .{});
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-sparse_reverse.png");
+}
+
+test "GridWidget: more header cells than body cells" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(4), .{}, .{});
+            defer grid.deinit();
+            {
+                for (0..4) |col| {
+                    var cell = grid.headerCell(@src(), col, .{ .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}", .{col}, .{});
+                }
+                for (0..2) |col| {
+                    for (0..4) |row| {
+                        var cell = grid.bodyCell(@src(), col, row, .{
+                            .border = dvui.Rect.all(1),
+                        });
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                    }
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-more_headers_than_body.png");
+}
+
+test "GridWidget: more body cells than header cells" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(4), .{}, .{});
+            defer grid.deinit();
+            {
+                for (0..2) |col| {
+                    var cell = grid.headerCell(@src(), col, .{ .border = dvui.Rect.all(1) });
+                    defer cell.deinit();
+                    dvui.label(@src(), "{}", .{col}, .{});
+                }
+                for (0..4) |col| {
+                    for (0..4) |row| {
+                        var cell = grid.bodyCell(@src(), col, row, .{
+                            .border = dvui.Rect.all(1),
+                        });
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                    }
+                }
+            }
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    try t.saveImage(frame, null, "GridWidget-more_body_than_header.png");
+}

--- a/src/widgets/GridWidget/testing.zig
+++ b/src/widgets/GridWidget/testing.zig
@@ -907,7 +907,7 @@ test "header size and shrink" {
         }
     };
     try dvui.testing.settle(frame.frame);
-    try t.saveImage(frame.frame, null, "GridWidget-reheader_pre_resize.png");
+    try t.saveImage(frame.frame, null, "GridWidget-header_pre_resize.png");
     frame.action = .resize;
     try dvui.testing.settle(frame.frame);
     try t.saveImage(frame.frame, null, "GridWidget-header_post_resize.png");
@@ -932,8 +932,8 @@ test "header body resize" {
                 for (0..10) |col| {
                     var cell = grid.headerCell(@src(), col, .{
                         .border = dvui.Rect.all(1),
+                        .size = if (action == .tall) .{ .h = 100 } else null,
                     });
-                    std.debug.print("{}:{}\n", .{ frame_number, cell.data().rect });
                     defer cell.deinit();
                     dvui.label(@src(), "{}", .{col}, .{});
                 }

--- a/src/widgets/GridWidget/testing.zig
+++ b/src/widgets/GridWidget/testing.zig
@@ -175,7 +175,7 @@ test "GridWidget: populate by reverse rol, col" {
 
     const frame = struct {
         fn frame() !dvui.App.Result {
-            var grid = dvui.grid(@src(), .numCols(10), .{}, .{}); // TODO:
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
             defer grid.deinit();
             for (0..10) |row| {
                 for (0..10) |col| {
@@ -221,7 +221,7 @@ test "GridWidget: col widths" {
     const frame = struct {
         var col_widths: [10]f32 = @splat(50);
         fn frame() !dvui.App.Result {
-            var grid = dvui.grid(@src(), .colWidths(&col_widths), .{}, .{ .expand = .both }); // TODO: No .expand
+            var grid = dvui.grid(@src(), .colWidths(&col_widths), .{}, .{});
             defer grid.deinit();
             for (0..10) |col| {
                 for (0..10) |row| {
@@ -614,4 +614,166 @@ test "GridWidget: more body cells than header cells" {
 
     try dvui.testing.settle(frame);
     try t.saveImage(frame, null, "GridWidget-more_body_than_header.png");
+}
+
+test "add rows" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        var frame_number: usize = 0;
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            {
+                const start: usize, const end: usize = if (frame_number == 0)
+                    .{ 0, 5 }
+                else
+                    .{ 0, 10 };
+                for (0..10) |col| {
+                    for (start..end) |row| {
+                        var cell = grid.bodyCell(@src(), col, row, .{
+                            .border = dvui.Rect.all(1),
+                        });
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                    }
+                }
+            }
+            return .ok;
+        }
+    };
+    try dvui.testing.settle(frame.frame);
+    frame.frame_number += 1;
+    try dvui.testing.settle(frame.frame);
+    try t.saveImage(frame.frame, null, "GridWidget-add_rows.png");
+}
+
+test "remove rows" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        var frame_number: usize = 0;
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            {
+                const start: usize, const end: usize = if (frame_number == 0)
+                    .{ 0, 10 }
+                else
+                    .{ 0, 5 };
+                for (0..10) |col| {
+                    for (start..end) |row| {
+                        var cell = grid.bodyCell(@src(), col, row, .{
+                            .border = dvui.Rect.all(1),
+                        });
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                    }
+                }
+            }
+            return .ok;
+        }
+    };
+    try dvui.testing.settle(frame.frame);
+    frame.frame_number += 1;
+    try dvui.testing.settle(frame.frame);
+    try t.saveImage(frame.frame, null, "GridWidget-remove_rows.png");
+}
+
+test "add cols" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        var frame_number: usize = 0;
+        fn frame() !dvui.App.Result {
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            {
+                const start: usize, const end: usize = if (frame_number == 0)
+                    .{ 0, 5 }
+                else
+                    .{ 0, 10 };
+                for (start..end) |col| {
+                    for (0..10) |row| {
+                        var cell = grid.bodyCell(@src(), col, row, .{
+                            .border = dvui.Rect.all(1),
+                        });
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                    }
+                }
+            }
+            return .ok;
+        }
+    };
+    try dvui.testing.settle(frame.frame);
+    frame.frame_number += 1;
+    try dvui.testing.settle(frame.frame);
+    try t.saveImage(frame.frame, null, "GridWidget-add_cols.png");
+}
+
+test "remove cols" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        var frame_number: usize = 0;
+        fn frame() !dvui.App.Result {
+            const start: usize, const end: usize = if (frame_number == 0)
+                .{ 0, 10 }
+            else
+                .{ 0, 5 };
+
+            var grid = dvui.grid(@src(), .numCols(10), .{}, .{});
+            defer grid.deinit();
+            {
+                for (start..end) |col| {
+                    for (0..10) |row| {
+                        var cell = grid.bodyCell(@src(), col, row, .{
+                            .border = dvui.Rect.all(1),
+                        });
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                    }
+                }
+            }
+            return .ok;
+        }
+    };
+    try dvui.testing.settle(frame.frame);
+    frame.frame_number += 1;
+    try dvui.testing.settle(frame.frame);
+    try t.saveImage(frame.frame, null, "GridWidget-remove_cols.png");
+}
+
+test "remove cols and shrink" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+    const frame = struct {
+        var frame_number: usize = 0;
+        fn frame() !dvui.App.Result {
+            const start: usize, const end: usize = if (frame_number == 0)
+                .{ 0, 10 }
+            else
+                .{ 0, 5 };
+
+            var grid = dvui.grid(@src(), .numCols(end), .{}, .{});
+            defer grid.deinit();
+            {
+                for (start..end) |col| {
+                    for (0..10) |row| {
+                        var cell = grid.bodyCell(@src(), col, row, .{
+                            .border = dvui.Rect.all(1),
+                        });
+                        defer cell.deinit();
+                        dvui.label(@src(), "{}:{}", .{ col, row }, .{});
+                    }
+                }
+            }
+            return .ok;
+        }
+    };
+    try dvui.testing.settle(frame.frame);
+    frame.frame_number += 1;
+    try dvui.testing.settle(frame.frame);
+    try t.saveImage(frame.frame, null, "GridWidget-remove_cols_shrink.png");
 }


### PR DESCRIPTION
Grid Widget: Remove headers from body and other improvements.
      - Header and body in different, linked scroll areas.
      - Ability to lay out by column, row or combination.
      - Removed the column() function.
      - Current column number is no longer stored internally.
      - Most grid functions now require column numbers to be passed as arguments.
      - General fixes and improvements.
      - Added tests

Fixes #403 
Partially implements #317 