### PR TITLE
icon stroke customization should not affect default color

### DIFF
--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -51,9 +51,11 @@ pub fn draw(self: *IconWidget) void {
     const rs = self.wd.parent.screenRectScale(self.wd.contentRect());
     var texOpts: dvui.RenderTextureOptions = .{ .rotation = self.wd.options.rotationGet() };
 
-    const default_icon_opts: dvui.IconRenderOptions = .{};
-
-    if (std.mem.eql(u8, std.mem.asBytes(&default_icon_opts), std.mem.asBytes(&self.icon_opts))) {
+    const white: ?dvui.Color = .white;
+    const as_bytes = std.mem.asBytes;
+    if (std.mem.eql(u8, as_bytes(&self.icon_opts.fill_color), as_bytes(&white)) and
+        std.mem.eql(u8, as_bytes(&self.icon_opts.stroke_color), as_bytes(&white)))
+    {
         // user is rasterizing icon with defaults (white), so always use
         // colormod (so icons default to text color)
         texOpts.colormod = self.wd.options.color(.text);


### PR DESCRIPTION
the logic around colormod + default colors for icons rendering was recently changed.
as of now if you customize stroke width the color (default black) turns white. this is counterintuitive behaviour.

this is because the check for colormod enabling checks also checks for default stroke width (null)
this PR changes the comparison logic to only check `stroke_color` and `fill_color`

note: the known 'quirk' of our implementation happens when a user tries to overwrite icons with white, this doesnt work because colormod is enabled and default color is not white. but i think we can live with that, because in this case the user should had used colormod anyways!