### PR TITLE
Uniform scroll speeds

### DIFF
--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -1228,7 +1228,7 @@ pub fn wndProc(
             const float_delta: f32 = @floatFromInt(delta);
             const wheel_delta: f32 = @floatFromInt(win32.WHEEL_DELTA);
             _ = stateFromHwnd(hwnd).dvui_window.addEventMouseWheel(
-                float_delta / wheel_delta * 20,
+                float_delta / wheel_delta * dvui.scroll_speed,
                 switch (msg) {
                     win32.WM_MOUSEWHEEL => .vertical,
                     win32.WM_MOUSEHWHEEL => .horizontal,

--- a/src/backends/raylib.zig
+++ b/src/backends/raylib.zig
@@ -599,14 +599,14 @@ pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !bool {
     //scroll wheel movement
     const scroll_wheel = c.GetMouseWheelMoveV();
     if (scroll_wheel.x != 0) {
-        if (try win.addEventMouseWheel(-scroll_wheel.x * 25, .horizontal)) disable_raylib_input = true;
+        if (try win.addEventMouseWheel(-scroll_wheel.x * dvui.scroll_speed, .horizontal)) disable_raylib_input = true;
 
         if (self.log_events) {
             std.debug.print("raylib event Mouse Wheel: {}\n", .{scroll_wheel});
         }
     }
     if (scroll_wheel.y != 0) {
-        if (try win.addEventMouseWheel(scroll_wheel.y * 25, .vertical)) disable_raylib_input = true;
+        if (try win.addEventMouseWheel(scroll_wheel.y * dvui.scroll_speed, .vertical)) disable_raylib_input = true;
 
         if (self.log_events) {
             std.debug.print("raylib event Mouse Wheel: {}\n", .{scroll_wheel});

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1037,12 +1037,14 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
             // TODO: some real solution to interpreting the mouse wheel across OSes
             switch (builtin.target.os.tag) {
                 .windows, .linux => {
-                    ticks_x *= 20;
-                    ticks_y *= 20;
+                    ticks_x *= dvui.scroll_speed;
+                    ticks_y *= dvui.scroll_speed;
                 },
                 .macos => {
-                    ticks_x *= 10;
-                    ticks_y *= 10;
+                    // TODO: Is this divided by 2 because of retina scale?
+                    //       In that case, should we scale by content_scale?
+                    ticks_x *= dvui.scroll_speed / 2;
+                    ticks_y *= dvui.scroll_speed / 2;
                 },
                 else => {},
             }

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -190,6 +190,12 @@ class Dvui {
      * list of tuple (touch identifier, initial index)
      * @type {[number, number][]} */
     touches = [];
+    /** The lowest data seen, used to determine the delta for one "tick"
+     * of the scroll wheel
+     *
+     * The first number is x and second is y
+     * @type {[number, number]} */
+    lowest_scroll_delta = [99999, 99999];
     /**
      * x y w h of on screen keyboard editing position, or empty if none
      *
@@ -1179,20 +1185,30 @@ class Dvui {
         this.gl.canvas.addEventListener("wheel", (ev) => {
             ev.preventDefault();
             if (ev.deltaX != 0) {
+                const min = Math.min(
+                    Math.abs(ev.deltaX),
+                    this.lowest_scroll_delta[0],
+                );
+                this.lowest_scroll_delta[0] = min;
                 this.instance.exports.add_event(
                     4,
                     0,
                     0,
-                    -ev.deltaX,
+                    ev.deltaX / min,
                     0,
                 );
             }
             if (ev.deltaY != 0) {
+                const min = Math.min(
+                    Math.abs(ev.deltaY),
+                    this.lowest_scroll_delta[1],
+                );
+                this.lowest_scroll_delta[1] = min;
                 this.instance.exports.add_event(
                     4,
                     1,
                     0,
-                    ev.deltaY,
+                    -ev.deltaY / min,
                     0,
                 );
             }

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -284,7 +284,7 @@ fn add_event_raw(w: *dvui.Window, which: u8, int1: u32, int2: u32, float1: f32, 
         1 => _ = try w.addEventMouseMotion(.{ .x = float1, .y = float2 }),
         2 => _ = try w.addEventMouseButton(buttonFromJS(int1), .press),
         3 => _ = try w.addEventMouseButton(buttonFromJS(int1), .release),
-        4 => _ = try w.addEventMouseWheel(if (float1 > 0) -20 else 20, if (int1 > 0) .vertical else .horizontal),
+        4 => _ = try w.addEventMouseWheel(float1 * dvui.scroll_speed, if (int1 > 0) .vertical else .horizontal),
         5 => {
             const str = @as([*]u8, @ptrFromInt(int1))[0..int2];
             _ = try w.addEventKey(.{

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -98,6 +98,9 @@ pub const TrackingAutoHashMap = @import("tracking_hash_map.zig").TrackingAutoHas
 pub const wasm = (builtin.target.cpu.arch == .wasm32 or builtin.target.cpu.arch == .wasm64);
 pub const useFreeType = !wasm;
 
+/// The amount of physical pixels to scroll per "tick" of the scroll wheel
+pub const scroll_speed = 20;
+
 /// Used as a default maximum in various places:
 /// * Options.max_size_content
 /// * Font.textSizeEx max_width


### PR DESCRIPTION
Closes #406

This makes scrolling uniform for all backends on my Windows machine. More testing needs to be done on other platforms. All platforms use the same scroll speed multiplier and the web backend translates to "ticks" by dividing by the smallest delta that has been seen.

The biggest questions is potential issues with devices with higher fidelity of scrolling, where one "tick" is supposed to be some fraction of a "normal" tick. Another is the `dvui.scroll_speed / 2` on macOS on SDL. Is this linked to the HIDPI? In that case it might need to be scaled by `content_scale`.