### PR TITLE
Use after deinit safety checks in data() calls.

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -4736,7 +4736,7 @@ pub const StrokeTest = struct {
     }
 
     pub fn data(self: *Self) *dvui.WidgetData {
-        return &self.wd;
+        return self.wd.validate();
     }
 
     pub fn rectFor(self: *Self, id: dvui.WidgetId, min_size: dvui.Size, e: dvui.Options.Expand, g: dvui.Options.Gravity) dvui.Rect {

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -89,7 +89,7 @@ const AnimatingDialog = struct {
         var win = FloatingWindowWidget.init(@src(), .{ .modal = modal }, .{ .id_extra = id.asUsize(), .max_size_content = .width(300) });
 
         if (dvui.firstFrame(win.data().id)) {
-            dvui.animation(win.wd.id, "rect_percent", .{ .start_val = 0.0, .end_val = 1.0, .end_time = duration, .easing = easing });
+            dvui.animation(win.data().id, "rect_percent", .{ .start_val = 0.0, .end_val = 1.0, .end_time = duration, .easing = easing });
         }
 
         const winHeight = win.data().rect.h;
@@ -148,7 +148,7 @@ const AnimatingDialog = struct {
         }
 
         if (closing) {
-            dvui.animation(win.wd.id, "rect_percent", .{ .start_val = 1.0, .end_val = 0.0, .end_time = duration, .easing = easing });
+            dvui.animation(win.data().id, "rect_percent", .{ .start_val = 1.0, .end_val = 0.0, .end_time = duration, .easing = easing });
         }
     }
 
@@ -438,7 +438,7 @@ pub fn demo() void {
                 defer box.deinit();
 
                 var options: dvui.Options = .{ .gravity_x = 0.5, .gravity_y = 1.0 };
-                if (dvui.captured(bw.wd.id)) options = options.override(.{ .color_text = .{ .color = options.color(.text_press) } });
+                if (dvui.captured(bw.data().id)) options = options.override(.{ .color_text = .{ .color = options.color(.text_press) } });
 
                 dvui.label(@src(), "{s}", .{e.name()}, options);
 
@@ -1872,7 +1872,7 @@ pub fn layout() void {
 
             dvui.label(@src(), "Left Side", .{}, .{});
             dvui.label(@src(), "collapses when width < {d}", .{paned_collapsed_width}, .{});
-            dvui.label(@src(), "current width {d}", .{paned.wd.rect.w}, .{});
+            dvui.label(@src(), "current width {d}", .{paned.data().rect.w}, .{});
             if (paned.collapsed() and dvui.button(@src(), "Goto Right", .{}, .{})) {
                 paned.animateSplit(0.0);
             }
@@ -2240,7 +2240,7 @@ pub fn reorderListsAdvanced() void {
 
         dvui.label(@src(), "Drag to add : {d}", .{g.strings_len}, .{});
 
-        if (dvui.ReorderWidget.draggable(@src(), .{ .top_left = hbox2.wd.rectScale().r.topLeft() }, .{ .expand = .vertical, .gravity_x = 1.0, .min_size_content = dvui.Size.all(22), .gravity_y = 0.5 })) |p| {
+        if (dvui.ReorderWidget.draggable(@src(), .{ .top_left = hbox2.data().rectScale().r.topLeft() }, .{ .expand = .vertical, .gravity_x = 1.0, .min_size_content = dvui.Size.all(22), .gravity_y = 0.5 })) |p| {
             // add to list, but will be removed if not dropped onto a list slot
             g.strings[g.strings_len] = g.strings_template[g.strings_len];
             added_idx = g.strings_len;
@@ -2303,7 +2303,7 @@ pub fn reorderListsAdvanced() void {
 
         dvui.label(@src(), "{s}", .{s}, .{});
 
-        if (dvui.ReorderWidget.draggable(@src(), .{ .top_left = reorderable.wd.rectScale().r.topLeft() }, .{ .expand = .vertical, .gravity_x = 1.0, .min_size_content = dvui.Size.all(22), .gravity_y = 0.5 })) |p| {
+        if (dvui.ReorderWidget.draggable(@src(), .{ .top_left = reorderable.data().rectScale().r.topLeft() }, .{ .expand = .vertical, .gravity_x = 1.0, .min_size_content = dvui.Size.all(22), .gravity_y = 0.5 })) |p| {
             reorder.dragStart(i, p); // reorder grabs capture
         }
     }
@@ -3611,9 +3611,9 @@ pub fn animations() void {
         mslabel.draw();
         mslabel.deinit();
 
-        if (dvui.timerDoneOrNone(mslabel.wd.id)) {
+        if (dvui.timerDoneOrNone(mslabel.data().id)) {
             const wait = 1000 * (1000 - left);
-            dvui.timer(mslabel.wd.id, wait);
+            dvui.timer(mslabel.data().id, wait);
         }
 
         dvui.label(@src(), "Estimate of frame overhead {d:6} us", .{dvui.currentWindow().loop_target_slop}, .{});
@@ -3894,11 +3894,11 @@ pub fn icon_browser(src: std.builtin.SourceLocation, show_flag: *bool, comptime 
 
     // we won't have the height the first frame, so always set it
     var scroll_info: ScrollInfo = .{ .vertical = .given };
-    if (dvui.dataGet(null, fwin.wd.id, "scroll_info", ScrollInfo)) |si| {
+    if (dvui.dataGet(null, fwin.data().id, "scroll_info", ScrollInfo)) |si| {
         scroll_info = si;
         scroll_info.virtual_size.h = height;
     }
-    defer dvui.dataSet(null, fwin.wd.id, "scroll_info", scroll_info);
+    defer dvui.dataSet(null, fwin.data().id, "scroll_info", scroll_info);
 
     var scroll = dvui.scrollArea(@src(), .{ .scroll_info = &scroll_info }, .{ .expand = .both });
     defer scroll.deinit();
@@ -4705,11 +4705,11 @@ pub const StrokeTest = struct {
             self.processEvent(e);
         }
 
-        self.wd.borderAndBackground(.{});
+        self.data().borderAndBackground(.{});
 
         _ = dvui.parentSet(self.widget());
 
-        const rs = self.wd.contentRectScale();
+        const rs = self.data().contentRectScale();
         const fill_color = dvui.Color{ .r = 200, .g = 200, .b = 200, .a = 255 };
         for (points, 0..) |p, i| {
             const rect = dvui.Rect.fromPoint(p.plus(.{ .x = -10, .y = -10 })).toSize(.{ .w = 20, .h = 20 });
@@ -4741,21 +4741,21 @@ pub const StrokeTest = struct {
 
     pub fn rectFor(self: *Self, id: dvui.WidgetId, min_size: dvui.Size, e: dvui.Options.Expand, g: dvui.Options.Gravity) dvui.Rect {
         _ = id;
-        return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
+        return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
     }
 
     pub fn screenRectScale(self: *Self, rect: dvui.Rect) dvui.RectScale {
-        return self.wd.contentRectScale().rectToRectScale(rect);
+        return self.data().contentRectScale().rectToRectScale(rect);
     }
 
     pub fn minSizeForChild(self: *Self, s: dvui.Size) void {
-        self.wd.minSizeMax(self.wd.options.padSize(s));
+        self.data().minSizeMax(self.data().options.padSize(s));
     }
 
     pub fn processEvent(self: *Self, e: *dvui.Event) void {
         switch (e.evt) {
             .mouse => |me| {
-                const rs = self.wd.contentRectScale();
+                const rs = self.data().contentRectScale();
                 const mp = rs.pointFromPhysical(me.p);
                 switch (me.action) {
                     .press => {
@@ -4796,7 +4796,7 @@ pub const StrokeTest = struct {
                             const dp = dps.scale(1 / rs.s, Point);
                             points[dragi.?].x += dp.x;
                             points[dragi.?].y += dp.y;
-                            dvui.refresh(null, @src(), self.wd.id);
+                            dvui.refresh(null, @src(), self.data().id);
                         }
                     },
                     .wheel_y => |ticks| {
@@ -4805,7 +4805,7 @@ pub const StrokeTest = struct {
                         const zs = @exp(@log(base) * ticks);
                         if (zs != 1.0) {
                             thickness *= zs;
-                            dvui.refresh(null, @src(), self.wd.id);
+                            dvui.refresh(null, @src(), self.data().id);
                         }
                     },
                     else => {},
@@ -4816,10 +4816,10 @@ pub const StrokeTest = struct {
     }
 
     pub fn deinit(self: *Self) void {
-        self.wd.minSizeSetAndRefresh();
-        self.wd.minSizeReportToParent();
+        self.data().minSizeSetAndRefresh();
+        self.data().minSizeReportToParent();
 
-        dvui.parentReset(self.wd.id, self.wd.parent);
+        dvui.parentReset(self.data().id, self.data().parent);
         self.* = undefined;
     }
 };

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -3609,12 +3609,12 @@ pub fn animations() void {
         var mslabel = dvui.LabelWidget.init(@src(), "{d:0>3} ms into second", .{@as(u32, @intCast(left))}, .{}, .{});
         mslabel.install();
         mslabel.draw();
-        mslabel.deinit();
 
         if (dvui.timerDoneOrNone(mslabel.data().id)) {
             const wait = 1000 * (1000 - left);
             dvui.timer(mslabel.data().id, wait);
         }
+        mslabel.deinit();
 
         dvui.label(@src(), "Estimate of frame overhead {d:6} us", .{dvui.currentWindow().loop_target_slop}, .{});
         switch (dvui.backend.kind) {

--- a/src/Widget.zig
+++ b/src/Widget.zig
@@ -69,7 +69,7 @@ pub fn init(
 }
 
 pub fn data(self: Widget) *WidgetData {
-    return self.vtable.data(self.ptr);
+    return self.vtable.data(self.ptr).validate();
 }
 
 pub fn extendId(self: Widget, src: std.builtin.SourceLocation, id_extra: usize) dvui.WidgetId {

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -321,8 +321,8 @@ pub fn minSizeReportToParent(self: *const WidgetData) void {
     }
 }
 
-pub inline fn validate(self: *WidgetData) *WidgetData {
-    std.debug.assert(self.id != .undef); // Indicates a use after deinit() error.
+pub inline fn validate(self: *const WidgetData) *WidgetData {
+    std.debug.assert(self.id != WidgetId.undef); // Indicates a use after deinit() error.
     return @constCast(self);
 }
 

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -8,7 +8,6 @@ const RectScale = dvui.RectScale;
 const Size = dvui.Size;
 const Widget = dvui.Widget;
 const WidgetId = dvui.WidgetId;
-
 const WidgetData = @This();
 
 pub const InitOptions = struct {
@@ -320,6 +319,11 @@ pub fn minSizeReportToParent(self: *const WidgetData) void {
     if (self.options.rect == null) {
         self.parent.minSizeForChild(self.min_size);
     }
+}
+
+pub inline fn validate(self: *WidgetData) *WidgetData {
+    std.debug.assert(self.id != .undef); // Indicates a use after deinit() error.
+    return @constCast(self);
 }
 
 test {

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -321,7 +321,7 @@ pub fn minSizeReportToParent(self: *const WidgetData) void {
     }
 }
 
-pub inline fn validate(self: *const WidgetData) *WidgetData {
+pub fn validate(self: *const WidgetData) *WidgetData {
     std.debug.assert(self.id != WidgetId.undef); // Indicates a use after deinit() error.
     return @constCast(self);
 }

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1800,7 +1800,7 @@ pub fn widget(self: *Self) Widget {
 }
 
 pub fn data(self: *Self) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *Self, id: WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -355,7 +355,7 @@ pub fn init(
 
     errdefer self.deinit();
 
-    self.focused_subwindowId = self.wd.id;
+    self.focused_subwindowId = self.data().id;
     self.frame_time_ns = 1;
 
     if (dvui.useFreeType) {
@@ -588,7 +588,7 @@ pub fn addEventKey(self: *Self, event: Event.Key) std.mem.Allocator.Error!bool {
         .focus_widgetId = if (self.subwindows.items.len == 0) null else self.subwindowFocused().focused_widgetId,
     });
 
-    const ret = (self.wd.id != self.focused_subwindowId);
+    const ret = (self.data().id != self.focused_subwindowId);
     try self.positionMouseEventAdd();
     return ret;
 }
@@ -615,7 +615,7 @@ pub fn addEventTextEx(self: *Self, text: []const u8, selected: bool) std.mem.All
         .focus_widgetId = if (self.subwindows.items.len == 0) null else self.subwindowFocused().focused_widgetId,
     });
 
-    const ret = (self.wd.id != self.focused_subwindowId);
+    const ret = (self.data().id != self.focused_subwindowId);
     try self.positionMouseEventAdd();
     return ret;
 }
@@ -649,7 +649,7 @@ pub fn addEventMouseMotion(self: *Self, newpt: Point.Physical) std.mem.Allocator
         },
     } });
 
-    const ret = (self.wd.id != winId);
+    const ret = (self.data().id != winId);
     try self.positionMouseEventAdd();
     return ret;
 }
@@ -691,7 +691,7 @@ pub fn addEventPointer(self: *Self, b: dvui.enums.Button, action: Event.Mouse.Ac
     self.positionMouseEventRemove();
 
     if (xynorm) |xyn| {
-        self.mouse_pt = (Point{ .x = xyn.x * self.wd.rect.w, .y = xyn.y * self.wd.rect.h }).scale(self.natural_scale, Point.Physical);
+        self.mouse_pt = (Point{ .x = xyn.x * self.data().rect.w, .y = xyn.y * self.data().rect.h }).scale(self.natural_scale, Point.Physical);
     }
 
     const winId = self.windowFor(self.mouse_pt);
@@ -700,10 +700,10 @@ pub fn addEventPointer(self: *Self, b: dvui.enums.Button, action: Event.Mouse.Ac
         // normally the focus event is what focuses windows, but since the
         // base window is instantiated before events are added, it has to
         // do any event processing as the events come in, right now
-        if (winId == self.wd.id) {
+        if (winId == self.data().id) {
             // focus the window here so any more key events get routed
             // properly
-            self.focusSubwindowInternal(self.wd.id, null);
+            self.focusSubwindowInternal(self.data().id, null);
         }
 
         // add focus event
@@ -730,7 +730,7 @@ pub fn addEventPointer(self: *Self, b: dvui.enums.Button, action: Event.Mouse.Ac
         },
     } });
 
-    const ret = (self.wd.id != winId);
+    const ret = (self.data().id != winId);
     try self.positionMouseEventAdd();
     return ret;
 }
@@ -772,7 +772,7 @@ pub fn addEventMouseWheel(self: *Self, ticks: f32, dir: dvui.enums.Direction) st
         },
     });
 
-    const ret = (self.wd.id != winId);
+    const ret = (self.data().id != winId);
     try self.positionMouseEventAdd();
     return ret;
 }
@@ -785,11 +785,11 @@ pub fn addEventMouseWheel(self: *Self, ticks: f32, dir: dvui.enums.Direction) st
 pub fn addEventTouchMotion(self: *Self, finger: dvui.enums.Button, xnorm: f32, ynorm: f32, dxnorm: f32, dynorm: f32) std.mem.Allocator.Error!bool {
     self.positionMouseEventRemove();
 
-    const newpt = (Point{ .x = xnorm * self.wd.rect.w, .y = ynorm * self.wd.rect.h }).scale(self.natural_scale, Point.Physical);
+    const newpt = (Point{ .x = xnorm * self.data().rect.w, .y = ynorm * self.data().rect.h }).scale(self.natural_scale, Point.Physical);
     //std.debug.print("touch motion {} {d} {d}\n", .{ finger, newpt.x, newpt.y });
     self.mouse_pt = newpt;
 
-    const dp = (Point{ .x = dxnorm * self.wd.rect.w, .y = dynorm * self.wd.rect.h }).scale(self.natural_scale, Point.Physical);
+    const dp = (Point{ .x = dxnorm * self.data().rect.w, .y = dynorm * self.data().rect.h }).scale(self.natural_scale, Point.Physical);
 
     const winId = self.windowFor(self.mouse_pt);
 
@@ -804,7 +804,7 @@ pub fn addEventTouchMotion(self: *Self, finger: dvui.enums.Button, xnorm: f32, y
         },
     } });
 
-    const ret = (self.wd.id != winId);
+    const ret = (self.data().id != winId);
     try self.positionMouseEventAdd();
     return ret;
 }
@@ -1074,14 +1074,14 @@ pub fn begin(
     self.rect_pixels = .fromSize(self.backend.pixelSize());
     dvui.clipSet(self.rect_pixels);
 
-    self.wd.rect = Rect.Natural.fromSize(self.backend.windowSize()).scale(1.0 / self.content_scale, Rect);
-    self.natural_scale = if (self.wd.rect.w == 0) 1.0 else self.rect_pixels.w / self.wd.rect.w;
+    self.data().rect = Rect.Natural.fromSize(self.backend.windowSize()).scale(1.0 / self.content_scale, Rect);
+    self.natural_scale = if (self.data().rect.w == 0) 1.0 else self.rect_pixels.w / self.data().rect.w;
 
-    //dvui.log.debug("window size {d} x {d} renderer size {d} x {d} scale {d}", .{ self.wd.rect.w, self.wd.rect.h, self.rect_pixels.w, self.rect_pixels.h, self.natural_scale });
+    //dvui.log.debug("window size {d} x {d} renderer size {d} x {d} scale {d}", .{ self.data().rect.w, self.data().rect.h, self.rect_pixels.w, self.rect_pixels.h, self.natural_scale });
 
-    dvui.subwindowAdd(self.wd.id, self.wd.rect, self.rect_pixels, false, null);
+    dvui.subwindowAdd(self.data().id, self.data().rect, self.rect_pixels, false, null);
 
-    _ = dvui.subwindowCurrentSet(self.wd.id, .cast(self.wd.rect));
+    _ = dvui.subwindowCurrentSet(self.data().id, .cast(self.data().rect));
 
     self.extra_frames_needed -|= 1;
     self.secs_since_last_frame = @as(f32, @floatFromInt(micros_since_last)) / 1_000_000;
@@ -1135,11 +1135,11 @@ pub fn begin(
     }
     self.captured_last_frame = false;
 
-    self.wd.parent = self.widget();
+    self.data().parent = self.widget();
 
     // Window's wd is kept frame to frame, so manually reset the cache.
-    self.wd.rect_scale_cache = null;
-    self.wd.register();
+    self.data().rect_scale_cache = null;
+    self.data().register();
 
     self.layout = .{};
 
@@ -1173,7 +1173,7 @@ pub fn windowFor(self: *const Self, p: Point.Physical) WidgetId {
         }
     }
 
-    return self.wd.id;
+    return self.data().id;
 }
 
 pub fn subwindowCurrent(self: *const Self) *Subwindow {
@@ -1216,7 +1216,7 @@ pub fn cursorRequested(self: *const Self) dvui.enums.Cursor {
 /// Client code should cache this if switching the platform's cursor is
 /// expensive.
 pub fn cursorRequestedFloating(self: *const Self) ?dvui.enums.Cursor {
-    if (self.capture != null or self.windowFor(self.mouse_pt) != self.wd.id) {
+    if (self.capture != null or self.windowFor(self.mouse_pt) != self.data().id) {
         // gui owns the cursor if we have mouse capture or if the mouse is above
         // a floating window
         return self.cursorRequested();
@@ -1673,7 +1673,7 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
             self.drag_name = "";
         }
 
-        if (!dvui.eventMatch(e, .{ .id = self.wd.id, .r = self.rect_pixels, .cleanup = true }))
+        if (!dvui.eventMatch(e, .{ .id = self.data().id, .r = self.rect_pixels, .cleanup = true }))
             continue;
 
         if (e.evt == .mouse) {
@@ -1799,12 +1799,12 @@ pub fn widget(self: *Self) Widget {
     return Widget.init(self, data, rectFor, screenRectScale, minSizeForChild);
 }
 
-pub fn data(self: *Self) *WidgetData {
+pub fn data(self: *const Self) *WidgetData {
     return self.wd.validate();
 }
 
 pub fn rectFor(self: *Self, id: WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
-    return self.layout.rectFor(self.wd.rect, id, min_size, e, g);
+    return self.layout.rectFor(self.data().rect, id, min_size, e, g);
 }
 
 pub fn rectScale(self: *Self) RectScale {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -147,10 +147,13 @@ pub const Error = std.mem.Allocator.Error || StbImageError || TvgError || FontEr
 pub const TvgError = error{tvgError};
 pub const StbImageError = error{stbImageError};
 pub const FontError = error{fontError};
+
 pub const log = std.log.scoped(.dvui);
 const dvui = @This();
+
 pub const WidgetId = enum(u64) {
     zero = 0,
+    // This may not work in future and is illegal behaviour / arch specfic to compare to undefined.
     undef = 0xAAAAAAAAAAAAAAAA,
     _,
 
@@ -1376,7 +1379,7 @@ pub fn focusWidget(id: ?WidgetId, subwindow_id: ?WidgetId, event_num: ?u16) void
                         cw.last_focused_id_this_frame = wid;
                     } else {
                         // walk parent chain
-                        var wd = cw.wd.parent.data();
+                        var wd = cw.data().parent.data();
 
                         while (true) : (wd = wd.parent.data()) {
                             if (wd.id == wid) {
@@ -1384,7 +1387,7 @@ pub fn focusWidget(id: ?WidgetId, subwindow_id: ?WidgetId, event_num: ?u16) void
                                 break;
                             }
 
-                            if (wd.id == cw.wd.id) {
+                            if (wd.id == cw.data().id) {
                                 // got to base Window
                                 break;
                             }
@@ -2655,7 +2658,7 @@ pub fn FPS() f32 {
 ///
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn parentGet() Widget {
-    return currentWindow().wd.parent;
+    return currentWindow().data().parent;
 }
 
 /// Make w the new parent widget.  See `parentGet`.
@@ -2663,7 +2666,7 @@ pub fn parentGet() Widget {
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn parentSet(w: Widget) void {
     const cw = currentWindow();
-    cw.wd.parent = w;
+    cw.data().parent = w;
 }
 
 /// Make a previous parent widget the current parent.
@@ -2674,11 +2677,11 @@ pub fn parentSet(w: Widget) void {
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn parentReset(id: WidgetId, w: Widget) void {
     const cw = currentWindow();
-    const actual_current = cw.wd.parent.data().id;
+    const actual_current = cw.data().parent.data().id;
     if (id != actual_current) {
         cw.debug_widget_id = actual_current;
 
-        var wd = cw.wd.parent.data();
+        var wd = cw.data().parent.data();
 
         log.err("widget is not closed within its parent. did you forget to call `.deinit()`?", .{});
 
@@ -2688,16 +2691,16 @@ pub fn parentReset(id: WidgetId, w: Widget) void {
                 wd.src.line,
                 wd.options.name orelse "???",
                 wd.id,
-                if (wd.id == cw.wd.id) "\n" else "",
+                if (wd.id == cw.data().id) "\n" else "",
             });
 
-            if (wd.id == cw.wd.id) {
+            if (wd.id == cw.data().id) {
                 // got to base Window
                 break;
             }
         }
     }
-    cw.wd.parent = w;
+    cw.data().parent = w;
 }
 
 /// Set if dvui should immediately render, and return the previous setting.
@@ -2719,8 +2722,8 @@ pub fn renderingSet(r: bool) bool {
 ///
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn windowRect() Rect.Natural {
-    // Window.wd.rect is the definition of natural
-    return .cast(currentWindow().wd.rect);
+    // Window.data().rect is the definition of natural
+    return .cast(currentWindow().data().rect);
 }
 
 /// Get the OS window size in pixels.  See `windowRect`.
@@ -3665,7 +3668,7 @@ pub fn windowHeader(str: []const u8, right_str: []const u8, openflag: ?*bool) Re
 
     const evts = events();
     for (evts) |*e| {
-        if (!eventMatch(e, .{ .id = over.wd.id, .r = over.wd.contentRectScale().r }))
+        if (!eventMatch(e, .{ .id = over.data().id, .r = over.data().contentRectScale().r }))
             continue;
 
         if (e.evt == .mouse and e.evt.mouse.action == .press and e.evt.mouse.button.pointer()) {
@@ -4576,7 +4579,7 @@ pub fn expander(src: std.builtin.SourceLocation, label_str: []const u8, init_opt
     defer bc.deinit();
 
     var expanded: bool = init_opts.default_expanded;
-    if (dvui.dataGet(null, bc.wd.id, "_expand", bool)) |e| {
+    if (dvui.dataGet(null, bc.data().id, "_expand", bool)) |e| {
         expanded = e;
     }
 
@@ -4601,7 +4604,7 @@ pub fn expander(src: std.builtin.SourceLocation, label_str: []const u8, init_opt
     }
     labelNoFmt(@src(), label_str, .{}, options.strip());
 
-    dvui.dataSet(null, bc.wd.id, "_expand", expanded);
+    dvui.dataSet(null, bc.data().id, "_expand", expanded);
 
     return expanded;
 }
@@ -5749,7 +5752,7 @@ pub fn slider(src: std.builtin.SourceLocation, dir: enums.Direction, fraction: *
     knob.install();
     knob.drawBackground();
     if (b.data().id == focusedWidgetId()) {
-        knob.wd.focusBorder();
+        knob.data().focusBorder();
     }
     knob.deinit();
 
@@ -5826,7 +5829,7 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
         var te = TextEntryWidget.init(@src(), .{ .text = .{ .buffer = te_buf } }, options.strip().override(.{ .min_size_content = .{}, .expand = .both, .tab_index = 0 }));
         te.install();
 
-        if (firstFrame(te.wd.id)) {
+        if (firstFrame(te.data().id)) {
             var sel = te.textLayout.selection;
             sel.start = 0;
             sel.cursor = 0;
@@ -6046,10 +6049,10 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
             }
         }
 
-        b.wd.borderAndBackground(.{ .fill_color = if (hover) b.wd.options.color(.fill_hover) else b.wd.options.color(.fill) });
+        b.data().borderAndBackground(.{ .fill_color = if (hover) b.data().options.color(.fill_hover) else b.data().options.color(.fill) });
 
         // only draw handle if we have a min and max
-        if (b.wd.visible() and init_opts.min != null and init_opts.max != null) {
+        if (b.data().visible() and init_opts.min != null and init_opts.max != null) {
             const how_far = (init_opts.value.* - init_opts.min.?) / (init_opts.max.? - init_opts.min.?);
             const knobRect = Rect{ .x = (br.w - knobsize) * math.clamp(how_far, 0, 1), .w = knobsize, .h = knobsize };
             const knobrs = b.widget().screenRectScale(knobRect);
@@ -6215,7 +6218,7 @@ pub fn checkbox(src: std.builtin.SourceLocation, target: *bool, label_str: ?[]co
 
     const rs = s.borderRectScale();
 
-    if (bw.wd.visible()) {
+    if (bw.data().visible()) {
         checkmark(target.*, bw.focused(), rs, bw.pressed(), bw.hovered(), options);
     }
 
@@ -6301,7 +6304,7 @@ pub fn radio(src: std.builtin.SourceLocation, active: bool, label_str: ?[]const 
 
     const rs = s.borderRectScale();
 
-    if (bw.wd.visible()) {
+    if (bw.data().visible()) {
         radioCircle(active, bw.focused(), rs, bw.pressed(), bw.hovered(), options);
     }
 
@@ -6611,7 +6614,7 @@ pub fn textEntryColor(src: std.builtin.SourceLocation, init_opts: TextEntryColor
         }
     }
 
-    if (init_opts.value != null and result.value == .Empty and focusedWidgetId() != te.wd.id) {
+    if (init_opts.value != null and result.value == .Empty and focusedWidgetId() != te.data().id) {
         // If the text entry is empty and we loose focus,
         // reset the hex value by invalidating the stored previous value
         dataRemove(null, id, "value");
@@ -7330,9 +7333,9 @@ pub const BasicLayout = struct {
                     wd.src.line,
                     wd.options.name orelse "???",
                     wd.id,
-                    if (wd.id == cw.wd.id) "\n" else "",
+                    if (wd.id == cw.data().id) "\n" else "",
                 });
-                if (wd.id == cw.wd.id) {
+                if (wd.id == cw.data().id) {
                     break;
                 }
             }

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -147,12 +147,11 @@ pub const Error = std.mem.Allocator.Error || StbImageError || TvgError || FontEr
 pub const TvgError = error{tvgError};
 pub const StbImageError = error{stbImageError};
 pub const FontError = error{fontError};
-
 pub const log = std.log.scoped(.dvui);
 const dvui = @This();
-
 pub const WidgetId = enum(u64) {
     zero = 0,
+    undef = 0xAAAAAAAAAAAAAAAA,
     _,
 
     pub fn asU64(self: WidgetId) u64 {

--- a/src/easing.zig
+++ b/src/easing.zig
@@ -223,7 +223,7 @@ test "DOCIMG easing plots" {
                 const y = easing(@floatCast(x));
                 line.point(x, y);
             }
-            line.stroke(1, plot.box.wd.options.color(.accent));
+            line.stroke(1, plot.box.data().options.color(.accent));
             return .ok;
         }
     };

--- a/src/widgets/AnimateWidget.zig
+++ b/src/widgets/AnimateWidget.zig
@@ -36,14 +36,14 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *AnimateWidget) void {
-    if (dvui.firstFrame(self.wd.id)) {
+    if (dvui.firstFrame(self.data().id)) {
         // start begin animation
         self.start();
     }
 
-    if (dvui.animationGet(self.wd.id, "_end")) |a| {
+    if (dvui.animationGet(self.data().id, "_end")) |a| {
         self.val = a.value();
-    } else if (dvui.animationGet(self.wd.id, "_start")) |a| {
+    } else if (dvui.animationGet(self.data().id, "_start")) |a| {
         self.val = a.value();
     }
 
@@ -55,22 +55,22 @@ pub fn install(self: *AnimateWidget) void {
                 dvui.themeGet().alpha *= std.math.clamp(v, 0, 1);
             },
             .vertical => {
-                if (dvui.minSizeGet(self.wd.id)) |ms| {
-                    if (self.wd.rect.h > ms.h + 0.001) {
+                if (dvui.minSizeGet(self.data().id)) |ms| {
+                    if (self.data().rect.h > ms.h + 0.001) {
                         // we are bigger than our min size (maybe expanded) - account for floating point
-                        const h = self.wd.rect.h;
-                        self.wd.rect.h *= @max(v, 0);
-                        self.wd.rect.y += self.wd.options.gravityGet().y * (h - self.wd.rect.h);
+                        const h = self.data().rect.h;
+                        self.data().rect.h *= @max(v, 0);
+                        self.data().rect.y += self.data().options.gravityGet().y * (h - self.data().rect.h);
                     }
                 }
             },
             .horizontal => {
-                if (dvui.minSizeGet(self.wd.id)) |ms| {
-                    if (self.wd.rect.w > ms.w + 0.001) {
+                if (dvui.minSizeGet(self.data().id)) |ms| {
+                    if (self.data().rect.w > ms.w + 0.001) {
                         // we are bigger than our min size (maybe expanded) - account for floating point
-                        const w = self.wd.rect.w;
-                        self.wd.rect.w *= @max(v, 0);
-                        self.wd.rect.x += self.wd.options.gravityGet().x * (w - self.wd.rect.w);
+                        const w = self.data().rect.w;
+                        self.data().rect.w *= @max(v, 0);
+                        self.data().rect.x += self.data().options.gravityGet().x * (w - self.data().rect.w);
                     }
                 }
             },
@@ -78,12 +78,12 @@ pub fn install(self: *AnimateWidget) void {
     }
 
     dvui.parentSet(self.widget());
-    self.wd.register();
-    self.wd.borderAndBackground(.{});
+    self.data().register();
+    self.data().borderAndBackground(.{});
 }
 
 pub fn start(self: *AnimateWidget) void {
-    dvui.animation(self.wd.id, "_start", .{
+    dvui.animation(self.data().id, "_start", .{
         .start_val = 0.0,
         .end_val = 1.0,
         .end_time = self.init_opts.duration,
@@ -92,7 +92,7 @@ pub fn start(self: *AnimateWidget) void {
 }
 
 pub fn startEnd(self: *AnimateWidget) void {
-    dvui.animation(self.wd.id, "_end", .{
+    dvui.animation(self.data().id, "_end", .{
         .start_val = 1.0,
         .end_val = 0.0,
         .end_time = self.init_opts.duration,
@@ -101,7 +101,7 @@ pub fn startEnd(self: *AnimateWidget) void {
 }
 
 pub fn end(self: *AnimateWidget) bool {
-    if (dvui.animationGet(self.wd.id, "_end")) |a| {
+    if (dvui.animationGet(self.data().id, "_end")) |a| {
         return a.done();
     }
 
@@ -118,15 +118,15 @@ pub fn data(self: *AnimateWidget) *WidgetData {
 
 pub fn rectFor(self: *AnimateWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
-    return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
+    return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }
 
 pub fn screenRectScale(self: *AnimateWidget, rect: Rect) RectScale {
-    return self.wd.contentRectScale().rectToRectScale(rect);
+    return self.data().contentRectScale().rectToRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *AnimateWidget, s: Size) void {
-    self.wd.minSizeMax(self.wd.options.padSize(s));
+    self.data().minSizeMax(self.data().options.padSize(s));
 }
 
 pub fn deinit(self: *AnimateWidget) void {
@@ -138,18 +138,18 @@ pub fn deinit(self: *AnimateWidget) void {
             },
             .vertical => {
                 // Negative height messes with layout
-                self.wd.min_size.h *= @max(v, 0);
+                self.data().min_size.h *= @max(v, 0);
             },
             .horizontal => {
                 // Negative width messes with layout
-                self.wd.min_size.w *= @max(v, 0);
+                self.data().min_size.w *= @max(v, 0);
             },
         }
     }
 
-    self.wd.minSizeSetAndRefresh();
-    self.wd.minSizeReportToParent();
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
+    dvui.parentReset(self.data().id, self.data().parent);
     self.* = undefined;
 }
 

--- a/src/widgets/AnimateWidget.zig
+++ b/src/widgets/AnimateWidget.zig
@@ -113,7 +113,7 @@ pub fn widget(self: *AnimateWidget) Widget {
 }
 
 pub fn data(self: *AnimateWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *AnimateWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/BoxWidget.zig
+++ b/src/widgets/BoxWidget.zig
@@ -56,10 +56,10 @@ pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Op
 }
 
 pub fn install(self: *BoxWidget) void {
-    self.wd.register();
+    self.data().register();
 
     // our rect for children has to start at 0,0
-    self.child_rect = self.wd.contentRect().justSize();
+    self.child_rect = self.data().contentRect().justSize();
 
     if (self.data_prev) |dp| {
         if (self.init_opts.equal_space) {
@@ -88,7 +88,7 @@ pub fn install(self: *BoxWidget) void {
 }
 
 pub fn drawBackground(self: *BoxWidget) void {
-    self.wd.borderAndBackground(.{});
+    self.data().borderAndBackground(.{});
 }
 
 pub fn matchEvent(self: *BoxWidget, e: *Event) bool {
@@ -113,7 +113,7 @@ pub fn rectFor(self: *BoxWidget, id: dvui.WidgetId, min_size: Size, e: Options.E
 
     if (self.child_positioned) {
         // don't pack this, we treat this like overlay - put it where they asked
-        return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
+        return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
     }
 
     self.packed_children += 1;
@@ -217,12 +217,12 @@ fn removeSpace(self: *BoxWidget, r: Rect, g: Options.Gravity) void {
 }
 
 pub fn screenRectScale(self: *BoxWidget, rect: Rect) RectScale {
-    return self.wd.contentRectScale().rectToRectScale(rect);
+    return self.data().contentRectScale().rectToRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *BoxWidget, s: Size) void {
     if (self.child_positioned) {
-        self.wd.minSizeMax(self.wd.options.padSize(s));
+        self.data().minSizeMax(self.data().options.padSize(s));
         return;
     }
 
@@ -261,14 +261,14 @@ pub fn deinit(self: *BoxWidget) void {
             // - maybe one is no longer expanded
             // - maybe one's min size shrunk (label changing text)
             // equal_space could mean we don't exactly use all the space (due to floating point)
-            dvui.refresh(null, @src(), self.wd.id);
+            dvui.refresh(null, @src(), self.data().id);
         }
 
         if (!self.init_opts.equal_space and self.pixels_per_w > 0 and self.ran_off) {
             // we have expanded children, thought we had extra space, but ran
             // off the end:
             // - maybe one's min size got bigger (label changing text)
-            dvui.refresh(null, @src(), self.wd.id);
+            dvui.refresh(null, @src(), self.data().id);
         }
 
         // if total_weight is 0, we are tight around all children, so our min
@@ -276,14 +276,14 @@ pub fn deinit(self: *BoxWidget) void {
         // minSizeSetAndRefresh()
     }
 
-    self.wd.minSizeMax(self.wd.options.padSize(ms));
+    self.data().minSizeMax(self.data().options.padSize(ms));
 
-    self.wd.minSizeSetAndRefresh();
-    self.wd.minSizeReportToParent();
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
 
-    dvui.dataSet(null, self.wd.id, "_data", Data{ .packed_children = self.packed_children, .total_weight = self.total_weight, .min_space_taken = self.min_space_taken });
+    dvui.dataSet(null, self.data().id, "_data", Data{ .packed_children = self.packed_children, .total_weight = self.total_weight, .min_space_taken = self.min_space_taken });
 
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    dvui.parentReset(self.data().id, self.data().parent);
     self.* = undefined;
 }
 

--- a/src/widgets/BoxWidget.zig
+++ b/src/widgets/BoxWidget.zig
@@ -100,7 +100,7 @@ pub fn widget(self: *BoxWidget) Widget {
 }
 
 pub fn data(self: *BoxWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *BoxWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -40,10 +40,10 @@ pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Op
 }
 
 pub fn install(self: *ButtonWidget) void {
-    self.wd.register();
+    self.data().register();
     dvui.parentSet(self.widget());
 
-    dvui.tabIndexSet(self.wd.id, self.wd.options.tab_index);
+    dvui.tabIndexSet(self.data().id, self.data().options.tab_index);
 }
 
 pub fn matchEvent(self: *ButtonWidget, e: *Event) bool {
@@ -56,23 +56,23 @@ pub fn processEvents(self: *ButtonWidget) void {
 
 pub fn drawBackground(self: *ButtonWidget) void {
     var fill_color: ?Color = null;
-    if (dvui.captured(self.wd.id)) {
-        fill_color = self.wd.options.color(.fill_press);
+    if (dvui.captured(self.data().id)) {
+        fill_color = self.data().options.color(.fill_press);
     } else if (self.hover) {
-        fill_color = self.wd.options.color(.fill_hover);
+        fill_color = self.data().options.color(.fill_hover);
     }
 
-    self.wd.borderAndBackground(.{ .fill_color = fill_color });
+    self.data().borderAndBackground(.{ .fill_color = fill_color });
 }
 
 pub fn drawFocus(self: *ButtonWidget) void {
     if (self.init_options.draw_focus and self.focused()) {
-        self.wd.focusBorder();
+        self.data().focusBorder();
     }
 }
 
 pub fn focused(self: *ButtonWidget) bool {
-    return self.wd.id == dvui.focusedWidgetId();
+    return self.data().id == dvui.focusedWidgetId();
 }
 
 pub fn hovered(self: *ButtonWidget) bool {
@@ -80,7 +80,7 @@ pub fn hovered(self: *ButtonWidget) bool {
 }
 
 pub fn pressed(self: *ButtonWidget) bool {
-    return dvui.captured(self.wd.id);
+    return dvui.captured(self.data().id);
 }
 
 pub fn clicked(self: *ButtonWidget) bool {
@@ -97,22 +97,22 @@ pub fn data(self: *ButtonWidget) *WidgetData {
 
 pub fn rectFor(self: *ButtonWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
-    return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
+    return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }
 
 pub fn screenRectScale(self: *ButtonWidget, rect: Rect) RectScale {
-    return self.wd.contentRectScale().rectToRectScale(rect);
+    return self.data().contentRectScale().rectToRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *ButtonWidget, s: Size) void {
-    self.wd.minSizeMax(self.wd.options.padSize(s));
+    self.data().minSizeMax(self.data().options.padSize(s));
 }
 
 pub fn deinit(self: *ButtonWidget) void {
     defer dvui.widgetFree(self);
-    self.wd.minSizeSetAndRefresh();
-    self.wd.minSizeReportToParent();
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
+    dvui.parentReset(self.data().id, self.data().parent);
     self.* = undefined;
 }
 

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -92,7 +92,7 @@ pub fn widget(self: *ButtonWidget) Widget {
 }
 
 pub fn data(self: *ButtonWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *ButtonWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/CacheWidget.zig
+++ b/src/widgets/CacheWidget.zig
@@ -136,7 +136,7 @@ pub fn widget(self: *CacheWidget) Widget {
 }
 
 pub fn data(self: *CacheWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *CacheWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -167,7 +167,7 @@ pub fn valueSaturationBox(src: std.builtin.SourceLocation, hsv: *Color.HSV, opts
     indicator.install();
     indicator.drawBackground();
     if (b.data().id == dvui.focusedWidgetId()) {
-        indicator.wd.focusBorder();
+        indicator.data().focusBorder();
     }
     indicator.deinit();
 
@@ -311,7 +311,7 @@ pub fn hueSlider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hue
     knob.install();
     knob.drawBackground();
     if (b.data().id == dvui.focusedWidgetId()) {
-        knob.wd.focusBorder();
+        knob.data().focusBorder();
     }
     knob.deinit();
 

--- a/src/widgets/ContextWidget.zig
+++ b/src/widgets/ContextWidget.zig
@@ -76,7 +76,7 @@ pub fn widget(self: *ContextWidget) Widget {
 }
 
 pub fn data(self: *ContextWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *ContextWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/ContextWidget.zig
+++ b/src/widgets/ContextWidget.zig
@@ -48,8 +48,8 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 pub fn install(self: *ContextWidget) void {
     dvui.parentSet(self.widget());
     self.prev_menu_root = dvui.MenuWidget.Root.set(.{ .ptr = self, .close = menu_root_close });
-    self.wd.register();
-    self.wd.borderAndBackground(.{});
+    self.data().register();
+    self.data().borderAndBackground(.{});
 }
 
 pub fn activePoint(self: *ContextWidget) ?Point.Natural {
@@ -81,16 +81,16 @@ pub fn data(self: *ContextWidget) *WidgetData {
 
 pub fn rectFor(self: *ContextWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
-    dvui.log.debug("{s}:{d} ContextWidget should not have normal child widgets, only menu stuff", .{ self.wd.src.file, self.wd.src.line });
-    return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
+    dvui.log.debug("{s}:{d} ContextWidget should not have normal child widgets, only menu stuff", .{ self.data().src.file, self.data().src.line });
+    return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }
 
 pub fn screenRectScale(self: *ContextWidget, rect: Rect) RectScale {
-    return self.wd.contentRectScale().rectToRectScale(rect);
+    return self.data().contentRectScale().rectToRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *ContextWidget, s: Size) void {
-    self.wd.minSizeMax(self.wd.options.padSize(s));
+    self.data().minSizeMax(self.data().options.padSize(s));
 }
 
 pub fn processEvents(self: *ContextWidget) void {
@@ -115,7 +115,7 @@ pub fn processEvent(self: *ContextWidget, e: *Event) void {
             } else if (me.action == .press and me.button == .right) {
                 e.handle(@src(), self.data());
 
-                dvui.focusWidget(self.wd.id, null, e.num);
+                dvui.focusWidget(self.data().id, null, e.num);
                 self.focused = true;
 
                 // scale the point back to natural so we can use it in Popup
@@ -132,15 +132,15 @@ pub fn processEvent(self: *ContextWidget, e: *Event) void {
 pub fn deinit(self: *ContextWidget) void {
     defer dvui.widgetFree(self);
     if (self.focused) {
-        dvui.dataSet(null, self.wd.id, "_activePt", self.activePt);
+        dvui.dataSet(null, self.data().id, "_activePt", self.activePt);
     }
 
     // we are always given a rect, so we don't do normal layout, don't do these
-    //self.wd.minSizeSetAndRefresh();
-    //self.wd.minSizeReportToParent();
+    //self.data().minSizeSetAndRefresh();
+    //self.data().minSizeReportToParent();
 
     _ = dvui.MenuWidget.Root.set(self.prev_menu_root);
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    dvui.parentReset(self.data().id, self.data().parent);
     self.* = undefined;
 }
 

--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -82,7 +82,7 @@ pub fn dropped(self: *DropdownWidget) bool {
     if (self.menuItem.activeRect()) |r| {
         self.drop = FloatingMenuWidget.init(@src(), .{ .from = r, .avoid = .none }, .{ .min_size_content = .cast(r.size()) });
         var drop = &self.drop.?;
-        self.drop_first_frame = dvui.firstFrame(drop.wd.id);
+        self.drop_first_frame = dvui.firstFrame(drop.data().id);
 
         const s = drop.scale_val;
 
@@ -102,8 +102,8 @@ pub fn dropped(self: *DropdownWidget) bool {
         drop.menu.submenus_activated = true;
 
         // only want a mouse-up to choose something if the mouse has moved in the dropup
-        var eat_mouse_up = dvui.dataGet(null, drop.wd.id, "_eat_mouse_up", bool) orelse true;
-        var drag_scroll = dvui.dataGet(null, drop.wd.id, "_drag_scroll", bool) orelse false;
+        var eat_mouse_up = dvui.dataGet(null, drop.data().id, "_eat_mouse_up", bool) orelse true;
+        var drag_scroll = dvui.dataGet(null, drop.data().id, "_drag_scroll", bool) orelse false;
 
         const drop_rs = drop.data().rectScale();
         const scroll_rs = drop.scroll.data().contentRectScale();
@@ -131,17 +131,17 @@ pub fn dropped(self: *DropdownWidget) bool {
                     if (eat_mouse_up) {
                         e.handle(@src(), drop.data());
                         eat_mouse_up = false;
-                        dvui.dataSet(null, drop.wd.id, "_eat_mouse_up", eat_mouse_up);
+                        dvui.dataSet(null, drop.data().id, "_eat_mouse_up", eat_mouse_up);
                     }
                 } else if (e.evt.mouse.action == .motion or (e.evt.mouse.action == .press and e.evt.mouse.button.pointer())) {
                     if (eat_mouse_up) {
                         eat_mouse_up = false;
-                        dvui.dataSet(null, drop.wd.id, "_eat_mouse_up", eat_mouse_up);
+                        dvui.dataSet(null, drop.data().id, "_eat_mouse_up", eat_mouse_up);
                     }
 
                     if (!drag_scroll) {
                         drag_scroll = true;
-                        dvui.dataSet(null, drop.wd.id, "_drag_scroll", drag_scroll);
+                        dvui.dataSet(null, drop.data().id, "_drag_scroll", drag_scroll);
                     }
                 }
             }
@@ -191,7 +191,7 @@ pub fn addChoice(self: *DropdownWidget) *MenuItemWidget {
     if (self.drop_first_frame) {
         if (self.init_options.selected_index) |si| {
             if (si == self.drop_mi_index) {
-                dvui.focusWidget(self.drop_mi.wd.id, null, null);
+                dvui.focusWidget(self.drop_mi.data().id, null, null);
                 dvui.dataSet(null, self.menu.wd.id, "_drop_adjust", self.drop_height);
             }
         }

--- a/src/widgets/FlexBoxWidget.zig
+++ b/src/widgets/FlexBoxWidget.zig
@@ -38,16 +38,16 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *FlexBoxWidget) void {
-    self.wd.register();
+    self.data().register();
     dvui.parentSet(self.widget());
 
-    self.prevClip = dvui.clip(self.wd.contentRectScale().r);
+    self.prevClip = dvui.clip(self.data().contentRectScale().r);
 }
 
 pub fn drawBackground(self: *FlexBoxWidget) void {
     const clip = dvui.clipGet();
     dvui.clipSet(self.prevClip);
-    self.wd.borderAndBackground(.{});
+    self.data().borderAndBackground(.{});
     dvui.clipSet(clip);
 }
 
@@ -64,13 +64,13 @@ pub fn rectFor(self: *FlexBoxWidget, id: dvui.WidgetId, min_size: Size, e: Optio
     _ = e;
     _ = g;
 
-    var container_width = self.wd.contentRect().w;
+    var container_width = self.data().contentRect().w;
     if (container_width == 0) {
         // if we are not being shown at all, probably this is the first
         // frame for us and we should calculate our min height assuming we
         // get at least our min width
 
-        container_width = self.wd.options.min_size_contentGet().w;
+        container_width = self.data().options.min_size_contentGet().w;
         if (container_width == 0) {
             // wasn't given a min width, assume something
             container_width = 500;
@@ -89,7 +89,7 @@ pub fn rectFor(self: *FlexBoxWidget, id: dvui.WidgetId, min_size: Size, e: Optio
     var ret = Rect.fromPoint(self.insert_pt).toSize(min_size);
     switch (self.init_options.justify_content) {
         .start => {},
-        .center => ret.x += (self.wd.contentRect().w - self.max_row_width_prev) / 2,
+        .center => ret.x += (self.data().contentRect().w - self.max_row_width_prev) / 2,
     }
 
     self.insert_pt.x += min_size.w;
@@ -98,23 +98,23 @@ pub fn rectFor(self: *FlexBoxWidget, id: dvui.WidgetId, min_size: Size, e: Optio
 }
 
 pub fn screenRectScale(self: *FlexBoxWidget, rect: Rect) RectScale {
-    return self.wd.contentRectScale().rectToRectScale(rect);
+    return self.data().contentRectScale().rectToRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *FlexBoxWidget, s: Size) void {
     self.row_size.w += s.w;
     self.max_row_width = @max(self.max_row_width, self.row_size.w);
     self.width_nobreak += s.w;
-    self.wd.min_size = self.wd.options.padSize(.{ .w = self.width_nobreak, .h = self.insert_pt.y + self.row_size.h });
+    self.data().min_size = self.data().options.padSize(.{ .w = self.width_nobreak, .h = self.insert_pt.y + self.row_size.h });
 }
 
 pub fn deinit(self: *FlexBoxWidget) void {
     defer dvui.widgetFree(self);
-    dvui.dataSet(null, self.wd.id, "_mrw", self.max_row_width);
+    dvui.dataSet(null, self.data().id, "_mrw", self.max_row_width);
     dvui.clipSet(self.prevClip);
-    self.wd.minSizeSetAndRefresh();
-    self.wd.minSizeReportToParent();
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
+    dvui.parentReset(self.data().id, self.data().parent);
     self.* = undefined;
 }
 

--- a/src/widgets/FlexBoxWidget.zig
+++ b/src/widgets/FlexBoxWidget.zig
@@ -56,7 +56,7 @@ pub fn widget(self: *FlexBoxWidget) Widget {
 }
 
 pub fn data(self: *FlexBoxWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *FlexBoxWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -175,7 +175,7 @@ pub fn widget(self: *FloatingMenuWidget) Widget {
 }
 
 pub fn data(self: *FloatingMenuWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *FloatingMenuWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -104,7 +104,7 @@ pub fn install(self: *FloatingMenuWidget) void {
 
     dvui.parentSet(self.widget());
 
-    self.prev_windowId = dvui.subwindowCurrentSet(self.wd.id, null).id;
+    self.prev_windowId = dvui.subwindowCurrentSet(self.data().id, null).id;
     self.parent_popup = popupSet(self);
     // prevents parents from processing key events if focus is inside the floating window:w
     self.prev_last_focus = dvui.lastFocusedIdInFrame(null);
@@ -116,25 +116,25 @@ pub fn install(self: *FloatingMenuWidget) void {
         .auto => unreachable,
     };
 
-    self.wd.rect = Rect.fromPoint(.cast(self.init_options.from.topLeft()));
-    if (dvui.minSizeGet(self.wd.id)) |_| {
-        const ms = dvui.minSize(self.wd.id, self.options.min_sizeGet());
-        self.wd.rect = self.wd.rect.toSize(ms);
-        self.wd.rect = .cast(dvui.placeOnScreen(dvui.windowRect(), self.init_options.from, avoid, .cast(self.wd.rect)));
+    self.data().rect = Rect.fromPoint(.cast(self.init_options.from.topLeft()));
+    if (dvui.minSizeGet(self.data().id)) |_| {
+        const ms = dvui.minSize(self.data().id, self.options.min_sizeGet());
+        self.data().rect = self.data().rect.toSize(ms);
+        self.data().rect = .cast(dvui.placeOnScreen(dvui.windowRect(), self.init_options.from, avoid, .cast(self.data().rect)));
     } else {
-        self.wd.rect = .cast(dvui.placeOnScreen(dvui.windowRect(), self.init_options.from, avoid, .cast(self.wd.rect)));
-        dvui.focusSubwindow(self.wd.id, null);
+        self.data().rect = .cast(dvui.placeOnScreen(dvui.windowRect(), self.init_options.from, avoid, .cast(self.data().rect)));
+        dvui.focusSubwindow(self.data().id, null);
 
         // need a second frame to fit contents (FocusWindow calls refresh but
         // here for clarity)
-        dvui.refresh(null, @src(), self.wd.id);
+        dvui.refresh(null, @src(), self.data().id);
     }
 
-    const rs = self.wd.rectScale();
+    const rs = self.data().rectScale();
 
-    dvui.subwindowAdd(self.wd.id, self.wd.rect, rs.r, false, null);
-    dvui.captureMouseMaintain(.{ .id = self.wd.id, .rect = rs.r, .subwindow_id = self.wd.id });
-    self.wd.register();
+    dvui.subwindowAdd(self.data().id, self.data().rect, rs.r, false, null);
+    dvui.captureMouseMaintain(.{ .id = self.data().id, .rect = rs.r, .subwindow_id = self.data().id });
+    self.data().register();
 
     // first break out of whatever clip we were in (so box shadows work, since
     // they are outside our window)
@@ -162,7 +162,7 @@ pub fn install(self: *FloatingMenuWidget) void {
 
     // if no widget in this popup has focus, make the menu have focus to handle keyboard events
     if (dvui.focusedWidgetIdInCurrentSubwindow() == null) {
-        dvui.focusWidget(self.menu.wd.id, null, null);
+        dvui.focusWidget(self.menu.data().id, null, null);
     }
 }
 
@@ -180,15 +180,15 @@ pub fn data(self: *FloatingMenuWidget) *WidgetData {
 
 pub fn rectFor(self: *FloatingMenuWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
-    return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
+    return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }
 
 pub fn screenRectScale(self: *FloatingMenuWidget, rect: Rect) RectScale {
-    return self.wd.contentRectScale().rectToRectScale(rect);
+    return self.data().contentRectScale().rectToRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *FloatingMenuWidget, s: Size) void {
-    self.wd.minSizeMax(self.wd.options.padSize(s));
+    self.data().minSizeMax(self.data().options.padSize(s));
 }
 
 pub fn chainFocused(self: *FloatingMenuWidget, self_call: bool) bool {
@@ -202,7 +202,7 @@ pub fn chainFocused(self: *FloatingMenuWidget, self_call: bool) bool {
     // we have to call chainFocused on our parent if we have one so we
     // can't return early
 
-    if (self.wd.id == dvui.focusedSubwindowId()) {
+    if (self.data().id == dvui.focusedSubwindowId()) {
         // we are focused
         ret = true;
     }
@@ -224,9 +224,9 @@ pub fn deinit(self: *FloatingMenuWidget) void {
     defer dvui.widgetFree(self);
 
     const evts = dvui.events();
-    const rs = self.wd.rectScale();
+    const rs = self.data().rectScale();
     for (evts) |*e| {
-        if (!dvui.eventMatch(e, .{ .id = self.wd.id, .r = rs.r, .cleanup = true }))
+        if (!dvui.eventMatch(e, .{ .id = self.data().id, .r = rs.r, .cleanup = true }))
             continue;
 
         if (e.evt == .mouse) {
@@ -272,14 +272,14 @@ pub fn deinit(self: *FloatingMenuWidget) void {
 
     // in case no children ever show up, this will provide a visual indication
     // that there is an empty floating menu
-    self.wd.minSizeMax(self.wd.options.padSize(.{ .w = 20, .h = 20 }));
+    self.data().minSizeMax(self.data().options.padSize(.{ .w = 20, .h = 20 }));
 
-    self.wd.minSizeSetAndRefresh();
+    self.data().minSizeSetAndRefresh();
 
-    // outside normal layout, don't call minSizeForChild or self.wd.minSizeReportToParent();
+    // outside normal layout, don't call minSizeForChild or self.data().minSizeReportToParent();
 
     _ = popupSet(self.parent_popup);
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    dvui.parentReset(self.data().id, self.data().parent);
     dvui.currentWindow().last_focused_id_this_frame = self.prev_last_focus;
     _ = dvui.subwindowCurrentSet(self.prev_windowId, null);
     dvui.clipSet(self.prevClip);

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -263,7 +263,7 @@ pub fn deinit(self: *FloatingMenuWidget) void {
         // only the last popup can do the check, you can't query the focus
         // status of children, only parents
         self.menu.close_chain(.unintentional);
-        dvui.refresh(null, @src(), self.wd.id);
+        dvui.refresh(null, @src(), self.data().id);
     }
 
     self.menu.deinit();

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -204,7 +204,7 @@ pub fn widget(self: *FloatingTooltipWidget) Widget {
 }
 
 pub fn data(self: *FloatingTooltipWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *FloatingTooltipWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -115,7 +115,7 @@ pub fn shown(self: *FloatingTooltipWidget) bool {
     // check for mouse position in active_rect
     const evts = dvui.events();
     for (evts) |*e| {
-        if (!dvui.eventMatch(e, .{ .id = self.wd.id, .r = self.init_options.active_rect })) {
+        if (!dvui.eventMatch(e, .{ .id = self.data().id, .r = self.init_options.active_rect })) {
             continue;
         }
 
@@ -131,31 +131,31 @@ pub fn shown(self: *FloatingTooltipWidget) bool {
         switch (self.init_options.position) {
             .horizontal, .vertical => |o| {
                 const ar = self.init_options.active_rect.toNatural();
-                const r = Rect.Natural.fromPoint(ar.topLeft()).toSize(.cast(self.wd.rect.size()));
-                self.wd.rect = .cast(dvui.placeOnScreen(dvui.windowRect(), ar, if (o == .horizontal) .horizontal else .vertical, r));
+                const r = Rect.Natural.fromPoint(ar.topLeft()).toSize(.cast(self.data().rect.size()));
+                self.data().rect = .cast(dvui.placeOnScreen(dvui.windowRect(), ar, if (o == .horizontal) .horizontal else .vertical, r));
             },
             .sticky => {
-                if (dvui.firstFrame(self.wd.id)) {
+                if (dvui.firstFrame(self.data().id)) {
                     const mp = dvui.currentWindow().mouse_pt.toNatural();
-                    dvui.dataSet(null, self.wd.id, "_sticky_pt", mp);
+                    dvui.dataSet(null, self.data().id, "_sticky_pt", mp);
                 } else {
-                    const mp = dvui.dataGet(null, self.wd.id, "_sticky_pt", dvui.Point.Natural) orelse dvui.Point.Natural{};
-                    var r = Rect.Natural.fromPoint(mp).toSize(.cast(self.wd.rect.size()));
+                    const mp = dvui.dataGet(null, self.data().id, "_sticky_pt", dvui.Point.Natural) orelse dvui.Point.Natural{};
+                    var r = Rect.Natural.fromPoint(mp).toSize(.cast(self.data().rect.size()));
                     r.x += 10;
                     r.y -= r.h + 10;
-                    self.wd.rect = .cast(dvui.placeOnScreen(dvui.windowRect(), .{}, .none, r));
+                    self.data().rect = .cast(dvui.placeOnScreen(dvui.windowRect(), .{}, .none, r));
                 }
             },
             .absolute => {},
         }
-        //std.debug.print("rect {}\n", .{self.wd.rect});
+        //std.debug.print("rect {}\n", .{self.data().rect});
 
         self.install();
 
         if (self.init_options.interactive) {
             // check for mouse position in tooltip window rect
             for (evts) |*e| {
-                if (!dvui.eventMatch(e, .{ .id = self.wd.id, .r = self.wd.borderRectScale().r })) {
+                if (!dvui.eventMatch(e, .{ .id = self.data().id, .r = self.data().borderRectScale().r })) {
                     continue;
                 }
 
@@ -177,14 +177,14 @@ pub fn install(self: *FloatingTooltipWidget) void {
 
     dvui.parentSet(self.widget());
 
-    self.prev_windowId = dvui.subwindowCurrentSet(self.wd.id, null).id;
+    self.prev_windowId = dvui.subwindowCurrentSet(self.data().id, null).id;
     self.parent_tooltip = tooltipSet(self);
 
-    const rs = self.wd.rectScale();
+    const rs = self.data().rectScale();
 
-    dvui.subwindowAdd(self.wd.id, self.wd.rect, rs.r, false, self.prev_windowId);
-    dvui.captureMouseMaintain(.{ .id = self.wd.id, .rect = rs.r, .subwindow_id = self.wd.id });
-    self.wd.register();
+    dvui.subwindowAdd(self.data().id, self.data().rect, rs.r, false, self.prev_windowId);
+    dvui.captureMouseMaintain(.{ .id = self.data().id, .rect = rs.r, .subwindow_id = self.data().id });
+    self.data().register();
 
     // first clip to the whole window to break out of whatever clipping we
     // might have been in (example: might be nested inside another tooltip)
@@ -209,15 +209,15 @@ pub fn data(self: *FloatingTooltipWidget) *WidgetData {
 
 pub fn rectFor(self: *FloatingTooltipWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
-    return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
+    return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }
 
 pub fn screenRectScale(self: *FloatingTooltipWidget, rect: Rect) RectScale {
-    return self.wd.contentRectScale().rectToRectScale(rect);
+    return self.data().contentRectScale().rectToRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *FloatingTooltipWidget, s: Size) void {
-    self.wd.minSizeMax(self.wd.options.padSize(s));
+    self.data().minSizeMax(self.data().options.padSize(s));
 }
 
 pub fn deinit(self: *FloatingTooltipWidget) void {
@@ -228,7 +228,7 @@ pub fn deinit(self: *FloatingTooltipWidget) void {
 
     // check if we should still be shown
     if (self.mouse_good_this_frame or (self.init_options.interactive and self.tt_child_shown)) {
-        dvui.dataSet(null, self.wd.id, "_showing", true);
+        dvui.dataSet(null, self.data().id, "_showing", true);
         var parent: ?*FloatingTooltipWidget = self.parent_tooltip;
         while (parent) |p| {
             p.tt_child_shown = true;
@@ -236,17 +236,17 @@ pub fn deinit(self: *FloatingTooltipWidget) void {
         }
     } else {
         // don't store showing if mouse is outside trigger and tooltip which will close it next frame
-        dvui.dataRemove(null, self.wd.id, "_showing");
-        dvui.refresh(null, @src(), self.wd.id); // refresh with new hidden state
+        dvui.dataRemove(null, self.data().id, "_showing");
+        dvui.refresh(null, @src(), self.data().id); // refresh with new hidden state
     }
 
     self.scaler.deinit();
-    self.wd.minSizeSetAndRefresh();
+    self.data().minSizeSetAndRefresh();
 
-    // outside normal layout, don't call minSizeForChild or self.wd.minSizeReportToParent();
+    // outside normal layout, don't call minSizeForChild or self.data().minSizeReportToParent();
 
     _ = tooltipSet(self.parent_tooltip);
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    dvui.parentReset(self.data().id, self.data().parent);
     _ = dvui.subwindowCurrentSet(self.prev_windowId, null);
     dvui.clipSet(self.prevClip);
     _ = dvui.renderingSet(self.prev_rendering);

--- a/src/widgets/FloatingWidget.zig
+++ b/src/widgets/FloatingWidget.zig
@@ -58,19 +58,19 @@ pub fn install(self: *FloatingWidget) void {
 
     dvui.parentSet(self.widget());
 
-    self.prev_windowId = dvui.subwindowCurrentSet(self.wd.id, null).id;
+    self.prev_windowId = dvui.subwindowCurrentSet(self.data().id, null).id;
 
-    const rs = self.wd.rectScale();
+    const rs = self.data().rectScale();
 
-    dvui.subwindowAdd(self.wd.id, self.wd.rect, rs.r, false, self.prev_windowId);
-    dvui.captureMouseMaintain(.{ .id = self.wd.id, .rect = rs.r, .subwindow_id = self.wd.id });
-    self.wd.register();
+    dvui.subwindowAdd(self.data().id, self.data().rect, rs.r, false, self.prev_windowId);
+    dvui.captureMouseMaintain(.{ .id = self.data().id, .rect = rs.r, .subwindow_id = self.data().id });
+    self.data().register();
 
     // first break out of whatever clipping we were in
     self.prevClip = dvui.clipGet();
     dvui.clipSet(dvui.windowRectPixels());
 
-    self.wd.borderAndBackground(.{});
+    self.data().borderAndBackground(.{});
 
     // clip to just our window (using clipSet since we are not inside our parent)
     _ = dvui.clip(rs.r);
@@ -89,25 +89,25 @@ pub fn data(self: *FloatingWidget) *WidgetData {
 
 pub fn rectFor(self: *FloatingWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
-    return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
+    return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }
 
 pub fn screenRectScale(self: *FloatingWidget, rect: Rect) RectScale {
-    return self.wd.contentRectScale().rectToRectScale(rect);
+    return self.data().contentRectScale().rectToRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *FloatingWidget, s: Size) void {
-    self.wd.minSizeMax(self.wd.options.padSize(s));
+    self.data().minSizeMax(self.data().options.padSize(s));
 }
 
 pub fn deinit(self: *FloatingWidget) void {
     defer dvui.widgetFree(self);
     self.scaler.deinit();
-    self.wd.minSizeSetAndRefresh();
+    self.data().minSizeSetAndRefresh();
 
-    // outside normal layout, don't call minSizeForChild or self.wd.minSizeReportToParent();
+    // outside normal layout, don't call minSizeForChild or self.data().minSizeReportToParent();
 
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    dvui.parentReset(self.data().id, self.data().parent);
     _ = dvui.subwindowCurrentSet(self.prev_windowId, null);
     dvui.clipSet(self.prevClip);
     _ = dvui.renderingSet(self.prev_rendering);

--- a/src/widgets/FloatingWidget.zig
+++ b/src/widgets/FloatingWidget.zig
@@ -84,7 +84,7 @@ pub fn widget(self: *FloatingWidget) Widget {
 }
 
 pub fn data(self: *FloatingWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *FloatingWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -521,7 +521,7 @@ pub fn widget(self: *FloatingWindowWidget) Widget {
 }
 
 pub fn data(self: *FloatingWindowWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *FloatingWindowWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -694,7 +694,7 @@ pub const HeaderResizeWidget = struct {
             .init_opts = init_options,
         };
 
-        if (dvui.dataGet(null, self.wd.id, "_offset", Point)) |offset| {
+        if (dvui.dataGet(null, self.data().id, "_offset", Point)) |offset| {
             self.offset = offset;
         }
 
@@ -702,8 +702,8 @@ pub const HeaderResizeWidget = struct {
     }
 
     pub fn install(self: *HeaderResizeWidget) void {
-        self.wd.register();
-        self.wd.borderAndBackground(.{});
+        self.data().register();
+        self.data().borderAndBackground(.{});
     }
 
     pub fn size(self: *HeaderResizeWidget) f32 {
@@ -737,7 +737,7 @@ pub const HeaderResizeWidget = struct {
     }
 
     pub fn matchEvent(self: *HeaderResizeWidget, e: *Event) bool {
-        var rs = self.wd.rectScale();
+        var rs = self.data().rectScale();
 
         // Clicking near the handle counts as clicking on the handle.
         const grab_extra = self.init_opts.grab_tolerance * rs.s;
@@ -751,7 +751,7 @@ pub const HeaderResizeWidget = struct {
                 rs.r.h += grab_extra;
             },
         }
-        return dvui.eventMatch(e, .{ .id = self.wd.id, .r = rs.r });
+        return dvui.eventMatch(e, .{ .id = self.data().id, .r = rs.r });
     }
 
     pub fn processEvents(self: *HeaderResizeWidget) void {
@@ -765,12 +765,12 @@ pub const HeaderResizeWidget = struct {
     }
 
     pub fn data(self: *HeaderResizeWidget) *WidgetData {
-        return &self.wd;
+        return self.wd.validate();
     }
 
     pub fn processEvent(self: *HeaderResizeWidget, e: *Event) void {
         if (e.evt == .mouse) {
-            const rs = self.wd.rectScale();
+            const rs = self.data().rectScale();
             const cursor: Cursor = switch (self.direction) {
                 .vertical => .arrow_w_e,
                 .horizontal => .arrow_n_s,
@@ -788,11 +788,11 @@ pub const HeaderResizeWidget = struct {
                 dvui.captureMouse(null);
                 dvui.dragEnd();
                 self.offset = .{};
-            } else if (e.evt.mouse.action == .motion and dvui.captured(self.wd.id)) {
+            } else if (e.evt.mouse.action == .motion and dvui.captured(self.data().id)) {
                 e.handle(@src(), self.data());
                 // move if dragging
                 if (dvui.dragging(e.evt.mouse.p)) |dps| {
-                    dvui.refresh(null, @src(), self.wd.id);
+                    dvui.refresh(null, @src(), self.data().id);
                     const unclamped_size =
                         switch (self.direction) {
                             .vertical => self.size() + dps.x / rs.s + self.offset.x,
@@ -825,9 +825,9 @@ pub const HeaderResizeWidget = struct {
     }
 
     pub fn deinit(self: *HeaderResizeWidget) void {
-        dvui.dataSet(null, self.wd.id, "_offset", self.offset);
-        self.wd.minSizeSetAndRefresh();
-        self.wd.minSizeReportToParent();
+        dvui.dataSet(null, self.data().id, "_offset", self.offset);
+        self.data().minSizeSetAndRefresh();
+        self.data().minSizeReportToParent();
         self.* = undefined;
     }
 };

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -331,7 +331,7 @@ pub fn deinit(self: *GridWidget) void {
 }
 
 pub fn data(self: *GridWidget) *WidgetData {
-    return &self.vbox.wd;
+    return self.vbox.data();
 }
 
 /// Create a header cell for the requested column

--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -35,8 +35,8 @@ pub fn init(src: std.builtin.SourceLocation, name: []const u8, tvg_bytes: []cons
 }
 
 pub fn install(self: *IconWidget) void {
-    self.wd.register();
-    self.wd.borderAndBackground(.{});
+    self.data().register();
+    self.data().borderAndBackground(.{});
 }
 
 pub fn data(self: *IconWidget) *WidgetData {
@@ -44,12 +44,12 @@ pub fn data(self: *IconWidget) *WidgetData {
 }
 
 pub fn matchEvent(self: *IconWidget, e: *dvui.Event) bool {
-    return dvui.eventMatchSimple(e, &self.wd);
+    return dvui.eventMatchSimple(e, self.data());
 }
 
 pub fn draw(self: *IconWidget) void {
-    const rs = self.wd.parent.screenRectScale(self.wd.contentRect());
-    var texOpts: dvui.RenderTextureOptions = .{ .rotation = self.wd.options.rotationGet() };
+    const rs = self.data().parent.screenRectScale(self.data().contentRect());
+    var texOpts: dvui.RenderTextureOptions = .{ .rotation = self.data().options.rotationGet() };
 
     const white: ?dvui.Color = .white;
     const as_bytes = std.mem.asBytes;
@@ -58,8 +58,8 @@ pub fn draw(self: *IconWidget) void {
     {
         // user is rasterizing icon with defaults (white), so always use
         // colormod (so icons default to text color)
-        texOpts.colormod = self.wd.options.color(.text);
-    } else if (self.wd.options.color_text) |ct| {
+        texOpts.colormod = self.data().options.color(.text);
+    } else if (self.data().options.color_text) |ct| {
         // user is customizing icon rasterization, only colormod if they passed
         // a text color
         texOpts.colormod = ct.resolve();
@@ -78,8 +78,8 @@ pub fn draw(self: *IconWidget) void {
 
 pub fn deinit(self: *IconWidget) void {
     defer dvui.widgetFree(self);
-    self.wd.minSizeSetAndRefresh();
-    self.wd.minSizeReportToParent();
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
     self.* = undefined;
 }
 

--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -40,7 +40,7 @@ pub fn install(self: *IconWidget) void {
 }
 
 pub fn data(self: *IconWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn matchEvent(self: *IconWidget, e: *dvui.Event) bool {

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -96,38 +96,38 @@ pub fn data(self: *LabelWidget) *WidgetData {
 }
 
 pub fn install(self: *LabelWidget) void {
-    self.wd.register();
-    self.wd.borderAndBackground(.{});
+    self.data().register();
+    self.data().borderAndBackground(.{});
 }
 
 pub fn draw(self: *LabelWidget) void {
     const label_gravity = self.init_options.gravityGet();
-    const rect = dvui.placeIn(self.wd.contentRect(), self.wd.options.min_size_contentGet(), .none, label_gravity);
-    var rs = self.wd.parent.screenRectScale(rect);
+    const rect = dvui.placeIn(self.data().contentRect(), self.data().options.min_size_contentGet(), .none, label_gravity);
+    var rs = self.data().parent.screenRectScale(rect);
     const oldclip = dvui.clip(rs.r);
     var iter = std.mem.splitScalar(u8, self.label_str, '\n');
     var line_height_adj: f32 = undefined;
     var first: bool = true;
     while (iter.next()) |line| {
         if (first) {
-            line_height_adj = self.wd.options.fontGet().textHeight() * (self.wd.options.fontGet().line_height_factor - 1.0);
+            line_height_adj = self.data().options.fontGet().textHeight() * (self.data().options.fontGet().line_height_factor - 1.0);
             first = false;
         } else {
             rs.r.y += rs.s * line_height_adj;
         }
 
-        const tsize = self.wd.options.fontGet().textSize(line);
+        const tsize = self.data().options.fontGet().textSize(line);
 
         // this is only about horizontal direction
-        const lineRect = dvui.placeIn(self.wd.contentRect(), tsize, .none, label_gravity);
-        const liners = self.wd.parent.screenRectScale(lineRect);
+        const lineRect = dvui.placeIn(self.data().contentRect(), tsize, .none, label_gravity);
+        const liners = self.data().parent.screenRectScale(lineRect);
 
         rs.r.x = liners.r.x;
         dvui.renderText(.{
-            .font = self.wd.options.fontGet(),
+            .font = self.data().options.fontGet(),
             .text = line,
             .rs = rs,
-            .color = self.wd.options.color(.text),
+            .color = self.data().options.color(.text),
         }) catch |err| {
             dvui.logError(@src(), err, "Failed to render text: {s}", .{line});
         };
@@ -143,8 +143,8 @@ pub fn matchEvent(self: *LabelWidget, e: *Event) bool {
 pub fn deinit(self: *LabelWidget) void {
     defer dvui.widgetFree(self);
     if (self.allocator) |alloc| alloc.free(self.label_str);
-    self.wd.minSizeSetAndRefresh();
-    self.wd.minSizeReportToParent();
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
     self.* = undefined;
 }
 

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -92,7 +92,7 @@ fn logAndHighlight(src: std.builtin.SourceLocation, opts: Options, err: anyerror
 }
 
 pub fn data(self: *LabelWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn install(self: *LabelWidget) void {

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -131,7 +131,7 @@ pub fn widget(self: *MenuItemWidget) Widget {
 }
 
 pub fn data(self: *MenuItemWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *MenuItemWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -41,18 +41,18 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *MenuItemWidget) void {
-    self.wd.register();
+    self.data().register();
 
-    dvui.tabIndexSet(self.wd.id, self.wd.options.tab_index);
+    dvui.tabIndexSet(self.data().id, self.data().options.tab_index);
 
-    self.wd.borderAndBackground(.{});
+    self.data().borderAndBackground(.{});
 
     dvui.parentSet(self.widget());
 }
 
 pub fn drawBackground(self: *MenuItemWidget, opts: struct { focus_as_outline: bool = false }) void {
     var focused: bool = false;
-    if (self.wd.id == dvui.focusedWidgetId()) {
+    if (self.data().id == dvui.focusedWidgetId()) {
         focused = true;
     }
 
@@ -62,7 +62,7 @@ pub fn drawBackground(self: *MenuItemWidget, opts: struct { focus_as_outline: bo
         dvui.focusWidget(null, null, null);
     }
 
-    if (focused or ((self.wd.id == dvui.focusedWidgetIdInCurrentSubwindow()) and self.highlight)) {
+    if (focused or ((self.data().id == dvui.focusedWidgetIdInCurrentSubwindow()) and self.highlight)) {
         if (!self.init_opts.submenu or !dvui.MenuWidget.current().?.submenus_activated) {
             if (!self.init_opts.highlight_only) {
                 self.show_active = true;
@@ -77,20 +77,20 @@ pub fn drawBackground(self: *MenuItemWidget, opts: struct { focus_as_outline: bo
 
     self.focused_last_frame = focused;
 
-    if (self.wd.visible()) {
+    if (self.data().visible()) {
         if (self.show_active) {
             if (opts.focus_as_outline) {
-                self.wd.focusBorder();
+                self.data().focusBorder();
             } else {
-                const rs = self.wd.backgroundRectScale();
-                rs.r.fill(self.wd.options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = self.wd.options.color(.accent) });
+                const rs = self.data().backgroundRectScale();
+                rs.r.fill(self.data().options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = self.data().options.color(.accent) });
             }
-        } else if ((self.wd.id == dvui.focusedWidgetIdInCurrentSubwindow()) or self.highlight) {
-            const rs = self.wd.backgroundRectScale();
-            rs.r.fill(self.wd.options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = self.wd.options.color(.fill_hover) });
-        } else if (self.wd.options.backgroundGet()) {
-            const rs = self.wd.backgroundRectScale();
-            rs.r.fill(self.wd.options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = self.wd.options.color(.fill) });
+        } else if ((self.data().id == dvui.focusedWidgetIdInCurrentSubwindow()) or self.highlight) {
+            const rs = self.data().backgroundRectScale();
+            rs.r.fill(self.data().options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = self.data().options.color(.fill_hover) });
+        } else if (self.data().options.backgroundGet()) {
+            const rs = self.data().backgroundRectScale();
+            rs.r.fill(self.data().options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = self.data().options.color(.fill) });
         }
     }
 }
@@ -112,7 +112,7 @@ pub fn processEvents(self: *MenuItemWidget) void {
 pub fn activeRect(self: *const MenuItemWidget) ?Rect.Natural {
     var act = false;
     if (self.init_opts.submenu) {
-        if (dvui.MenuWidget.current().?.submenus_activated and (self.wd.id == dvui.focusedWidgetIdInCurrentSubwindow())) {
+        if (dvui.MenuWidget.current().?.submenus_activated and (self.data().id == dvui.focusedWidgetIdInCurrentSubwindow())) {
             act = true;
         }
     } else if (self.activated) {
@@ -120,7 +120,7 @@ pub fn activeRect(self: *const MenuItemWidget) ?Rect.Natural {
     }
 
     if (act) {
-        return self.wd.backgroundRectScale().r.toNatural();
+        return self.data().backgroundRectScale().r.toNatural();
     } else {
         return null;
     }
@@ -130,13 +130,13 @@ pub fn widget(self: *MenuItemWidget) Widget {
     return Widget.init(self, data, rectFor, screenRectScale, minSizeForChild);
 }
 
-pub fn data(self: *MenuItemWidget) *WidgetData {
+pub fn data(self: *const MenuItemWidget) *WidgetData {
     return self.wd.validate();
 }
 
 pub fn rectFor(self: *MenuItemWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
-    return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
+    return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }
 
 pub fn screenRectScale(self: *MenuItemWidget, rect: Rect) RectScale {
@@ -144,7 +144,7 @@ pub fn screenRectScale(self: *MenuItemWidget, rect: Rect) RectScale {
 }
 
 pub fn minSizeForChild(self: *MenuItemWidget, s: Size) void {
-    self.wd.minSizeMax(self.wd.options.padSize(s));
+    self.wd.minSizeMax(self.data().options.padSize(s));
 }
 
 pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
@@ -153,7 +153,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
             if (me.action == .focus) {
                 dvui.MenuWidget.current().?.mouse_mode = true;
                 e.handle(@src(), self.data());
-                dvui.focusWidget(self.wd.id, null, e.num);
+                dvui.focusWidget(self.data().id, null, e.num);
             } else if (me.action == .press and me.button.pointer()) {
                 // This works differently than normal (like buttons) where we
                 // captureMouse on press, to support the mouse
@@ -177,17 +177,17 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
             } else if (me.action == .release) {
                 dvui.MenuWidget.current().?.mouse_mode = true;
                 e.handle(@src(), self.data());
-                if (!self.init_opts.submenu and (self.wd.id == dvui.focusedWidgetIdInCurrentSubwindow())) {
+                if (!self.init_opts.submenu and (self.data().id == dvui.focusedWidgetIdInCurrentSubwindow())) {
                     self.activated = true;
-                    dvui.refresh(null, @src(), self.wd.id);
+                    dvui.refresh(null, @src(), self.data().id);
                 }
-                if (dvui.captured(self.wd.id)) {
+                if (dvui.captured(self.data().id)) {
                     // should only happen with touch
                     dvui.captureMouse(null);
                     dvui.dragEnd();
                 }
             } else if (me.action == .motion and me.button.touch()) {
-                if (dvui.captured(self.wd.id)) {
+                if (dvui.captured(self.data().id)) {
                     if (dvui.dragging(me.p)) |_| {
                         // if we overcame the drag threshold, then that
                         // means the person probably didn't want to touch
@@ -211,7 +211,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
                     // we shouldn't have gotten this event if the motion
                     // was towards a submenu (caught in MenuWidget)
                     dvui.focusSubwindow(null, null); // focuses the window we are in
-                    dvui.focusWidget(self.wd.id, null, null);
+                    dvui.focusWidget(self.data().id, null, null);
 
                     if (self.init_opts.submenu) {
                         dvui.MenuWidget.current().?.submenus_in_child = true;
@@ -227,7 +227,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
                     dvui.MenuWidget.current().?.submenus_activated = true;
                 } else {
                     self.activated = true;
-                    dvui.refresh(null, @src(), self.wd.id);
+                    dvui.refresh(null, @src(), self.data().id);
                 }
             } else if (ke.code == .right and ke.action == .down) {
                 if (self.init_opts.submenu and dvui.MenuWidget.current().?.init_opts.dir == .vertical) {
@@ -249,10 +249,10 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
 
 pub fn deinit(self: *MenuItemWidget) void {
     defer dvui.widgetFree(self);
-    dvui.dataSet(null, self.wd.id, "_focus_last", self.focused_last_frame);
-    self.wd.minSizeSetAndRefresh();
-    self.wd.minSizeReportToParent();
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    dvui.dataSet(null, self.data().id, "_focus_last", self.focused_last_frame);
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
+    dvui.parentReset(self.data().id, self.data().parent);
     self.* = undefined;
 }
 

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -70,7 +70,7 @@ pub fn drawBackground(self: *MenuItemWidget, opts: struct { focus_as_outline: bo
 
             if (!self.focused_last_frame) {
                 // in case we are in a scrollable dropdown, scroll
-                dvui.scrollTo(.{ .screen_rect = self.wd.borderRectScale().r });
+                dvui.scrollTo(.{ .screen_rect = self.data().borderRectScale().r });
             }
         }
     }
@@ -140,11 +140,11 @@ pub fn rectFor(self: *MenuItemWidget, id: dvui.WidgetId, min_size: Size, e: Opti
 }
 
 pub fn screenRectScale(self: *MenuItemWidget, rect: Rect) RectScale {
-    return self.wd.contentRectScale().rectToRectScale(rect);
+    return self.data().contentRectScale().rectToRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *MenuItemWidget, s: Size) void {
-    self.wd.minSizeMax(self.data().options.padSize(s));
+    self.data().minSizeMax(self.data().options.padSize(s));
 }
 
 pub fn processEvent(self: *MenuItemWidget, e: *Event) void {

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -152,7 +152,7 @@ pub fn widget(self: *MenuWidget) Widget {
 }
 
 pub fn data(self: *MenuWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *MenuWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -108,8 +108,8 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 pub fn install(self: *MenuWidget) void {
     dvui.parentSet(self.widget());
     self.parentMenu = menuSet(self);
-    self.wd.register();
-    self.wd.borderAndBackground(.{});
+    self.data().register();
+    self.data().borderAndBackground(.{});
 
     const evts = dvui.events();
     for (evts) |*e| {
@@ -119,13 +119,13 @@ pub fn install(self: *MenuWidget) void {
         self.processEvent(e);
     }
 
-    self.box = BoxWidget.init(@src(), .{ .dir = self.init_opts.dir }, self.wd.options.strip().override(.{ .expand = .both }));
+    self.box = BoxWidget.init(@src(), .{ .dir = self.init_opts.dir }, self.data().options.strip().override(.{ .expand = .both }));
     self.box.install();
     self.box.drawBackground();
 }
 
 pub fn close(self: *MenuWidget) void {
-    dvui.refresh(null, @src(), self.wd.id);
+    dvui.refresh(null, @src(), self.data().id);
     self.close_chain(.intentional);
 }
 
@@ -157,15 +157,15 @@ pub fn data(self: *MenuWidget) *WidgetData {
 
 pub fn rectFor(self: *MenuWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
-    return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
+    return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }
 
 pub fn screenRectScale(self: *MenuWidget, rect: Rect) RectScale {
-    return self.wd.contentRectScale().rectToRectScale(rect);
+    return self.data().contentRectScale().rectToRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *MenuWidget, s: Size) void {
-    self.wd.minSizeMax(self.wd.options.padSize(s));
+    self.data().minSizeMax(self.data().options.padSize(s));
 }
 
 pub fn processEvent(self: *MenuWidget, e: *Event) void {
@@ -174,7 +174,7 @@ pub fn processEvent(self: *MenuWidget, e: *Event) void {
             if (me.action == .position) {
                 if (dvui.mouseTotalMotion().nonZero()) {
                     self.mouse_mode = true;
-                    if (dvui.dataGet(null, self.wd.id, "_child_popup", Rect.Physical)) |r| {
+                    if (dvui.dataGet(null, self.data().id, "_child_popup", Rect.Physical)) |r| {
                         const center = Point.Physical{ .x = r.x + r.w / 2, .y = r.y + r.h / 2 };
                         const cw = dvui.currentWindow();
                         const to_center = center.diff(cw.mouse_pt_prev);
@@ -204,7 +204,7 @@ pub fn processEventsAfter(self: *MenuWidget) void {
 
     const evts = dvui.events();
     for (evts) |*e| {
-        if (!dvui.eventMatch(e, .{ .id = self.wd.id, .focus_id = focus_id, .r = self.wd.borderRectScale().r }))
+        if (!dvui.eventMatch(e, .{ .id = self.data().id, .focus_id = focus_id, .r = self.data().borderRectScale().r }))
             continue;
 
         switch (e.evt) {
@@ -270,15 +270,15 @@ pub fn deinit(self: *MenuWidget) void {
 
     defer dvui.widgetFree(self);
     self.box.deinit();
-    dvui.dataSet(null, self.wd.id, "_mouse_mode", self.mouse_mode);
-    dvui.dataSet(null, self.wd.id, "_sub_act", self.submenus_activated);
+    dvui.dataSet(null, self.data().id, "_mouse_mode", self.mouse_mode);
+    dvui.dataSet(null, self.data().id, "_sub_act", self.submenus_activated);
     if (self.child_popup_rect) |r| {
-        dvui.dataSet(null, self.wd.id, "_child_popup", r);
+        dvui.dataSet(null, self.data().id, "_child_popup", r);
     }
-    self.wd.minSizeSetAndRefresh();
-    self.wd.minSizeReportToParent();
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
     _ = menuSet(self.parentMenu);
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    dvui.parentReset(self.data().id, self.data().parent);
     self.* = undefined;
 }
 

--- a/src/widgets/OverlayWidget.zig
+++ b/src/widgets/OverlayWidget.zig
@@ -20,11 +20,11 @@ pub fn init(src: std.builtin.SourceLocation, opts: Options) OverlayWidget {
 
 pub fn install(self: *OverlayWidget) void {
     dvui.parentSet(self.widget());
-    self.wd.register();
+    self.data().register();
 }
 
 pub fn drawBackground(self: *OverlayWidget) void {
-    self.wd.borderAndBackground(.{});
+    self.data().borderAndBackground(.{});
 }
 
 pub fn widget(self: *OverlayWidget) Widget {
@@ -37,22 +37,22 @@ pub fn data(self: *OverlayWidget) *WidgetData {
 
 pub fn rectFor(self: *OverlayWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
-    return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
+    return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }
 
 pub fn screenRectScale(self: *OverlayWidget, rect: Rect) RectScale {
-    return self.wd.contentRectScale().rectToRectScale(rect);
+    return self.data().contentRectScale().rectToRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *OverlayWidget, s: Size) void {
-    self.wd.minSizeMax(self.wd.options.padSize(s));
+    self.data().minSizeMax(self.data().options.padSize(s));
 }
 
 pub fn deinit(self: *OverlayWidget) void {
     defer dvui.widgetFree(self);
-    self.wd.minSizeSetAndRefresh();
-    self.wd.minSizeReportToParent();
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
+    dvui.parentReset(self.data().id, self.data().parent);
     self.* = undefined;
 }
 

--- a/src/widgets/OverlayWidget.zig
+++ b/src/widgets/OverlayWidget.zig
@@ -32,7 +32,7 @@ pub fn widget(self: *OverlayWidget) Widget {
 }
 
 pub fn data(self: *OverlayWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *OverlayWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -121,10 +121,10 @@ pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Op
 }
 
 pub fn install(self: *PanedWidget) void {
-    self.wd.register();
+    self.data().register();
 
-    self.wd.borderAndBackground(.{});
-    self.prevClip = dvui.clip(self.wd.contentRectScale().r);
+    self.data().borderAndBackground(.{});
+    self.prevClip = dvui.clip(self.data().contentRectScale().r);
 
     dvui.parentSet(self.widget());
 }
@@ -146,7 +146,7 @@ pub fn processEvents(self: *PanedWidget) void {
 pub fn draw(self: *PanedWidget) void {
     if (self.collapsed()) return;
 
-    if (dvui.captured(self.wd.id)) {
+    if (dvui.captured(self.data().id)) {
         // we are dragging it, draw it fully
         self.mouse_dist = 0;
     }
@@ -163,7 +163,7 @@ pub fn draw(self: *PanedWidget) void {
         if (self.mouse_dist > self.handle_thick + 3) return;
     }
 
-    const rs = self.wd.contentRectScale();
+    const rs = self.data().contentRectScale();
     var r = rs.r;
     const thick = self.handle_thick * rs.s; // physical
     switch (self.init_opts.direction) {
@@ -182,7 +182,7 @@ pub fn draw(self: *PanedWidget) void {
             r.w = width;
         },
     }
-    r.fill(.all(thick), .{ .color = self.wd.options.color(.text).opacity(0.5) });
+    r.fill(.all(thick), .{ .color = self.data().options.color(.text).opacity(0.5) });
 }
 
 pub fn collapsed(self: *PanedWidget) bool {
@@ -203,7 +203,7 @@ pub fn showSecond(self: *PanedWidget) bool {
 }
 
 pub fn animateSplit(self: *PanedWidget, end_val: f32) void {
-    dvui.animation(self.wd.id, "_split_ratio", dvui.Animation{ .start_val = self.split_ratio.*, .end_val = end_val, .end_time = 250_000 });
+    dvui.animation(self.data().id, "_split_ratio", dvui.Animation{ .start_val = self.split_ratio.*, .end_val = end_val, .end_time = 250_000 });
 }
 
 pub fn widget(self: *PanedWidget) Widget {
@@ -216,7 +216,7 @@ pub fn data(self: *PanedWidget) *WidgetData {
 
 pub fn rectFor(self: *PanedWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) dvui.Rect {
     _ = id;
-    var r = self.wd.contentRect().justSize();
+    var r = self.data().contentRect().justSize();
     if (self.first_side) {
         self.first_side = false;
         if (self.collapsed()) {
@@ -270,16 +270,16 @@ pub fn rectFor(self: *PanedWidget, id: dvui.WidgetId, min_size: Size, e: Options
 }
 
 pub fn screenRectScale(self: *PanedWidget, rect: Rect) RectScale {
-    return self.wd.contentRectScale().rectToRectScale(rect);
+    return self.data().contentRectScale().rectToRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *PanedWidget, s: dvui.Size) void {
-    self.wd.minSizeMax(self.wd.options.padSize(s));
+    self.data().minSizeMax(self.data().options.padSize(s));
 }
 
 pub fn processEvent(self: *PanedWidget, e: *Event) void {
     if (e.evt == .mouse) {
-        const rs = self.wd.contentRectScale();
+        const rs = self.data().contentRectScale();
         const cursor: enums.Cursor = switch (self.init_opts.direction) {
             .horizontal => .arrow_w_e,
             .vertical => .arrow_n_s,
@@ -295,7 +295,7 @@ pub fn processEvent(self: *PanedWidget, e: *Event) void {
             self.handle_thick = std.math.clamp(hd.handle_size_max - mouse_dist_outside / 2, self.init_opts.handle_size, hd.handle_size_max);
         }
 
-        if (dvui.captured(self.wd.id) or self.mouse_dist <= @max(self.handle_thick / 2, 2)) {
+        if (dvui.captured(self.data().id) or self.mouse_dist <= @max(self.handle_thick / 2, 2)) {
             if (e.evt.mouse.action == .press and e.evt.mouse.button.pointer()) {
                 e.handle(@src(), self.data());
                 // capture and start drag
@@ -306,7 +306,7 @@ pub fn processEvent(self: *PanedWidget, e: *Event) void {
                 // stop possible drag and capture
                 dvui.captureMouse(null);
                 dvui.dragEnd();
-            } else if (e.evt.mouse.action == .motion and dvui.captured(self.wd.id)) {
+            } else if (e.evt.mouse.action == .motion and dvui.captured(self.data().id)) {
                 e.handle(@src(), self.data());
                 // move if dragging
                 if (dvui.dragging(e.evt.mouse.p)) |dps| {
@@ -332,12 +332,12 @@ pub fn processEvent(self: *PanedWidget, e: *Event) void {
 pub fn deinit(self: *PanedWidget) void {
     defer dvui.widgetFree(self);
     dvui.clipSet(self.prevClip);
-    dvui.dataSet(null, self.wd.id, "_collapsing", self.collapsing);
-    dvui.dataSet(null, self.wd.id, "_collapsed", self.collapsed_state);
-    dvui.dataSet(null, self.wd.id, "_split_ratio", self.split_ratio.*);
-    self.wd.minSizeSetAndRefresh();
-    self.wd.minSizeReportToParent();
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    dvui.dataSet(null, self.data().id, "_collapsing", self.collapsing);
+    dvui.dataSet(null, self.data().id, "_collapsed", self.collapsed_state);
+    dvui.dataSet(null, self.data().id, "_split_ratio", self.split_ratio.*);
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
+    dvui.parentReset(self.data().id, self.data().parent);
     self.* = undefined;
 }
 

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -211,7 +211,7 @@ pub fn widget(self: *PanedWidget) Widget {
 }
 
 pub fn data(self: *PanedWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *PanedWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) dvui.Rect {

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -318,8 +318,8 @@ pub const Reorderable = struct {
 
     pub fn reinstall(self: *Reorderable) void {
         // send our target rect to the parent for sizing
-        self.wd.minSizeMax(self.wd.rect.size());
-        self.wd.minSizeReportToParent();
+        self.data().minSizeMax(self.data().rect.size());
+        self.data().minSizeReportToParent();
 
         // reinstall ourselves getting the next rect from parent
         self.wd = WidgetData.init(self.wd.src, .{}, self.options);

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -29,8 +29,8 @@ pub fn init(src: std.builtin.SourceLocation, opts: Options) ReorderWidget {
 }
 
 pub fn install(self: *ReorderWidget) void {
-    self.wd.register();
-    self.wd.borderAndBackground(.{});
+    self.data().register();
+    self.data().borderAndBackground(.{});
 
     dvui.parentSet(self.widget());
 }
@@ -62,15 +62,15 @@ pub fn data(self: *ReorderWidget) *WidgetData {
 
 pub fn rectFor(self: *ReorderWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
-    return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
+    return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }
 
 pub fn screenRectScale(self: *ReorderWidget, rect: Rect) RectScale {
-    return self.wd.contentRectScale().rectToRectScale(rect);
+    return self.data().contentRectScale().rectToRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *ReorderWidget, s: Size) void {
-    self.wd.minSizeMax(self.wd.options.padSize(s));
+    self.data().minSizeMax(self.data().options.padSize(s));
 }
 
 pub fn matchEvent(self: *ReorderWidget, e: *dvui.Event) bool {
@@ -88,20 +88,20 @@ pub fn processEvents(self: *ReorderWidget) void {
 }
 
 pub fn processEvent(self: *ReorderWidget, e: *dvui.Event) void {
-    if (dvui.captured(self.wd.id)) {
+    if (dvui.captured(self.data().id)) {
         switch (e.evt) {
             .mouse => |me| {
                 if ((me.action == .press or me.action == .release) and me.button.pointer()) {
                     self.drag_ending = true;
                     dvui.captureMouse(null);
                     dvui.dragEnd();
-                    dvui.refresh(null, @src(), self.wd.id);
+                    dvui.refresh(null, @src(), self.data().id);
                 } else if (me.action == .motion) {
                     self.drag_point = me.p;
                     dvui.scrollDrag(.{
                         .mouse_pt = me.p,
-                        .screen_rect = self.wd.rectScale().r,
-                        .capture_id = self.wd.id,
+                        .screen_rect = self.data().rectScale().r,
+                        .capture_id = self.data().id,
                     });
                 }
             },
@@ -118,22 +118,22 @@ pub fn deinit(self: *ReorderWidget) void {
     }
 
     if (self.id_reorderable) |idr| {
-        dvui.dataSet(null, self.wd.id, "_id_reorderable", idr);
+        dvui.dataSet(null, self.data().id, "_id_reorderable", idr);
     } else {
-        dvui.dataRemove(null, self.wd.id, "_id_reorderable");
+        dvui.dataRemove(null, self.data().id, "_id_reorderable");
     }
 
     if (self.drag_point) |dp| {
-        dvui.dataSet(null, self.wd.id, "_drag_point", dp);
+        dvui.dataSet(null, self.data().id, "_drag_point", dp);
     } else {
-        dvui.dataRemove(null, self.wd.id, "_drag_point");
+        dvui.dataRemove(null, self.data().id, "_drag_point");
     }
 
-    dvui.dataSet(null, self.wd.id, "_reorderable_size", self.reorderable_size);
+    dvui.dataSet(null, self.data().id, "_reorderable_size", self.reorderable_size);
 
-    self.wd.minSizeSetAndRefresh();
-    self.wd.minSizeReportToParent();
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
+    dvui.parentReset(self.data().id, self.data().parent);
     self.* = undefined;
 }
 
@@ -163,16 +163,16 @@ pub fn draggable(src: std.builtin.SourceLocation, init_opts: draggableInitOption
                 if (me.action == .press and me.button.pointer()) {
                     e.handle(@src(), iw.data());
                     dvui.captureMouse(iw.data());
-                    const reo_top_left: ?dvui.Point.Physical = if (init_opts.reorderable) |reo| reo.wd.rectScale().r.topLeft() else null;
+                    const reo_top_left: ?dvui.Point.Physical = if (init_opts.reorderable) |reo| reo.data().rectScale().r.topLeft() else null;
                     const top_left: ?dvui.Point.Physical = init_opts.top_left orelse reo_top_left;
-                    dvui.dragPreStart(me.p, .{ .offset = (top_left orelse iw.wd.rectScale().r.topLeft()).diff(me.p) });
+                    dvui.dragPreStart(me.p, .{ .offset = (top_left orelse iw.data().rectScale().r.topLeft()).diff(me.p) });
                 } else if (me.action == .motion) {
-                    if (dvui.captured(iw.wd.id)) {
+                    if (dvui.captured(iw.data().id)) {
                         e.handle(@src(), iw.data());
                         if (dvui.dragging(me.p)) |_| {
                             ret = me.p;
                             if (init_opts.reorderable) |reo| {
-                                reo.reorder.dragStart(reo.wd.id.asUsize(), me.p); // reorder grabs capture
+                                reo.reorder.dragStart(reo.data().id.asUsize(), me.p); // reorder grabs capture
                             }
                             break :loop;
                         }
@@ -234,7 +234,7 @@ pub const Reorderable = struct {
     // can call this after init before install
     pub fn floating(self: *Reorderable) bool {
         // if drag_point is non-null, id_reorderable is non-null
-        if (self.reorder.drag_point != null and self.reorder.id_reorderable.? == (self.init_options.reorder_id orelse self.wd.id.asUsize())) {
+        if (self.reorder.drag_point != null and self.reorder.id_reorderable.? == (self.init_options.reorder_id orelse self.data().id.asUsize())) {
             return true;
         }
 
@@ -245,20 +245,20 @@ pub const Reorderable = struct {
         self.installed = true;
         if (self.reorder.drag_point) |dp| {
             const topleft = dp.plus(dvui.dragOffset());
-            if (self.reorder.id_reorderable.? == (self.init_options.reorder_id orelse self.wd.id.asUsize())) {
+            if (self.reorder.id_reorderable.? == (self.init_options.reorder_id orelse self.data().id.asUsize())) {
                 // we are being dragged - put in floating widget
-                self.wd.register();
+                self.data().register();
                 dvui.parentSet(self.widget());
 
                 self.floating_widget = dvui.FloatingWidget.init(@src(), .{ .rect = Rect.fromPoint(.cast(topleft.toNatural())), .min_size_content = self.reorder.reorderable_size });
                 self.floating_widget.?.install();
             } else {
                 if (self.init_options.last_slot) {
-                    self.wd = WidgetData.init(self.wd.src, .{}, self.options.override(.{ .min_size_content = self.reorder.reorderable_size }));
+                    self.wd = WidgetData.init(self.data().src, .{}, self.options.override(.{ .min_size_content = self.reorder.reorderable_size }));
                 } else {
-                    self.wd = WidgetData.init(self.wd.src, .{}, self.options);
+                    self.wd = WidgetData.init(self.data().src, .{}, self.options);
                 }
-                const rs = self.wd.rectScale();
+                const rs = self.data().rectScale();
                 const dragRect = Rect.Physical.fromPoint(topleft).toSize(self.reorder.reorderable_size.scale(rs.s, Size.Physical));
 
                 if (!self.reorder.found_slot and !rs.r.intersect(dragRect).empty()) {
@@ -276,12 +276,12 @@ pub const Reorderable = struct {
                 }
 
                 if (self.target_rs == null or self.init_options.last_slot) {
-                    self.wd.register();
+                    self.data().register();
                     dvui.parentSet(self.widget());
                 }
             }
         } else {
-            self.wd = WidgetData.init(self.wd.src, .{}, self.options);
+            self.wd = WidgetData.init(self.data().src, .{}, self.options);
             self.reorder.reorderable_size = self.wd.rect.size();
 
             self.wd.register();
@@ -295,7 +295,7 @@ pub const Reorderable = struct {
 
     pub fn removed(self: *Reorderable) bool {
         // if drag_ending is true, id_reorderable is non-null
-        if (self.reorder.drag_ending and self.reorder.id_reorderable.? == (self.init_options.reorder_id orelse self.wd.id.asUsize())) {
+        if (self.reorder.drag_ending and self.reorder.id_reorderable.? == (self.init_options.reorder_id orelse self.data().id.asUsize())) {
             return true;
         }
 
@@ -337,28 +337,28 @@ pub const Reorderable = struct {
 
     pub fn rectFor(self: *Reorderable, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
         _ = id;
-        return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
+        return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
     }
 
     pub fn screenRectScale(self: *Reorderable, rect: Rect) RectScale {
-        return self.wd.contentRectScale().rectToRectScale(rect);
+        return self.data().contentRectScale().rectToRectScale(rect);
     }
 
     pub fn minSizeForChild(self: *Reorderable, s: Size) void {
-        self.wd.minSizeMax(self.wd.options.padSize(s));
+        self.data().minSizeMax(self.data().options.padSize(s));
     }
 
     pub fn deinit(self: *Reorderable) void {
         defer dvui.widgetFree(self);
         if (self.floating_widget) |*fw| {
-            self.wd.minSizeMax(fw.wd.min_size);
+            self.data().minSizeMax(fw.data().min_size);
             fw.deinit();
         }
 
-        self.wd.minSizeSetAndRefresh();
-        self.wd.minSizeReportToParent();
+        self.data().minSizeSetAndRefresh();
+        self.data().minSizeReportToParent();
 
-        dvui.parentReset(self.wd.id, self.wd.parent);
+        dvui.parentReset(self.data().id, self.data().parent);
         self.* = undefined;
     }
 };

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -57,7 +57,7 @@ pub fn widget(self: *ReorderWidget) Widget {
 }
 
 pub fn data(self: *ReorderWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *ReorderWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
@@ -332,7 +332,7 @@ pub const Reorderable = struct {
     }
 
     pub fn data(self: *Reorderable) *WidgetData {
-        return &self.wd;
+        return self.wd.validate();
     }
 
     pub fn rectFor(self: *Reorderable, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/ScaleWidget.zig
+++ b/src/widgets/ScaleWidget.zig
@@ -134,7 +134,7 @@ pub fn widget(self: *ScaleWidget) Widget {
 }
 
 pub fn data(self: *ScaleWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *ScaleWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/ScaleWidget.zig
+++ b/src/widgets/ScaleWidget.zig
@@ -53,12 +53,12 @@ pub fn install(self: *ScaleWidget) void {
     if (self.init_options.scale) |init_s| {
         self.scale = init_s;
     } else {
-        self.scale = dvui.dataGetPtrDefault(null, self.wd.id, "_scale", f32, 1.0);
+        self.scale = dvui.dataGetPtrDefault(null, self.data().id, "_scale", f32, 1.0);
     }
 
     dvui.parentSet(self.widget());
-    self.wd.register();
-    self.wd.borderAndBackground(.{});
+    self.data().register();
+    self.data().borderAndBackground(.{});
 }
 
 pub fn matchEvent(self: *ScaleWidget, e: *Event) bool {
@@ -67,7 +67,7 @@ pub fn matchEvent(self: *ScaleWidget, e: *Event) bool {
         !e.handled and
         e.evt == .mouse and
         (self.init_options.pinch_zoom == .global or e.evt.mouse.floating_win == dvui.subwindowCurrentId()) and
-        self.wd.borderRectScale().r.contains(e.evt.mouse.p) and
+        self.data().borderRectScale().r.contains(e.evt.mouse.p) and
         dvui.clipGet().contains(e.evt.mouse.p) and
         (e.evt.mouse.button == .touch0 or e.evt.mouse.button == .touch1);
 }
@@ -99,7 +99,7 @@ pub fn processEvent(self: *ScaleWidget, e: *Event) void {
             },
             .release => {
                 self.touchPoints[idx] = null;
-                if (dvui.captured(self.wd.id)) {
+                if (dvui.captured(self.data().id)) {
                     e.handle(@src(), self.data());
                     dvui.captureMouse(null);
                 }
@@ -144,26 +144,26 @@ pub fn rectFor(self: *ScaleWidget, id: dvui.WidgetId, min_size: Size, e: Options
         // prevent divide by zero
         1_000_000.0;
 
-    return self.layout.rectFor(self.wd.contentRect().justSize().scale(s, Rect), id, min_size, e, g);
+    return self.layout.rectFor(self.data().contentRect().justSize().scale(s, Rect), id, min_size, e, g);
 }
 
 pub fn screenRectScale(self: *ScaleWidget, rect: Rect) RectScale {
-    var rs = self.wd.contentRectScale();
+    var rs = self.data().contentRectScale();
     rs.s *= self.scale.*;
     return rs.rectToRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *ScaleWidget, s: Size) void {
     const ms = self.layout.minSizeForChild(s.scale(self.scale.*, Size));
-    self.wd.minSizeMax(self.wd.options.padSize(ms));
+    self.data().minSizeMax(self.data().options.padSize(ms));
 }
 
 pub fn deinit(self: *ScaleWidget) void {
     defer dvui.widgetFree(self);
-    dvui.dataSet(null, self.wd.id, "_scale", self.scale.*);
-    self.wd.minSizeSetAndRefresh();
-    self.wd.minSizeReportToParent();
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    dvui.dataSet(null, self.data().id, "_scale", self.scale.*);
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
+    dvui.parentReset(self.data().id, self.data().parent);
     self.* = undefined;
 }
 

--- a/src/widgets/ScrollAreaWidget.zig
+++ b/src/widgets/ScrollAreaWidget.zig
@@ -175,7 +175,7 @@ pub fn installScrollBars(self: *ScrollAreaWidget) void {
 }
 
 pub fn data(self: *ScrollAreaWidget) *WidgetData {
-    return self.hbox.wd.validate();
+    return self.hbox.data();
 }
 
 pub fn deinit(self: *ScrollAreaWidget) void {

--- a/src/widgets/ScrollAreaWidget.zig
+++ b/src/widgets/ScrollAreaWidget.zig
@@ -175,7 +175,7 @@ pub fn installScrollBars(self: *ScrollAreaWidget) void {
 }
 
 pub fn data(self: *ScrollAreaWidget) *WidgetData {
-    return &self.hbox.wd;
+    return self.hbox.wd.validate();
 }
 
 pub fn deinit(self: *ScrollAreaWidget) void {

--- a/src/widgets/ScrollAreaWidget.zig
+++ b/src/widgets/ScrollAreaWidget.zig
@@ -72,10 +72,10 @@ pub fn installScrollBars(self: *ScrollAreaWidget) void {
     if (self.init_opts.scroll_info) |si| {
         self.si = si;
         if (self.init_opts.vertical != null) {
-            dvui.log.debug("ScrollAreaWidget {x} init_opts.vertical .{s} overridden by init_opts.scroll_info.vertical .{s}\n", .{ self.hbox.wd.id, @tagName(self.init_opts.vertical.?), @tagName(si.vertical) });
+            dvui.log.debug("ScrollAreaWidget {x} init_opts.vertical .{s} overridden by init_opts.scroll_info.vertical .{s}\n", .{ self.hbox.data().id, @tagName(self.init_opts.vertical.?), @tagName(si.vertical) });
         }
         if (self.init_opts.horizontal != null) {
-            dvui.log.debug("ScrollAreaWidget {x} init_opts.horizontal .{s} overridden by init_opts.scroll_info.horizontal .{s}\n", .{ self.hbox.wd.id, @tagName(self.init_opts.horizontal.?), @tagName(si.horizontal) });
+            dvui.log.debug("ScrollAreaWidget {x} init_opts.horizontal .{s} overridden by init_opts.scroll_info.horizontal .{s}\n", .{ self.hbox.data().id, @tagName(self.init_opts.horizontal.?), @tagName(si.horizontal) });
         }
     } else if (dvui.dataGet(null, self.hbox.data().id, "_scroll_info", ScrollInfo)) |si| {
         self.si_store = si;

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -63,7 +63,7 @@ pub fn install(self: *ScrollBarWidget) void {
 }
 
 pub fn data(self: *ScrollBarWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn processEvents(self: *ScrollBarWidget, grabrs: Rect.Physical) void {

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -41,24 +41,24 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *ScrollBarWidget) void {
-    self.wd.register();
-    self.wd.borderAndBackground(.{});
+    self.data().register();
+    self.data().borderAndBackground(.{});
 
-    self.grabRect = self.wd.contentRect();
+    self.grabRect = self.data().contentRect();
     switch (self.dir) {
         .vertical => {
             self.grabRect.h = @min(self.grabRect.h, @max(20.0, self.grabRect.h * self.si.visibleFraction(self.dir)));
-            const insideH = self.wd.contentRect().h - self.grabRect.h;
+            const insideH = self.data().contentRect().h - self.grabRect.h;
             self.grabRect.y += insideH * self.si.offsetFraction(self.dir);
         },
         .horizontal => {
             self.grabRect.w = @min(self.grabRect.w, @max(20.0, self.grabRect.w * self.si.visibleFraction(self.dir)));
-            const insideH = self.wd.contentRect().w - self.grabRect.w;
+            const insideH = self.data().contentRect().w - self.grabRect.w;
             self.grabRect.x += insideH * self.si.offsetFraction(self.dir);
         },
     }
 
-    const grabrs = self.wd.parent.screenRectScale(self.grabRect);
+    const grabrs = self.data().parent.screenRectScale(self.grabRect);
     self.processEvents(grabrs.r);
 }
 
@@ -67,7 +67,7 @@ pub fn data(self: *ScrollBarWidget) *WidgetData {
 }
 
 pub fn processEvents(self: *ScrollBarWidget, grabrs: Rect.Physical) void {
-    const rs = self.wd.borderRectScale();
+    const rs = self.data().borderRectScale();
     const evts = dvui.events();
     for (evts) |*e| {
         if (!dvui.eventMatchSimple(e, self.data()))
@@ -101,7 +101,7 @@ pub fn processEvents(self: *ScrollBarWidget, grabrs: Rect.Physical) void {
                                     self.si.scrollPageDown(self.dir);
                                 }
 
-                                dvui.refresh(null, @src(), self.wd.id);
+                                dvui.refresh(null, @src(), self.data().id);
                             }
                         }
                     },
@@ -136,7 +136,7 @@ pub fn processEvents(self: *ScrollBarWidget, grabrs: Rect.Physical) void {
                                     f = (grabmid - min) / (max - min);
                                 }
                                 self.si.scrollToFraction(self.dir, f);
-                                dvui.refresh(null, @src(), self.wd.id);
+                                dvui.refresh(null, @src(), self.data().id);
                             }
                         }
                     },
@@ -148,7 +148,7 @@ pub fn processEvents(self: *ScrollBarWidget, grabrs: Rect.Physical) void {
                         if (self.dir == .horizontal) {
                             e.handle(@src(), self.data());
                             self.si.scrollByOffset(self.dir, ticks);
-                            dvui.refresh(null, @src(), self.wd.id);
+                            dvui.refresh(null, @src(), self.data().id);
                         }
                     },
                     .wheel_y => |ticks| {
@@ -156,7 +156,7 @@ pub fn processEvents(self: *ScrollBarWidget, grabrs: Rect.Physical) void {
                         // horizontal scrollBar seems still natural to be scrolled
                         e.handle(@src(), self.data());
                         self.si.scrollByOffset(self.dir, -ticks);
-                        dvui.refresh(null, @src(), self.wd.id);
+                        dvui.refresh(null, @src(), self.data().id);
                     },
                 }
             },
@@ -175,21 +175,21 @@ pub const Grab = struct {
 };
 
 pub fn grab(self: *ScrollBarWidget) Grab {
-    var fill = self.wd.options.color(.text).opacity(0.5);
-    if (dvui.captured(self.wd.id) or self.highlight) {
-        fill = self.wd.options.color(.text).opacity(0.3);
+    var fill = self.data().options.color(.text).opacity(0.5);
+    if (dvui.captured(self.data().id) or self.highlight) {
+        fill = self.data().options.color(.text).opacity(0.3);
     }
 
     return .{
-        .rect = self.wd.parent.screenRectScale(self.grabRect.insetAll(2)).r,
+        .rect = self.data().parent.screenRectScale(self.grabRect.insetAll(2)).r,
         .color = fill,
     };
 }
 
 pub fn deinit(self: *ScrollBarWidget) void {
     defer dvui.widgetFree(self);
-    self.wd.minSizeSetAndRefresh();
-    self.wd.minSizeReportToParent();
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
     self.* = undefined;
 }
 

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -82,10 +82,10 @@ pub fn init(src: std.builtin.SourceLocation, io_scroll_info: *ScrollInfo, init_o
 }
 
 pub fn install(self: *ScrollContainerWidget) void {
-    self.wd.register();
+    self.data().register();
 
     // user code might have changed our rect
-    const crect = self.wd.contentRect();
+    const crect = self.data().contentRect();
     self.si.viewport.w = crect.w;
     self.si.viewport.h = crect.h;
 
@@ -100,15 +100,15 @@ pub fn install(self: *ScrollContainerWidget) void {
         .given => {},
     }
 
-    self.wd.borderAndBackground(.{});
+    self.data().borderAndBackground(.{});
 
-    self.prevClip = dvui.clip(self.wd.contentRectScale().r);
+    self.prevClip = dvui.clip(self.data().contentRectScale().r);
 
     self.frame_viewport = self.init_opts.frame_viewport orelse self.si.viewport.topLeft();
     if (self.init_opts.lock_visible) {
         // we don't want to see anything until we find first_visible_id
-        self.first_visible_id = dvui.dataGet(null, self.wd.id, "_fv_id", dvui.WidgetId) orelse .zero;
-        self.first_visible_offset = dvui.dataGet(null, self.wd.id, "_fv_offset", Point) orelse .{};
+        self.first_visible_id = dvui.dataGet(null, self.data().id, "_fv_id", dvui.WidgetId) orelse .zero;
+        self.first_visible_offset = dvui.dataGet(null, self.data().id, "_fv_offset", Point) orelse .{};
         self.frame_viewport = .{ .x = -10000, .y = -10000 };
     }
 
@@ -124,7 +124,7 @@ pub fn matchEvent(self: *ScrollContainerWidget, e: *Event) bool {
         self.finger_down = false;
     }
 
-    return dvui.eventMatch(e, .{ .id = self.wd.id, .r = self.init_opts.event_rect orelse self.wd.borderRectScale().r });
+    return dvui.eventMatch(e, .{ .id = self.data().id, .r = self.init_opts.event_rect orelse self.data().borderRectScale().r });
 }
 
 pub fn processEvents(self: *ScrollContainerWidget) void {
@@ -156,7 +156,7 @@ pub fn processVelocity(self: *ScrollContainerWidget) void {
             if (@abs(self.si.velocity.x) > 1) {
                 //std.debug.print("vel x {d}\n", .{self.si.velocity.x});
                 self.si.viewport.x += self.si.velocity.x * 50 * dvui.secondsSinceLastFrame();
-                dvui.refresh(null, @src(), self.wd.id);
+                dvui.refresh(null, @src(), self.data().id);
             } else {
                 self.si.velocity.x = 0;
             }
@@ -168,7 +168,7 @@ pub fn processVelocity(self: *ScrollContainerWidget) void {
             if (@abs(self.si.velocity.y) > 1) {
                 //std.debug.print("vel y {d}\n", .{self.si.velocity.y});
                 self.si.viewport.y += self.si.velocity.y * 50 * dvui.secondsSinceLastFrame();
-                dvui.refresh(null, @src(), self.wd.id);
+                dvui.refresh(null, @src(), self.data().id);
             } else {
                 self.si.velocity.y = 0;
             }
@@ -182,13 +182,13 @@ pub fn processVelocity(self: *ScrollContainerWidget) void {
             self.si.velocity.x = 0;
             self.si.viewport.x = @min(0, @max(-20, self.si.viewport.x + 250 * dvui.secondsSinceLastFrame()));
             if (self.si.viewport.x < 0) {
-                dvui.refresh(null, @src(), self.wd.id);
+                dvui.refresh(null, @src(), self.data().id);
             }
         } else if (self.si.viewport.x > max_scroll) {
             self.si.velocity.x = 0;
             self.si.viewport.x = @max(max_scroll, @min(max_scroll + 20, self.si.viewport.x - 250 * dvui.secondsSinceLastFrame()));
             if (self.si.viewport.x > max_scroll) {
-                dvui.refresh(null, @src(), self.wd.id);
+                dvui.refresh(null, @src(), self.data().id);
             }
         }
     }
@@ -200,13 +200,13 @@ pub fn processVelocity(self: *ScrollContainerWidget) void {
             self.si.velocity.y = 0;
             self.si.viewport.y = @min(0, @max(-20, self.si.viewport.y + 250 * dvui.secondsSinceLastFrame()));
             if (self.si.viewport.y < 0) {
-                dvui.refresh(null, @src(), self.wd.id);
+                dvui.refresh(null, @src(), self.data().id);
             }
         } else if (self.si.viewport.y > max_scroll) {
             self.si.velocity.y = 0;
             self.si.viewport.y = @max(max_scroll, @min(max_scroll + 20, self.si.viewport.y - 250 * dvui.secondsSinceLastFrame()));
             if (self.si.viewport.y > max_scroll) {
-                dvui.refresh(null, @src(), self.wd.id);
+                dvui.refresh(null, @src(), self.data().id);
             }
         }
     }
@@ -288,7 +288,7 @@ pub fn screenRectScale(self: *ScrollContainerWidget, rect: Rect) RectScale {
     r.y -= self.frame_viewport.y;
     r.x -= self.frame_viewport.x;
 
-    return self.wd.contentRectScale().rectToRectScale(r);
+    return self.data().contentRectScale().rectToRectScale(r);
 }
 
 pub fn minSizeForChild(self: *ScrollContainerWidget, s: Size) void {
@@ -358,7 +358,7 @@ pub fn processScrollDrag(
             self.si.scrollByOffset(.horizontal, scrollx);
         }
 
-        dvui.refresh(null, @src(), self.wd.id);
+        dvui.refresh(null, @src(), self.data().id);
 
         // if we are scrolling, then we need a motion event next
         // frame so that the child widget can adjust selection
@@ -381,7 +381,7 @@ pub fn processScrollTo(
             if (!st.over_scroll) {
                 self.si.scrollToOffset(.vertical, self.si.viewport.y);
             }
-            dvui.refresh(null, @src(), self.wd.id);
+            dvui.refresh(null, @src(), self.data().id);
         }
 
         const ypx2 = @max(0.0, (st.screen_rect.y + st.screen_rect.h) - (rs.r.y + rs.r.h));
@@ -390,7 +390,7 @@ pub fn processScrollTo(
             if (!st.over_scroll) {
                 self.si.scrollToOffset(.vertical, self.si.viewport.y);
             }
-            dvui.refresh(null, @src(), self.wd.id);
+            dvui.refresh(null, @src(), self.data().id);
         }
     }
 
@@ -401,7 +401,7 @@ pub fn processScrollTo(
             if (!st.over_scroll) {
                 self.si.scrollToOffset(.horizontal, self.si.viewport.x);
             }
-            dvui.refresh(null, @src(), self.wd.id);
+            dvui.refresh(null, @src(), self.data().id);
         }
 
         const xpx2 = @max(0.0, (st.screen_rect.x + st.screen_rect.w) - (rs.r.x + rs.r.w));
@@ -410,13 +410,13 @@ pub fn processScrollTo(
             if (!st.over_scroll) {
                 self.si.scrollToOffset(.horizontal, self.si.viewport.x);
             }
-            dvui.refresh(null, @src(), self.wd.id);
+            dvui.refresh(null, @src(), self.data().id);
         }
     }
 }
 
 pub fn processMotionScroll(self: *ScrollContainerWidget, motion: dvui.Point.Physical) void {
-    const rs = self.wd.borderRectScale();
+    const rs = self.data().borderRectScale();
 
     // We propagate (instead of not handling the motion event) because we have
     // capture.
@@ -434,7 +434,7 @@ pub fn processMotionScroll(self: *ScrollContainerWidget, motion: dvui.Point.Phys
     if (self.si.vertical != .none) {
         self.si.viewport.y -= motion.y / rs.s;
         self.si.velocity.y = -motion.y / rs.s;
-        dvui.refresh(null, @src(), self.wd.id);
+        dvui.refresh(null, @src(), self.data().id);
         if (@abs(motion.y) > @abs(motion.x) and (self.si.viewport.y < 0 or self.si.viewport.y > self.si.scrollMax(.vertical))) {
             propagate = true;
         }
@@ -442,7 +442,7 @@ pub fn processMotionScroll(self: *ScrollContainerWidget, motion: dvui.Point.Phys
     if (self.si.horizontal != .none) {
         self.si.viewport.x -= motion.x / rs.s;
         self.si.velocity.x = -motion.x / rs.s;
-        dvui.refresh(null, @src(), self.wd.id);
+        dvui.refresh(null, @src(), self.data().id);
         if (@abs(motion.x) > @abs(motion.y) and (self.si.viewport.x < 0 or self.si.viewport.x > self.si.scrollMax(.horizontal))) {
             propagate = true;
         }
@@ -460,7 +460,7 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
 
     const evts = dvui.events();
     for (evts) |*e| {
-        if (!dvui.eventMatch(e, .{ .id = self.wd.id, .focus_id = focus_id, .r = self.init_opts.event_rect orelse self.wd.borderRectScale().r }))
+        if (!dvui.eventMatch(e, .{ .id = self.data().id, .focus_id = focus_id, .r = self.init_opts.event_rect orelse self.data().borderRectScale().r }))
             continue;
 
         switch (e.evt) {
@@ -468,7 +468,7 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
                 if (me.action == .focus) {
                     e.handle(@src(), self.data());
                     // focus so that we can receive keyboard input
-                    dvui.focusWidget(self.wd.id, null, e.num);
+                    dvui.focusWidget(self.data().id, null, e.num);
                 } else if (me.action == .wheel_x) {
                     if (self.si.scrollMax(.horizontal) > 0) {
                         if ((me.action.wheel_x < 0 and self.si.viewport.x <= 0) or (me.action.wheel_x > 0 and self.si.viewport.x >= self.si.scrollMax(.horizontal))) {
@@ -476,7 +476,7 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
                         } else {
                             e.handle(@src(), self.data());
                             self.si.scrollByOffset(.horizontal, me.action.wheel_x);
-                            dvui.refresh(null, @src(), self.wd.id);
+                            dvui.refresh(null, @src(), self.data().id);
                         }
                     }
                 } else if (me.action == .wheel_y) {
@@ -491,7 +491,7 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
                         } else {
                             e.handle(@src(), self.data());
                             self.si.scrollByOffset(.vertical, -me.action.wheel_y);
-                            dvui.refresh(null, @src(), self.wd.id);
+                            dvui.refresh(null, @src(), self.data().id);
                         }
                     } else if (self.si.scrollMax(.horizontal) > 0) {
                         if ((me.action.wheel_y > 0 and self.si.viewport.x <= 0) or (me.action.wheel_y < 0 and self.si.viewport.x >= self.si.scrollMax(.horizontal))) {
@@ -499,7 +499,7 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
                         } else {
                             e.handle(@src(), self.data());
                             self.si.scrollByOffset(.horizontal, -me.action.wheel_y);
-                            dvui.refresh(null, @src(), self.wd.id);
+                            dvui.refresh(null, @src(), self.data().id);
                         }
                     }
                 } else if (me.action == .press and me.button.touch()) {
@@ -507,7 +507,7 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
                     // which would capture the mouse preventing scrolling
                     e.handle(@src(), self.data());
                     dvui.captureMouse(self.data());
-                } else if (me.action == .release and dvui.captured(self.wd.id)) {
+                } else if (me.action == .release and dvui.captured(self.data().id)) {
                     e.handle(@src(), self.data());
                     dvui.captureMouse(null);
                     dvui.dragEnd();
@@ -575,9 +575,9 @@ pub fn deinit(self: *ScrollContainerWidget) void {
         self.processEventsAfter();
     }
 
-    dvui.dataSet(null, self.wd.id, "_fv_id", self.first_visible_id);
-    dvui.dataSet(null, self.wd.id, "_fv_offset", self.first_visible_offset);
-    dvui.dataSet(null, self.wd.id, "_finger_down", self.finger_down);
+    dvui.dataSet(null, self.data().id, "_fv_id", self.first_visible_id);
+    dvui.dataSet(null, self.data().id, "_fv_offset", self.first_visible_offset);
+    dvui.dataSet(null, self.data().id, "_finger_down", self.finger_down);
 
     if (self.inject_capture_id) |ci| {
         // Only do this if the widget that called the scrollDrag still has
@@ -590,26 +590,26 @@ pub fn deinit(self: *ScrollContainerWidget) void {
         }
     }
 
-    const padded = self.wd.options.padSize(self.nextVirtualSize);
+    const padded = self.data().options.padSize(self.nextVirtualSize);
     switch (self.si.horizontal) {
-        .none => self.wd.min_size.w = padded.w,
+        .none => self.data().min_size.w = padded.w,
         .auto => {
-            self.wd.min_size.w = padded.w;
+            self.data().min_size.w = padded.w;
             if (self.nextVirtualSize.w != self.si.virtual_size.w) {
                 self.si.virtual_size.w = self.nextVirtualSize.w;
-                dvui.refresh(null, @src(), self.wd.id);
+                dvui.refresh(null, @src(), self.data().id);
             }
         },
         .given => {},
     }
 
     switch (self.si.vertical) {
-        .none => self.wd.min_size.h = padded.h,
+        .none => self.data().min_size.h = padded.h,
         .auto => {
-            self.wd.min_size.h = padded.h;
+            self.data().min_size.h = padded.h;
             if (self.nextVirtualSize.h != self.si.virtual_size.h) {
                 self.si.virtual_size.h = self.nextVirtualSize.h;
-                dvui.refresh(null, @src(), self.wd.id);
+                dvui.refresh(null, @src(), self.data().id);
             }
         },
         .given => {},
@@ -618,7 +618,7 @@ pub fn deinit(self: *ScrollContainerWidget) void {
     self.wd.minSizeSetAndRefresh();
     self.wd.minSizeReportToParent();
     _ = scrollSet(self.parentScroll);
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    dvui.parentReset(self.data().id, self.data().parent);
     self.* = undefined;
 }
 

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -223,7 +223,7 @@ pub fn widget(self: *ScrollContainerWidget) Widget {
 }
 
 pub fn data(self: *ScrollContainerWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *ScrollContainerWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -72,9 +72,9 @@ pub fn init(src: std.builtin.SourceLocation, io_scroll_info: *ScrollInfo, init_o
         .last_focus = dvui.lastFocusedIdInFrame(null),
     };
 
-    if (dvui.dataGet(null, self.wd.id, "_finger_down", bool)) |down| self.finger_down = down;
+    if (dvui.dataGet(null, self.data().id, "_finger_down", bool)) |down| self.finger_down = down;
 
-    const crect = self.wd.contentRect();
+    const crect = self.data().contentRect();
     self.si.viewport.w = crect.w;
     self.si.viewport.h = crect.h;
 
@@ -319,7 +319,7 @@ pub fn processScrollDrag(
     self: *ScrollContainerWidget,
     sd: dvui.ScrollDragOptions,
 ) void {
-    const rs = self.wd.contentRectScale();
+    const rs = self.data().contentRectScale();
     var scrolly: f32 = 0;
     if (sd.mouse_pt.y <= rs.r.y and // want to scroll up
         sd.screen_rect.y < rs.r.y and // scrolling would show more of child
@@ -372,7 +372,7 @@ pub fn processScrollTo(
     self: *ScrollContainerWidget,
     st: dvui.ScrollToOptions,
 ) void {
-    const rs = self.wd.contentRectScale();
+    const rs = self.data().contentRectScale();
 
     if (self.si.vertical != .none) {
         const ypx = @max(0.0, rs.r.y - st.screen_rect.y);
@@ -530,33 +530,33 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
                     if (self.si.vertical != .none) {
                         self.si.scrollByOffset(.vertical, -10);
                     }
-                    dvui.refresh(null, @src(), self.wd.id);
+                    dvui.refresh(null, @src(), self.data().id);
                 } else if (ke.code == .down and (ke.action == .down or ke.action == .repeat)) {
                     e.handle(@src(), self.data());
                     if (self.si.vertical != .none) {
                         self.si.scrollByOffset(.vertical, 10);
                     }
-                    dvui.refresh(null, @src(), self.wd.id);
+                    dvui.refresh(null, @src(), self.data().id);
                 } else if (ke.code == .left and (ke.action == .down or ke.action == .repeat)) {
                     e.handle(@src(), self.data());
                     if (self.si.horizontal != .none) {
                         self.si.scrollByOffset(.horizontal, -10);
                     }
-                    dvui.refresh(null, @src(), self.wd.id);
+                    dvui.refresh(null, @src(), self.data().id);
                 } else if (ke.code == .right and (ke.action == .down or ke.action == .repeat)) {
                     e.handle(@src(), self.data());
                     if (self.si.horizontal != .none) {
                         self.si.scrollByOffset(.horizontal, 10);
                     }
-                    dvui.refresh(null, @src(), self.wd.id);
+                    dvui.refresh(null, @src(), self.data().id);
                 } else if (ke.code == .page_up and (ke.action == .down or ke.action == .repeat)) {
                     e.handle(@src(), self.data());
                     self.si.scrollPageUp(.vertical);
-                    dvui.refresh(null, @src(), self.wd.id);
+                    dvui.refresh(null, @src(), self.data().id);
                 } else if (ke.code == .page_down and (ke.action == .down or ke.action == .repeat)) {
                     e.handle(@src(), self.data());
                     self.si.scrollPageDown(.vertical);
-                    dvui.refresh(null, @src(), self.wd.id);
+                    dvui.refresh(null, @src(), self.data().id);
                 }
             },
             else => {},
@@ -615,8 +615,8 @@ pub fn deinit(self: *ScrollContainerWidget) void {
         .given => {},
     }
 
-    self.wd.minSizeSetAndRefresh();
-    self.wd.minSizeReportToParent();
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
     _ = scrollSet(self.parentScroll);
     dvui.parentReset(self.data().id, self.data().parent);
     self.* = undefined;

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -336,7 +336,7 @@ pub fn widget(self: *TextEntryWidget) Widget {
 }
 
 pub fn data(self: *TextEntryWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *TextEntryWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -232,49 +232,49 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, show_touch_draggables: bool = true }) void {
-    self.focus_at_start = opts.focused orelse (self.wd.id == dvui.focusedWidgetId());
+    self.focus_at_start = opts.focused orelse (self.data().id == dvui.focusedWidgetId());
 
-    self.wd.register();
+    self.data().register();
     dvui.parentSet(self.widget());
 
     if (self.selection_in) |sel| {
         self.selection = sel;
     } else {
-        if (dvui.dataGet(null, self.wd.id, "_selection", Selection)) |s| {
+        if (dvui.dataGet(null, self.data().id, "_selection", Selection)) |s| {
             self.selection_store = s;
         }
         self.selection = &self.selection_store;
     }
 
-    if (dvui.captured(self.wd.id)) {
-        if (dvui.dataGet(null, self.wd.id, "_sel_move_mouse_byte", usize)) |p| {
+    if (dvui.captured(self.data().id)) {
+        if (dvui.dataGet(null, self.data().id, "_sel_move_mouse_byte", usize)) |p| {
             self.sel_move = .{ .mouse = .{ .byte = p } };
         }
 
-        if (dvui.dataGet(null, self.wd.id, "_sel_move_expand_pt_which", @TypeOf(self.sel_move.expand_pt.which))) |w| {
-            if (dvui.dataGet(null, self.wd.id, "_sel_move_expand_pt_bytes", [2]usize)) |bytes| {
+        if (dvui.dataGet(null, self.data().id, "_sel_move_expand_pt_which", @TypeOf(self.sel_move.expand_pt.which))) |w| {
+            if (dvui.dataGet(null, self.data().id, "_sel_move_expand_pt_bytes", [2]usize)) |bytes| {
                 // set done to true, only matters if we are dragging which sets it back to false
                 self.sel_move = .{ .expand_pt = .{ .which = w, .bytes = bytes, .done = true } };
             }
         }
     }
 
-    if (dvui.dataGet(null, self.wd.id, "_sel_move_cursor_updown_pt", Point)) |p| {
+    if (dvui.dataGet(null, self.data().id, "_sel_move_cursor_updown_pt", Point)) |p| {
         self.sel_move = .{ .cursor_updown = .{ .pt = p } };
-        dvui.dataRemove(null, self.wd.id, "_sel_move_cursor_updown_pt");
-        if (dvui.dataGet(null, self.wd.id, "_sel_move_cursor_updown_select", bool)) |cud| {
+        dvui.dataRemove(null, self.data().id, "_sel_move_cursor_updown_pt");
+        if (dvui.dataGet(null, self.data().id, "_sel_move_cursor_updown_select", bool)) |cud| {
             self.sel_move.cursor_updown.select = cud;
-            dvui.dataRemove(null, self.wd.id, "_sel_move_cursor_updown_select");
+            dvui.dataRemove(null, self.data().id, "_sel_move_cursor_updown_select");
         }
     }
 
-    const rs = self.wd.contentRectScale();
+    const rs = self.data().contentRectScale();
 
-    self.wd.borderAndBackground(.{});
+    self.data().borderAndBackground(.{});
 
     self.prevClip = dvui.clip(rs.r);
 
-    if (opts.show_touch_draggables and self.touch_editing and self.te_show_draggables and self.focus_at_start and self.wd.visible()) {
+    if (opts.show_touch_draggables and self.touch_editing and self.te_show_draggables and self.focus_at_start and self.data().visible()) {
         const size = 36;
         {
 
@@ -303,12 +303,12 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
             var fc = dvui.FloatingWidget.init(@src(), .{ .rect = rect });
             fc.install();
 
-            var offset: Point.Physical = dvui.dataGet(null, fc.wd.id, "_offset", Point.Physical) orelse .{};
+            var offset: Point.Physical = dvui.dataGet(null, fc.data().id, "_offset", Point.Physical) orelse .{};
 
-            const fcrs = fc.wd.rectScale();
+            const fcrs = fc.data().rectScale();
             const evts = dvui.events();
             for (evts) |*e| {
-                if (!dvui.eventMatch(e, .{ .id = fc.wd.id, .r = fcrs.r }))
+                if (!dvui.eventMatch(e, .{ .id = fc.data().id, .r = fcrs.r }))
                     continue;
 
                 if (e.evt == .mouse) {
@@ -323,17 +323,17 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
                     } else if (me.action == .release and me.button.touch()) {
                         dvui.captureMouse(null);
                         dvui.dragEnd();
-                    } else if (me.action == .motion and dvui.captured(fc.wd.id)) {
+                    } else if (me.action == .motion and dvui.captured(fc.data().id)) {
                         const corner = me.p.plus(offset);
-                        self.sel_pts[0] = self.wd.contentRectScale().pointFromPhysical(corner);
+                        self.sel_pts[0] = self.data().contentRectScale().pointFromPhysical(corner);
                         self.sel_pts[1] = self.sel_end_r.topLeft().plus(.{ .y = self.sel_end_r.h / 2 });
 
                         self.sel_pts[0].?.y = @min(self.sel_pts[0].?.y, self.sel_pts[1].?.y);
 
                         dvui.scrollDrag(.{
                             .mouse_pt = e.evt.mouse.p,
-                            .screen_rect = self.wd.rectScale().r,
-                            .capture_id = self.wd.id,
+                            .screen_rect = self.data().rectScale().r,
+                            .capture_id = self.data().id,
                         });
                     }
                 }
@@ -347,10 +347,10 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
                 path.addArc(.{ .x = fcrs.r.x + fcrs.r.w / 2, .y = fcrs.r.y + fcrs.r.h / 2 }, fcrs.r.w / 2, std.math.pi, 0, true);
 
                 path.build().fillConvex(.{ .color = dvui.themeGet().color_fill_control, .blur = 0.5 });
-                path.build().stroke(.{ .thickness = 1.0 * fcrs.s, .color = self.wd.options.color(.border), .closed = true });
+                path.build().stroke(.{ .thickness = 1.0 * fcrs.s, .color = self.data().options.color(.border), .closed = true });
             }
 
-            dvui.dataSet(null, fc.wd.id, "_offset", offset);
+            dvui.dataSet(null, fc.data().id, "_offset", offset);
             fc.deinit();
         }
 
@@ -373,12 +373,12 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
             var fc = dvui.FloatingWidget.init(@src(), .{ .rect = rect });
             fc.install();
 
-            var offset: Point.Physical = dvui.dataGet(null, fc.wd.id, "_offset", Point.Physical) orelse .{};
+            var offset: Point.Physical = dvui.dataGet(null, fc.data().id, "_offset", Point.Physical) orelse .{};
 
-            const fcrs = fc.wd.rectScale();
+            const fcrs = fc.data().rectScale();
             const evts = dvui.events();
             for (evts) |*e| {
-                if (!dvui.eventMatch(e, .{ .id = fc.wd.id, .r = fcrs.r }))
+                if (!dvui.eventMatch(e, .{ .id = fc.data().id, .r = fcrs.r }))
                     continue;
 
                 if (e.evt == .mouse) {
@@ -393,17 +393,17 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
                     } else if (me.action == .release and me.button.touch()) {
                         dvui.captureMouse(null);
                         dvui.dragEnd();
-                    } else if (me.action == .motion and dvui.captured(fc.wd.id)) {
+                    } else if (me.action == .motion and dvui.captured(fc.data().id)) {
                         const corner = me.p.plus(offset);
                         self.sel_pts[0] = self.sel_start_r.topLeft().plus(.{ .y = self.sel_start_r.h / 2 });
-                        self.sel_pts[1] = self.wd.contentRectScale().pointFromPhysical(corner);
+                        self.sel_pts[1] = self.data().contentRectScale().pointFromPhysical(corner);
 
                         self.sel_pts[1].?.y = @max(self.sel_pts[0].?.y, self.sel_pts[1].?.y);
 
                         dvui.scrollDrag(.{
                             .mouse_pt = e.evt.mouse.p,
-                            .screen_rect = self.wd.rectScale().r,
-                            .capture_id = self.wd.id,
+                            .screen_rect = self.data().rectScale().r,
+                            .capture_id = self.data().id,
                         });
                     }
                 }
@@ -417,10 +417,10 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
                 path.addArc(.{ .x = fcrs.r.x + fcrs.r.w / 2, .y = fcrs.r.y + fcrs.r.h / 2 }, fcrs.r.w / 2, std.math.pi, 0, true);
 
                 path.build().fillConvex(.{ .color = dvui.themeGet().color_fill_control, .blur = 0.5 });
-                path.build().stroke(.{ .thickness = 1.0 * fcrs.s, .color = self.wd.options.color(.border), .closed = true });
+                path.build().stroke(.{ .thickness = 1.0 * fcrs.s, .color = self.data().options.color(.border), .closed = true });
             }
 
-            dvui.dataSet(null, fc.wd.id, "_offset", offset);
+            dvui.dataSet(null, fc.data().id, "_offset", offset);
             fc.deinit();
         }
     }
@@ -731,7 +731,7 @@ fn selMoveText(self: *TextLayoutWidget, txt: []const u8, start_idx: usize) void 
                 clr.count -= 1;
 
                 self.scroll_to_cursor_next_frame = true;
-                dvui.refresh(null, @src(), self.wd.id);
+                dvui.refresh(null, @src(), self.data().id);
             }
         },
         .cursor_updown => {},
@@ -822,7 +822,7 @@ fn selMoveText(self: *TextLayoutWidget, txt: []const u8, start_idx: usize) void 
                 }
 
                 self.scroll_to_cursor_next_frame = true;
-                dvui.refresh(null, @src(), self.wd.id);
+                dvui.refresh(null, @src(), self.data().id);
             }
         },
     }
@@ -866,7 +866,7 @@ fn cursorSeen(self: *TextLayoutWidget) void {
                     self.selection.end = @max(self.selection.end, ep.bytes[1]);
                 }
 
-                dvui.refresh(null, @src(), self.wd.id);
+                dvui.refresh(null, @src(), self.data().id);
             }
         },
         .char_left_right => |*clr| {
@@ -907,7 +907,7 @@ fn cursorSeen(self: *TextLayoutWidget) void {
                 clr.count = 0;
 
                 self.scroll_to_cursor_next_frame = true;
-                dvui.refresh(null, @src(), self.wd.id);
+                dvui.refresh(null, @src(), self.data().id);
             }
         },
         .cursor_updown => |*cud| {
@@ -920,14 +920,14 @@ fn cursorSeen(self: *TextLayoutWidget) void {
 
                 // forward the pixel position we want the cursor to be in to
                 // the next frame
-                dvui.dataSet(null, self.wd.id, "_sel_move_cursor_updown_pt", updown_pt);
-                dvui.dataSet(null, self.wd.id, "_sel_move_cursor_updown_select", cud.select);
-                dvui.refresh(null, @src(), self.wd.id);
+                dvui.dataSet(null, self.data().id, "_sel_move_cursor_updown_pt", updown_pt);
+                dvui.dataSet(null, self.data().id, "_sel_move_cursor_updown_select", cud.select);
+                dvui.refresh(null, @src(), self.data().id);
 
                 // scroll up/down to where we want the cursor, don't need
                 // overscroll because we are staying within the current text
                 dvui.scrollTo(.{
-                    .screen_rect = self.screenRectScale(cr_new.outset(self.wd.options.paddingGet())).r,
+                    .screen_rect = self.screenRectScale(cr_new.outset(self.data().options.paddingGet())).r,
                 });
 
                 // even though we scrolled to where we thought the cursor would
@@ -943,14 +943,14 @@ fn cursorSeen(self: *TextLayoutWidget) void {
                 wlr.count = 0;
 
                 self.scroll_to_cursor_next_frame = true;
-                dvui.refresh(null, @src(), self.wd.id);
+                dvui.refresh(null, @src(), self.data().id);
             }
         },
     }
 
     if (self.scroll_to_cursor) {
         dvui.scrollTo(.{
-            .screen_rect = self.screenRectScale(cr.outset(self.wd.options.paddingGet())).r,
+            .screen_rect = self.screenRectScale(cr.outset(self.data().options.paddingGet())).r,
             // cursor might just have transitioned to a new line, so scroll area has not expanded yet
             .over_scroll = true,
         });
@@ -968,7 +968,7 @@ fn addTextEx(self: *TextLayoutWidget, text: []const u8, action: AddTextExAction,
 
     const cw = dvui.currentWindow();
 
-    const options = self.wd.options.override(opts);
+    const options = self.data().options.override(opts);
     const msize = options.fontGet().sizeM(1, 1);
     const line_height = options.fontGet().lineHeight();
     self.current_line_height = @max(self.current_line_height, line_height);
@@ -978,13 +978,13 @@ fn addTextEx(self: *TextLayoutWidget, text: []const u8, action: AddTextExAction,
     };
     defer if (text.ptr != txt.ptr) cw.lifo().free(txt);
 
-    var container_width = self.wd.contentRect().w;
+    var container_width = self.data().contentRect().w;
     if (container_width == 0) {
         // if we are not being shown at all, probably this is the first
         // frame for us and we should calculate our min height assuming we
         // get at least our min width
 
-        container_width = self.wd.options.min_size_contentGet().w;
+        container_width = self.data().options.min_size_contentGet().w;
         if (container_width == 0) {
             // wasn't given a min width, assume something
             container_width = 500;
@@ -1157,7 +1157,7 @@ fn addTextEx(self: *TextLayoutWidget, text: []const u8, action: AddTextExAction,
                 self.selection.end = @max(sel_bytes[0].?, sel_bytes[1].?);
 
                 // changing touch selection, need to refresh to move draggables
-                dvui.refresh(null, @src(), self.wd.id);
+                dvui.refresh(null, @src(), self.data().id);
             } else if (sel_bytes[0] != null or sel_bytes[1] != null) {
                 self.selection.end = sel_bytes[0] orelse sel_bytes[1].?;
             }
@@ -1190,7 +1190,7 @@ fn addTextEx(self: *TextLayoutWidget, text: []const u8, action: AddTextExAction,
         }
 
         { // Scope here is for deallocating rtxt before handling copying to clipboard on the arena
-            const rs = self.screenRectScale(Rect{ .x = self.insert_pt.x, .y = self.insert_pt.y, .w = width, .h = @max(0, self.wd.contentRect().h - self.insert_pt.y) });
+            const rs = self.screenRectScale(Rect{ .x = self.insert_pt.x, .y = self.insert_pt.y, .w = width, .h = @max(0, self.data().contentRect().h - self.insert_pt.y) });
             //std.debug.print("renderText: {} {s}\n", .{ rs.r, txt[0..end] });
             var rtxt = if (newline) txt[0 .. end - 1] else txt[0..end];
 
@@ -1224,9 +1224,9 @@ fn addTextEx(self: *TextLayoutWidget, text: []const u8, action: AddTextExAction,
         // might size based on that (might be in a scroll area)
         self.insert_pt.x += s.w;
         self.current_line_width += s.w;
-        const size = self.wd.options.padSize(.{ .w = self.current_line_width, .h = self.insert_pt.y + s.h });
-        self.wd.min_size.w = @max(self.wd.min_size.w, size.w + width_after);
-        self.wd.min_size.h = @max(self.wd.min_size.h, size.h);
+        const size = self.data().options.padSize(.{ .w = self.current_line_width, .h = self.insert_pt.y + s.h });
+        self.data().min_size.w = @max(self.data().min_size.w, size.w + width_after);
+        self.data().min_size.h = @max(self.data().min_size.h, size.h);
 
         if (self.copy_sel) |sel| {
             // we are copying to clipboard
@@ -1278,9 +1278,9 @@ fn addTextEx(self: *TextLayoutWidget, text: []const u8, action: AddTextExAction,
             self.current_line_height = line_height;
 
             if (newline) {
-                const newline_size = self.wd.options.padSize(.{ .w = self.current_line_width, .h = self.insert_pt.y + s.h });
-                self.wd.min_size.w = @max(self.wd.min_size.w, newline_size.w);
-                self.wd.min_size.h = @max(self.wd.min_size.h, newline_size.h);
+                const newline_size = self.data().options.padSize(.{ .w = self.current_line_width, .h = self.insert_pt.y + s.h });
+                self.data().min_size.w = @max(self.data().min_size.w, newline_size.w);
+                self.data().min_size.h = @max(self.data().min_size.h, newline_size.h);
                 self.current_line_width = 0.0;
             } else if (txt.len > 0) {
                 self.lineBreak();
@@ -1297,7 +1297,7 @@ fn addTextEx(self: *TextLayoutWidget, text: []const u8, action: AddTextExAction,
             self.sel_end_r_new = .{ .x = self.insert_pt.x, .y = self.insert_pt.y, .w = 1, .h = s.h };
         }
 
-        if (self.wd.options.rect != null) {
+        if (self.data().options.rect != null) {
             // we were given a rect, so don't need to calculate our min height,
             // so stop as soon as we run off the end of the clipping region
             // this helps for performance
@@ -1326,7 +1326,7 @@ pub fn addTextDone(self: *TextLayoutWidget, opts: Options) void {
     self.selection.start = @min(self.selection.start, self.bytes_seen);
     self.selection.end = @min(self.selection.end, self.bytes_seen);
 
-    const options = self.wd.options.override(opts);
+    const options = self.data().options.override(opts);
     const text_height = options.fontGet().textHeight();
 
     if (!self.cursor_seen) {
@@ -1380,7 +1380,7 @@ pub fn addTextDone(self: *TextLayoutWidget, opts: Options) void {
 
     if (self.sel_start_r_new) |start_r| {
         if (!self.sel_start_r.equals(start_r)) {
-            dvui.refresh(null, @src(), self.wd.id);
+            dvui.refresh(null, @src(), self.data().id);
         }
         self.sel_start_r = start_r;
     }
@@ -1388,13 +1388,13 @@ pub fn addTextDone(self: *TextLayoutWidget, opts: Options) void {
     if (self.selection.start > self.bytes_seen or self.bytes_seen == 0) {
         self.sel_start_r = .{ .x = self.insert_pt.x, .y = self.insert_pt.y, .w = 1, .h = text_height };
         if (self.selection.start > self.bytes_seen) {
-            dvui.refresh(null, @src(), self.wd.id);
+            dvui.refresh(null, @src(), self.data().id);
         }
     }
 
     if (self.sel_end_r_new) |end_r| {
         if (!self.sel_end_r.equals(end_r)) {
-            dvui.refresh(null, @src(), self.wd.id);
+            dvui.refresh(null, @src(), self.data().id);
         }
         self.sel_end_r = end_r;
     }
@@ -1402,28 +1402,28 @@ pub fn addTextDone(self: *TextLayoutWidget, opts: Options) void {
     if (self.selection.end > self.bytes_seen or self.bytes_seen == 0) {
         self.sel_end_r = .{ .x = self.insert_pt.x, .y = self.insert_pt.y, .w = 1, .h = text_height };
         if (self.selection.end > self.bytes_seen) {
-            dvui.refresh(null, @src(), self.wd.id);
+            dvui.refresh(null, @src(), self.data().id);
         }
     }
 }
 
 pub fn touchEditing(self: *TextLayoutWidget) ?*FloatingWidget {
-    if (self.touch_editing and self.te_show_context_menu and self.focus_at_start and self.wd.visible()) {
+    if (self.touch_editing and self.te_show_context_menu and self.focus_at_start and self.data().visible()) {
         self.te_floating = dvui.FloatingWidget.init(@src(), .{});
 
         const r = dvui.windowRectScale().rectFromPhysical(dvui.clipGet());
         if (dvui.minSizeGet(self.te_floating.data().id)) |_| {
             const ms = dvui.minSize(self.te_floating.data().id, self.te_floating.data().options.min_sizeGet());
-            self.te_floating.wd.rect.w = ms.w;
-            self.te_floating.wd.rect.h = ms.h;
+            self.te_floating.data().rect.w = ms.w;
+            self.te_floating.data().rect.h = ms.h;
 
-            self.te_floating.wd.rect.x = r.x + r.w - self.te_floating.wd.rect.w;
-            self.te_floating.wd.rect.y = r.y - self.te_floating.wd.rect.h - self.wd.options.paddingGet().y;
+            self.te_floating.data().rect.x = r.x + r.w - self.te_floating.data().rect.w;
+            self.te_floating.data().rect.y = r.y - self.te_floating.data().rect.h - self.data().options.paddingGet().y;
 
-            self.te_floating.wd.rect = .cast(dvui.placeOnScreen(dvui.windowRect(), .{ .x = self.te_floating.wd.rect.x, .y = self.te_floating.wd.rect.y }, .vertical, .cast(self.te_floating.wd.rect)));
+            self.te_floating.data().rect = .cast(dvui.placeOnScreen(dvui.windowRect(), .{ .x = self.te_floating.data().rect.x, .y = self.te_floating.data().rect.y }, .vertical, .cast(self.te_floating.data().rect)));
         } else {
             // need another frame to get our min size
-            dvui.refresh(null, @src(), self.te_floating.wd.id);
+            dvui.refresh(null, @src(), self.te_floating.data().id);
         }
 
         self.te_floating.install();
@@ -1478,9 +1478,9 @@ pub fn rectFor(self: *TextLayoutWidget, id: dvui.WidgetId, min_size: Size, e: Op
     // For corner widgets, they might want to be closer to the border than the
     // text, so fit them without padding, but then need to adjust origin
     // because screenRectScale assumes we placed in the contentRect
-    var ret = dvui.placeIn(self.wd.backgroundRect().justSize(), min_size, e, g);
-    ret.x -= self.wd.options.paddingGet().x;
-    ret.y -= self.wd.options.paddingGet().y;
+    var ret = dvui.placeIn(self.data().backgroundRect().justSize(), min_size, e, g);
+    ret.x -= self.data().options.paddingGet().x;
+    ret.y -= self.data().options.paddingGet().y;
 
     const i: usize = if (g.y < 0.5) if (g.x < 0.5)
         0 // upleft
@@ -1497,7 +1497,7 @@ pub fn rectFor(self: *TextLayoutWidget, id: dvui.WidgetId, min_size: Size, e: Op
 }
 
 pub fn screenRectScale(self: *TextLayoutWidget, rect: Rect) RectScale {
-    return self.wd.contentRectScale().rectToRectScale(rect);
+    return self.data().contentRectScale().rectToRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *TextLayoutWidget, s: Size) void {
@@ -1524,7 +1524,7 @@ pub fn matchEvent(self: *TextLayoutWidget, e: *Event) bool {
     if (self.touch_editing and e.evt == .mouse and e.evt.mouse.action == .release and e.evt.mouse.button.touch()) {
         self.te_show_draggables = true;
         self.te_show_context_menu = true;
-        dvui.refresh(null, @src(), self.wd.id);
+        dvui.refresh(null, @src(), self.data().id);
     }
 
     return dvui.eventMatchSimple(e, self.data());
@@ -1546,7 +1546,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event) void {
             if (me.action == .focus) {
                 e.handle(@src(), self.data());
                 // focus so that we can receive keyboard input
-                dvui.focusWidget(self.wd.id, null, e.num);
+                dvui.focusWidget(self.data().id, null, e.num);
             } else if (me.action == .press and me.button.pointer()) {
                 e.handle(@src(), self.data());
                 // capture and start drag
@@ -1559,11 +1559,11 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event) void {
                         self.te_show_context_menu = false;
 
                         // need to refresh draggables
-                        dvui.refresh(null, @src(), self.wd.id);
+                        dvui.refresh(null, @src(), self.data().id);
                     }
                 } else {
                     // a click always sets sel_move - has the highest priority
-                    const p = self.wd.contentRectScale().pointFromPhysical(me.p);
+                    const p = self.data().contentRectScale().pointFromPhysical(me.p);
                     self.sel_move = .{ .mouse = .{ .down_pt = p } };
                     self.scroll_to_cursor = true;
 
@@ -1578,10 +1578,10 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event) void {
             } else if (me.action == .release and me.button.pointer()) {
                 e.handle(@src(), self.data());
 
-                if (dvui.captured(self.wd.id)) {
+                if (dvui.captured(self.data().id)) {
                     if (!self.touch_editing and dvui.dragging(me.p) == null) {
                         // click without drag
-                        self.click_pt = self.wd.contentRectScale().pointFromPhysical(me.p);
+                        self.click_pt = self.data().contentRectScale().pointFromPhysical(me.p);
 
                         self.click_num += 1;
                         if (self.click_num == 4) {
@@ -1592,7 +1592,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event) void {
                     if (me.button.touch()) {
                         // this was a touch-release without drag, which transitions
                         // us between touch editing
-                        const p = self.wd.contentRectScale().pointFromPhysical(me.p);
+                        const p = self.data().contentRectScale().pointFromPhysical(me.p);
 
                         if (self.te_focus_on_touchdown) {
                             self.touch_editing = !self.touch_editing;
@@ -1616,28 +1616,28 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event) void {
                                 self.sel_move = .{ .expand_pt = .{ .which = .word, .pt = p } };
                             }
                         }
-                        dvui.refresh(null, @src(), self.wd.id);
+                        dvui.refresh(null, @src(), self.data().id);
                     }
 
                     dvui.captureMouse(null);
                     dvui.dragEnd();
                 }
-            } else if (me.action == .motion and dvui.captured(self.wd.id)) {
+            } else if (me.action == .motion and dvui.captured(self.data().id)) {
                 if (dvui.dragging(me.p)) |_| {
                     self.click_num = 0;
                     if (!me.button.touch()) {
                         e.handle(@src(), self.data());
                         if (self.sel_move == .mouse) {
-                            self.sel_move.mouse.drag_pt = self.wd.contentRectScale().pointFromPhysical(me.p);
+                            self.sel_move.mouse.drag_pt = self.data().contentRectScale().pointFromPhysical(me.p);
                         } else if (self.sel_move == .expand_pt) {
-                            self.sel_move.expand_pt.pt = self.wd.contentRectScale().pointFromPhysical(me.p);
+                            self.sel_move.expand_pt.pt = self.data().contentRectScale().pointFromPhysical(me.p);
                             self.sel_move.expand_pt.done = false;
                             self.sel_move.expand_pt.dragging = true;
                         }
                         dvui.scrollDrag(.{
                             .mouse_pt = me.p,
-                            .screen_rect = self.wd.rectScale().r,
-                            .capture_id = self.wd.id,
+                            .screen_rect = self.data().rectScale().r,
+                            .capture_id = self.data().id,
                         });
                     } else {
                         // user intended to scroll with a finger swipe
@@ -1648,7 +1648,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event) void {
             } else if (me.action == .motion) {
                 self.click_num = 0;
             } else if (me.action == .position) {
-                self.cursor_pt = self.wd.contentRectScale().pointFromPhysical(me.p);
+                self.cursor_pt = self.data().contentRectScale().pointFromPhysical(me.p);
             }
         },
         .key => |ke| blk: {
@@ -1786,33 +1786,33 @@ pub fn deinit(self: *TextLayoutWidget) void {
         }
     }
 
-    dvui.dataSet(null, self.wd.id, "_touch_editing", self.touch_editing);
-    dvui.dataSet(null, self.wd.id, "_te_first", self.te_first);
-    dvui.dataSet(null, self.wd.id, "_te_show_draggables", self.te_show_draggables);
-    dvui.dataSet(null, self.wd.id, "_te_show_context_menu", self.te_show_context_menu);
-    dvui.dataSet(null, self.wd.id, "_te_focus_on_touchdown", self.te_focus_on_touchdown);
-    dvui.dataSet(null, self.wd.id, "_sel_start_r", self.sel_start_r);
-    dvui.dataSet(null, self.wd.id, "_sel_end_r", self.sel_end_r);
-    dvui.dataSet(null, self.wd.id, "_selection", self.selection.*);
+    dvui.dataSet(null, self.data().id, "_touch_editing", self.touch_editing);
+    dvui.dataSet(null, self.data().id, "_te_first", self.te_first);
+    dvui.dataSet(null, self.data().id, "_te_show_draggables", self.te_show_draggables);
+    dvui.dataSet(null, self.data().id, "_te_show_context_menu", self.te_show_context_menu);
+    dvui.dataSet(null, self.data().id, "_te_focus_on_touchdown", self.te_focus_on_touchdown);
+    dvui.dataSet(null, self.data().id, "_sel_start_r", self.sel_start_r);
+    dvui.dataSet(null, self.data().id, "_sel_end_r", self.sel_end_r);
+    dvui.dataSet(null, self.data().id, "_selection", self.selection.*);
 
     if (self.scroll_to_cursor_next_frame) {
-        dvui.dataSet(null, self.wd.id, "_scroll_to_cursor", true);
+        dvui.dataSet(null, self.data().id, "_scroll_to_cursor", true);
     }
 
-    if (dvui.captured(self.wd.id)) {
+    if (dvui.captured(self.data().id)) {
         if (self.sel_move == .mouse) {
             // once we figure out where the mousedown was, we need to save it
             // as long as we are dragging
-            dvui.dataSet(null, self.wd.id, "_sel_move_mouse_byte", self.sel_move.mouse.byte.?);
+            dvui.dataSet(null, self.data().id, "_sel_move_mouse_byte", self.sel_move.mouse.byte.?);
         } else if (self.sel_move == .expand_pt and (self.sel_move.expand_pt.which == .word or self.sel_move.expand_pt.which == .line)) {
-            dvui.dataSet(null, self.wd.id, "_sel_move_expand_pt_which", self.sel_move.expand_pt.which);
-            dvui.dataSet(null, self.wd.id, "_sel_move_expand_pt_bytes", self.sel_move.expand_pt.bytes);
+            dvui.dataSet(null, self.data().id, "_sel_move_expand_pt_which", self.sel_move.expand_pt.which);
+            dvui.dataSet(null, self.data().id, "_sel_move_expand_pt_bytes", self.sel_move.expand_pt.bytes);
         }
     }
     if (self.click_num == 0) {
-        dvui.dataRemove(null, self.wd.id, "_click_num");
+        dvui.dataRemove(null, self.data().id, "_click_num");
     } else {
-        dvui.dataSet(null, self.wd.id, "_click_num", self.click_num);
+        dvui.dataSet(null, self.data().id, "_click_num", self.click_num);
     }
     dvui.clipSet(self.prevClip);
 
@@ -1820,12 +1820,12 @@ pub fn deinit(self: *TextLayoutWidget) void {
     const left_height = (self.corners_min_size[0] orelse Size{}).h + (self.corners_min_size[2] orelse Size{}).h;
     const right_height = (self.corners_min_size[1] orelse Size{}).h + (self.corners_min_size[3] orelse Size{}).h;
     // adjust for corner widgets not being inside textLayout's padding
-    const padded = self.wd.options.padSize(.{ .h = @max(left_height, right_height) }).padNeg(self.wd.options.paddingGet());
-    self.wd.min_size.h = @max(self.wd.min_size.h, padded.h);
+    const padded = self.data().options.padSize(.{ .h = @max(left_height, right_height) }).padNeg(self.data().options.paddingGet());
+    self.data().min_size.h = @max(self.data().min_size.h, padded.h);
 
-    self.wd.minSizeSetAndRefresh();
-    self.wd.minSizeReportToParent();
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
+    dvui.parentReset(self.data().id, self.data().parent);
     self.* = undefined;
 }
 

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -1469,7 +1469,7 @@ pub fn widget(self: *TextLayoutWidget) Widget {
 }
 
 pub fn data(self: *TextLayoutWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *TextLayoutWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/widgets/VirtualParentWidget.zig
+++ b/src/widgets/VirtualParentWidget.zig
@@ -25,7 +25,7 @@ pub fn init(src: std.builtin.SourceLocation, opts: Options) VirtualParentWidget 
 
 pub fn install(self: *VirtualParentWidget) void {
     dvui.parentSet(self.widget());
-    self.wd.register();
+    self.data().register();
 }
 
 pub fn widget(self: *VirtualParentWidget) Widget {
@@ -37,7 +37,7 @@ pub fn data(self: *VirtualParentWidget) *WidgetData {
 }
 
 pub fn rectFor(self: *VirtualParentWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
-    const ret = self.wd.parent.rectFor(id, min_size, e, g);
+    const ret = self.data().parent.rectFor(id, min_size, e, g);
     if (self.child_rect_union) |u| {
         self.child_rect_union = u.unionWith(ret);
     } else {
@@ -47,19 +47,19 @@ pub fn rectFor(self: *VirtualParentWidget, id: dvui.WidgetId, min_size: Size, e:
 }
 
 pub fn screenRectScale(self: *VirtualParentWidget, rect: Rect) RectScale {
-    return self.wd.parent.screenRectScale(rect);
+    return self.data().parent.screenRectScale(rect);
 }
 
 pub fn minSizeForChild(self: *VirtualParentWidget, s: Size) void {
-    self.wd.parent.minSizeForChild(s);
+    self.data().parent.minSizeForChild(s);
 }
 
 pub fn deinit(self: *VirtualParentWidget) void {
     defer dvui.widgetFree(self);
     if (self.child_rect_union) |u| {
-        dvui.dataSet(null, self.wd.id, "_rect", u);
+        dvui.dataSet(null, self.data().id, "_rect", u);
     }
-    dvui.parentReset(self.wd.id, self.wd.parent);
+    dvui.parentReset(self.data().id, self.data().parent);
     self.* = undefined;
 }
 

--- a/src/widgets/VirtualParentWidget.zig
+++ b/src/widgets/VirtualParentWidget.zig
@@ -33,7 +33,7 @@ pub fn widget(self: *VirtualParentWidget) Widget {
 }
 
 pub fn data(self: *VirtualParentWidget) *WidgetData {
-    return &self.wd;
+    return self.wd.validate();
 }
 
 pub fn rectFor(self: *VirtualParentWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {


### PR DESCRIPTION
## Description
 - Adds an .undef element to WidgetId enum.
 - Adds validate() to WidgetData
 - Added validation of Widget Id to all data() returns of *WidgetData by calling validate()
 - Changes all instances of self.wd to self.data() except in widget init() functions.

 ## Discussion
1. Zig really doesn't want people to compare to undefined. Encoding the undefined value directly was the cleanest of all the tricks I tried. 
2. Comparing to undefined is unchecked illegal behavior and may not work in the future. 
3. The check is in an assert, so it will only impact safe build modes.
4. The rule I decided was that self.wd is allowed in init() and data(), but everywhere else should use self.data(). The exception to this is if self.wd is assigned or created within a non init() function. Then we can assume self.wd is valid for the remainder of the function.
5. validate() returning a *WidgetData seems nice to me. But it does require a `@constCast()` to allow this chaining.
6. This is draft until I review and double-check the changes.
7. All of the demo appears to work, except for the 2 issues noted below.
8. Removing the inline from validate() gives better error messages. Better errors are good, so I'll remove the inline before merging. Maybe only use this for debug and provide an inline one that just returns the WidgetData for release modes (including safe?)
9. What deters future widget writers and users from just using wd instead of data? Not something for this PR, but worth thinking about.
10. I need to check why I needed to make data() *const Self.
```
C:\Users\phatc\AppData\Roaming\Code\User\globalStorage\ziglang.vscode-zig\zig\x86_64-windows-0.14.1\lib\std\debug.zig:550:14: 0x7ff78f94949d in assert (sdl2-standalone.exe.obj)
    if (!ok) unreachable; // assertion failure
C:\src\dvui-dev\src\widgets\LabelWidget.zig:95:28: 0x7ff78faa58db in data (sdl2-standalone.exe.obj)       
    return self.wd.validate();
```
vs
```
C:\Users\phatc\AppData\Roaming\Code\User\globalStorage\ziglang.vscode-zig\zig\x86_64-windows-0.14.1\lib\std\debug.zig:550:14: 0x7ff78f94949d in assert (sdl2-standalone.exe.obj)
    if (!ok) unreachable; // assertion failure
             ^
C:\src\dvui-dev\src\WidgetData.zig:327:21: 0x7ff78f9f5776 in validate (sdl2-standalone.exe.obj)
    std.debug.assert(self.id != WidgetId.undef); // Indicates a use after deinit() error.
                    ^
C:\src\dvui-dev\src\widgets\LabelWidget.zig:95:28: 0x7ff78faa58db in data (sdl2-standalone.exe.obj)       
    return self.wd.validate();
```

Implements: #423
