### PR TITLE
Unmanaged containers and removal unnecessary default undefined values 

### DIFF
--- a/src/Font.zig
+++ b/src/Font.zig
@@ -140,14 +140,14 @@ pub const TTFBytes = struct {
     //pub const OpenDyslexicBdIt = @embedFile("fonts/OpenDyslexic/compiled/OpenDyslexic-Bold-Italic.otf");
 };
 
-pub fn initTTFBytesDatabase(allocator: std.mem.Allocator) std.mem.Allocator.Error!std.StringHashMap(dvui.FontBytesEntry) {
-    var result = std.StringHashMap(dvui.FontBytesEntry).init(allocator);
+pub fn initTTFBytesDatabase(allocator: std.mem.Allocator) std.mem.Allocator.Error!std.StringHashMapUnmanaged(dvui.FontBytesEntry) {
+    var result: std.StringHashMapUnmanaged(dvui.FontBytesEntry) = .empty;
     inline for (@typeInfo(TTFBytes).@"struct".decls) |decl| {
-        try result.putNoClobber(decl.name, dvui.FontBytesEntry{ .ttf_bytes = @field(TTFBytes, decl.name), .allocator = null });
+        try result.putNoClobber(allocator, decl.name, dvui.FontBytesEntry{ .ttf_bytes = @field(TTFBytes, decl.name), .allocator = null });
     }
 
     if (!dvui.wasm) {
-        try result.putNoClobber("Noto", dvui.FontBytesEntry{ .ttf_bytes = @embedFile("fonts/NotoSansKR-Regular.ttf"), .allocator = null });
+        try result.putNoClobber(allocator, "Noto", dvui.FontBytesEntry{ .ttf_bytes = @embedFile("fonts/NotoSansKR-Regular.ttf"), .allocator = null });
     }
 
     return result;

--- a/src/ScrollInfo.zig
+++ b/src/ScrollInfo.zig
@@ -142,12 +142,11 @@ pub fn scrollPage(self: *ScrollInfo, dir: enums.Direction, up: bool) void {
     // the last page is offset fraction 1.0, so there is
     // one less scroll position between 0 and 1.0
     fi = 1.0 / ((1.0 / fi) - 1);
-    var f: f32 = undefined;
-    if (up) {
-        f = self.offsetFraction(dir) - fi;
-    } else {
-        f = self.offsetFraction(dir) + fi;
-    }
+    const f: f32 = if (up)
+        self.offsetFraction(dir) - fi
+    else
+        self.offsetFraction(dir) + fi;
+
     self.scrollToFraction(dir, f);
 }
 

--- a/src/Vertex.zig
+++ b/src/Vertex.zig
@@ -2,7 +2,7 @@ const dvui = @import("dvui.zig");
 
 pos: dvui.Point.Physical,
 col: dvui.Color.PMA,
-uv: @Vector(2, f32),
+uv: @Vector(2, f32) = @splat(0),
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -16,49 +16,47 @@ pub const InitOptions = struct {
     subwindow: bool = false,
 };
 
-id: WidgetId = undefined,
-parent: Widget = undefined,
-init_options: InitOptions = undefined,
-rect: Rect = Rect{},
-min_size: Size = Size{},
-options: Options = undefined,
+id: WidgetId,
+parent: Widget,
+init_options: InitOptions,
+rect: Rect,
+min_size: Size,
+options: Options,
 src: std.builtin.SourceLocation,
 rect_scale_cache: ?RectScale = null,
 
-pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Options) WidgetData {
-    var self = WidgetData{ .src = src };
-    self.init_options = init_options;
-    self.options = opts;
+pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, options: Options) WidgetData {
+    const parent = dvui.parentGet();
+    const id = parent.extendId(src, options.idExtra());
+    const min_size = options.min_sizeGet().min(options.max_sizeGet());
 
-    self.parent = dvui.parentGet();
-    self.id = self.parent.extendId(src, opts.idExtra());
+    const ms = dvui.minSize(id, min_size);
 
-    self.min_size = self.options.min_sizeGet();
-    self.min_size = self.min_size.min(self.options.max_sizeGet());
-
-    const ms = dvui.minSize(self.id, self.min_size);
-
-    if (self.options.rect) |r| {
-        self.rect = r;
-        if (self.options.expandGet().isHorizontal()) {
-            self.rect.w = self.parent.data().contentRect().w;
-        } else if (self.rect.w == 0) {
-            self.rect.w = ms.w;
+    const rect = if (options.rect) |r|
+        r.toSize(.{
+            .w = if (options.expandGet().isHorizontal())
+                parent.data().contentRect().w
+            else if (r.w == 0) ms.w else r.w,
+            .h = if (options.expandGet().isVertical())
+                parent.data().contentRect().h
+            else if (r.h == 0) ms.h else r.h,
+        })
+    else blk: {
+        if (options.expandGet() == .ratio and (ms.w == 0 or ms.h == 0)) {
+            dvui.log.debug("rectFor {x} expand is .ratio but min size is zero\n", .{id});
         }
+        break :blk parent.rectFor(id, ms, options.expandGet(), options.gravityGet());
+    };
 
-        if (self.options.expandGet().isVertical()) {
-            self.rect.h = self.parent.data().contentRect().h;
-        } else if (self.rect.h == 0) {
-            self.rect.h = ms.h;
-        }
-    } else {
-        if (self.options.expandGet() == .ratio and (ms.w == 0 or ms.h == 0)) {
-            dvui.log.debug("rectFor {x} expand is .ratio but min size is zero\n", .{self.id});
-        }
-        self.rect = self.parent.rectFor(self.id, ms, self.options.expandGet(), self.options.gravityGet());
-    }
-
-    return self;
+    return .{
+        .id = id,
+        .parent = parent,
+        .init_options = init_options,
+        .min_size = min_size,
+        .rect = rect,
+        .options = options,
+        .src = src,
+    };
 }
 
 pub fn register(self: *WidgetData) void {

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -15,7 +15,8 @@ previous_window: ?*Window = null,
 
 /// list of subwindows including base, later windows are on top of earlier
 /// windows
-subwindows: std.ArrayList(Subwindow),
+/// Uses `gpa` allocator
+subwindows: std.ArrayListUnmanaged(Subwindow) = .empty,
 
 /// id of the subwindow widgets are being added to
 subwindow_currentId: WidgetId = .zero,
@@ -39,6 +40,7 @@ text_input_rect: ?Rect.Natural = null,
 snap_to_pixels: bool = true,
 alpha: f32 = 1.0,
 
+/// Uses `arena` allocator
 events: std.ArrayListUnmanaged(Event) = .{},
 event_num: u16 = 0,
 /// mouse_pt tracks the last position we got a mouse event for
@@ -74,26 +76,40 @@ secs_since_last_frame: f32 = 0,
 extra_frames_needed: u8 = 0,
 clipRect: dvui.Rect.Physical = .{},
 
-// SAFETY: Is set by `init` after the theme map has been created
-theme: Theme = undefined,
+theme: Theme,
 
+/// Uses `gpa` allocator
 min_sizes: dvui.TrackingAutoHashMap(WidgetId, Size, .put_only) = .empty,
+/// Uses `gpa` allocator
 tags: dvui.TrackingAutoHashMap([]const u8, dvui.TagData, .put_only) = .empty,
 data_mutex: std.Thread.Mutex = .{},
+/// Uses `gpa` allocator
 datas: dvui.TrackingAutoHashMap(u64, SavedData, .get_and_put) = .empty,
-datas_trash: std.ArrayList(SavedData) = undefined,
+/// Uses `arena` allocator
+datas_trash: std.ArrayListUnmanaged(SavedData) = .empty,
+/// Uses `gpa` allocator
 animations: dvui.TrackingAutoHashMap(u64, Animation, .get_and_put) = .empty,
-tab_index_prev: std.ArrayList(dvui.TabIndex),
-tab_index: std.ArrayList(dvui.TabIndex),
+/// Uses `gpa` allocator
+tab_index_prev: std.ArrayListUnmanaged(dvui.TabIndex) = .empty,
+/// Uses `gpa` allocator
+tab_index: std.ArrayListUnmanaged(dvui.TabIndex) = .empty,
+/// Uses `gpa` allocator
 font_cache: dvui.TrackingAutoHashMap(u64, dvui.FontCacheEntry, .get_and_put) = .empty,
-font_bytes: std.StringHashMap(dvui.FontBytesEntry),
+/// Uses `gpa` allocator
+font_bytes: std.StringHashMapUnmanaged(dvui.FontBytesEntry) = .empty,
+/// Uses `gpa` allocator
 texture_cache: dvui.TrackingAutoHashMap(u64, dvui.TextureCacheEntry, .get_and_put) = .empty,
-texture_trash: std.ArrayList(dvui.Texture) = undefined,
+/// Uses `arena` allocator
+texture_trash: std.ArrayListUnmanaged(dvui.Texture) = .empty,
 dialog_mutex: std.Thread.Mutex = .{},
-dialogs: std.ArrayList(Dialog),
-toasts: std.ArrayList(Toast),
-keybinds: std.StringHashMap(dvui.enums.Keybind),
-themes: std.StringArrayHashMap(Theme),
+/// Uses `gpa` allocator
+dialogs: std.ArrayListUnmanaged(Dialog) = .empty,
+/// Uses `gpa` allocator
+toasts: std.ArrayListUnmanaged(Toast) = .empty,
+/// Uses `gpa` allocator
+keybinds: std.StringHashMapUnmanaged(dvui.enums.Keybind) = .empty,
+/// Uses `gpa` allocator
+themes: std.StringArrayHashMapUnmanaged(Theme) = .empty,
 
 cursor_requested: ?dvui.enums.Cursor = null,
 cursor_dragging: ?dvui.enums.Cursor = null,
@@ -139,11 +155,13 @@ debug_touch_simulate_down: bool = false,
 
 pub const Subwindow = struct {
     id: WidgetId,
-    rect: Rect = Rect{},
-    rect_pixels: dvui.Rect.Physical = .{},
+    rect: Rect,
+    rect_pixels: dvui.Rect.Physical,
     focused_widgetId: ?WidgetId = null,
-    render_cmds: std.ArrayList(dvui.RenderCommand),
-    render_cmds_after: std.ArrayList(dvui.RenderCommand),
+    /// Uses `arena` allocator
+    render_cmds: std.ArrayListUnmanaged(dvui.RenderCommand) = .empty,
+    /// Uses `arena` allocator
+    render_cmds_after: std.ArrayListUnmanaged(dvui.RenderCommand) = .empty,
     used: bool = true,
     modal: bool = false,
     stay_above_parent_window: ?WidgetId = null,
@@ -191,12 +209,6 @@ pub fn init(
         ._arena = init_opts.arena orelse .init(gpa),
         ._lifo_arena = .init(gpa),
         ._widget_stack = .init(gpa),
-        .subwindows = .init(gpa),
-        .tab_index_prev = .init(gpa),
-        .tab_index = .init(gpa),
-        .dialogs = .init(gpa),
-        .toasts = .init(gpa),
-        .keybinds = .init(gpa),
         .wd = WidgetData{
             .src = src,
             .id = hashval,
@@ -211,11 +223,11 @@ pub fn init(
         },
         .backend = backend_ctx,
         .font_bytes = try dvui.Font.initTTFBytesDatabase(gpa),
-        .themes = .init(gpa),
+        .theme = if (init_opts.theme) |t| t.* else @import("themes/Adwaita.zig").light,
     };
 
-    try self.themes.putNoClobber("Adwaita Light", @import("themes/Adwaita.zig").light);
-    try self.themes.putNoClobber("Adwaita Dark", @import("themes/Adwaita.zig").dark);
+    try self.themes.putNoClobber(self.gpa, "Adwaita Light", @import("themes/Adwaita.zig").light);
+    try self.themes.putNoClobber(self.gpa, "Adwaita Dark", @import("themes/Adwaita.zig").dark);
 
     inline for (@typeInfo(Theme.QuickTheme.builtin).@"struct".decls) |decl| {
         const quick_theme = Theme.QuickTheme.fromString(self.arena(), @field(Theme.QuickTheme.builtin, decl.name)) catch {
@@ -223,22 +235,17 @@ pub fn init(
         };
         defer quick_theme.deinit();
         const theme = try quick_theme.value.toTheme(self.gpa);
-        try self.themes.putNoClobber(theme.name, theme);
+        try self.themes.putNoClobber(self.gpa, theme.name, theme);
     }
 
     // Sort themes alphabetically
     const Context = struct {
-        hashmap: *std.StringArrayHashMap(Theme),
+        hashmap: *std.StringArrayHashMapUnmanaged(Theme),
         pub fn lessThan(ctx: @This(), lhs: usize, rhs: usize) bool {
             return std.ascii.orderIgnoreCase(ctx.hashmap.values()[lhs].name, ctx.hashmap.values()[rhs].name) == .lt;
         }
     };
     self.themes.sort(Context{ .hashmap = &self.themes });
-    if (init_opts.theme) |t| {
-        self.theme = t.*;
-    } else {
-        self.theme = self.themes.get("Adwaita Light").?;
-    }
 
     try self.initEvents();
 
@@ -251,91 +258,91 @@ pub fn init(
     };
 
     if (kb == .windows or kb == .mac) {
-        try self.keybinds.putNoClobber("activate", .{ .key = .enter, .also = "activate_1" });
-        try self.keybinds.putNoClobber("activate_1", .{ .key = .space });
+        try self.keybinds.putNoClobber(self.gpa, "activate", .{ .key = .enter, .also = "activate_1" });
+        try self.keybinds.putNoClobber(self.gpa, "activate_1", .{ .key = .space });
 
-        try self.keybinds.putNoClobber("next_widget", .{ .key = .tab, .shift = false });
-        try self.keybinds.putNoClobber("prev_widget", .{ .key = .tab, .shift = true });
+        try self.keybinds.putNoClobber(self.gpa, "next_widget", .{ .key = .tab, .shift = false });
+        try self.keybinds.putNoClobber(self.gpa, "prev_widget", .{ .key = .tab, .shift = true });
     }
 
     switch (kb) {
         .none => {},
         .windows => {
             // zig fmt: off
-                try self.keybinds.putNoClobber("cut",        .{ .key = .x, .control = true });
-                try self.keybinds.putNoClobber("copy",       .{ .key = .c, .control = true });
-                try self.keybinds.putNoClobber("paste",      .{ .key = .v, .control = true });
-                try self.keybinds.putNoClobber("select_all", .{ .key = .a, .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "cut",        .{ .key = .x, .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "copy",       .{ .key = .c, .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "paste",      .{ .key = .v, .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "select_all", .{ .key = .a, .control = true });
 
                 // use with mod.matchBind
-                try self.keybinds.putNoClobber("ctrl/cmd",   .{ .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "ctrl/cmd",   .{ .control = true });
 
-                try self.keybinds.putNoClobber("text_start",        .{ .key = .home, .shift = false, .control = true });
-                try self.keybinds.putNoClobber("text_end",          .{ .key = .end,  .shift = false, .control = true });
-                try self.keybinds.putNoClobber("text_start_select", .{ .key = .home, .shift = true,  .control = true });
-                try self.keybinds.putNoClobber("text_end_select",   .{ .key = .end,  .shift = true,  .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "text_start",        .{ .key = .home, .shift = false, .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "text_end",          .{ .key = .end,  .shift = false, .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "text_start_select", .{ .key = .home, .shift = true,  .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "text_end_select",   .{ .key = .end,  .shift = true,  .control = true });
 
-                try self.keybinds.putNoClobber("line_start",        .{ .key = .home, .shift = false, .control = false });
-                try self.keybinds.putNoClobber("line_end",          .{ .key = .end,  .shift = false, .control = false });
-                try self.keybinds.putNoClobber("line_start_select", .{ .key = .home, .shift = true,  .control = false });
-                try self.keybinds.putNoClobber("line_end_select",   .{ .key = .end,  .shift = true,  .control = false });
+                try self.keybinds.putNoClobber(self.gpa, "line_start",        .{ .key = .home, .shift = false, .control = false });
+                try self.keybinds.putNoClobber(self.gpa, "line_end",          .{ .key = .end,  .shift = false, .control = false });
+                try self.keybinds.putNoClobber(self.gpa, "line_start_select", .{ .key = .home, .shift = true,  .control = false });
+                try self.keybinds.putNoClobber(self.gpa, "line_end_select",   .{ .key = .end,  .shift = true,  .control = false });
 
-                try self.keybinds.putNoClobber("word_left",         .{ .key = .left,  .shift = false, .control = true });
-                try self.keybinds.putNoClobber("word_right",        .{ .key = .right, .shift = false, .control = true });
-                try self.keybinds.putNoClobber("word_left_select",  .{ .key = .left,  .shift = true,  .control = true });
-                try self.keybinds.putNoClobber("word_right_select", .{ .key = .right, .shift = true,  .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "word_left",         .{ .key = .left,  .shift = false, .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "word_right",        .{ .key = .right, .shift = false, .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "word_left_select",  .{ .key = .left,  .shift = true,  .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "word_right_select", .{ .key = .right, .shift = true,  .control = true });
 
-                try self.keybinds.putNoClobber("char_left",         .{ .key = .left,  .shift = false, .control = false });
-                try self.keybinds.putNoClobber("char_right",        .{ .key = .right, .shift = false, .control = false });
-                try self.keybinds.putNoClobber("char_left_select",  .{ .key = .left,  .shift = true,  .control = false });
-                try self.keybinds.putNoClobber("char_right_select", .{ .key = .right, .shift = true,  .control = false });
+                try self.keybinds.putNoClobber(self.gpa, "char_left",         .{ .key = .left,  .shift = false, .control = false });
+                try self.keybinds.putNoClobber(self.gpa, "char_right",        .{ .key = .right, .shift = false, .control = false });
+                try self.keybinds.putNoClobber(self.gpa, "char_left_select",  .{ .key = .left,  .shift = true,  .control = false });
+                try self.keybinds.putNoClobber(self.gpa, "char_right_select", .{ .key = .right, .shift = true,  .control = false });
 
-                try self.keybinds.putNoClobber("char_up",          .{ .key = .up,   .shift = false });
-                try self.keybinds.putNoClobber("char_down",        .{ .key = .down, .shift = false });
-                try self.keybinds.putNoClobber("char_up_select",   .{ .key = .up,   .shift = true });
-                try self.keybinds.putNoClobber("char_down_select", .{ .key = .down, .shift = true });
+                try self.keybinds.putNoClobber(self.gpa, "char_up",          .{ .key = .up,   .shift = false });
+                try self.keybinds.putNoClobber(self.gpa, "char_down",        .{ .key = .down, .shift = false });
+                try self.keybinds.putNoClobber(self.gpa, "char_up_select",   .{ .key = .up,   .shift = true });
+                try self.keybinds.putNoClobber(self.gpa, "char_down_select", .{ .key = .down, .shift = true });
 
-                try self.keybinds.putNoClobber("delete_prev_word", .{ .key = .backspace, .control = true });
-                try self.keybinds.putNoClobber("delete_next_word", .{ .key = .delete,    .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "delete_prev_word", .{ .key = .backspace, .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "delete_next_word", .{ .key = .delete,    .control = true });
                 // zig fmt: on
         },
         .mac => {
             // zig fmt: off
-                try self.keybinds.putNoClobber("cut",        .{ .key = .x, .command = true });
-                try self.keybinds.putNoClobber("copy",       .{ .key = .c, .command = true });
-                try self.keybinds.putNoClobber("paste",      .{ .key = .v, .command = true });
-                try self.keybinds.putNoClobber("select_all", .{ .key = .a, .command = true });
+                try self.keybinds.putNoClobber(self.gpa, "cut",        .{ .key = .x, .command = true });
+                try self.keybinds.putNoClobber(self.gpa, "copy",       .{ .key = .c, .command = true });
+                try self.keybinds.putNoClobber(self.gpa, "paste",      .{ .key = .v, .command = true });
+                try self.keybinds.putNoClobber(self.gpa, "select_all", .{ .key = .a, .command = true });
 
                 // use with mod.matchBind
-                try self.keybinds.putNoClobber("ctrl/cmd",   .{ .command = true });
+                try self.keybinds.putNoClobber(self.gpa, "ctrl/cmd",   .{ .command = true });
 
-                try self.keybinds.putNoClobber("text_start",        .{ .key = .up,   .shift = false, .command = true });
-                try self.keybinds.putNoClobber("text_end",          .{ .key = .down, .shift = false, .command = true });
-                try self.keybinds.putNoClobber("text_start_select", .{ .key = .up,   .shift = true,  .command = true });
-                try self.keybinds.putNoClobber("text_end_select",   .{ .key = .down, .shift = true,  .command = true });
+                try self.keybinds.putNoClobber(self.gpa, "text_start",        .{ .key = .up,   .shift = false, .command = true });
+                try self.keybinds.putNoClobber(self.gpa, "text_end",          .{ .key = .down, .shift = false, .command = true });
+                try self.keybinds.putNoClobber(self.gpa, "text_start_select", .{ .key = .up,   .shift = true,  .command = true });
+                try self.keybinds.putNoClobber(self.gpa, "text_end_select",   .{ .key = .down, .shift = true,  .command = true });
 
-                try self.keybinds.putNoClobber("line_start",        .{ .key = .left,  .shift = false, .command = true });
-                try self.keybinds.putNoClobber("line_end",          .{ .key = .right, .shift = false, .command = true });
-                try self.keybinds.putNoClobber("line_start_select", .{ .key = .left,  .shift = true,  .command = true });
-                try self.keybinds.putNoClobber("line_end_select",   .{ .key = .right, .shift = true,  .command = true });
+                try self.keybinds.putNoClobber(self.gpa, "line_start",        .{ .key = .left,  .shift = false, .command = true });
+                try self.keybinds.putNoClobber(self.gpa, "line_end",          .{ .key = .right, .shift = false, .command = true });
+                try self.keybinds.putNoClobber(self.gpa, "line_start_select", .{ .key = .left,  .shift = true,  .command = true });
+                try self.keybinds.putNoClobber(self.gpa, "line_end_select",   .{ .key = .right, .shift = true,  .command = true });
 
-                try self.keybinds.putNoClobber("word_left",         .{ .key = .left,  .shift = false, .alt = true });
-                try self.keybinds.putNoClobber("word_right",        .{ .key = .right, .shift = false, .alt = true });
-                try self.keybinds.putNoClobber("word_left_select",  .{ .key = .left,  .shift = true,  .alt = true });
-                try self.keybinds.putNoClobber("word_right_select", .{ .key = .right, .shift = true,  .alt = true });
+                try self.keybinds.putNoClobber(self.gpa, "word_left",         .{ .key = .left,  .shift = false, .alt = true });
+                try self.keybinds.putNoClobber(self.gpa, "word_right",        .{ .key = .right, .shift = false, .alt = true });
+                try self.keybinds.putNoClobber(self.gpa, "word_left_select",  .{ .key = .left,  .shift = true,  .alt = true });
+                try self.keybinds.putNoClobber(self.gpa, "word_right_select", .{ .key = .right, .shift = true,  .alt = true });
 
-                try self.keybinds.putNoClobber("char_left",         .{ .key = .left,  .shift = false, .alt = false });
-                try self.keybinds.putNoClobber("char_right",        .{ .key = .right, .shift = false, .alt = false });
-                try self.keybinds.putNoClobber("char_left_select",  .{ .key = .left,  .shift = true,  .alt = false });
-                try self.keybinds.putNoClobber("char_right_select", .{ .key = .right, .shift = true,  .alt = false });
+                try self.keybinds.putNoClobber(self.gpa, "char_left",         .{ .key = .left,  .shift = false, .alt = false });
+                try self.keybinds.putNoClobber(self.gpa, "char_right",        .{ .key = .right, .shift = false, .alt = false });
+                try self.keybinds.putNoClobber(self.gpa, "char_left_select",  .{ .key = .left,  .shift = true,  .alt = false });
+                try self.keybinds.putNoClobber(self.gpa, "char_right_select", .{ .key = .right, .shift = true,  .alt = false });
 
-                try self.keybinds.putNoClobber("char_up",          .{ .key = .up,   .shift = false, .command = false });
-                try self.keybinds.putNoClobber("char_down",        .{ .key = .down, .shift = false, .command = false });
-                try self.keybinds.putNoClobber("char_up_select",   .{ .key = .up,   .shift = true,  .command = false });
-                try self.keybinds.putNoClobber("char_down_select", .{ .key = .down, .shift = true,  .command = false });
+                try self.keybinds.putNoClobber(self.gpa, "char_up",          .{ .key = .up,   .shift = false, .command = false });
+                try self.keybinds.putNoClobber(self.gpa, "char_down",        .{ .key = .down, .shift = false, .command = false });
+                try self.keybinds.putNoClobber(self.gpa, "char_up_select",   .{ .key = .up,   .shift = true,  .command = false });
+                try self.keybinds.putNoClobber(self.gpa, "char_down_select", .{ .key = .down, .shift = true,  .command = false });
 
-                try self.keybinds.putNoClobber("delete_prev_word", .{ .key = .backspace, .alt = true });
-                try self.keybinds.putNoClobber("delete_next_word", .{ .key = .delete,    .alt = true });
+                try self.keybinds.putNoClobber(self.gpa, "delete_prev_word", .{ .key = .backspace, .alt = true });
+                try self.keybinds.putNoClobber(self.gpa, "delete_next_word", .{ .key = .delete,    .alt = true });
                 // zig fmt: on
         },
     }
@@ -372,12 +379,12 @@ pub fn deinit(self: *Self) void {
     for (self.datas_trash.items) |sd| {
         sd.free(self.gpa);
     }
-    self.datas_trash.deinit();
+    self.datas_trash.deinit(self.arena());
 
     for (self.texture_trash.items) |tex| {
         self.backend.textureDestroy(tex);
     }
-    self.texture_trash.deinit();
+    self.texture_trash.deinit(self.arena());
 
     {
         var it = self.datas.iterator();
@@ -390,7 +397,7 @@ pub fn deinit(self: *Self) void {
         self.debug_under_mouse_info = "";
     }
 
-    self.subwindows.deinit();
+    self.subwindows.deinit(self.gpa);
     self.min_sizes.deinit(self.gpa);
 
     {
@@ -403,8 +410,8 @@ pub fn deinit(self: *Self) void {
     }
 
     self.animations.deinit(self.gpa);
-    self.tab_index_prev.deinit();
-    self.tab_index.deinit();
+    self.tab_index_prev.deinit(self.gpa);
+    self.tab_index.deinit(self.gpa);
 
     {
         var it = self.font_cache.iterator();
@@ -423,9 +430,9 @@ pub fn deinit(self: *Self) void {
         self.texture_cache.deinit(self.gpa);
     }
 
-    self.dialogs.deinit();
-    self.toasts.deinit();
-    self.keybinds.deinit();
+    self.dialogs.deinit(self.gpa);
+    self.toasts.deinit(self.gpa);
+    self.keybinds.deinit(self.gpa);
     self._arena.deinit();
     self._lifo_arena.deinit();
     self._widget_stack.deinit();
@@ -438,14 +445,14 @@ pub fn deinit(self: *Self) void {
             }
         }
     }
-    self.font_bytes.deinit();
+    self.font_bytes.deinit(self.gpa);
 
     {
         for (self.themes.values()) |*theme| {
             theme.deinit(self.gpa);
         }
     }
-    self.themes.deinit();
+    self.themes.deinit(self.gpa);
     self.* = undefined;
 }
 
@@ -972,8 +979,6 @@ pub fn begin(
     self: *Self,
     time_ns: i128,
 ) dvui.Backend.GenericError!void {
-    const larena = self.arena();
-
     var micros_since_last: u32 = 1;
     if (time_ns > self.frame_time_ns) {
         // enforce monotinicity
@@ -1012,8 +1017,8 @@ pub fn begin(
         self.debug_under_mouse_info = "";
     }
 
-    self.datas_trash = std.ArrayList(SavedData).init(larena);
-    self.texture_trash = std.ArrayList(dvui.Texture).init(larena);
+    self.datas_trash = .empty;
+    self.texture_trash = .empty;
 
     {
         var i: usize = 0;
@@ -1068,9 +1073,10 @@ pub fn begin(
         //std.debug.print("datas {d}\n", .{self.datas.count()});
     }
 
-    self.tab_index_prev.deinit();
-    self.tab_index_prev = self.tab_index;
-    self.tab_index = @TypeOf(self.tab_index).init(self.tab_index.allocator);
+    // Swap current and previous tab index lists
+    std.mem.swap(@TypeOf(self.tab_index), &self.tab_index, &self.tab_index_prev);
+    // Retain capacity because it's likely to be small and that the same capacity will be needed again
+    self.tab_index.clearRetainingCapacity();
 
     self.rect_pixels = .fromSize(self.backend.pixelSize());
     dvui.clipSet(self.rect_pixels);
@@ -1236,7 +1242,7 @@ pub fn textInputRequested(self: *const Self) ?Rect.Natural {
     return self.text_input_rect;
 }
 
-pub fn renderCommands(self: *Self, queue: std.ArrayList(dvui.RenderCommand)) !void {
+pub fn renderCommands(self: *Self, queue: []const dvui.RenderCommand) !void {
     const oldsnap = dvui.snapToPixels();
     defer _ = dvui.snapToPixelsSet(oldsnap);
 
@@ -1246,7 +1252,7 @@ pub fn renderCommands(self: *Self, queue: std.ArrayList(dvui.RenderCommand)) !vo
     const old_rendering = dvui.renderingSet(true);
     defer _ = dvui.renderingSet(old_rendering);
 
-    for (queue.items) |*drc| {
+    for (queue) |*drc| {
         _ = dvui.snapToPixelsSet(drc.snap);
         dvui.clipSet(drc.clip);
         switch (drc.cmd) {
@@ -1325,7 +1331,7 @@ pub fn dataSetAdvanced(self: *Self, id: WidgetId, key: []const u8, data_in: anyt
 
     if (previous_kv) |kv| {
         //std.debug.print("dataSet: already had data for id {x} key {s}, freeing previous data\n", .{ id, kv.key });
-        self.datas_trash.append(kv.value) catch |err| {
+        self.datas_trash.append(self.arena(), kv.value) catch |err| {
             log.err("Previous data could not be added to the trash, got {!} for id {x} key {s}\n", .{ err, id, key });
             return;
         };
@@ -1358,7 +1364,7 @@ pub fn dataRemove(self: *Self, id: WidgetId, key: []const u8) void {
     defer self.data_mutex.unlock();
 
     if (self.datas.fetchRemove(hash)) |dd| {
-        self.datas_trash.append(dd.value) catch |err| {
+        self.datas_trash.append(self.arena(), dd.value) catch |err| {
             log.err("Previous data could not be added to the trash, got {!} for id {x} key {s}\n", .{ err, id, key });
             return;
         };
@@ -1383,7 +1389,7 @@ pub fn dialogAdd(self: *Self, id: WidgetId, display: dvui.DialogDisplayFn) *std.
             break;
         }
     } else {
-        self.dialogs.append(Dialog{ .id = id, .display = display }) catch |err| {
+        self.dialogs.append(self.gpa, Dialog{ .id = id, .display = display }) catch |err| {
             dvui.logError(@src(), err, "Could not add dialog to the list", .{});
         };
     }
@@ -1464,7 +1470,7 @@ pub fn toastAdd(self: *Self, id: WidgetId, subwindow_id: ?WidgetId, display: dvu
             break;
         }
     } else {
-        self.toasts.append(Toast{ .id = id, .subwindow_id = subwindow_id, .display = display }) catch |err| {
+        self.toasts.append(self.gpa, Toast{ .id = id, .subwindow_id = subwindow_id, .display = display }) catch |err| {
             dvui.logError(@src(), err, "Could not add toast {x} to the list", .{id});
         };
     }
@@ -1624,15 +1630,17 @@ pub fn endRendering(self: *Self, opts: endOptions) void {
     }
 
     for (self.subwindows.items) |*sw| {
-        self.renderCommands(sw.render_cmds) catch |err| {
+        self.renderCommands(sw.render_cmds.items) catch |err| {
             dvui.logError(@src(), err, "Failed to render commands for subwindow {x}", .{sw.id});
         };
-        sw.render_cmds.clearAndFree();
+        // Set to empty because it's allocated on the arena and will be freed there
+        sw.render_cmds = .empty;
 
-        self.renderCommands(sw.render_cmds_after) catch |err| {
+        self.renderCommands(sw.render_cmds_after.items) catch |err| {
             dvui.logError(@src(), err, "Failed to render commands after for subwindow {x}", .{sw.id});
         };
-        sw.render_cmds_after.clearAndFree();
+        // Set to empty because it's allocated on the arena and will be freed there
+        sw.render_cmds_after = .empty;
     }
 
     self.end_rendering_done = true;
@@ -1654,12 +1662,14 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
     for (self.datas_trash.items) |sd| {
         sd.free(self.gpa);
     }
-    self.datas_trash.clearAndFree();
+    // Set to empty because it's allocated on the arena and will be freed there
+    self.datas_trash = .empty;
 
     for (self.texture_trash.items) |tex| {
         self.backend.textureDestroy(tex);
     }
-    self.texture_trash.clearAndFree();
+    // Set to empty because it's allocated on the arena and will be freed there
+    self.texture_trash = .empty;
 
     // events may have been tagged with a focus widget that never showed up
     const evts = dvui.events();

--- a/src/backends/raylib.zig
+++ b/src/backends/raylib.zig
@@ -18,10 +18,10 @@ pub const Context = *RaylibBackend;
 
 const log = std.log.scoped(.RaylibBackend);
 
-gpa: std.mem.Allocator = undefined,
+gpa: std.mem.Allocator,
 we_own_window: bool = false,
-shader: c.Shader = undefined,
-VAO: u32 = undefined,
+shader: c.Shader,
+VAO: u32,
 arena: std.mem.Allocator = undefined,
 log_events: bool = false,
 pressed_keys: std.bit_set.ArrayBitSet(u32, 512) = std.bit_set.ArrayBitSet(u32, 512).initEmpty(),
@@ -30,7 +30,7 @@ mouse_button_cache: [RaylibMouseButtons.len]bool = .{false} ** RaylibMouseButton
 touch_position_cache: c.Vector2 = .{ .x = 0, .y = 0 },
 dvui_consumed_events: bool = false,
 cursor_last: dvui.enums.Cursor = .arrow,
-frame_buffers: std.AutoArrayHashMap(u32, u32) = undefined,
+frame_buffers: std.AutoArrayHashMap(u32, u32),
 fb_width: ?c_int = null,
 fb_height: ?c_int = null,
 

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -252,7 +252,7 @@ export fn arena_u8(len: usize) [*c]u8 {
 
 export fn new_font(ptr: [*c]u8, len: usize) void {
     if (win_ok) {
-        win.font_bytes.put("Noto", dvui.FontBytesEntry{ .ttf_bytes = ptr[0..len], .allocator = gpa }) catch unreachable;
+        win.font_bytes.put(win.gpa, "Noto", dvui.FontBytesEntry{ .ttf_bytes = ptr[0..len], .allocator = gpa }) catch unreachable;
     }
 }
 

--- a/src/widgets/AnimateWidget.zig
+++ b/src/widgets/AnimateWidget.zig
@@ -24,8 +24,8 @@ pub const Kind = enum {
     horizontal,
 };
 
-wd: WidgetData = undefined,
-init_opts: InitOptions = undefined,
+wd: WidgetData,
+init_opts: InitOptions,
 val: ?f32 = null,
 
 prev_alpha: f32 = 1.0,

--- a/src/widgets/BoxWidget.zig
+++ b/src/widgets/BoxWidget.zig
@@ -31,28 +31,28 @@ const Data = struct {
     min_space_taken: f32,
 };
 
-wd: WidgetData = undefined,
-init_opts: InitOptions = undefined,
+wd: WidgetData,
+init_opts: InitOptions,
 max_space: f32 = 0, // equal_space max min size of child in direction
 max_thick: f32 = 0, // max min size of child against direction
-data_prev: ?Data = undefined,
+data_prev: ?Data,
 min_space_taken: f32 = 0,
 packed_children: f32 = 0,
 total_weight: f32 = 0,
 child_rect: Rect = Rect{},
 child_positioned: bool = false,
-ratio_extra: f32 = undefined,
-ran_off: bool = undefined,
-pixels_per_w: f32 = undefined,
+ratio_extra: f32 = 0,
+ran_off: bool = false,
+pixels_per_w: f32 = 0,
 
 pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Options) BoxWidget {
-    var self = BoxWidget{ .init_opts = init_options };
     const defaults = Options{ .name = "Box" };
-    self.wd = WidgetData.init(src, .{}, defaults.override(opts));
-    self.data_prev = dvui.dataGet(null, self.wd.id, "_data", Data);
-    self.ran_off = false;
-    self.pixels_per_w = 0;
-    return self;
+    const wd = WidgetData.init(src, .{}, defaults.override(opts));
+    return .{
+        .wd = wd,
+        .init_opts = init_options,
+        .data_prev = dvui.dataGet(null, wd.id, "_data", Data),
+    };
 }
 
 pub fn install(self: *BoxWidget) void {
@@ -148,9 +148,7 @@ pub fn rectFor(self: *BoxWidget, id: dvui.WidgetId, min_size: Size, e: Options.E
     // min size after ratio
     const child_min_size = ms;
 
-    var ret: Rect = undefined;
-
-    if (self.init_opts.equal_space) {
+    const ret: Rect = if (self.init_opts.equal_space) blk: {
         // position child inside the space we allocate for it
         switch (self.init_opts.dir) {
             .horizontal => {
@@ -158,18 +156,18 @@ pub fn rectFor(self: *BoxWidget, id: dvui.WidgetId, min_size: Size, e: Options.E
                 ms.h = available.h;
                 const avail = dvui.placeIn(available, ms, .none, g);
                 self.removeSpace(avail, g);
-                ret = dvui.placeIn(avail, child_min_size, e, g);
+                break :blk dvui.placeIn(avail, child_min_size, e, g);
             },
             .vertical => {
                 ms.h = self.pixels_per_w;
                 ms.w = available.w;
                 const avail = dvui.placeIn(available, ms, .none, g);
                 self.removeSpace(avail, g);
-                ret = dvui.placeIn(avail, child_min_size, e, g);
+                break :blk dvui.placeIn(avail, child_min_size, e, g);
             },
         }
-    } else {
-        // adjust min size for normal expand (since you only get prorated extra space)
+    } else blk: {
+        //  adjust min size for normal expand (since you only get prorated extra space)
         // - keep the expand in the non box direction
         var ee: Options.Expand = .none;
         switch (self.init_opts.dir) {
@@ -183,9 +181,10 @@ pub fn rectFor(self: *BoxWidget, id: dvui.WidgetId, min_size: Size, e: Options.E
             },
         }
 
-        ret = dvui.placeIn(available, ms, ee, g);
+        const ret = dvui.placeIn(available, ms, ee, g);
         self.removeSpace(ret, g);
-    }
+        break :blk ret;
+    };
 
     switch (self.init_opts.dir) {
         .horizontal => if (ret.w + 0.001 < child_min_size.w) {
@@ -240,25 +239,20 @@ pub fn minSizeForChild(self: *BoxWidget, s: Size) void {
 
 pub fn deinit(self: *BoxWidget) void {
     defer dvui.widgetFree(self);
-    var ms: Size = undefined;
-    var extra_space = false;
-    if (self.init_opts.dir == .horizontal) {
-        if (self.init_opts.equal_space) {
-            ms.w = self.max_space * self.packed_children;
-        } else {
-            ms.w = self.min_space_taken;
-        }
-        ms.h = self.max_thick;
-        extra_space = self.child_rect.w > 0.001;
-    } else {
-        if (self.init_opts.equal_space) {
-            ms.h = self.max_space * self.packed_children;
-        } else {
-            ms.h = self.min_space_taken;
-        }
-        ms.w = self.max_thick;
-        extra_space = self.child_rect.h > 0.001;
-    }
+    const extra_space = (if (self.init_opts.dir == .horizontal) self.child_rect.w else self.child_rect.h) > 0.001;
+    const ms: Size = if (self.init_opts.dir == .horizontal) .{
+        .w = if (self.init_opts.equal_space)
+            self.max_space * self.packed_children
+        else
+            self.min_space_taken,
+        .h = self.max_thick,
+    } else .{
+        .h = if (self.init_opts.equal_space)
+            self.max_space * self.packed_children
+        else
+            self.min_space_taken,
+        .w = self.max_thick,
+    };
 
     if ((self.init_opts.equal_space and self.packed_children > 0) or self.total_weight > 0) {
         if (extra_space) {

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -26,17 +26,17 @@ pub const InitOptions = struct {
     draw_focus: bool = true,
 };
 
-wd: WidgetData = undefined,
-init_options: InitOptions = undefined,
+wd: WidgetData,
+init_options: InitOptions,
 hover: bool = false,
 focus: bool = false,
 click: bool = false,
 
-pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) ButtonWidget {
-    var self = ButtonWidget{};
-    self.init_options = init_opts;
-    self.wd = WidgetData.init(src, .{}, defaults.override(opts));
-    return self;
+pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Options) ButtonWidget {
+    return .{
+        .wd = .init(src, .{}, defaults.override(opts)),
+        .init_options = init_options,
+    };
 }
 
 pub fn install(self: *ButtonWidget) void {

--- a/src/widgets/CacheWidget.zig
+++ b/src/widgets/CacheWidget.zig
@@ -14,27 +14,28 @@ pub const InitOptions = struct {
     invalidate: bool = false,
 };
 
-wd: WidgetData = undefined,
-hash: u64 = undefined,
-refresh_prev_value: u8 = undefined,
+wd: WidgetData,
+hash: u64,
+refresh_prev_value: u8,
 state: enum { ok, texture_create_error, unsupported } = .ok,
 caching_tex: ?dvui.TextureTarget = null,
-tex_uv: Size = undefined,
+tex_uv: Size,
+/// SAFETY: Must be set when `caching_tex` is not null
 old_target: dvui.RenderTarget = undefined,
 old_clip: ?Rect.Physical = null,
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) CacheWidget {
     _ = init_opts;
-    var self = CacheWidget{};
     const defaults = Options{ .name = "Cache" };
-    self.wd = WidgetData.init(src, .{}, defaults.override(opts));
-
-    self.hash = dvui.hashIdKey(self.wd.id, "_tex");
-    if (dvui.dataGet(null, self.wd.id, "_tex_uv", Size)) |uv| self.tex_uv = uv;
-    if (dvui.dataGet(null, self.wd.id, "_unsupported", bool) orelse false) self.state = .unsupported;
-    self.tex_uv = dvui.dataGet(null, self.wd.id, "_tex_uv", Size) orelse .{};
-    self.refresh_prev_value = dvui.currentWindow().extra_frames_needed;
+    const wd = WidgetData.init(src, .{}, defaults.override(opts));
+    var self = CacheWidget{
+        .wd = wd,
+        .hash = dvui.hashIdKey(wd.id, "_tex"),
+        .tex_uv = dvui.dataGet(null, wd.id, "_tex_uv", Size) orelse .{},
+        .refresh_prev_value = dvui.currentWindow().extra_frames_needed,
+    };
     dvui.currentWindow().extra_frames_needed = 0;
+    if (dvui.dataGet(null, self.wd.id, "_unsupported", bool) orelse false) self.state = .unsupported;
     return self;
 }
 

--- a/src/widgets/ContextWidget.zig
+++ b/src/widgets/ContextWidget.zig
@@ -17,20 +17,21 @@ pub const InitOptions = struct {
     rect: Rect.Physical,
 };
 
-wd: WidgetData = undefined,
-init_options: InitOptions = undefined,
+wd: WidgetData,
+init_options: InitOptions,
 
 prev_menu_root: ?dvui.MenuWidget.Root = null,
-winId: dvui.WidgetId = undefined,
+winId: dvui.WidgetId,
 focused: bool = false,
 activePt: Point.Natural = .{},
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) ContextWidget {
-    var self = ContextWidget{};
     const defaults = Options{ .name = "Context" };
-    self.wd = WidgetData.init(src, .{}, defaults.override(opts).override(.{ .rect = dvui.parentGet().data().rectScale().rectFromPhysical(init_opts.rect) }));
-    self.init_options = init_opts;
-    self.winId = dvui.subwindowCurrentId();
+    var self = ContextWidget{
+        .wd = WidgetData.init(src, .{}, defaults.override(opts).override(.{ .rect = dvui.parentGet().data().rectScale().rectFromPhysical(init_opts.rect) })),
+        .init_options = init_opts,
+        .winId = dvui.subwindowCurrentId(),
+    };
     if (dvui.focusedWidgetIdInCurrentSubwindow()) |fid| {
         if (fid == self.wd.id) {
             self.focused = true;

--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -1,16 +1,20 @@
 pub const DropdownWidget = @This();
 
-options: Options = undefined,
-init_options: InitOptions = undefined,
-menu: MenuWidget = undefined,
+options: Options,
+init_options: InitOptions,
+menu: MenuWidget,
+/// SAFETY: Will always be set by `install`
+/// TODO: This will panic if `install` is not called but `deinit` is.
+///       Is that a scenario we should handle?
 menuItem: MenuItemWidget = undefined,
 drop: ?FloatingMenuWidget = null,
 drop_first_frame: bool = false,
-drop_mi: ?MenuItemWidget = null,
+/// SAFETY: Will always be set by `addChoice` before use
+drop_mi: MenuItemWidget = undefined,
 drop_mi_id: ?dvui.WidgetId = null,
 drop_mi_index: usize = 0,
 drop_height: f32 = 0,
-drop_adjust: f32 = undefined,
+drop_adjust: f32 = 0,
 
 pub var defaults: Options = .{
     .color_fill = .{ .name = .fill_control },
@@ -27,11 +31,13 @@ pub const InitOptions = struct {
 };
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) DropdownWidget {
-    var self = DropdownWidget{};
-    self.options = defaults.override(opts);
-    self.init_options = init_opts;
-    self.menu = MenuWidget.init(src, .{ .dir = .horizontal }, self.options.wrapOuter());
-    self.drop_adjust = dvui.dataGet(null, self.menu.wd.id, "_drop_adjust", f32) orelse 0;
+    const options = defaults.override(opts);
+    var self = DropdownWidget{
+        .options = options,
+        .init_options = init_opts,
+        .menu = MenuWidget.init(src, .{ .dir = .horizontal }, options.wrapOuter()),
+    };
+    if (dvui.dataGet(null, self.menu.wd.id, "_drop_adjust", f32)) |adjust| self.drop_adjust = adjust;
     return self;
 }
 
@@ -177,22 +183,22 @@ pub fn addChoice(self: *DropdownWidget) *MenuItemWidget {
     }
 
     self.drop_mi = MenuItemWidget.init(@src(), .{}, .{ .id_extra = self.drop_mi_index, .expand = .horizontal });
-    self.drop_mi_id = self.drop_mi.?.data().id;
-    self.drop_mi.?.install();
-    self.drop_mi.?.processEvents();
-    self.drop_mi.?.drawBackground(.{});
+    self.drop_mi_id = self.drop_mi.data().id;
+    self.drop_mi.install();
+    self.drop_mi.processEvents();
+    self.drop_mi.drawBackground(.{});
 
     if (self.drop_first_frame) {
         if (self.init_options.selected_index) |si| {
             if (si == self.drop_mi_index) {
-                dvui.focusWidget(self.drop_mi.?.wd.id, null, null);
+                dvui.focusWidget(self.drop_mi.wd.id, null, null);
                 dvui.dataSet(null, self.menu.wd.id, "_drop_adjust", self.drop_height);
             }
         }
     }
     self.drop_mi_index += 1;
 
-    return &self.drop_mi.?;
+    return &self.drop_mi;
 }
 
 pub fn deinit(self: *DropdownWidget) void {

--- a/src/widgets/FlexBoxWidget.zig
+++ b/src/widgets/FlexBoxWidget.zig
@@ -17,9 +17,10 @@ pub const InitOptions = struct {
 
 pub const ContentPosition = enum { start, center };
 
-wd: WidgetData = undefined,
-init_options: InitOptions = undefined,
-prevClip: Rect.Physical = .{},
+wd: WidgetData,
+init_options: InitOptions,
+/// SAFETY: Set by `install`
+prevClip: Rect.Physical = undefined,
 insert_pt: dvui.Point = .{},
 row_size: Size = .{},
 max_row_width: f32 = 0.0,
@@ -27,11 +28,12 @@ max_row_width_prev: f32 = 0.0,
 width_nobreak: f32 = 0.0, // width if all children were on one row
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) FlexBoxWidget {
-    var self = FlexBoxWidget{};
     const defaults = Options{ .name = "FlexBox" };
-    self.wd = WidgetData.init(src, .{}, defaults.override(opts));
-    self.init_options = init_opts;
-    self.max_row_width_prev = dvui.dataGet(null, self.wd.id, "_mrw", f32) orelse 0.0;
+    var self = FlexBoxWidget{
+        .wd = WidgetData.init(src, .{}, defaults.override(opts)),
+        .init_options = init_opts,
+    };
+    if (dvui.dataGet(null, self.wd.id, "_mrw", f32)) |mrw| self.max_row_width_prev = mrw;
     return self;
 }
 

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -47,38 +47,45 @@ pub const InitOptions = struct {
     avoid: FloatingMenuAvoid = .auto,
 };
 
+/// SAFETY: Set by `install`
 prev_rendering: bool = undefined,
-wd: WidgetData = undefined,
-options: Options = undefined,
+wd: WidgetData,
+/// options is for our embedded ScrollAreaWidget
+options: Options,
 prev_windowId: dvui.WidgetId = .zero,
 prev_last_focus: dvui.WidgetId = undefined,
 parent_popup: ?*FloatingMenuWidget = null,
 have_popup_child: bool = false,
+init_options: InitOptions,
+/// SAFETY: Set by `install`
+prevClip: Rect.Physical = undefined,
+scale_val: f32,
+/// TODO: If `install` isn't called, this will panic in `deinti`. Should we handle that?
+/// SAFETY: Set by `install`
 menu: MenuWidget = undefined,
-init_options: InitOptions = undefined,
-prevClip: Rect.Physical = .{},
-scale_val: f32 = undefined,
+/// SAFETY: Set by `install`
 scaler: dvui.ScaleWidget = undefined,
+/// SAFETY: Set by `install`
 scroll: ScrollAreaWidget = undefined,
 
-pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) FloatingMenuWidget {
-    var self = FloatingMenuWidget{};
-
-    // options is really for our embedded ScrollAreaWidget, so save them for the
-    // end of install()
-    self.options = defaults.override(opts);
-
+pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Options) FloatingMenuWidget {
     // the widget itself doesn't have any styling, it comes from the
     // embedded MenuWidget
     // passing options.rect will stop WidgetData.init from calling
     // rectFor/minSizeForChild which is important because we are outside
     // normal layout
-    self.wd = WidgetData.init(src, .{ .subwindow = true }, .{ .id_extra = opts.id_extra, .rect = .{} });
+    const wd = WidgetData.init(src, .{ .subwindow = true }, .{ .id_extra = opts.id_extra, .rect = .{} });
 
-    // get scale from parent
-    self.scale_val = self.wd.parent.screenRectScale(Rect{}).s / dvui.windowNaturalScale();
+    var self = FloatingMenuWidget{
+        .wd = wd,
+        // options is really for our embedded ScrollAreaWidget, so save them for the
+        // end of install()
+        .options = defaults.override(opts),
+        // get scale from parent
+        .scale_val = wd.parent.screenRectScale(Rect{}).s / dvui.windowNaturalScale(),
+        .init_options = init_options,
+    };
 
-    self.init_options = init_opts;
     if (self.init_options.avoid == .auto) {
         if (dvui.MenuWidget.current()) |pm| {
             self.init_options.avoid = switch (pm.init_opts.dir) {

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -49,14 +49,18 @@ pub const InitOptions = struct {
 };
 
 parent_tooltip: ?*FloatingTooltipWidget = null,
+/// SAFETY: Set by `install`
 prev_rendering: bool = undefined,
-wd: WidgetData = undefined,
+wd: WidgetData,
+/// SAFETY: Set by `install`
 prev_windowId: dvui.WidgetId = undefined,
-prevClip: Rect.Physical = .{},
-scale_val: f32 = undefined,
+/// SAFETY: Set by `install`
+prevClip: Rect.Physical = undefined,
+scale_val: f32,
+/// SAFETY: Set by `install`, so is only valid if `installed` is true
 scaler: dvui.ScaleWidget = undefined,
-options: Options = undefined,
-init_options: InitOptions = undefined,
+options: Options,
+init_options: InitOptions,
 showing: bool = false,
 mouse_good_this_frame: bool = false,
 installed: bool = false,
@@ -77,25 +81,27 @@ tt_child_shown: bool = false,
 /// Use FloatingWindowWidget for a floating window that the user can change
 /// size, move around, and adjust stacking.
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts_in: Options) FloatingTooltipWidget {
-    var self = FloatingTooltipWidget{};
+    var self = FloatingTooltipWidget{
+        .wd = WidgetData.init(src, .{ .subwindow = true }, (Options{ .name = "FloatingTooltip" }).override(.{
+            // passing options.rect will stop WidgetData.init from calling
+            // rectFor/minSizeForChild which is important because we are outside
+            // normal layout
+            .rect = opts_in.rect orelse .{},
+        })),
+        // get scale from parent
+        .scale_val = dvui.parentGet().screenRectScale(Rect{}).s / dvui.windowNaturalScale(),
+        .options = defaults.override(opts_in),
+        .init_options = init_opts,
+    };
 
-    // get scale from parent
-    self.scale_val = dvui.parentGet().screenRectScale(Rect{}).s / dvui.windowNaturalScale();
-    self.options = defaults.override(opts_in);
     if (self.options.min_size_content) |msc| {
         self.options.min_size_content = msc.scale(self.scale_val, Size);
     }
 
-    // passing options.rect will stop WidgetData.init from calling
-    // rectFor/minSizeForChild which is important because we are outside
-    // normal layout
-    self.wd = WidgetData.init(src, .{ .subwindow = true }, (Options{ .name = "FloatingTooltip" }).override(.{ .rect = self.options.rect orelse .{} }));
-
     // if a rect got passed, we don't want to also pass it to scaler
     self.options.rect = null;
 
-    self.init_options = init_opts;
-    self.showing = dvui.dataGet(null, self.wd.id, "_showing", bool) orelse false;
+    if (dvui.dataGet(null, self.wd.id, "_showing", bool)) |showing| self.showing = showing;
 
     return self;
 }

--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -7,31 +7,31 @@ const WidgetData = dvui.WidgetData;
 
 const IconWidget = @This();
 
-wd: WidgetData = undefined,
-name: []const u8 = undefined,
-tvg_bytes: []const u8 = undefined,
-icon_opts: dvui.IconRenderOptions = undefined,
+wd: WidgetData,
+name: []const u8,
+tvg_bytes: []const u8,
+icon_opts: dvui.IconRenderOptions,
 
 pub fn init(src: std.builtin.SourceLocation, name: []const u8, tvg_bytes: []const u8, icon_opts: dvui.IconRenderOptions, opts: Options) IconWidget {
-    var self = IconWidget{};
-    const options = (Options{ .name = "Icon" }).override(opts);
-    self.name = name;
-    self.tvg_bytes = tvg_bytes;
-
     var size = Size{};
-    if (options.min_size_content) |msc| {
+    if (opts.min_size_content) |msc| {
         // user gave us a min size, use it
         size = msc;
         size.w = @max(size.w, dvui.iconWidth(name, tvg_bytes, size.h) catch size.w);
     } else {
         // user didn't give us one, make it the height of text
-        const h = options.fontGet().textHeight();
+        const h = opts.fontGet().textHeight();
         size = Size{ .w = dvui.iconWidth(name, tvg_bytes, h) catch h, .h = h };
     }
 
-    self.wd = WidgetData.init(src, .{}, options.override(.{ .min_size_content = size }));
-    self.icon_opts = icon_opts;
-    return self;
+    const defaults = Options{ .name = "Icon" };
+
+    return .{
+        .wd = WidgetData.init(src, .{}, defaults.override(opts).override(.{ .min_size_content = size })),
+        .name = name,
+        .tvg_bytes = tvg_bytes,
+        .icon_opts = icon_opts,
+    };
 }
 
 pub fn install(self: *IconWidget) void {

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -23,7 +23,7 @@ pub const InitOptions = struct {
     }
 };
 
-wd: WidgetData = undefined,
+wd: WidgetData,
 label_str: []const u8,
 /// An allocator to free `label_str` on `deinit`
 allocator: ?std.mem.Allocator,

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -22,21 +22,22 @@ pub const InitOptions = struct {
     highlight_only: bool = false,
 };
 
-wd: WidgetData = undefined,
-focused_last_frame: bool = undefined,
+wd: WidgetData,
+focused_last_frame: bool,
 highlight: bool = false,
-init_opts: InitOptions = undefined,
+init_opts: InitOptions,
 activated: bool = false,
 show_active: bool = false,
 mouse_over: bool = false,
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) MenuItemWidget {
-    var self = MenuItemWidget{};
     const options = defaults.override(opts);
-    self.wd = WidgetData.init(src, .{}, options);
-    self.init_opts = init_opts;
-    self.focused_last_frame = dvui.dataGet(null, self.wd.id, "_focus_last", bool) orelse false;
-    return self;
+    const wd = WidgetData.init(src, .{}, options);
+    return .{
+        .wd = wd,
+        .init_opts = init_opts,
+        .focused_last_frame = dvui.dataGet(null, wd.id, "_focus_last", bool) orelse false,
+    };
 }
 
 pub fn install(self: *MenuItemWidget) void {

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -58,16 +58,17 @@ pub var defaults: Options = .{
 };
 
 pub const InitOptions = struct {
-    dir: enums.Direction = undefined,
+    dir: enums.Direction,
 };
 
-wd: WidgetData = undefined,
+wd: WidgetData,
 
-init_opts: InitOptions = undefined,
-winId: dvui.WidgetId = undefined,
+init_opts: InitOptions,
+winId: dvui.WidgetId,
 parentMenu: ?*MenuWidget = null,
 parentSubwindowId: ?dvui.WidgetId = null,
-last_focus: dvui.WidgetId = undefined,
+last_focus: dvui.WidgetId,
+/// SAFETY: Set in `install`
 box: BoxWidget = undefined,
 
 // whether submenus should be open
@@ -86,20 +87,20 @@ child_popup_rect: ?Rect.Physical = null,
 mouse_mode: bool = false,
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) MenuWidget {
-    var self = MenuWidget{};
-    const options = defaults.override(opts);
-    self.wd = WidgetData.init(src, .{}, options);
-    self.init_opts = init_opts;
-    self.last_focus = dvui.lastFocusedIdInFrame(null);
+    var self = MenuWidget{
+        .wd = WidgetData.init(src, .{}, defaults.override(opts)),
+        .init_opts = init_opts,
+        .winId = dvui.subwindowCurrentId(),
+        .last_focus = dvui.lastFocusedIdInFrame(null),
+    };
 
-    self.winId = dvui.subwindowCurrentId();
     if (dvui.dataGet(null, self.wd.id, "_sub_act", bool)) |a| {
         self.submenus_activated = a;
     } else if (current()) |pm| {
         self.submenus_activated = pm.submenus_in_child;
     }
 
-    self.mouse_mode = dvui.dataGet(null, self.wd.id, "_mouse_mode", bool) orelse false;
+    if (dvui.dataGet(null, self.wd.id, "_mouse_mode", bool)) |mouse_mode| self.mouse_mode = mouse_mode;
 
     return self;
 }

--- a/src/widgets/OverlayWidget.zig
+++ b/src/widgets/OverlayWidget.zig
@@ -11,7 +11,7 @@ const WidgetData = dvui.WidgetData;
 
 const OverlayWidget = @This();
 
-wd: WidgetData = undefined,
+wd: WidgetData,
 
 pub fn init(src: std.builtin.SourceLocation, opts: Options) OverlayWidget {
     const defaults = Options{ .name = "Overlay" };

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -10,7 +10,7 @@ const WidgetData = dvui.WidgetData;
 
 const ReorderWidget = @This();
 
-wd: WidgetData = undefined,
+wd: WidgetData,
 id_reorderable: ?usize = null, // matches Reorderable.reorder_id
 drag_point: ?dvui.Point.Physical = null,
 drag_ending: bool = false,
@@ -18,13 +18,14 @@ reorderable_size: Size = .{},
 found_slot: bool = false,
 
 pub fn init(src: std.builtin.SourceLocation, opts: Options) ReorderWidget {
-    var self = ReorderWidget{};
     const defaults = Options{ .name = "Reorder" };
-    self.wd = WidgetData.init(src, .{}, defaults.override(opts));
-    self.id_reorderable = dvui.dataGet(null, self.wd.id, "_id_reorderable", usize) orelse null;
-    self.drag_point = dvui.dataGet(null, self.wd.id, "_drag_point", dvui.Point.Physical) orelse null;
-    self.reorderable_size = dvui.dataGet(null, self.wd.id, "_reorderable_size", dvui.Size) orelse dvui.Size{};
-    return self;
+    const wd = WidgetData.init(src, .{}, defaults.override(opts));
+    return .{
+        .wd = wd,
+        .id_reorderable = dvui.dataGet(null, wd.id, "_id_reorderable", usize),
+        .drag_point = dvui.dataGet(null, wd.id, "_drag_point", dvui.Point.Physical),
+        .reorderable_size = dvui.dataGet(null, wd.id, "_reorderable_size", dvui.Size) orelse .{},
+    };
 }
 
 pub fn install(self: *ReorderWidget) void {
@@ -211,23 +212,23 @@ pub const Reorderable = struct {
         reinstall: bool = true,
     };
 
-    wd: WidgetData = undefined,
-    reorder: *ReorderWidget = undefined,
-    init_options: InitOptions = undefined,
-    options: Options = undefined,
+    wd: WidgetData,
+    reorder: *ReorderWidget,
+    init_options: InitOptions,
+    options: Options,
     installed: bool = false,
     floating_widget: ?dvui.FloatingWidget = null,
     target_rs: ?dvui.RectScale = null,
 
     pub fn init(src: std.builtin.SourceLocation, reorder: *ReorderWidget, init_opts: InitOptions, opts: Options) Reorderable {
-        var self = Reorderable{};
-        self.reorder = reorder;
         const defaults = Options{ .name = "Reorderable" };
-        self.init_options = init_opts;
-        self.options = defaults.override(opts);
-        self.wd = WidgetData.init(src, .{}, self.options.override(.{ .rect = .{} }));
-
-        return self;
+        const options = defaults.override(opts);
+        return .{
+            .reorder = reorder,
+            .init_options = init_opts,
+            .options = options,
+            .wd = WidgetData.init(src, .{}, options.override(.{ .rect = .{} })),
+        };
     }
 
     // can call this after init before install

--- a/src/widgets/ScrollAreaWidget.zig
+++ b/src/widgets/ScrollAreaWidget.zig
@@ -25,6 +25,7 @@ pub var defaults: Options = .{
 };
 
 pub const InitOpts = struct {
+    // TODO: Make scroll info and vertical/horizontal mutually exclusive with a union
     scroll_info: ?*ScrollInfo = null,
     vertical: ?ScrollInfo.ScrollMode = null, // .auto is default
     vertical_bar: ScrollInfo.ScrollBarMode = .auto,
@@ -36,25 +37,24 @@ pub const InitOpts = struct {
     process_events_after: bool = true,
 };
 
-hbox: BoxWidget = undefined,
+hbox: BoxWidget,
 vbar: ?ScrollBarWidget = null,
 vbar_grab: ?ScrollBarWidget.Grab = null,
+/// SAFETY: Set by `installScrollBars`
 vbox: BoxWidget = undefined,
 hbar: ?ScrollBarWidget = null,
 hbar_grab: ?ScrollBarWidget.Grab = null,
-init_opts: InitOpts = undefined,
+init_opts: InitOpts,
+/// SAFETY: Set by `installScrollBars`, might point to `si_store`
 si: *ScrollInfo = undefined,
 si_store: ScrollInfo = .{},
 scroll: ?ScrollContainerWidget = null,
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOpts, opts: Options) ScrollAreaWidget {
-    var self = ScrollAreaWidget{};
-    self.init_opts = init_opts;
-    const options = defaults.override(opts);
-
-    self.hbox = BoxWidget.init(src, .{ .dir = .horizontal }, options);
-
-    return self;
+    return .{
+        .hbox = BoxWidget.init(src, .{ .dir = .horizontal }, defaults.override(opts)),
+        .init_opts = init_opts,
+    };
 }
 
 pub fn install(self: *ScrollAreaWidget) void {

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -24,23 +24,20 @@ pub const InitOptions = struct {
     focus_id: ?dvui.WidgetId = null,
 };
 
-wd: WidgetData = undefined,
+wd: WidgetData,
 grabRect: Rect = Rect{},
-si: *ScrollInfo = undefined,
+si: *ScrollInfo,
 focus_id: ?dvui.WidgetId = null,
-dir: enums.Direction = undefined,
+dir: enums.Direction,
 highlight: bool = false,
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) ScrollBarWidget {
-    var self = ScrollBarWidget{};
-    self.si = init_opts.scroll_info;
-    self.focus_id = init_opts.focus_id;
-    self.dir = init_opts.direction;
-
-    const options = defaults.override(opts);
-    self.wd = WidgetData.init(src, .{}, options);
-
-    return self;
+    return .{
+        .si = init_opts.scroll_info,
+        .focus_id = init_opts.focus_id,
+        .dir = init_opts.direction,
+        .wd = WidgetData.init(src, .{}, defaults.override(opts)),
+    };
 }
 
 pub fn install(self: *ScrollBarWidget) void {

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -40,10 +40,10 @@ pub const InitOptions = struct {
     process_events_after: bool = true,
 };
 
-wd: WidgetData = undefined,
-si: *ScrollInfo = undefined,
-init_opts: InitOptions = undefined,
-last_focus: dvui.WidgetId = undefined,
+wd: WidgetData,
+si: *ScrollInfo,
+init_opts: InitOptions,
+last_focus: dvui.WidgetId,
 parentScroll: ?*ScrollContainerWidget = null,
 
 // si.viewport.x/y might be updated in the middle of a frame, this prevents
@@ -64,14 +64,15 @@ seen_scroll_drag: bool = false,
 finger_down: bool = false,
 
 pub fn init(src: std.builtin.SourceLocation, io_scroll_info: *ScrollInfo, init_options: InitOptions, opts: Options) ScrollContainerWidget {
-    var self = ScrollContainerWidget{ .init_opts = init_options };
     const options = defaults.override(opts);
+    var self = ScrollContainerWidget{
+        .wd = WidgetData.init(src, .{}, options),
+        .si = io_scroll_info,
+        .init_opts = init_options,
+        .last_focus = dvui.lastFocusedIdInFrame(null),
+    };
 
-    self.wd = WidgetData.init(src, .{}, options);
-    self.last_focus = dvui.lastFocusedIdInFrame(null);
-
-    self.si = io_scroll_info;
-    self.finger_down = dvui.dataGet(null, self.wd.id, "_finger_down", bool) orelse false;
+    if (dvui.dataGet(null, self.wd.id, "_finger_down", bool)) |down| self.finger_down = down;
 
     const crect = self.wd.contentRect();
     self.si.viewport.w = crect.w;

--- a/src/widgets/SuggestionWidget.zig
+++ b/src/widgets/SuggestionWidget.zig
@@ -1,14 +1,16 @@
 pub const SuggestionWidget = @This();
 
-id: dvui.WidgetId = undefined,
-options: Options = undefined,
-init_options: InitOptions = undefined,
+id: dvui.WidgetId,
+/// Is for the floating menu widget that might open
+options: Options,
+init_options: InitOptions,
 
+/// SAFETY: Set in `install`
 menu: *MenuWidget = undefined,
 drop: ?*FloatingMenuWidget = null,
 drop_mi: ?MenuItemWidget = null,
 drop_mi_index: usize = 0,
-selected_index: usize = undefined, // 0 indexed
+selected_index: usize = 0, // 0 indexed
 activate_selected: bool = false,
 
 pub var defaults: Options = .{
@@ -21,12 +23,13 @@ pub const InitOptions = struct {
 };
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) SuggestionWidget {
-    var self = SuggestionWidget{};
-    self.id = dvui.parentGet().extendId(src, opts.idExtra());
-    self.options = defaults.override(opts);
-    self.init_options = init_opts;
-    self.selected_index = dvui.dataGet(null, self.id, "_selected", usize) orelse 0;
-    return self;
+    const id = dvui.parentGet().extendId(src, opts.idExtra());
+    return .{
+        .id = id,
+        .options = defaults.override(opts),
+        .init_options = init_opts,
+        .selected_index = dvui.dataGet(null, id, "_selected", usize) orelse 0,
+    };
 }
 
 pub fn install(self: *SuggestionWidget) void {

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -1,10 +1,11 @@
 pub const TabsWidget = @This();
 
-options: Options = undefined,
-init_options: InitOptions = undefined,
-scroll: ScrollAreaWidget = undefined,
+init_options: InitOptions,
+scroll: ScrollAreaWidget,
+/// SAFETY: Set in `install`
 box: BoxWidget = undefined,
 tab_index: usize = 0,
+/// SAFETY: Set in `addTab`
 tab_button: ButtonWidget = undefined,
 
 pub var defaults: Options = .{
@@ -18,16 +19,14 @@ pub const InitOptions = struct {
 };
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) TabsWidget {
-    var self = TabsWidget{};
-    self.options = defaults.override(opts);
-    self.init_options = init_opts;
-    var scroll_opts: ScrollAreaWidget.InitOpts = .{};
-    switch (self.init_options.dir) {
-        .horizontal => scroll_opts = .{ .vertical = .none, .horizontal = .auto, .horizontal_bar = .hide },
-        .vertical => scroll_opts = .{ .vertical = .auto, .vertical_bar = .hide },
-    }
-    self.scroll = ScrollAreaWidget.init(src, scroll_opts, self.options);
-    return self;
+    const scroll_opts: ScrollAreaWidget.InitOpts = switch (init_opts.dir) {
+        .horizontal => .{ .vertical = .none, .horizontal = .auto, .horizontal_bar = .hide },
+        .vertical => .{ .vertical = .auto, .vertical_bar = .hide },
+    };
+    return .{
+        .init_options = init_opts,
+        .scroll = ScrollAreaWidget.init(src, scroll_opts, defaults.override(opts)),
+    };
 }
 
 pub fn install(self: *TabsWidget) void {

--- a/src/widgets/VirtualParentWidget.zig
+++ b/src/widgets/VirtualParentWidget.zig
@@ -13,7 +13,7 @@ const WidgetData = dvui.WidgetData;
 
 const VirtualParentWidget = @This();
 
-wd: WidgetData = undefined,
+wd: WidgetData,
 child_rect_union: ?Rect = null,
 
 pub fn init(src: std.builtin.SourceLocation, opts: Options) VirtualParentWidget {


### PR DESCRIPTION
Having multiple or most fields in widgets default to `undefined` was always a bit confusing to me. It wasn't immediately obvious if the fields where set after `init`, `install` or some other function. This removes all default undefined values for fields that can be set in `init` and adds `SAFETY:` comments above the rest specifying when they are set.

Additionally, to remove some undefined values for the hash maps and array lists in `Window`, all `Window` containers have been changed to use their `...Unmanaged` variants. They all have a doc comment specifying which allocator is supposed to be used for each (which is important for users adding themes or key binds for example).

Sidenote, during this is became very obvious that most of these fields are only valid after `install` has been called. That means that `deinit` would probably panic on `undefined` values if `install` didn't get called. I realised that `WidgetData.rect_scale_cache` only gets set by `register`, which should only be called in `install`, so we can use that to detect if a widget was installed. This way we could make `deinit` safe to call even if `install` isn't called. I don't know if that is something we'd want to support or maybe the panic enforces correctness? This technique for detecting if a widget was installed can still be used by `ReorderWidget` and `FloatingTooltipWidget` though.