### PR TITLE
Mark mouse events during capture to "handle" all captured events

### DIFF
--- a/src/Event.zig
+++ b/src/Event.zig
@@ -35,6 +35,14 @@ pub fn handle(self: *Event, src: std.builtin.SourceLocation, wd: *const dvui.Wid
     self.handled = true;
 }
 
+pub fn focusable(self: *const Event) bool {
+    return switch (self.evt) {
+        // Only wheel events cannot be focused/captured
+        .mouse => |me| me.action != .wheel_x and me.action != .wheel_y,
+        else => true,
+    };
+}
+
 pub const Text = struct {
     txt: []u8,
     selected: bool = false,

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -2261,7 +2261,8 @@ pub fn reorderListsAdvanced() void {
     defer vbox.deinit();
 
     if (added_idx) |ai| {
-        reorder.dragStart(ai, added_idx_p.?); // reorder grabs capture
+        // FIXME: What events should/shouldn't be marked by this?
+        reorder.dragStart(ai, added_idx_p.?, 0); // reorder grabs capture
     }
 
     var seen_non_floating = false;
@@ -2304,7 +2305,8 @@ pub fn reorderListsAdvanced() void {
         dvui.label(@src(), "{s}", .{s}, .{});
 
         if (dvui.ReorderWidget.draggable(@src(), .{ .top_left = reorderable.wd.rectScale().r.topLeft() }, .{ .expand = .vertical, .gravity_x = 1.0, .min_size_content = dvui.Size.all(22), .gravity_y = 0.5 })) |p| {
-            reorder.dragStart(i, p); // reorder grabs capture
+            // FIXME: What events should/shouldn't be marked by this?
+            reorder.dragStart(i, p, 0); // reorder grabs capture
         }
     }
 
@@ -3015,7 +3017,7 @@ pub fn scrollCanvas() void {
                         .mouse => |me| {
                             if (me.action == .press and me.button.pointer()) {
                                 e.handle(@src(), dragBox.data());
-                                dvui.captureMouse(dbox.data());
+                                dvui.captureMouse(dbox.data(), e.num);
                                 dvui.dragPreStart(me.p, .{ .name = "box_transfer" });
                             } else if (me.action == .motion) {
                                 if (dvui.captured(dbox.data().id)) {
@@ -3025,7 +3027,7 @@ pub fn scrollCanvas() void {
                                         drag_box_window.* = i;
                                         drag_box_content.* = k;
                                         // give up capture so target can get mouse events, but don't end drag
-                                        dvui.captureMouse(null);
+                                        dvui.captureMouse(null, e.num);
                                     }
                                 }
                             } else if (me.action == .position) {
@@ -3049,13 +3051,13 @@ pub fn scrollCanvas() void {
                 .mouse => |me| {
                     if (me.action == .press and me.button.pointer()) {
                         e.handle(@src(), dragBox.data());
-                        dvui.captureMouse(dragBox.data());
+                        dvui.captureMouse(dragBox.data(), e.num);
                         const offset = me.p.diff(dragBox.data().rectScale().r.topLeft()); // pixel offset from dragBox corner
                         dvui.dragPreStart(me.p, .{ .offset = offset });
                     } else if (me.action == .release and me.button.pointer()) {
                         if (dvui.captured(dragBox.data().id)) {
                             e.handle(@src(), dragBox.data());
-                            dvui.captureMouse(null);
+                            dvui.captureMouse(null, e.num);
                             dvui.dragEnd();
                         }
                     } else if (me.action == .motion) {
@@ -3094,12 +3096,12 @@ pub fn scrollCanvas() void {
             .mouse => |me| {
                 if (me.action == .press and me.button.pointer()) {
                     e.handle(@src(), scrollContainer.data());
-                    dvui.captureMouse(scrollContainer.data());
+                    dvui.captureMouse(scrollContainer.data(), e.num);
                     dvui.dragPreStart(me.p, .{});
                 } else if (me.action == .release and me.button.pointer()) {
                     if (dvui.captured(scrollContainer.data().id)) {
                         e.handle(@src(), scrollContainer.data());
-                        dvui.captureMouse(null);
+                        dvui.captureMouse(null, e.num);
                         dvui.dragEnd();
                     }
                 } else if (me.action == .motion) {
@@ -4778,7 +4780,7 @@ pub const StrokeTest = struct {
                             }
 
                             if (dragi != null) {
-                                dvui.captureMouse(self.data());
+                                dvui.captureMouse(self.data(), e.num);
                                 dvui.dragPreStart(me.p, .{ .cursor = .crosshair });
                             }
                         }
@@ -4786,7 +4788,7 @@ pub const StrokeTest = struct {
                     .release => {
                         if (me.button == .left) {
                             e.handle(@src(), self.data());
-                            dvui.captureMouse(null);
+                            dvui.captureMouse(null, e.num);
                             dvui.dragEnd();
                         }
                     },

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -97,12 +97,12 @@ pub fn valueSaturationBox(src: std.builtin.SourceLocation, hsv: *Color.HSV, opts
                     dvui.focusWidget(b.data().id, null, e.num);
                 } else if (me.action == .press and me.button.pointer()) {
                     // capture
-                    dvui.captureMouse(b.data());
+                    dvui.captureMouse(b.data(), e.num);
                     e.handle(@src(), b.data());
                     p = me.p;
                 } else if (me.action == .release and me.button.pointer()) {
                     // stop capture
-                    dvui.captureMouse(null);
+                    dvui.captureMouse(null, e.num);
                     dvui.dragEnd();
                     e.handle(@src(), b.data());
                 } else if (me.action == .motion and dvui.captured(b.data().id)) {
@@ -224,12 +224,12 @@ pub fn hueSlider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hue
                     dvui.focusWidget(b.data().id, null, e.num);
                 } else if (me.action == .press and me.button.pointer()) {
                     // capture
-                    dvui.captureMouse(b.data());
+                    dvui.captureMouse(b.data(), e.num);
                     e.handle(@src(), b.data());
                     p = me.p;
                 } else if (me.action == .release and me.button.pointer()) {
                     // stop capture
-                    dvui.captureMouse(null);
+                    dvui.captureMouse(null, e.num);
                     dvui.dragEnd();
                     e.handle(@src(), b.data());
                 } else if (me.action == .motion and dvui.captured(b.data().id)) {

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -385,7 +385,7 @@ pub fn processEventsBefore(self: *FloatingWindowWidget) void {
                 }
 
                 if (me.action == .release and me.button.pointer()) {
-                    dvui.captureMouse(null); // stop drag and capture
+                    dvui.captureMouse(null, e.num); // stop drag and capture
                     dvui.dragEnd();
                     e.handle(@src(), self.data());
                     continue;
@@ -395,7 +395,7 @@ pub fn processEventsBefore(self: *FloatingWindowWidget) void {
             if (dragPart(me, rs) == .bottom_right) {
                 if (me.action == .press and me.button.pointer()) {
                     // capture and start drag
-                    dvui.captureMouse(self.data());
+                    dvui.captureMouse(self.data(), e.num);
                     self.drag_part = .bottom_right;
                     dvui.dragStart(me.p, .{ .cursor = .arrow_nw_se, .offset = .diff(rs.r.bottomRight(), me.p) });
                     e.handle(@src(), self.data());
@@ -447,7 +447,7 @@ pub fn processEventsAfter(self: *FloatingWindowWidget) void {
                             }
                             e.handle(@src(), self.data());
                             // capture and start drag
-                            dvui.captureMouse(self.data());
+                            dvui.captureMouse(self.data(), e.num);
                             self.drag_part = dp;
                             dvui.dragPreStart(e.evt.mouse.p, .{ .cursor = self.drag_part.?.cursor() });
                         }
@@ -455,7 +455,7 @@ pub fn processEventsAfter(self: *FloatingWindowWidget) void {
                     .release => {
                         if (me.button.pointer() and dvui.captured(self.wd.id)) {
                             e.handle(@src(), self.data());
-                            dvui.captureMouse(null); // stop drag and capture
+                            dvui.captureMouse(null, e.num); // stop drag and capture
                             dvui.dragEnd();
                         }
                     },

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -779,13 +779,13 @@ pub const HeaderResizeWidget = struct {
             if (e.evt.mouse.action == .press and e.evt.mouse.button.pointer()) {
                 e.handle(@src(), self.data());
                 // capture and start drag
-                dvui.captureMouse(self.data());
+                dvui.captureMouse(self.data(), e.num);
                 dvui.dragPreStart(e.evt.mouse.p, .{ .cursor = cursor });
                 self.offset = .{};
             } else if (e.evt.mouse.action == .release and e.evt.mouse.button.pointer()) {
                 e.handle(@src(), self.data());
                 // stop possible drag and capture
-                dvui.captureMouse(null);
+                dvui.captureMouse(null, e.num);
                 dvui.dragEnd();
                 self.offset = .{};
             } else if (e.evt.mouse.action == .motion and dvui.captured(self.wd.id)) {

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -171,7 +171,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
                 if (me.button.touch()) {
                     // with touch we have to capture otherwise any motion will
                     // cause scroll to capture
-                    dvui.captureMouse(self.data());
+                    dvui.captureMouse(self.data(), e.num);
                     dvui.dragPreStart(me.p, .{});
                 }
             } else if (me.action == .release) {
@@ -183,7 +183,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
                 }
                 if (dvui.captured(self.wd.id)) {
                     // should only happen with touch
-                    dvui.captureMouse(null);
+                    dvui.captureMouse(null, e.num);
                     dvui.dragEnd();
                 }
             } else if (me.action == .motion and me.button.touch()) {
@@ -192,7 +192,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
                         // if we overcame the drag threshold, then that
                         // means the person probably didn't want to touch
                         // this, maybe they were trying to scroll
-                        dvui.captureMouse(null);
+                        dvui.captureMouse(null, e.num);
                         dvui.dragEnd();
                     }
                 }

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -299,12 +299,12 @@ pub fn processEvent(self: *PanedWidget, e: *Event) void {
             if (e.evt.mouse.action == .press and e.evt.mouse.button.pointer()) {
                 e.handle(@src(), self.data());
                 // capture and start drag
-                dvui.captureMouse(self.data());
+                dvui.captureMouse(self.data(), e.num);
                 dvui.dragPreStart(e.evt.mouse.p, .{ .cursor = cursor });
             } else if (e.evt.mouse.action == .release and e.evt.mouse.button.pointer()) {
                 e.handle(@src(), self.data());
                 // stop possible drag and capture
-                dvui.captureMouse(null);
+                dvui.captureMouse(null, e.num);
                 dvui.dragEnd();
             } else if (e.evt.mouse.action == .motion and dvui.captured(self.wd.id)) {
                 e.handle(@src(), self.data());

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -93,7 +93,7 @@ pub fn processEvent(self: *ReorderWidget, e: *dvui.Event) void {
             .mouse => |me| {
                 if ((me.action == .press or me.action == .release) and me.button.pointer()) {
                     self.drag_ending = true;
-                    dvui.captureMouse(null);
+                    dvui.captureMouse(null, e.num);
                     dvui.dragEnd();
                     dvui.refresh(null, @src(), self.wd.id);
                 } else if (me.action == .motion) {
@@ -137,11 +137,11 @@ pub fn deinit(self: *ReorderWidget) void {
     self.* = undefined;
 }
 
-pub fn dragStart(self: *ReorderWidget, reorder_id: usize, p: dvui.Point.Physical) void {
+pub fn dragStart(self: *ReorderWidget, reorder_id: usize, p: dvui.Point.Physical, event_num: u16) void {
     self.id_reorderable = reorder_id;
     self.drag_point = p;
     self.found_slot = true;
-    dvui.captureMouse(self.data());
+    dvui.captureMouse(self.data(), event_num);
 }
 
 pub const draggableInitOptions = struct {
@@ -162,7 +162,7 @@ pub fn draggable(src: std.builtin.SourceLocation, init_opts: draggableInitOption
             .mouse => |me| {
                 if (me.action == .press and me.button.pointer()) {
                     e.handle(@src(), iw.data());
-                    dvui.captureMouse(iw.data());
+                    dvui.captureMouse(iw.data(), e.num);
                     const reo_top_left: ?dvui.Point.Physical = if (init_opts.reorderable) |reo| reo.wd.rectScale().r.topLeft() else null;
                     const top_left: ?dvui.Point.Physical = init_opts.top_left orelse reo_top_left;
                     dvui.dragPreStart(me.p, .{ .offset = (top_left orelse iw.wd.rectScale().r.topLeft()).diff(me.p) });
@@ -172,7 +172,7 @@ pub fn draggable(src: std.builtin.SourceLocation, init_opts: draggableInitOption
                         if (dvui.dragging(me.p)) |_| {
                             ret = me.p;
                             if (init_opts.reorderable) |reo| {
-                                reo.reorder.dragStart(reo.wd.id.asUsize(), me.p); // reorder grabs capture
+                                reo.reorder.dragStart(reo.wd.id.asUsize(), me.p, e.num); // reorder grabs capture
                             }
                             break :loop;
                         }

--- a/src/widgets/ScaleWidget.zig
+++ b/src/widgets/ScaleWidget.zig
@@ -94,14 +94,14 @@ pub fn processEvent(self: *ScaleWidget, e: *Event) void {
 
                     // end any drag that might have been happening
                     dvui.dragEnd();
-                    dvui.captureMouse(self.data());
+                    dvui.captureMouse(self.data(), e.num);
                 }
             },
             .release => {
                 self.touchPoints[idx] = null;
                 if (dvui.captured(self.wd.id)) {
                     e.handle(@src(), self.data());
-                    dvui.captureMouse(null);
+                    dvui.captureMouse(null, e.num);
                 }
             },
             .motion => {

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -87,7 +87,7 @@ pub fn processEvents(self: *ScrollBarWidget, grabrs: Rect.Physical) void {
                             e.handle(@src(), self.data());
                             if (grabrs.contains(me.p)) {
                                 // capture and start drag
-                                dvui.captureMouse(self.data());
+                                dvui.captureMouse(self.data(), e.num);
                                 switch (self.dir) {
                                     .vertical => dvui.dragPreStart(me.p, .{ .cursor = .arrow, .offset = .{ .y = me.p.y - (grabrs.y + grabrs.h / 2) } }),
                                     .horizontal => dvui.dragPreStart(me.p, .{ .cursor = .arrow, .offset = .{ .x = me.p.x - (grabrs.x + grabrs.w / 2) } }),
@@ -109,7 +109,7 @@ pub fn processEvents(self: *ScrollBarWidget, grabrs: Rect.Physical) void {
                         if (me.button.pointer()) {
                             e.handle(@src(), self.data());
                             // stop possible drag and capture
-                            dvui.captureMouse(null);
+                            dvui.captureMouse(null, e.num);
                             dvui.dragEnd();
                         }
                     },

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -506,10 +506,10 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
                     // don't let this event go through to floating window
                     // which would capture the mouse preventing scrolling
                     e.handle(@src(), self.data());
-                    dvui.captureMouse(self.data());
+                    dvui.captureMouse(self.data(), e.num);
                 } else if (me.action == .release and dvui.captured(self.wd.id)) {
                     e.handle(@src(), self.data());
-                    dvui.captureMouse(null);
+                    dvui.captureMouse(null, e.num);
                     dvui.dragEnd();
                 } else if (me.action == .motion and me.button.touch()) {
                     e.handle(@src(), self.data());
@@ -519,7 +519,7 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
                     // a touch down on a button, which captures.  Then when the
                     // drag starts the button gives up capture, so we get here,
                     // never having seen the touch down.
-                    dvui.captureMouse(self.data());
+                    dvui.captureMouse(self.data(), e.num);
 
                     self.processMotionScroll(me.action.motion);
                 }

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -314,14 +314,14 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
                 if (e.evt == .mouse) {
                     const me = e.evt.mouse;
                     if (me.action == .press and me.button.touch()) {
-                        dvui.captureMouse(fc.data());
+                        dvui.captureMouse(fc.data(), e.num);
                         self.te_show_context_menu = false;
                         offset = fcrs.r.topRight().diff(me.p);
 
                         // give an extra offset of half the cursor height
                         offset.y -= self.sel_start_r.h * 0.5 * rs.s;
                     } else if (me.action == .release and me.button.touch()) {
-                        dvui.captureMouse(null);
+                        dvui.captureMouse(null, e.num);
                         dvui.dragEnd();
                     } else if (me.action == .motion and dvui.captured(fc.wd.id)) {
                         const corner = me.p.plus(offset);
@@ -384,14 +384,14 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
                 if (e.evt == .mouse) {
                     const me = e.evt.mouse;
                     if (me.action == .press and me.button.touch()) {
-                        dvui.captureMouse(fc.data());
+                        dvui.captureMouse(fc.data(), e.num);
                         self.te_show_context_menu = false;
                         offset = fcrs.r.topLeft().diff(me.p);
 
                         // give an extra offset of half the cursor height
                         offset.y -= self.sel_start_r.h * 0.5 * rs.s;
                     } else if (me.action == .release and me.button.touch()) {
-                        dvui.captureMouse(null);
+                        dvui.captureMouse(null, e.num);
                         dvui.dragEnd();
                     } else if (me.action == .motion and dvui.captured(fc.wd.id)) {
                         const corner = me.p.plus(offset);
@@ -1550,7 +1550,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event) void {
             } else if (me.action == .press and me.button.pointer()) {
                 e.handle(@src(), self.data());
                 // capture and start drag
-                dvui.captureMouse(self.data());
+                dvui.captureMouse(self.data(), e.num);
                 dvui.dragPreStart(me.p, .{ .cursor = .ibeam });
 
                 if (me.button.touch()) {
@@ -1619,7 +1619,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event) void {
                         dvui.refresh(null, @src(), self.wd.id);
                     }
 
-                    dvui.captureMouse(null);
+                    dvui.captureMouse(null, e.num);
                     dvui.dragEnd();
                 }
             } else if (me.action == .motion and dvui.captured(self.wd.id)) {
@@ -1641,7 +1641,7 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event) void {
                         });
                     } else {
                         // user intended to scroll with a finger swipe
-                        dvui.captureMouse(null); // stop possible drag and capture
+                        dvui.captureMouse(null, e.num); // stop possible drag and capture
                         dvui.dragEnd();
                     }
                 }


### PR DESCRIPTION
Closes #422

This prevents the motion event from the following pattern from being handled by some containing widget:

- mouse down (widget A captures)
- mouse motion (widget A declines to process, leaves it unhandled)
- mouse up (widget A ends capture)

This repurposes the `focus_widgetId` and `foces_windowId` from the key event focus marking. I'm considering if these should be renamed to `widget_id_mark` and `window_id_mark` along with `focusRemaining...` being renamed `markRemaining...` to distance them from focus only?

This does however make it impossible to scroll the "multiline text area" in the demo with touch within a single frame. The capture always happens on press and only 2 frames later is the capture automatically removed and the scroll area can see the event. I don't know what the correct behaviour here is. 