### PR TITLE
Color: store pixels in []Color.PMA for better type safety and ergonomics

### DIFF
--- a/src/Color.zig
+++ b/src/Color.zig
@@ -265,14 +265,48 @@ pub fn average(self: Color, other: Color) Color {
     };
 }
 
-/// A color premultiplied by alpha, mostly used for vertex colors
+/// A color premultiplied by alpha
+///
+/// This type is safe to `@bitCast` to and from a `[@sizeOf(Color.PMA)]u8`.
+/// This also means `@ptrCast` of `[]Color.PMA` to and from `[]u8` is safe,
+/// as long as the length is a multiple of `@sizeOf(Color.PMA)`.
+///
+/// The pixel format will always be RGBA.
 pub const PMA = extern struct {
     r: u8,
     g: u8,
     b: u8,
     a: u8,
 
+    // duplicated names from Color
+    pub const white: PMA = .fromColor(.white);
+    pub const silver: PMA = .fromColor(.silver);
+    pub const gray: PMA = .fromColor(.gray);
+    pub const black: PMA = .fromColor(.black);
+    pub const red: PMA = .fromColor(.red);
+    pub const maroon: PMA = .fromColor(.maroon);
+    pub const yellow: PMA = .fromColor(.yellow);
+    pub const olive: PMA = .fromColor(.olive);
+    pub const lime: PMA = .fromColor(.lime);
+    pub const green: PMA = .fromColor(.green);
+    pub const aqua: PMA = .fromColor(.aqua);
+    pub const teal: PMA = .fromColor(.teal);
+    pub const blue: PMA = .fromColor(.blue);
+    pub const navy: PMA = .fromColor(.navy);
+    pub const fuchsia: PMA = .fromColor(.fuchsia);
+    pub const purple: PMA = .fromColor(.purple);
+    pub const cyan = PMA.aqua;
+    pub const magenta = PMA.fuchsia;
+    pub const darl_cyan = PMA.teal;
+    pub const dark_magenta = PMA.purple;
+
     pub const transparent = PMA{ .r = 0, .g = 0, .b = 0, .a = 0 };
+
+    comptime {
+        std.debug.assert(@sizeOf(Color.PMA) == 4);
+        // Validate that the memory layout of @ptrCast(Color.PMA) is the same as an RGBA []u8
+        std.debug.assert(std.mem.eql(u8, &.{ 12, 34, 56, 78 }, @ptrCast(&[_]Color.PMA{.{ .r = 12, .g = 34, .b = 56, .a = 78 }})));
+    }
 
     /// Convert premultiplied alpha color to a `Color`.
     pub fn toColor(self: PMA) Color {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -701,10 +701,10 @@ pub const FontCacheEntry = struct {
 
         const cw = currentWindow();
 
-        var pixels = try cw.lifo().alloc(u8, @as(usize, @intFromFloat(size.w * size.h)) * 4);
+        var pixels = try cw.lifo().alloc(Color.PMA, @as(usize, @intFromFloat(size.w * size.h)));
         defer cw.lifo().free(pixels);
         // set all pixels to zero alpha
-        @memset(pixels, 0);
+        @memset(pixels, .transparent);
 
         //const num_glyphs = fce.glyph_info.count();
         //std.debug.print("font size {d} regen glyph atlas num {d} max size {}\n", .{ sized_font.size, num_glyphs, size });
@@ -742,13 +742,10 @@ pub const FontCacheEntry = struct {
                         const src = bitmap.buffer[@as(usize, @intCast(row * bitmap.pitch + col))];
 
                         // because of the extra edge, offset by 1 row and 1 col
-                        const di = @as(usize, @intCast((y + row + pad) * @as(i32, @intFromFloat(size.w)) * 4 + (x + col + pad) * 4));
+                        const di = @as(usize, @intCast((y + row + pad) * @as(i32, @intFromFloat(size.w)) + (x + col + pad)));
 
                         // premultiplied white
-                        pixels[di + 0] = src;
-                        pixels[di + 1] = src;
-                        pixels[di + 2] = src;
-                        pixels[di + 3] = src;
+                        pixels[di] = .{ .r = src, .g = src, .b = src, .a = src };
                     }
                 }
             } else {
@@ -763,18 +760,15 @@ pub const FontCacheEntry = struct {
 
                 c.stbtt_MakeCodepointBitmapSubpixel(&fce.face, bitmap.ptr, @as(c_int, @intCast(out_w)), @as(c_int, @intCast(out_h)), @as(c_int, @intCast(out_w)), fce.scaleFactor, fce.scaleFactor, 0.0, 0.0, @as(c_int, @intCast(codepoint)));
 
-                const stride = @as(usize, @intFromFloat(size.w)) * 4;
-                const di = @as(usize, @intCast(y)) * stride + @as(usize, @intCast(x * 4));
+                const stride = @as(usize, @intFromFloat(size.w));
+                const di = @as(usize, @intCast(y)) * stride + @as(usize, @intCast(x));
                 for (0..out_h) |row| {
                     for (0..out_w) |col| {
                         const src = bitmap[row * out_w + col];
-                        const dest = di + (row + pad) * stride + (col + pad) * 4;
+                        const dest = di + (row + pad) * stride + (col + pad);
 
                         // premultiplied white
-                        pixels[dest + 0] = src;
-                        pixels[dest + 1] = src;
-                        pixels[dest + 2] = src;
-                        pixels[dest + 3] = src;
+                        pixels[dest] = .{ .r = src, .g = src, .b = src, .a = src };
                     }
                 }
             }
@@ -788,7 +782,7 @@ pub const FontCacheEntry = struct {
             }
         }
 
-        fce.texture_atlas_cache = try textureCreate(.cast(pixels), @as(u32, @intFromFloat(size.w)), @as(u32, @intFromFloat(size.h)), .linear);
+        fce.texture_atlas_cache = try textureCreate(.{ .pma = pixels }, @as(u32, @intFromFloat(size.w)), @as(u32, @intFromFloat(size.h)), .linear);
         return fce.texture_atlas_cache.?;
     }
 
@@ -1110,7 +1104,7 @@ pub const TextureCacheEntry = struct {
                 _ = cw.texture_cache.remove(h);
             },
             .pixels => |p| {
-                const h = dvui.TextureCacheEntry.hashImageBytes(p.bytes.pma);
+                const h = dvui.TextureCacheEntry.hashImageBytes(@ptrCast(p.bytes.pma));
                 _ = cw.texture_cache.remove(h);
             },
         }
@@ -1129,11 +1123,8 @@ pub const TextureCacheEntry = struct {
             return StbImageError.stbImageError;
         }
         defer c.stbi_image_free(data);
-        var pixels: []u8 = undefined;
-        pixels.ptr = data;
-        pixels.len = @intCast(w * h * 4);
 
-        const texture = try textureCreate(.fromRGBA(pixels), @intCast(w), @intCast(h), .linear);
+        const texture = try textureCreate(.fromRGBA(data[0..@intCast(w * h * @sizeOf(Color.PMA))]), @intCast(w), @intCast(h), .linear);
 
         const entry = TextureCacheEntry{ .texture = texture };
         try cw.texture_cache.put(cw.gpa, tex_hash, entry);
@@ -1142,7 +1133,7 @@ pub const TextureCacheEntry = struct {
 
     pub fn fromPixels(pma: dvui.RGBAPixelsPMA, width: u32, height: u32) Backend.TextureError!dvui.TextureCacheEntry {
         var cw = dvui.currentWindow();
-        const tex_hash = dvui.TextureCacheEntry.hashImageBytes(pma.pma);
+        const tex_hash = dvui.TextureCacheEntry.hashImageBytes(@ptrCast(pma.pma));
         if (cw.texture_cache.getPtr(tex_hash)) |tce| return tce.*;
         const texture = try dvui.textureCreate(pma, width, height, .linear);
         const entry = dvui.TextureCacheEntry{ .texture = texture };
@@ -6905,8 +6896,7 @@ pub fn renderText(opts: renderTextOptions) Backend.GenericError!void {
 ///
 /// To convert non PMA pixels, use `RGBAPixelsPMA.fromRGBA`
 pub const RGBAPixelsPMA = struct {
-    /// Should only ever store RGBA pixels with premultiplied alpha
-    pma: []u8,
+    pma: []Color.PMA,
 
     /// Alpha multiplies `pixels` in place
     pub fn fromRGBA(pixels: []u8) RGBAPixelsPMA {
@@ -6917,12 +6907,12 @@ pub const RGBAPixelsPMA = struct {
             pixels[i + 1] = @intCast(@divTrunc(@as(u16, pixels[i + 1]) * a, 255));
             pixels[i + 2] = @intCast(@divTrunc(@as(u16, pixels[i + 2]) * a, 255));
         }
-        return .{ .pma = pixels };
+        return .{ .pma = @ptrCast(pixels) };
     }
 
     /// Unapplies the alpha multiplication in place, returning the inner slice
     pub fn toRGBA(pma_pixels: RGBAPixelsPMA) []u8 {
-        var pixels = pma_pixels.pma;
+        var pixels: []u8 = @ptrCast(pma_pixels.pma);
         for (0..pixels.len / 4) |ii| {
             const i = ii * 4;
             const a = pixels[i + 3];
@@ -6939,7 +6929,7 @@ pub const RGBAPixelsPMA = struct {
     ///
     /// Does no modifications of the pixels
     pub fn cast(pixels: []u8) RGBAPixelsPMA {
-        return .{ .pma = pixels };
+        return .{ .pma = @ptrCast(pixels) };
     }
 };
 
@@ -6949,10 +6939,10 @@ pub const RGBAPixelsPMA = struct {
 ///
 /// Only valid between `Window.begin` and `Window.end`.
 pub fn textureCreate(pixels: RGBAPixelsPMA, width: u32, height: u32, interpolation: enums.TextureInterpolation) Backend.TextureError!Texture {
-    if (pixels.pma.len != width * height * 4) {
-        log.err("Texture was created with an incorrect amount of pixels, expected {d} but got {d} (w: {d}, h: {d})", .{ pixels.pma.len, width * height * 4, width, height });
+    if (pixels.pma.len != width * height) {
+        log.err("Texture was created with an incorrect amount of pixels, expected {d} but got {d} (w: {d}, h: {d})", .{ pixels.pma.len, width * height, width, height });
     }
-    return currentWindow().backend.textureCreate(pixels.pma.ptr, width, height, interpolation);
+    return currentWindow().backend.textureCreate(@ptrCast(pixels.pma.ptr), width, height, interpolation);
 }
 
 /// Create a texture that can be rendered with `renderTexture` and drawn to
@@ -6971,13 +6961,13 @@ pub fn textureCreateTarget(width: u32, height: u32, interpolation: enums.Texture
 ///
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn textureReadTarget(arena: std.mem.Allocator, texture: TextureTarget) Backend.TextureError!RGBAPixelsPMA {
-    const size: usize = texture.width * texture.height * 4;
+    const size: usize = texture.width * texture.height * @sizeOf(Color.PMA);
     const pixels = try arena.alloc(u8, size);
     errdefer arena.free(pixels);
 
     try currentWindow().backend.textureReadTarget(texture, pixels.ptr);
 
-    return .{ .pma = pixels };
+    return .{ .pma = @ptrCast(pixels) };
 }
 
 /// Convert a target texture to a normal texture.  target is destroyed.

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -328,7 +328,7 @@ pub fn getHueSelectorTexture(dir: dvui.enums.Direction) dvui.Backend.TextureErro
             .vertical => .{ 1, hue_selector_colors.len },
         };
         // FIXME: textureCreate should not need a non const pointer to pixels
-        res.value_ptr.texture = try dvui.textureCreate(.cast(@constCast(&hue_selector_pixels)), width, height, .linear);
+        res.value_ptr.texture = try dvui.textureCreate(.{ .pma = @constCast(&hue_selector_colors) }, width, height, .linear);
     }
     return res.value_ptr.texture;
 }
@@ -338,26 +338,14 @@ pub fn getValueSaturationTexture(hue: f32) dvui.Backend.TextureError!dvui.Textur
     const cw = dvui.currentWindow();
     const res = try cw.texture_cache.getOrPut(cw.gpa, hue_texture_id);
     if (!res.found_existing) {
-        var pixels = Color.white.toRGBA() ** 2 ++ Color.black.toRGBA() ** 2;
-        comptime std.debug.assert(pixels.len == 2 * 2 * 4);
+        var pixels: [4]Color.PMA = .{ .white, .cast(Color.HSV.toColor(.{ .h = hue })), .black, .black };
         // set top right corner to the max value of that hue
-        @memcpy(pixels[4..8], &Color.HSV.toColor(.{ .h = hue }).toRGBA());
-        res.value_ptr.texture = try dvui.textureCreate(.cast(&pixels), 2, 2, .linear);
+        res.value_ptr.texture = try dvui.textureCreate(.{ .pma = &pixels }, 2, 2, .linear);
     }
     return res.value_ptr.texture;
 }
 
-const hue_selector_colors: [7]Color = .{ .red, .yellow, .lime, .cyan, .blue, .magenta, .red };
-const hue_selector_pixels: [hue_selector_colors.len * 4]u8 = blk: {
-    var pixels: [hue_selector_colors.len * 4]u8 = undefined;
-    for (0.., hue_selector_colors) |i, c| {
-        pixels[i * 4 + 0] = c.r;
-        pixels[i * 4 + 1] = c.g;
-        pixels[i * 4 + 2] = c.b;
-        pixels[i * 4 + 3] = c.a;
-    }
-    break :blk pixels;
-};
+const hue_selector_colors: [7]Color.PMA = .{ .red, .yellow, .lime, .cyan, .blue, .magenta, .red };
 
 const Options = dvui.Options;
 const Color = dvui.Color;


### PR DESCRIPTION
Because of the `extern` on `Color.PMA`, the layout should always match the c abi and the fields should never be reordered. This means that `Color.PMA` is safe to `@bitCast` to and from a `[@sizeOf(Color.PMA)]u8` and `@ptrCast([]Color.PMA)` to and from `[]u8` is safe, as long as the length is a multiple of `@sizeOf(Color.PMA)`.

A comptime assert has been added to verify this casting behaviour (and this can be reverted if that ever causes an error on some platform but it really shouldn't). 

This removes a lot of `* 4` when calculating the amount of pixels. It also makes creating arrays of pixels much simpler with the added color decls, see "animating frames" demo,  `ColorPickerWidget.getValueSaturationTexture` and font atlas creation.