### PR TITLE
Reuse data allocations if they are the same size

### DIFF
--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -858,9 +858,12 @@ pub fn getText(self: *const TextEntryWidget) []u8 {
 
 pub fn deinit(self: *TextEntryWidget) void {
     defer dvui.widgetFree(self);
-    if (self.len == 0 or self.len + realloc_bin_size + @divTrunc(realloc_bin_size, 2) <= self.text.len) {
+    const needed_binds = @divTrunc(self.len, realloc_bin_size) + 1;
+    const current_bins = @divTrunc(self.text.len, realloc_bin_size);
+    // dvui.log.debug("TextEntry {x} needs {d} bins, has {d}", .{ self.data().id, needed_binds, current_bins });
+    if (self.len == 0 or needed_binds < current_bins) {
         // we want to shrink the allocation
-        const new_len = if (self.len == 0) 0 else realloc_bin_size * (@divTrunc(self.len, realloc_bin_size) + 1);
+        const new_len = if (self.len == 0) 0 else realloc_bin_size * needed_binds;
         switch (self.init_opts.text) {
             .buffer => {},
             .buffer_dynamic => |b| {


### PR DESCRIPTION
This was removed in #209 but it causes large amounts of reallocations for the common pattern of `dataGet` and then later `dataSet` with the same id and key.

In the app demo the amount of trashed data in a single frame peaks at 2694 when opening the demo window. The scrolling demo also has a ~1000 data trashed every frame. With this change we go back to reusing the previous allocation as long as the size matches, otherwise it's trashed. With this change it peaks at 7 while caching and is 0 most frames.

This still prevents segmentation faults if a value or pointer was gotten earlier in the frame. The only difference in behavior is if you use `dataGetPtr` or `dataGetSlice` and then `dataSet`/`dataSetSlice` with the same size, you will see the new value updated through the pointer/slice. I don't believe this is an issue and was the working behavior before #209.