### PR TITLE
Catch use-after-free errors with no reuse option in ShrinkingArenaAllocator 

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -125,10 +125,10 @@ capture: ?dvui.CaptureMouse = null,
 captured_last_frame: bool = false,
 
 gpa: std.mem.Allocator,
-_arena: dvui.ShrinkingArenaAllocator(.{}),
-_lifo_arena: dvui.ShrinkingArenaAllocator(.{}),
+_arena: dvui.ShrinkingArenaAllocator(.{ .reuse_memory = builtin.mode != .Debug }),
+_lifo_arena: dvui.ShrinkingArenaAllocator(.{ .reuse_memory = builtin.mode != .Debug }),
 /// Used to allocate widgets with a fixed location
-_widget_stack: dvui.ShrinkingArenaAllocator(.{}),
+_widget_stack: dvui.ShrinkingArenaAllocator(.{ .reuse_memory = builtin.mode != .Debug }),
 render_target: dvui.RenderTarget = .{ .texture = null, .offset = .{} },
 end_rendering_done: bool = false,
 

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -125,10 +125,10 @@ capture: ?dvui.CaptureMouse = null,
 captured_last_frame: bool = false,
 
 gpa: std.mem.Allocator,
-_arena: dvui.ShrinkingArenaAllocator,
-_lifo_arena: dvui.ShrinkingArenaAllocator,
+_arena: dvui.ShrinkingArenaAllocator(.{}),
+_lifo_arena: dvui.ShrinkingArenaAllocator(.{}),
 /// Used to allocate widgets with a fixed location
-_widget_stack: dvui.ShrinkingArenaAllocator,
+_widget_stack: dvui.ShrinkingArenaAllocator(.{}),
 render_target: dvui.RenderTarget = .{ .texture = null, .offset = .{} },
 end_rendering_done: bool = false,
 
@@ -187,7 +187,7 @@ const SavedData = struct {
 
 pub const InitOptions = struct {
     id_extra: usize = 0,
-    arena: ?dvui.ShrinkingArenaAllocator = null,
+    arena: ?std.heap.ArenaAllocator = null,
     theme: ?*Theme = null,
     keybinds: ?enum {
         none,
@@ -206,7 +206,7 @@ pub fn init(
 
     var self = Self{
         .gpa = gpa,
-        ._arena = init_opts.arena orelse .init(gpa),
+        ._arena = if (init_opts.arena) |a| .initArena(a) else .init(gpa),
         ._lifo_arena = .init(gpa),
         ._widget_stack = .init(gpa),
         .wd = WidgetData{

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -92,7 +92,7 @@ pub const StructFieldOptions = se.StructFieldOptions;
 pub const enums = @import("enums.zig");
 pub const easing = @import("easing.zig");
 pub const testing = @import("testing.zig");
-pub const ShrinkingArenaAllocator = @import("shrinking_arena_allocator.zig");
+pub const ShrinkingArenaAllocator = @import("shrinking_arena_allocator.zig").ShrinkingArenaAllocator;
 pub const TrackingAutoHashMap = @import("tracking_hash_map.zig").TrackingAutoHashMap;
 
 pub const wasm = (builtin.target.cpu.arch == .wasm32 or builtin.target.cpu.arch == .wasm64);

--- a/src/shrinking_arena_allocator.zig
+++ b/src/shrinking_arena_allocator.zig
@@ -1,195 +1,205 @@
-//! This is a wrapper of the `ArenaAllocator` that keeps
-//! track of the peak memory used in order to retain only
-//! the most minimal allocation.
-//!
-//! This is important because dvui applications may allocate
-//! large files like images on the arena, but never again for
-//! the lifetime of the application. Retaining the capacity
-//! for these the large files does no make sense when only
-//! a fraction of that is used during a normal frame.
-
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Alignment = std.mem.Alignment;
 const ArenaAllocator = std.heap.ArenaAllocator;
 
-const ShrinkingArenaAllocator = @This();
+const InitOptions = struct {};
 
-arena: ArenaAllocator,
-peak_usage: usize = 0,
-current_usage: usize = 0,
-
-pub fn init(child_allocator: Allocator) ShrinkingArenaAllocator {
-    return .{ .arena = .init(child_allocator) };
-}
-
-pub fn deinit(self: ShrinkingArenaAllocator) void {
-    self.arena.deinit();
-}
-
-pub const ResetMode = union(enum) {
-    /// Releases all allocated memory in the arena.
-    free_all,
-    /// This will pre-heat the arena for future allocations by allocating
-    /// a large enough buffer for all previously done allocations.
-    /// Preheating will speed up the allocation process by invoking
-    /// the backing allocator less often than before. If `reset()`
-    /// is used in a loop, this means that after the biggest operation,
-    /// no memory allocations are performed anymore.
-    retain_capacity,
-    /// Shrinks the capacity to the peak usage plus some fraction
-    /// of the peak usage. This ensures that small variations in
-    /// the allocated memory won't cause any new allocations.
-    shrink_to_peak_usage,
-    /// Shrinks the capacity to exactly the peak amount used. This
-    /// means that any additional amount of capacity needed will
-    /// cause a new buffer to be allocated by the backing allocator.
-    shrink_to_peak_usage_exact,
-};
-
-/// Resets the inner arena using the strategy decided by `mode`
+/// This is a wrapper of the `ArenaAllocator` that keeps
+/// track of the peak memory used in order to retain only
+/// the most minimal allocation.
 ///
-/// The function will return whether the reset operation was
-/// successful or not. If the reallocation failed `false` is
-/// returned. The arena will still be fully functional in that
-/// case, all memory is released. Future allocations just
-/// might be slower.
-pub fn reset(self: *ShrinkingArenaAllocator, mode: ResetMode) bool {
-    defer self.current_usage = 0;
-    defer self.peak_usage = 0;
-    return switch (mode) {
-        .free_all => self.arena.reset(.free_all),
-        .retain_capacity => self.arena.reset(.retain_capacity),
-        .shrink_to_peak_usage => self.arena.reset(.{ .retain_with_limit = self.peak_usage + self.peak_usage / 2 }),
-        .shrink_to_peak_usage_exact => self.arena.reset(.{ .retain_with_limit = self.peak_usage }),
-    };
-}
+/// This is important because dvui applications may allocate
+/// large files like images on the arena, but never again for
+/// the lifetime of the application. Retaining the capacity
+/// for these the large files does no make sense when only
+/// a fraction of that is used during a normal frame.
+pub fn ShrinkingArenaAllocator(comptime opts: InitOptions) type {
+    _ = opts;
+    return struct {
+        arena: ArenaAllocator,
+        peak_usage: usize = 0,
+        current_usage: usize = 0,
 
-pub fn debug_log(self: *const ShrinkingArenaAllocator) void {
-    std.log.debug("{*} current used: {d}", .{ self, self.current_usage });
-    std.log.debug("{*} peak used: {d}", .{ self, self.peak_usage });
-    std.log.debug("{*} arena buf len: {d}", .{ self, self.arena.state.buffer_list.len() });
-    std.log.debug("{*} arena capacity: {d}", .{ self, self.arena.queryCapacity() });
-}
+        const Self = @This();
 
-pub fn allocator(self: *ShrinkingArenaAllocator) Allocator {
-    return .{
-        .ptr = self,
-        .vtable = &.{
-            .alloc = alloc,
-            .resize = resize,
-            .remap = remap,
-            .free = free,
-        },
-    };
-}
-
-/// This version of the allocator enforces that all calls to
-/// free succeeds, meaning all allocations and frees are
-/// performed in the order of last allocated, first freed.
-///
-/// This is most easily achieved by immidietly deferring the
-/// freeing of allocated memory.
-pub fn allocatorLIFO(self: *ShrinkingArenaAllocator) Allocator {
-    return .{
-        .ptr = self,
-        .vtable = &.{
-            .alloc = alloc,
-            .resize = resize,
-            .remap = remap,
-            .free = freeLIFO,
-        },
-    };
-}
-
-pub fn has_expanded(self: *const ShrinkingArenaAllocator) bool {
-    if (self.arena.state.buffer_list.first) |first| {
-        // If there is a second buffer, we expanded past our first
-        return first.next != null;
-    } else return false;
-}
-
-/// Attempts to free the given memory and returns whether it
-/// succeeded or not.
-fn attemptFree(self: *ShrinkingArenaAllocator, memory: []u8, alignment: Alignment, ret_addr: usize) bool {
-    const end_before = self.arena.state.end_index;
-    self.arena.allocator().rawFree(memory, alignment, ret_addr);
-
-    if (memory.len == 0) {
-        // The allocation had no bytes, so cannot fail freeing
-        return true;
-    }
-
-    if (!self.has_expanded()) {
-        // Attempt to free acounting for alignment padding of allocations after the current one
-        var align_diff: usize = 8;
-        while (self.arena.state.end_index == end_before and align_diff > 0) : (align_diff >>= 1) {
-            var mem = memory;
-            mem.len = std.mem.alignForward(usize, @intFromPtr(memory.ptr) + memory.len, align_diff) - @intFromPtr(memory.ptr);
-            self.arena.allocator().rawFree(mem, alignment, ret_addr);
+        pub fn init(child_allocator: Allocator) Self {
+            return .{ .arena = .init(child_allocator) };
         }
-    }
-    const succeeded = self.arena.state.end_index < end_before;
-    if (succeeded) {
-        self.current_usage -= memory.len;
-    }
-    return succeeded;
-}
 
-fn alloc(ctx: *anyopaque, len: usize, alignment: Alignment, ret_addr: usize) ?[*]u8 {
-    const self: *ShrinkingArenaAllocator = @ptrCast(@alignCast(ctx));
-    const buf = self.arena.allocator().rawAlloc(len, alignment, ret_addr) orelse return null;
-    self.current_usage += len;
-    self.peak_usage = @max(self.peak_usage, self.current_usage);
-    return buf;
-}
+        pub fn initArena(arena: ArenaAllocator) Self {
+            return .{ .arena = arena };
+        }
 
-fn free(ctx: *anyopaque, memory: []u8, alignment: Alignment, ret_addr: usize) void {
-    const self: *ShrinkingArenaAllocator = @ptrCast(@alignCast(ctx));
-    _ = self.attemptFree(memory, alignment, ret_addr);
-}
+        pub fn deinit(self: Self) void {
+            self.arena.deinit();
+        }
 
-fn freeLIFO(ctx: *anyopaque, memory: []u8, alignment: Alignment, ret_addr: usize) void {
-    const self: *ShrinkingArenaAllocator = @ptrCast(@alignCast(ctx));
-    if (!self.attemptFree(memory, alignment, ret_addr) and !self.has_expanded()) {
-        var addresses: [8]usize = undefined;
-        var trace = std.builtin.StackTrace{
-            .index = 0,
-            .instruction_addresses = &addresses,
+        pub const ResetMode = union(enum) {
+            /// Releases all allocated memory in the arena.
+            free_all,
+            /// This will pre-heat the arena for future allocations by allocating
+            /// a large enough buffer for all previously done allocations.
+            /// Preheating will speed up the allocation process by invoking
+            /// the backing allocator less often than before. If `reset()`
+            /// is used in a loop, this means that after the biggest operation,
+            /// no memory allocations are performed anymore.
+            retain_capacity,
+            /// Shrinks the capacity to the peak usage plus some fraction
+            /// of the peak usage. This ensures that small variations in
+            /// the allocated memory won't cause any new allocations.
+            shrink_to_peak_usage,
+            /// Shrinks the capacity to exactly the peak amount used. This
+            /// means that any additional amount of capacity needed will
+            /// cause a new buffer to be allocated by the backing allocator.
+            shrink_to_peak_usage_exact,
         };
-        std.debug.captureStackTrace(ret_addr, &trace);
-        std.log.debug("Free from lifo arena failed. Somewhere between when this was allocated and this call to free there was another allocation that was not freed first. Stack trace: {}", .{trace});
-    }
-}
 
-fn remap(ctx: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
-    const self: *ShrinkingArenaAllocator = @ptrCast(@alignCast(ctx));
-    const end_before = self.arena.state.end_index;
-    const buf = self.arena.allocator().rawRemap(memory, alignment, new_len, ret_addr) orelse return null;
-    if (self.arena.state.end_index != end_before) {
-        if (new_len < memory.len) {
-            self.current_usage -= memory.len - new_len;
-        } else {
-            self.current_usage += new_len - memory.len;
-            self.peak_usage = @max(self.peak_usage, self.current_usage);
+        /// Resets the inner arena using the strategy decided by `mode`
+        ///
+        /// The function will return whether the reset operation was
+        /// successful or not. If the reallocation failed `false` is
+        /// returned. The arena will still be fully functional in that
+        /// case, all memory is released. Future allocations just
+        /// might be slower.
+        pub fn reset(self: *Self, mode: ResetMode) bool {
+            defer self.current_usage = 0;
+            defer self.peak_usage = 0;
+            return switch (mode) {
+                .free_all => self.arena.reset(.free_all),
+                .retain_capacity => self.arena.reset(.retain_capacity),
+                .shrink_to_peak_usage => self.arena.reset(.{ .retain_with_limit = self.peak_usage + self.peak_usage / 2 }),
+                .shrink_to_peak_usage_exact => self.arena.reset(.{ .retain_with_limit = self.peak_usage }),
+            };
         }
-    }
-    return buf;
-}
 
-fn resize(ctx: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, ret_addr: usize) bool {
-    const self: *ShrinkingArenaAllocator = @ptrCast(@alignCast(ctx));
-    if (self.arena.allocator().rawResize(memory, alignment, new_len, ret_addr)) {
-        if (new_len < memory.len) {
-            self.current_usage -= memory.len - new_len;
-        } else {
-            self.current_usage += new_len - memory.len;
-            self.peak_usage = @max(self.peak_usage, self.current_usage);
+        pub fn debug_log(self: *const Self) void {
+            std.log.debug("{*} current used: {d}", .{ self, self.current_usage });
+            std.log.debug("{*} peak used: {d}", .{ self, self.peak_usage });
+            std.log.debug("{*} arena buf len: {d}", .{ self, self.arena.state.buffer_list.len() });
+            std.log.debug("{*} arena capacity: {d}", .{ self, self.arena.queryCapacity() });
         }
-        return true;
-    } else {
-        return false;
-    }
+
+        pub fn allocator(self: *Self) Allocator {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .alloc = alloc,
+                    .resize = resize,
+                    .remap = remap,
+                    .free = free,
+                },
+            };
+        }
+
+        /// This version of the allocator enforces that all calls to
+        /// free succeeds, meaning all allocations and frees are
+        /// performed in the order of last allocated, first freed.
+        ///
+        /// This is most easily achieved by immidietly deferring the
+        /// freeing of allocated memory.
+        pub fn allocatorLIFO(self: *Self) Allocator {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .alloc = alloc,
+                    .resize = resize,
+                    .remap = remap,
+                    .free = freeLIFO,
+                },
+            };
+        }
+
+        pub fn has_expanded(self: *const Self) bool {
+            if (self.arena.state.buffer_list.first) |first| {
+                // If there is a second buffer, we expanded past our first
+                return first.next != null;
+            } else return false;
+        }
+
+        /// Attempts to free the given memory and returns whether it
+        /// succeeded or not.
+        fn attemptFree(self: *Self, memory: []u8, alignment: Alignment, ret_addr: usize) bool {
+            const end_before = self.arena.state.end_index;
+            self.arena.allocator().rawFree(memory, alignment, ret_addr);
+
+            if (memory.len == 0) {
+                // The allocation had no bytes, so cannot fail freeing
+                return true;
+            }
+
+            if (!self.has_expanded()) {
+                // Attempt to free acounting for alignment padding of allocations after the current one
+                var align_diff: usize = 8;
+                while (self.arena.state.end_index == end_before and align_diff > 0) : (align_diff >>= 1) {
+                    var mem = memory;
+                    mem.len = std.mem.alignForward(usize, @intFromPtr(memory.ptr) + memory.len, align_diff) - @intFromPtr(memory.ptr);
+                    self.arena.allocator().rawFree(mem, alignment, ret_addr);
+                }
+            }
+            const succeeded = self.arena.state.end_index < end_before;
+            if (succeeded) {
+                self.current_usage -= memory.len;
+            }
+            return succeeded;
+        }
+
+        fn alloc(ctx: *anyopaque, len: usize, alignment: Alignment, ret_addr: usize) ?[*]u8 {
+            const self: *Self = @ptrCast(@alignCast(ctx));
+            const buf = self.arena.allocator().rawAlloc(len, alignment, ret_addr) orelse return null;
+            self.current_usage += len;
+            self.peak_usage = @max(self.peak_usage, self.current_usage);
+            return buf;
+        }
+
+        fn free(ctx: *anyopaque, memory: []u8, alignment: Alignment, ret_addr: usize) void {
+            const self: *Self = @ptrCast(@alignCast(ctx));
+            _ = self.attemptFree(memory, alignment, ret_addr);
+        }
+
+        fn freeLIFO(ctx: *anyopaque, memory: []u8, alignment: Alignment, ret_addr: usize) void {
+            const self: *Self = @ptrCast(@alignCast(ctx));
+            if (!self.attemptFree(memory, alignment, ret_addr) and !self.has_expanded()) {
+                var addresses: [8]usize = undefined;
+                var trace = std.builtin.StackTrace{
+                    .index = 0,
+                    .instruction_addresses = &addresses,
+                };
+                std.debug.captureStackTrace(ret_addr, &trace);
+                std.log.debug("Free from lifo arena failed. Somewhere between when this was allocated and this call to free there was another allocation that was not freed first. Stack trace: {}", .{trace});
+            }
+        }
+
+        fn remap(ctx: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
+            const self: *Self = @ptrCast(@alignCast(ctx));
+            const end_before = self.arena.state.end_index;
+            const buf = self.arena.allocator().rawRemap(memory, alignment, new_len, ret_addr) orelse return null;
+            if (self.arena.state.end_index != end_before) {
+                if (new_len < memory.len) {
+                    self.current_usage -= memory.len - new_len;
+                } else {
+                    self.current_usage += new_len - memory.len;
+                    self.peak_usage = @max(self.peak_usage, self.current_usage);
+                }
+            }
+            return buf;
+        }
+
+        fn resize(ctx: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, ret_addr: usize) bool {
+            const self: *Self = @ptrCast(@alignCast(ctx));
+            if (self.arena.allocator().rawResize(memory, alignment, new_len, ret_addr)) {
+                if (new_len < memory.len) {
+                    self.current_usage -= memory.len - new_len;
+                } else {
+                    self.current_usage += new_len - memory.len;
+                    self.peak_usage = @max(self.peak_usage, self.current_usage);
+                }
+                return true;
+            } else {
+                return false;
+            }
+        }
+    };
 }
 
 test {


### PR DESCRIPTION
@foxnne encountered a use-after-free in the examples (7556eca79bff56756c4e3da224c87dd3bbf99972) which was not caught by `WidgetData.validate`. This indicates that reusing memory prevents the effectiveness of the undefined checks that have been implemented, as mentioned in #414.

This PR makes `ShrinkingArenaAllocator` configurable and add the `reuse_memory` option which can be disabled. This duplicates all allocations in a separate `std.heap.ArenaAllocator` that never frees anything and only returns pointers to that memory. It does still perform the allocations in the normal arena to validate lifo behaviours.

