### PR TITLE
ImageSource and texture cache changes

### DIFF
--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -69,9 +69,9 @@ pub fn drawClippedTriangles(self: Backend, texture: ?dvui.Texture, vtx: []const 
     return self.impl.drawClippedTriangles(texture, vtx, idx, clipr);
 }
 
-/// Create a `dvui.Texture` from the given `pixels` in RGBA.  The returned
-/// pointer is what will later be passed to `drawClippedTriangles`.
-pub fn textureCreate(self: Backend, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) TextureError!dvui.Texture {
+/// Create a `dvui.Texture` from premultiplied alpha `pixels` in RGBA.  The
+/// returned pointer is what will later be passed to `drawClippedTriangles`.
+pub fn textureCreate(self: Backend, pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) TextureError!dvui.Texture {
     return self.impl.textureCreate(pixels, width, height, interpolation);
 }
 

--- a/src/Color.zig
+++ b/src/Color.zig
@@ -354,6 +354,32 @@ pub const PMA = extern struct {
     pub fn castToColor(self: PMA) Color {
         return .{ .r = self.r, .g = self.g, .b = self.b, .a = self.a };
     }
+
+    /// Alpha multiplies `pixels` in place
+    pub fn sliceFromRGBA(pixels: []u8) []Color.PMA {
+        for (0..pixels.len / 4) |ii| {
+            const i = ii * 4;
+            const a = pixels[i + 3];
+            pixels[i + 0] = @intCast(@divTrunc(@as(u16, pixels[i + 0]) * a, 255));
+            pixels[i + 1] = @intCast(@divTrunc(@as(u16, pixels[i + 1]) * a, 255));
+            pixels[i + 2] = @intCast(@divTrunc(@as(u16, pixels[i + 2]) * a, 255));
+        }
+        return @ptrCast(pixels);
+    }
+
+    /// Unapplies the alpha multiplication in place, returning the inner slice
+    pub fn sliceToRGBA(pma_pixels: []Color.PMA) []u8 {
+        var pixels: []u8 = @ptrCast(pma_pixels);
+        for (0..pixels.len / 4) |ii| {
+            const i = ii * 4;
+            const a = pixels[i + 3];
+            if (a == 0) continue;
+            pixels[i + 0] = @intCast(@divTrunc(@as(u16, pixels[i + 0]) * 255, a));
+            pixels[i + 1] = @intCast(@divTrunc(@as(u16, pixels[i + 1]) * 255, a));
+            pixels[i + 2] = @intCast(@divTrunc(@as(u16, pixels[i + 2]) * 255, a));
+        }
+        return pixels;
+    }
 };
 
 pub const HexString = [7]u8;

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -98,7 +98,7 @@ font_cache: dvui.TrackingAutoHashMap(u64, dvui.FontCacheEntry, .get_and_put) = .
 /// Uses `gpa` allocator
 font_bytes: std.StringHashMapUnmanaged(dvui.FontBytesEntry) = .empty,
 /// Uses `gpa` allocator
-texture_cache: dvui.TrackingAutoHashMap(u64, dvui.TextureCacheEntry, .get_and_put) = .empty,
+texture_cache: dvui.TrackingAutoHashMap(dvui.Texture.CacheKey, dvui.Texture, .get_and_put) = .empty,
 /// Uses `arena` allocator
 texture_trash: std.ArrayListUnmanaged(dvui.Texture) = .empty,
 dialog_mutex: std.Thread.Mutex = .{},
@@ -420,7 +420,7 @@ pub fn deinit(self: *Self) void {
     {
         var it = self.texture_cache.iterator();
         while (it.next()) |item| {
-            self.backend.textureDestroy(item.value_ptr.texture);
+            self.backend.textureDestroy(item.value_ptr.*);
         }
         self.texture_cache.deinit(self.gpa);
     }
@@ -1164,7 +1164,7 @@ pub fn begin(
         defer self.lifo().free(deadTextures);
         for (deadTextures) |id| {
             const ice = self.texture_cache.fetchRemove(id).?;
-            self.backend.textureDestroy(ice.value.texture);
+            self.backend.textureDestroy(ice.value);
         }
         //std.debug.print("texture_cache {d}\n", .{self.texture_cache.count()});
     }

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -658,7 +658,7 @@ fn createBuffer(state: *WindowState, bind_type: anytype, comptime InitialType: t
 }
 
 // ############ Satisfy DVUI interfaces ############
-pub fn textureCreate(self: Context, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.Texture {
+pub fn textureCreate(self: Context, pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.Texture {
     const state = stateFromHwnd(hwndFromContext(self));
 
     var texture: *win32.ID3D11Texture2D = undefined;

--- a/src/backends/raylib.zig
+++ b/src/backends/raylib.zig
@@ -292,7 +292,7 @@ pub fn drawClippedTriangles(self: *RaylibBackend, texture: ?dvui.Texture, vtx: [
     }
 }
 
-pub fn textureCreate(_: *RaylibBackend, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.Texture {
+pub fn textureCreate(_: *RaylibBackend, pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.Texture {
     const texid = c.rlLoadTexture(pixels, @intCast(width), @intCast(height), c.PIXELFORMAT_UNCOMPRESSED_R8G8B8A8, 1);
     if (texid <= 0) return dvui.Backend.TextureError.TextureCreate;
 

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -721,7 +721,7 @@ pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []co
     }
 }
 
-pub fn textureCreate(self: *SDLBackend, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.Texture {
+pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.Texture {
     if (!sdl3) switch (interpolation) {
         .nearest => _ = c.SDL_SetHint(c.SDL_HINT_RENDER_SCALE_QUALITY, "nearest"),
         .linear => _ = c.SDL_SetHint(c.SDL_HINT_RENDER_SCALE_QUALITY, "linear"),
@@ -732,12 +732,12 @@ pub fn textureCreate(self: *SDLBackend, pixels: [*]u8, width: u32, height: u32, 
             @as(c_int, @intCast(width)),
             @as(c_int, @intCast(height)),
             c.SDL_PIXELFORMAT_ABGR8888,
-            pixels,
+            @constCast(pixels),
             @as(c_int, @intCast(4 * width)),
         ) orelse return logErr("SDL_CreateSurfaceFrom in textureCreate")
     else
         c.SDL_CreateRGBSurfaceWithFormatFrom(
-            pixels,
+            @constCast(pixels),
             @as(c_int, @intCast(width)),
             @as(c_int, @intCast(height)),
             32,

--- a/src/backends/testing.zig
+++ b/src/backends/testing.zig
@@ -85,7 +85,7 @@ pub fn drawClippedTriangles(_: *TestingBackend, _: ?dvui.Texture, _: []const dvu
 
 /// Create a texture from the given pixels in RGBA.  The returned
 /// pointer is what will later be passed to drawClippedTriangles.
-pub fn textureCreate(self: *TestingBackend, pixels: [*]u8, width: u32, height: u32, _: dvui.enums.TextureInterpolation) !dvui.Texture {
+pub fn textureCreate(self: *TestingBackend, pixels: [*]const u8, width: u32, height: u32, _: dvui.enums.TextureInterpolation) !dvui.Texture {
     const new_pixels = self.allocator.dupe(u8, pixels[0 .. width * height * 4]) catch @panic("Couldn't create texture: OOM");
     return .{
         .width = width,

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -46,7 +46,7 @@ pub const wasm = if (!builtin.is_test) struct {
     pub extern "dvui" fn wasm_canvas_height() f32;
 
     pub extern "dvui" fn wasm_frame_buffer() u8;
-    pub extern "dvui" fn wasm_textureCreate(pixels: [*]u8, width: u32, height: u32, interp: u8) u32;
+    pub extern "dvui" fn wasm_textureCreate(pixels: [*]const u8, width: u32, height: u32, interp: u8) u32;
     pub extern "dvui" fn wasm_textureCreateTarget(width: u32, height: u32, interp: u8) u32;
     pub extern "dvui" fn wasm_textureRead(texture: u32, pixels_out: [*]u8, width: u32, height: u32) void;
     pub extern "dvui" fn wasm_renderTarget(u32) void;
@@ -98,7 +98,7 @@ pub const wasm = if (!builtin.is_test) struct {
     pub fn wasm_frame_buffer() u8 {
         return undefined;
     }
-    pub fn wasm_textureCreate(_: [*]u8, _: u32, _: u32, _: u8) u32 {
+    pub fn wasm_textureCreate(_: [*]const u8, _: u32, _: u32, _: u8) u32 {
         return undefined;
     }
     pub fn wasm_textureCreateTarget(_: u32, _: u32, _: u8) u32 {
@@ -623,7 +623,7 @@ pub fn drawClippedTriangles(_: *WebBackend, texture: ?dvui.Texture, vtx: []const
     );
 }
 
-pub fn textureCreate(_: *WebBackend, pixels: [*]u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.Texture {
+pub fn textureCreate(_: *WebBackend, pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.Texture {
     const wasm_interp: u8 = switch (interpolation) {
         .nearest => 0,
         .linear => 1,

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5390,9 +5390,6 @@ pub const ImageSource = struct {
 
     interpolation: enums.TextureInterpolation = .linear,
 
-    /// Used for debugging output.
-    name: []const u8 = "image",
-
     /// Ensures next time `image()` is called a new texture will be generated.
     ///
     /// Only valid between `Window.begin`and `Window.end`.
@@ -5461,7 +5458,7 @@ pub const ImageInitOptions = struct {
 ///
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn image(src: std.builtin.SourceLocation, init_opts: ImageInitOptions, opts: Options) WidgetData {
-    const options = (Options{ .name = init_opts.source.name }).override(opts);
+    const options = (Options{ .name = "image" }).override(opts);
 
     var size = Size{};
     if (options.min_size_content) |msc| {
@@ -5522,7 +5519,7 @@ pub fn image(src: std.builtin.SourceLocation, init_opts: ImageInitOptions, opts:
         .background_color = renderBackground,
     };
     const content_rs = wd.contentRectScale();
-    renderImage(init_opts.source, content_rs, render_tex_opts) catch |err| logError(@src(), err, "Could not render image {s} at {}", .{ init_opts.source.name, content_rs });
+    renderImage(init_opts.source, content_rs, render_tex_opts) catch |err| logError(@src(), err, "Could not render image {?s} at {}", .{ opts.name, content_rs });
     wd.minSizeSetAndRefresh();
     wd.minSizeReportToParent();
 

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -327,9 +327,9 @@ pub fn getHueSelectorTexture(dir: dvui.enums.Direction) dvui.Backend.TextureErro
             .horizontal => .{ hue_selector_colors.len, 1 },
             .vertical => .{ 1, hue_selector_colors.len },
         };
-        res.value_ptr.texture = try dvui.textureCreate(&hue_selector_colors, width, height, .linear);
+        res.value_ptr.* = try dvui.textureCreate(&hue_selector_colors, width, height, .linear);
     }
-    return res.value_ptr.texture;
+    return res.value_ptr.*;
 }
 
 pub fn getValueSaturationTexture(hue: f32) dvui.Backend.TextureError!dvui.Texture {
@@ -339,9 +339,9 @@ pub fn getValueSaturationTexture(hue: f32) dvui.Backend.TextureError!dvui.Textur
     if (!res.found_existing) {
         var pixels: [4]Color.PMA = .{ .white, .cast(Color.HSV.toColor(.{ .h = hue })), .black, .black };
         // set top right corner to the max value of that hue
-        res.value_ptr.texture = try dvui.textureCreate(&pixels, 2, 2, .linear);
+        res.value_ptr.* = try dvui.textureCreate(&pixels, 2, 2, .linear);
     }
-    return res.value_ptr.texture;
+    return res.value_ptr.*;
 }
 
 const hue_selector_colors: [7]Color.PMA = .{ .red, .yellow, .lime, .cyan, .blue, .magenta, .red };

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -327,8 +327,7 @@ pub fn getHueSelectorTexture(dir: dvui.enums.Direction) dvui.Backend.TextureErro
             .horizontal => .{ hue_selector_colors.len, 1 },
             .vertical => .{ 1, hue_selector_colors.len },
         };
-        // FIXME: textureCreate should not need a non const pointer to pixels
-        res.value_ptr.texture = try dvui.textureCreate(.{ .pma = @constCast(&hue_selector_colors) }, width, height, .linear);
+        res.value_ptr.texture = try dvui.textureCreate(&hue_selector_colors, width, height, .linear);
     }
     return res.value_ptr.texture;
 }
@@ -340,7 +339,7 @@ pub fn getValueSaturationTexture(hue: f32) dvui.Backend.TextureError!dvui.Textur
     if (!res.found_existing) {
         var pixels: [4]Color.PMA = .{ .white, .cast(Color.HSV.toColor(.{ .h = hue })), .black, .black };
         // set top right corner to the max value of that hue
-        res.value_ptr.texture = try dvui.textureCreate(.{ .pma = &pixels }, 2, 2, .linear);
+        res.value_ptr.texture = try dvui.textureCreate(&pixels, 2, 2, .linear);
     }
     return res.value_ptr.texture;
 }


### PR DESCRIPTION
This extends #442 

This adds functions to interact with the texture cache directly which means `TextureCacheEntry` is no longer needed for hashing. The creation and caching of textures has been separated so that `ImageSource` can do it's own logic while also letting users create textures and cache them as they need.

This way the user can choose to create their own textures and use the dvui cache for automatic cleanup (some more docs on `textureAddToCache` are needed before merging).

`ImageSource` has also been changed to a `union(enum)` to avoid more levels of `.{ .XXX = .{ ... } }`. The `hash` function also makes it possible for the user to invalidate the texture using `textureInvalidateCache` without some special function on `ImageSource`. If we want, each anonymous struct in the union could also be extracted and named separately.

Additionally, hashing of `interpolation` is included as well as an invalidation strategy to determine how the hash is calcualted.