### PR TITLE
GridWidget: really fix scroll sync/refresh issue

### DIFF
--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -324,7 +324,7 @@ pub fn deinit(self: *GridWidget) void {
     defer self.* = undefined;
     defer dvui.widgetFree(self);
 
-    if (self.hsi.viewport.x != self.frame_viewport.x) self.hsi.viewport.x = self.bsi.viewport.x;
+    if (self.bsi.viewport.x != self.frame_viewport.x) self.hsi.viewport.x = self.bsi.viewport.x;
 
     // resizing if row heights changed or a resize was requested via init options.
     if (self.resizing) {


### PR DESCRIPTION
Revert of #450, also reverted the correct fix put in #448.
This change restores the correct fix.