### PR TITLE
GridWidget: Various fixes

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -5182,7 +5182,8 @@ fn gridVirtualScrolling() void {
     };
     highlight_hovered.processEvents(grid);
 
-    const borders: CellStyle.Borders = .initBox(2, num_rows, 1);
+    var borders: CellStyle.Borders = .initBox(2, num_rows, 1, 1);
+    borders.external.y = 0; // The grid border already does this side.
 
     const cell_style: CellStyle.Combine(CellStyle.HoveredRow, CellStyle.Borders) = .{
         .style1 = highlight_hovered,

--- a/src/widgets/GridWidget/CellStyle.zig
+++ b/src/widgets/GridWidget/CellStyle.zig
@@ -204,18 +204,18 @@ pub const Borders = struct {
     cell_opts: CellOptions = .{},
     opts: Options = .{},
 
-    pub fn initBox(num_cols: usize, num_rows: usize, border_width: f32) Borders {
+    pub fn initBox(num_cols: usize, num_rows: usize, border_external_w: f32, border_internal_w: f32) Borders {
         return .{
-            .external = Rect.all(border_width),
-            .internal = .{ .w = 1, .h = 1 },
+            .external = Rect.all(border_external_w),
+            .internal = .{ .w = border_internal_w, .h = border_internal_w },
             .num_cols = num_cols,
             .num_rows = num_rows,
         };
     }
 
-    pub fn initOutline(num_cols: usize, num_rows: usize, border_width: f32) Borders {
+    pub fn initOutline(num_cols: usize, num_rows: usize, border_external_w: f32) Borders {
         return .{
-            .external = Rect.all(border_width),
+            .external = Rect.all(border_external_w),
             .internal = Rect.all(0),
             .num_cols = num_cols,
             .num_rows = num_rows,


### PR DESCRIPTION
- Fixed issue with HeaderResizeWidget not calculating offset correctly
- Reverted HeaderResizeWidget "max_size_total" changes until they can be better tested / refactored.
- CellStyle.Borders now accepts a width for the internal borders
- Removed all viewport sync code from GridWidget.deinit(). This is hopefully the final and correct fix for this!