### PR TITLE
Tree: Add option to disable reordering event handling

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -2372,6 +2372,9 @@ pub fn reorderTree() void {
     exampleFileTree(
         @src(),
         .{
+            .enable_reordering = false,
+        },
+        .{
             .background = true,
             .border = dvui.Rect.all(1),
             .padding = dvui.Rect.all(4),
@@ -2688,10 +2691,10 @@ fn exampleFileTreeSetup(const_file_tree: []const ConstTreeEntry, mutable_file_tr
     }
 }
 
-pub fn exampleFileTree(src: std.builtin.SourceLocation, tree_options: dvui.Options, branch_options: dvui.Options, expander_options: dvui.Options) !void {
+pub fn exampleFileTree(src: std.builtin.SourceLocation, tree_init_options: dvui.TreeWidget.InitOptions, tree_options: dvui.Options, branch_options: dvui.Options, expander_options: dvui.Options) !void {
     const uniqueId = dvui.parentGet().extendId(@src(), 0);
 
-    var tree = dvui.TreeWidget.tree(src, tree_options);
+    var tree = dvui.TreeWidget.tree(src, tree_init_options, tree_options);
     defer tree.deinit();
 
     var color_index: usize = 0;

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -2372,7 +2372,7 @@ pub fn reorderTree() void {
     exampleFileTree(
         @src(),
         .{
-            .enable_reordering = false,
+            .enable_reordering = true,
         },
         .{
             .background = true,

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -2719,8 +2719,8 @@ pub fn exampleFileTree(src: std.builtin.SourceLocation, tree_init_options: dvui.
     }
 }
 
-pub fn fileTree(src: std.builtin.SourceLocation, root_directory: []const u8, tree_options: dvui.Options, branch_options: dvui.Options, expander_options: dvui.Options) !void {
-    var tree = dvui.TreeWidget.tree(src, tree_options);
+pub fn fileTree(src: std.builtin.SourceLocation, root_directory: []const u8, tree_init_options: dvui.TreeWidget.InitOptions, tree_options: dvui.Options, branch_options: dvui.Options, expander_options: dvui.Options) !void {
+    var tree = dvui.TreeWidget.tree(src, tree_init_options, tree_options);
     defer tree.deinit();
 
     const uniqueId = dvui.parentGet().extendId(@src(), 0);


### PR DESCRIPTION
As suggested [here](https://github.com/david-vanderson/dvui/pull/413#issuecomment-3038579623).

@david-vanderson Not sure if you have any opinions surrounding that comment, we could reduce the effects on the example file tree, I just felt like it showcased what all you can do. There are regular `Options` for the file tree's box, each branch's button, and the expanded and indented box where borders outline the files. I think other than the missing switch to disable reordering, the other requests are possible with various styling of the boxes and what's added to each. 

I guess it would take someone trying to achieve something specific to test that out though.


