### PR TITLE
Examples cleanup

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -826,7 +826,7 @@ const dialogs = @import("Examples/dialogs.zig").dialogs;
 const animations = @import("Examples/animations.zig").animations;
 const structUI = @import("Examples/struct_ui.zig").structUI;
 const debuggingErrors = @import("Examples/debugging.zig").debuggingErrors;
-const icon_browser = @import("Examples/icon_browser.zig").icon_browser;
+const icon_browser = @import("Examples/icon_browser.zig").iconBrowser;
 
 const grid_examples = @import("Examples/grid.zig");
 const gridStyling = grid_examples.gridStyling;

--- a/src/Examples/animations.zig
+++ b/src/Examples/animations.zig
@@ -182,16 +182,18 @@ pub fn animations() void {
         const millis = @divFloor(dvui.frameTimeNS(), 1_000_000);
         const left = @as(i32, @intCast(@rem(millis, 1000)));
 
-        var mslabel = dvui.LabelWidget.init(@src(), "{d:0>3} ms into second", .{@as(u32, @intCast(left))}, .{}, .{});
-        mslabel.install();
-        mslabel.draw();
+        {
+            var mslabel = dvui.LabelWidget.init(@src(), "{d:0>3} ms into second", .{@as(u32, @intCast(left))}, .{}, .{});
+            defer mslabel.deinit();
 
-        if (dvui.timerDoneOrNone(mslabel.data().id)) {
-            const wait = 1000 * (1000 - left);
-            dvui.timer(mslabel.data().id, wait);
+            mslabel.install();
+            mslabel.draw();
+
+            if (dvui.timerDoneOrNone(mslabel.data().id)) {
+                const wait = 1000 * (1000 - left);
+                dvui.timer(mslabel.data().id, wait);
+            }
         }
-        mslabel.deinit();
-
         dvui.label(@src(), "Estimate of frame overhead {d:6} us", .{dvui.currentWindow().loop_target_slop}, .{});
         switch (dvui.backend.kind) {
             .sdl2, .sdl3 => dvui.label(@src(), "sdl: updated when not interrupted by event", .{}, .{}),

--- a/src/Examples/basic_widgets.zig
+++ b/src/Examples/basic_widgets.zig
@@ -281,6 +281,7 @@ pub fn dropdownAdvanced() void {
 
     var dd = dvui.DropdownWidget.init(@src(), .{ .selected_index = g.choice }, .{ .min_size_content = .{ .w = 100 } });
     dd.install();
+    defer dd.deinit();
 
     // Here's what is shown when the dropdown is not dropped
     {
@@ -339,7 +340,6 @@ pub fn dropdownAdvanced() void {
         if (dd.addChoiceLabel("just text")) {
             g.choice = 1;
         }
-
         {
             var mi = dd.addChoice();
             defer mi.deinit();
@@ -358,8 +358,6 @@ pub fn dropdownAdvanced() void {
             }
         }
     }
-
-    dd.deinit();
 }
 
 const std = @import("std");

--- a/src/Examples/icon_browser.zig
+++ b/src/Examples/icon_browser.zig
@@ -1,5 +1,5 @@
 /// ![image](Examples-icon_browser.png)
-pub fn icon_browser(src: std.builtin.SourceLocation, show_flag: *bool, comptime icon_decl_name: []const u8, comptime icon_decl: type) void {
+pub fn iconBrowser(src: std.builtin.SourceLocation, show_flag: *bool, comptime icon_decl_name: []const u8, comptime icon_decl: type) void {
     const num_icons = @typeInfo(icon_decl).@"struct".decls.len;
     const Settings = struct {
         icon_size: f32 = 20,

--- a/src/Examples/layout.zig
+++ b/src/Examples/layout.zig
@@ -143,38 +143,42 @@ pub fn layout() void {
         _ = dvui.sliderEntry(@src(), "border {d:0.0}", .{ .value = &layout_border.y, .min = 0, .max = 20.0, .interval = 1 }, .{});
         _ = dvui.sliderEntry(@src(), "padding {d:0.0}", .{ .value = &layout_padding.y, .min = 0, .max = 20.0, .interval = 1 }, .{});
         vbox2.deinit();
-
-        var hbox = dvui.box(@src(), .horizontal, .{});
-
-        vbox2 = dvui.box(@src(), .vertical, .{ .gravity_y = 0.5 });
-        _ = dvui.sliderEntry(@src(), "margin {d:0.0}", .{ .value = &layout_margin.x, .min = 0, .max = 20.0, .interval = 1 }, .{});
-        _ = dvui.sliderEntry(@src(), "border {d:0.0}", .{ .value = &layout_border.x, .min = 0, .max = 20.0, .interval = 1 }, .{});
-        _ = dvui.sliderEntry(@src(), "padding {d:0.0}", .{ .value = &layout_padding.x, .min = 0, .max = 20.0, .interval = 1 }, .{});
-        vbox2.deinit();
-
-        var o = dvui.overlay(@src(), .{ .min_size_content = .{ .w = 164, .h = 140 } });
-        var o2 = dvui.overlay(@src(), .{ .background = true, .gravity_x = 0.5, .gravity_y = 0.5 });
-        if (dvui.button(@src(), "reset", .{}, .{ .margin = layout_margin, .border = layout_border, .padding = layout_padding })) {
-            layout_margin = Rect.all(4);
-            layout_border = Rect.all(0);
-            layout_padding = Rect.all(4);
+        {
+            var hbox = dvui.box(@src(), .horizontal, .{});
+            defer hbox.deinit();
+            {
+                vbox2 = dvui.box(@src(), .vertical, .{ .gravity_y = 0.5 });
+                defer vbox2.deinit();
+                _ = dvui.sliderEntry(@src(), "margin {d:0.0}", .{ .value = &layout_margin.x, .min = 0, .max = 20.0, .interval = 1 }, .{});
+                _ = dvui.sliderEntry(@src(), "border {d:0.0}", .{ .value = &layout_border.x, .min = 0, .max = 20.0, .interval = 1 }, .{});
+                _ = dvui.sliderEntry(@src(), "padding {d:0.0}", .{ .value = &layout_padding.x, .min = 0, .max = 20.0, .interval = 1 }, .{});
+            }
+            {
+                var o = dvui.overlay(@src(), .{ .min_size_content = .{ .w = 164, .h = 140 } });
+                defer o.deinit();
+                var o2 = dvui.overlay(@src(), .{ .background = true, .gravity_x = 0.5, .gravity_y = 0.5 });
+                defer o2.deinit();
+                if (dvui.button(@src(), "reset", .{}, .{ .margin = layout_margin, .border = layout_border, .padding = layout_padding })) {
+                    layout_margin = Rect.all(4);
+                    layout_border = Rect.all(0);
+                    layout_padding = Rect.all(4);
+                }
+            }
+            {
+                vbox2 = dvui.box(@src(), .vertical, .{ .gravity_y = 0.5 });
+                defer vbox2.deinit();
+                _ = dvui.sliderEntry(@src(), "margin {d:0.0}", .{ .value = &layout_margin.w, .min = 0, .max = 20.0, .interval = 1 }, .{});
+                _ = dvui.sliderEntry(@src(), "border {d:0.0}", .{ .value = &layout_border.w, .min = 0, .max = 20.0, .interval = 1 }, .{});
+                _ = dvui.sliderEntry(@src(), "padding {d:0.0}", .{ .value = &layout_padding.w, .min = 0, .max = 20.0, .interval = 1 }, .{});
+            }
         }
-        o2.deinit();
-        o.deinit();
-
-        vbox2 = dvui.box(@src(), .vertical, .{ .gravity_y = 0.5 });
-        _ = dvui.sliderEntry(@src(), "margin {d:0.0}", .{ .value = &layout_margin.w, .min = 0, .max = 20.0, .interval = 1 }, .{});
-        _ = dvui.sliderEntry(@src(), "border {d:0.0}", .{ .value = &layout_border.w, .min = 0, .max = 20.0, .interval = 1 }, .{});
-        _ = dvui.sliderEntry(@src(), "padding {d:0.0}", .{ .value = &layout_padding.w, .min = 0, .max = 20.0, .interval = 1 }, .{});
-        vbox2.deinit();
-
-        hbox.deinit();
-
-        vbox2 = dvui.box(@src(), .vertical, .{ .gravity_x = 0.5 });
-        _ = dvui.sliderEntry(@src(), "margin {d:0.0}", .{ .value = &layout_margin.h, .min = 0, .max = 20.0, .interval = 1 }, .{});
-        _ = dvui.sliderEntry(@src(), "border {d:0.0}", .{ .value = &layout_border.h, .min = 0, .max = 20.0, .interval = 1 }, .{});
-        _ = dvui.sliderEntry(@src(), "padding {d:0.0}", .{ .value = &layout_padding.h, .min = 0, .max = 20.0, .interval = 1 }, .{});
-        vbox2.deinit();
+        {
+            vbox2 = dvui.box(@src(), .vertical, .{ .gravity_x = 0.5 });
+            defer vbox2.deinit();
+            _ = dvui.sliderEntry(@src(), "margin {d:0.0}", .{ .value = &layout_margin.h, .min = 0, .max = 20.0, .interval = 1 }, .{});
+            _ = dvui.sliderEntry(@src(), "border {d:0.0}", .{ .value = &layout_border.h, .min = 0, .max = 20.0, .interval = 1 }, .{});
+            _ = dvui.sliderEntry(@src(), "padding {d:0.0}", .{ .value = &layout_padding.h, .min = 0, .max = 20.0, .interval = 1 }, .{});
+        }
     }
 
     dvui.label(@src(), "Boxes", .{}, .{});
@@ -188,7 +192,6 @@ pub fn layout() void {
         hbox.install();
         hbox.drawBackground();
         defer hbox.deinit();
-
         {
             var hbox2 = dvui.box(@src(), .horizontal, .{ .min_size_content = .{ .w = breakpoint / 2, .h = 140 }, .max_size_content = .width(breakpoint / 2), .expand = if (equal) .horizontal else .none });
             defer hbox2.deinit();
@@ -200,7 +203,6 @@ pub fn layout() void {
                 _ = dvui.button(@src(), "expand", .{}, .{ .expand = .both, .gravity_x = 0.5 });
                 _ = dvui.button(@src(), "a", .{}, .{ .gravity_x = 0.5 });
             }
-
             {
                 var vbox = dvui.boxEqual(@src(), .vertical, opts);
                 defer vbox.deinit();
@@ -210,7 +212,6 @@ pub fn layout() void {
                 _ = dvui.button(@src(), "a", .{}, .{ .gravity_x = 0.5 });
             }
         }
-
         {
             var vbox2 = dvui.box(@src(), .vertical, .{ .max_size_content = .zero, .expand = .both });
             defer vbox2.deinit();
@@ -222,7 +223,6 @@ pub fn layout() void {
                 _ = dvui.button(@src(), "expand", .{}, .{ .expand = .both, .gravity_y = 0.5 });
                 _ = dvui.button(@src(), "a", .{}, .{ .gravity_y = 0.5 });
             }
-
             {
                 var hbox2 = dvui.boxEqual(@src(), .horizontal, opts);
                 defer hbox2.deinit();
@@ -233,7 +233,6 @@ pub fn layout() void {
             }
         }
     }
-
     {
         {
             var hbox2 = dvui.box(@src(), .horizontal, .{});
@@ -249,7 +248,7 @@ pub fn layout() void {
             var fbox = dvui.flexbox(@src(), .{ .justify_content = layout_flex_content_justify }, .{ .border = dvui.Rect.all(1), .background = true, .padding = .{ .w = 4, .h = 4 } });
             defer fbox.deinit();
 
-            for (0..10) |i| {
+            for (0..11) |i| {
                 var labelbox = dvui.box(@src(), .vertical, .{ .id_extra = i, .margin = .{ .x = 4, .y = 4 }, .border = dvui.Rect.all(1), .background = true });
                 defer labelbox.deinit();
 

--- a/src/Examples/menus.zig
+++ b/src/Examples/menus.zig
@@ -32,36 +32,36 @@ pub fn menus() void {
     {
         var hbox = dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
         defer hbox.deinit();
+        {
+            var m = dvui.menu(@src(), .horizontal, .{});
+            defer m.deinit();
 
-        var m = dvui.menu(@src(), .horizontal, .{});
+            if (dvui.menuItemLabel(@src(), "File", .{ .submenu = true }, .{ .expand = .horizontal })) |r| {
+                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+                defer fw.deinit();
 
-        if (dvui.menuItemLabel(@src(), "File", .{ .submenu = true }, .{ .expand = .horizontal })) |r| {
-            var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
-            defer fw.deinit();
+                submenus();
 
-            submenus();
+                _ = dvui.checkbox(@src(), &checkbox_bool, "Checkbox", .{});
 
-            _ = dvui.checkbox(@src(), &checkbox_bool, "Checkbox", .{});
+                if (dvui.menuItemLabel(@src(), "Dialog", .{}, .{ .expand = .horizontal }) != null) {
+                    fw.close();
+                    Examples.show_dialog = true;
+                }
 
-            if (dvui.menuItemLabel(@src(), "Dialog", .{}, .{ .expand = .horizontal }) != null) {
-                fw.close();
-                Examples.show_dialog = true;
+                if (dvui.menuItemLabel(@src(), "Close Menu", .{}, .{ .expand = .horizontal }) != null) {
+                    fw.close();
+                }
             }
 
-            if (dvui.menuItemLabel(@src(), "Close Menu", .{}, .{ .expand = .horizontal }) != null) {
-                fw.close();
+            if (dvui.menuItemLabel(@src(), "Edit", .{ .submenu = true }, .{ .expand = .horizontal })) |r| {
+                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+                defer fw.deinit();
+                _ = dvui.menuItemLabel(@src(), "Dummy", .{}, .{ .expand = .horizontal });
+                _ = dvui.menuItemLabel(@src(), "Dummy Long", .{}, .{ .expand = .horizontal });
+                _ = dvui.menuItemLabel(@src(), "Dummy Super Long", .{}, .{ .expand = .horizontal });
             }
         }
-
-        if (dvui.menuItemLabel(@src(), "Edit", .{ .submenu = true }, .{ .expand = .horizontal })) |r| {
-            var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
-            defer fw.deinit();
-            _ = dvui.menuItemLabel(@src(), "Dummy", .{}, .{ .expand = .horizontal });
-            _ = dvui.menuItemLabel(@src(), "Dummy Long", .{}, .{ .expand = .horizontal });
-            _ = dvui.menuItemLabel(@src(), "Dummy Super Long", .{}, .{ .expand = .horizontal });
-        }
-
-        m.deinit();
 
         dvui.labelNoFmt(@src(), "Right click for a context menu", .{}, .{ .gravity_x = 1.0 });
     }
@@ -89,34 +89,37 @@ pub fn menus() void {
         tl.addText("This box has a complex tooltip with a fade in and nested tooltip.", .{});
         tl.deinit();
 
-        var tt: dvui.FloatingTooltipWidget = .init(@src(), .{
-            .active_rect = hbox.data().borderRectScale().r,
-            .interactive = true,
-        }, .{ .background = false, .border = .{} });
-        if (tt.shown()) {
-            var animator = dvui.animate(@src(), .{ .kind = .alpha, .duration = 250_000 }, .{ .expand = .both });
-            defer animator.deinit();
+        {
+            var tt: dvui.FloatingTooltipWidget = .init(@src(), .{
+                .active_rect = hbox.data().borderRectScale().r,
+                .interactive = true,
+            }, .{ .background = false, .border = .{} });
+            defer tt.deinit();
+            if (tt.shown()) {
+                var animator = dvui.animate(@src(), .{ .kind = .alpha, .duration = 250_000 }, .{ .expand = .both });
+                defer animator.deinit();
 
-            var vbox2 = dvui.box(@src(), .vertical, dvui.FloatingTooltipWidget.defaults.override(.{ .expand = .both }));
-            defer vbox2.deinit();
+                var vbox2 = dvui.box(@src(), .vertical, dvui.FloatingTooltipWidget.defaults.override(.{ .expand = .both }));
+                defer vbox2.deinit();
 
-            var tl2 = dvui.textLayout(@src(), .{}, .{ .background = false });
-            tl2.addText("This is the tooltip text", .{});
-            tl2.deinit();
+                var tl2 = dvui.textLayout(@src(), .{}, .{ .background = false });
+                tl2.addText("This is the tooltip text", .{});
+                tl2.deinit();
 
-            _ = dvui.checkbox(@src(), &checkbox_bool, "Checkbox", .{});
-
-            var tt2: dvui.FloatingTooltipWidget = .init(@src(), .{
-                .active_rect = tt.data().borderRectScale().r,
-            }, .{ .max_size_content = .width(200), .box_shadow = .{} });
-            if (tt2.shown()) {
-                var tl3 = dvui.textLayout(@src(), .{}, .{ .background = false });
-                tl3.addText("Text in a nested tooltip with box shadow", .{});
-                tl3.deinit();
+                _ = dvui.checkbox(@src(), &checkbox_bool, "Checkbox", .{});
+                {
+                    var tt2: dvui.FloatingTooltipWidget = .init(@src(), .{
+                        .active_rect = tt.data().borderRectScale().r,
+                    }, .{ .max_size_content = .width(200), .box_shadow = .{} });
+                    defer tt2.deinit();
+                    if (tt2.shown()) {
+                        var tl3 = dvui.textLayout(@src(), .{}, .{ .background = false });
+                        tl3.addText("Text in a nested tooltip with box shadow", .{});
+                        tl3.deinit();
+                    }
+                }
             }
-            tt2.deinit();
         }
-        tt.deinit();
     }
 
     _ = dvui.spacer(@src(), .{ .min_size_content = .height(12) });
@@ -125,15 +128,15 @@ pub fn menus() void {
         var hbox = dvui.box(@src(), .horizontal, .{});
         const layout_dir = dvui.dataGetPtrDefault(null, hbox.data().id, "layout_dir", dvui.enums.Direction, .horizontal);
         const active_tab = dvui.dataGetPtrDefault(null, hbox.data().id, "active_tab", usize, 0);
-
-        const entries = [_][]const u8{ "Horizontal", "Vertical" };
-        for (0..2) |i| {
-            if (dvui.radio(@src(), @intFromEnum(layout_dir.*) == i, entries[i], .{ .id_extra = i })) {
-                layout_dir.* = @enumFromInt(i);
+        {
+            defer hbox.deinit();
+            const entries = [_][]const u8{ "Horizontal", "Vertical" };
+            for (0..2) |i| {
+                if (dvui.radio(@src(), @intFromEnum(layout_dir.*) == i, entries[i], .{ .id_extra = i })) {
+                    layout_dir.* = @enumFromInt(i);
+                }
             }
         }
-        hbox.deinit();
-
         // reverse orientation because horizontal tabs go above content
         var tbox = dvui.box(@src(), if (layout_dir.* == .vertical) .horizontal else .vertical, .{ .max_size_content = .{ .w = 400, .h = 200 } });
         defer tbox.deinit();
@@ -223,13 +226,13 @@ pub fn focus() void {
 
         var te = dvui.textEntry(@src(), .{}, .{});
         const teId = te.data().id;
-
-        // firstFrame must be called before te.deinit()
-        if (dvui.firstFrame(te.data().id)) {
-            dvui.focusWidget(te.data().id, null, null);
+        {
+            defer te.deinit();
+            // firstFrame must be called before te.deinit()
+            if (dvui.firstFrame(te.data().id)) {
+                dvui.focusWidget(te.data().id, null, null);
+            }
         }
-
-        te.deinit();
 
         // Get a unique Id without making a widget
         const uniqueId = dvui.parentGet().extendId(@src(), 0);
@@ -304,6 +307,7 @@ pub fn focus() void {
 
         var hbox = dvui.BoxWidget.init(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .padding = dvui.Rect.all(4) });
         hbox.install();
+        defer hbox.deinit();
         const evts = dvui.events();
         for (evts) |*e| {
             if (!dvui.eventMatchSimple(e, hbox.data())) {
@@ -315,9 +319,7 @@ pub fn focus() void {
                 hbox.data().options.color_fill = .fill_hover;
             }
         }
-
         hbox.drawBackground();
-        defer hbox.deinit();
 
         inline for (@typeInfo(RadioChoice).@"enum".fields, 0..) |field, i| {
             if (dvui.radio(@src(), radio_choice == @as(RadioChoice, @enumFromInt(field.value)), "Radio " ++ field.name, .{ .id_extra = i })) {

--- a/src/Examples/plots.zig
+++ b/src/Examples/plots.zig
@@ -49,24 +49,27 @@ pub fn plots() void {
         };
     };
 
-    var plot = dvui.plot(@src(), .{
-        .title = "Plot Title",
-        .x_axis = &Static.xaxis,
-        .y_axis = &Static.yaxis,
-        .border_thick = 1.0,
-        .mouse_hover = true,
-    }, .{ .expand = .both });
-    var s1 = plot.line();
+    {
+        var plot = dvui.plot(@src(), .{
+            .title = "Plot Title",
+            .x_axis = &Static.xaxis,
+            .y_axis = &Static.yaxis,
+            .border_thick = 1.0,
+            .mouse_hover = true,
+        }, .{ .expand = .both });
+        defer plot.deinit();
 
-    const points: usize = 1000;
-    const freq: f32 = 5;
-    for (0..points + 1) |i| {
-        const fval: f64 = @sin(2.0 * std.math.pi * @as(f64, @floatFromInt(i)) / @as(f64, @floatFromInt(points)) * freq);
-        s1.point(@as(f64, @floatFromInt(i)) / @as(f64, @floatFromInt(points)), fval);
+        var s1 = plot.line();
+        defer s1.deinit();
+
+        const points: usize = 1000;
+        const freq: f32 = 5;
+        for (0..points + 1) |i| {
+            const fval: f64 = @sin(2.0 * std.math.pi * @as(f64, @floatFromInt(i)) / @as(f64, @floatFromInt(points)) * freq);
+            s1.point(@as(f64, @floatFromInt(i)) / @as(f64, @floatFromInt(points)), fval);
+        }
+        s1.stroke(1, dvui.themeGet().color_accent);
     }
-    s1.stroke(1, dvui.themeGet().color_accent);
-    s1.deinit();
-    plot.deinit();
 
     if (pic) |*p| {
         p.stop();

--- a/src/Examples/scrolling.zig
+++ b/src/Examples/scrolling.zig
@@ -6,115 +6,117 @@ pub fn scrolling() void {
         scroll_info: ScrollInfo = .{},
     };
 
-    var hbox = dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
-
-    const Data = dvui.dataGetPtrDefault(null, hbox.data().id, "data", Data1, .{});
-
-    var scroll_to_msg: ?usize = null;
-    var scroll_to_bottom_after = false;
-    var scroll_lock_visible = false;
-
     {
-        var vbox = dvui.box(@src(), .vertical, .{ .expand = .vertical });
-        defer vbox.deinit();
+        var hbox = dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
+        defer hbox.deinit();
+        const Data = dvui.dataGetPtrDefault(null, hbox.data().id, "data", Data1, .{});
 
-        dvui.label(@src(), "{d} total widgets", .{2 * (Data.msg_end - Data.msg_start)}, .{});
-
-        if (dvui.button(@src(), "Scroll to Top", .{}, .{})) {
-            Data.scroll_info.scrollToOffset(.vertical, 0);
-        }
+        var scroll_to_msg: ?usize = null;
+        var scroll_to_bottom_after = false;
+        var scroll_lock_visible = false;
 
         {
-            var h2 = dvui.box(@src(), .horizontal, .{});
-            defer h2.deinit();
-            if (dvui.button(@src(), "Add Above", .{}, .{})) {
+            var vbox = dvui.box(@src(), .vertical, .{ .expand = .vertical });
+            defer vbox.deinit();
+
+            dvui.label(@src(), "{d} total widgets", .{2 * (Data.msg_end - Data.msg_start)}, .{});
+
+            if (dvui.button(@src(), "Scroll to Top", .{}, .{})) {
+                Data.scroll_info.scrollToOffset(.vertical, 0);
+            }
+
+            {
+                var h2 = dvui.box(@src(), .horizontal, .{});
+                defer h2.deinit();
+                if (dvui.button(@src(), "Add Above", .{}, .{})) {
+                    Data.msg_start -|= 10;
+                }
+
+                if (dvui.button(@src(), "Del Above", .{}, .{})) {
+                    Data.msg_start = @min(Data.msg_end, Data.msg_start + 10);
+                }
+            }
+
+            if (dvui.button(@src(), "Add Above No Scroll", .{}, .{})) {
                 Data.msg_start -|= 10;
+                scroll_lock_visible = true;
             }
 
-            if (dvui.button(@src(), "Del Above", .{}, .{})) {
+            if (dvui.button(@src(), "Del Above No Scroll", .{}, .{})) {
                 Data.msg_start = @min(Data.msg_end, Data.msg_start + 10);
+                scroll_lock_visible = true;
             }
-        }
 
-        if (dvui.button(@src(), "Add Above No Scroll", .{}, .{})) {
-            Data.msg_start -|= 10;
-            scroll_lock_visible = true;
-        }
+            _ = dvui.spacer(@src(), .{ .expand = .vertical });
 
-        if (dvui.button(@src(), "Del Above No Scroll", .{}, .{})) {
-            Data.msg_start = @min(Data.msg_end, Data.msg_start + 10);
-            scroll_lock_visible = true;
-        }
+            dvui.label(@src(), "Scroll to msg:", .{}, .{});
+            const result = dvui.textEntryNumber(@src(), usize, .{ .min = Data.msg_start, .max = Data.msg_end }, .{ .min_size_content = dvui.Options.sizeM(8, 1) });
+            const label = switch (result.value) {
+                .TooBig => "Too Big",
+                .TooSmall => "Too Small",
+                .Invalid => "Invalid",
+                .Valid, .Empty => " ",
+            };
+            dvui.labelNoFmt(@src(), label, .{}, .{});
+            if (result.value == .Valid and result.enter_pressed) {
+                scroll_to_msg = result.value.Valid;
+            }
 
-        _ = dvui.spacer(@src(), .{ .expand = .vertical });
+            _ = dvui.spacer(@src(), .{ .expand = .vertical });
 
-        dvui.label(@src(), "Scroll to msg:", .{}, .{});
-        const result = dvui.textEntryNumber(@src(), usize, .{ .min = Data.msg_start, .max = Data.msg_end }, .{ .min_size_content = dvui.Options.sizeM(8, 1) });
-        const label = switch (result.value) {
-            .TooBig => "Too Big",
-            .TooSmall => "Too Small",
-            .Invalid => "Invalid",
-            .Valid, .Empty => " ",
-        };
-        dvui.labelNoFmt(@src(), label, .{}, .{});
-        if (result.value == .Valid and result.enter_pressed) {
-            scroll_to_msg = result.value.Valid;
-        }
+            {
+                var h2 = dvui.box(@src(), .horizontal, .{});
+                defer h2.deinit();
+                if (dvui.button(@src(), "Add Below", .{}, .{})) {
+                    Data.msg_end += 10;
+                }
 
-        _ = dvui.spacer(@src(), .{ .expand = .vertical });
+                if (dvui.button(@src(), "Del Below", .{}, .{})) {
+                    Data.msg_end = @max(Data.msg_start, Data.msg_end - 10);
+                }
+            }
 
-        {
-            var h2 = dvui.box(@src(), .horizontal, .{});
-            defer h2.deinit();
-            if (dvui.button(@src(), "Add Below", .{}, .{})) {
+            if (dvui.button(@src(), "Add Below + Scroll", .{}, .{})) {
                 Data.msg_end += 10;
+                scroll_to_bottom_after = true;
             }
 
-            if (dvui.button(@src(), "Del Below", .{}, .{})) {
-                Data.msg_end = @max(Data.msg_start, Data.msg_end - 10);
+            if (dvui.button(@src(), "Scroll to Bottom", .{}, .{})) {
+                Data.scroll_info.scrollToOffset(.vertical, std.math.maxInt(usize));
+            }
+        }
+        {
+            var vbox = dvui.box(@src(), .vertical, .{ .expand = .horizontal, .max_size_content = .height(300) });
+            defer vbox.deinit();
+
+            dvui.label(@src(), "{d:0>4.2}% visible, offset {d} frac {d:0>4.2}", .{ Data.scroll_info.visibleFraction(.vertical) * 100.0, Data.scroll_info.viewport.y, Data.scroll_info.offsetFraction(.vertical) }, .{});
+
+            var scroll = dvui.scrollArea(@src(), .{ .scroll_info = &Data.scroll_info, .lock_visible = scroll_lock_visible }, .{ .expand = .horizontal, .min_size_content = .{ .h = 250 } });
+            defer scroll.deinit();
+
+            for (Data.msg_start..Data.msg_end + 1) |i| {
+                {
+                    var tl = dvui.textLayout(@src(), .{}, .{ .id_extra = i, .color_fill = .fill_window });
+                    defer tl.deinit();
+
+                    tl.format("Message {d}", .{i}, .{});
+
+                    if (scroll_to_msg != null and scroll_to_msg.? == i) {
+                        Data.scroll_info.scrollToOffset(.vertical, tl.data().rect.y);
+                    }
+                }
+
+                var tl2 = dvui.textLayout(@src(), .{}, .{ .id_extra = i, .gravity_x = 1.0, .color_fill = .fill_window });
+                tl2.format("Reply {d}", .{i}, .{});
+                tl2.deinit();
             }
         }
 
-        if (dvui.button(@src(), "Add Below + Scroll", .{}, .{})) {
-            Data.msg_end += 10;
-            scroll_to_bottom_after = true;
-        }
-
-        if (dvui.button(@src(), "Scroll to Bottom", .{}, .{})) {
+        if (scroll_to_bottom_after) {
+            // do this after scrollArea has given scroll_info the new size
             Data.scroll_info.scrollToOffset(.vertical, std.math.maxInt(usize));
         }
     }
-    {
-        var vbox = dvui.box(@src(), .vertical, .{ .expand = .horizontal, .max_size_content = .height(300) });
-        defer vbox.deinit();
-
-        dvui.label(@src(), "{d:0>4.2}% visible, offset {d} frac {d:0>4.2}", .{ Data.scroll_info.visibleFraction(.vertical) * 100.0, Data.scroll_info.viewport.y, Data.scroll_info.offsetFraction(.vertical) }, .{});
-
-        var scroll = dvui.scrollArea(@src(), .{ .scroll_info = &Data.scroll_info, .lock_visible = scroll_lock_visible }, .{ .expand = .horizontal, .min_size_content = .{ .h = 250 } });
-        defer scroll.deinit();
-
-        for (Data.msg_start..Data.msg_end + 1) |i| {
-            var tl = dvui.textLayout(@src(), .{}, .{ .id_extra = i, .color_fill = .fill_window });
-            tl.format("Message {d}", .{i}, .{});
-
-            if (scroll_to_msg != null and scroll_to_msg.? == i) {
-                Data.scroll_info.scrollToOffset(.vertical, tl.data().rect.y);
-            }
-
-            tl.deinit();
-
-            var tl2 = dvui.textLayout(@src(), .{}, .{ .id_extra = i, .gravity_x = 1.0, .color_fill = .fill_window });
-            tl2.format("Reply {d}", .{i}, .{});
-            tl2.deinit();
-        }
-    }
-
-    if (scroll_to_bottom_after) {
-        // do this after scrollArea has given scroll_info the new size
-        Data.scroll_info.scrollToOffset(.vertical, std.math.maxInt(usize));
-    }
-
-    hbox.deinit();
 
     _ = dvui.spacer(@src(), .{ .min_size_content = .all(12) });
     _ = dvui.separator(@src(), .{ .expand = .horizontal });
@@ -129,74 +131,82 @@ pub fn scrolling() void {
 
     // save the viewport so everything is synced this frame
     const fv = siMain.viewport.topLeft();
-
-    var main_area = dvui.ScrollAreaWidget.init(@src(), .{ .scroll_info = siMain, .frame_viewport = fv }, .{ .expand = .both, .max_size_content = .height(300), .background = false });
-    main_area.installScrollBars();
-
     const left_side_width = 80;
-
     {
-        var hboxTop = dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
-        defer hboxTop.deinit();
+        var main_area = dvui.ScrollAreaWidget.init(@src(), .{ .scroll_info = siMain, .frame_viewport = fv }, .{ .expand = .both, .max_size_content = .height(300), .background = false });
+        defer main_area.deinit();
+        main_area.installScrollBars();
 
-        var lbox = dvui.box(@src(), .vertical, .{ .min_size_content = .width(left_side_width) });
-        dvui.label(@src(), "Linked\nScrolling", .{}, .{ .gravity_x = 0.5, .gravity_y = 0.5 });
-        lbox.deinit();
+        {
+            var hboxTop = dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
+            defer hboxTop.deinit();
+
+            var lbox = dvui.box(@src(), .vertical, .{ .min_size_content = .width(left_side_width) });
+            dvui.label(@src(), "Linked\nScrolling", .{}, .{ .gravity_x = 0.5, .gravity_y = 0.5 });
+            lbox.deinit();
+
+            _ = dvui.spacer(@src(), .{ .min_size_content = .all(10) });
+
+            {
+                var top_area = dvui.scrollArea(@src(), .{ .scroll_info = siTop, .frame_viewport = .{ .x = fv.x }, .horizontal_bar = .hide, .process_events_after = false }, .{ .expand = .both });
+                defer top_area.deinit();
+                {
+                    // inside top area
+                    var topbox = dvui.box(@src(), .horizontal, .{});
+                    defer topbox.deinit();
+
+                    for (0..20) |i| {
+                        dvui.label(@src(), "label {d}", .{i}, .{ .id_extra = i });
+                    }
+                }
+            }
+        }
 
         _ = dvui.spacer(@src(), .{ .min_size_content = .all(10) });
 
-        var top_area = dvui.scrollArea(@src(), .{ .scroll_info = siTop, .frame_viewport = .{ .x = fv.x }, .horizontal_bar = .hide, .process_events_after = false }, .{ .expand = .both });
         {
-            // inside top area
-            var topbox = dvui.box(@src(), .horizontal, .{});
-            defer topbox.deinit();
+            var hbox3 = dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
+            defer hbox3.deinit();
 
-            for (0..20) |i| {
-                dvui.label(@src(), "label {d}", .{i}, .{ .id_extra = i });
+            var side_area = dvui.scrollArea(@src(), .{ .scroll_info = siLeft, .frame_viewport = .{ .y = fv.y }, .vertical_bar = .hide, .process_events_after = false }, .{ .min_size_content = .{ .w = left_side_width, .h = 200 }, .expand = .vertical });
+            {
+                // inside side area
+                var sidebox = dvui.box(@src(), .vertical, .{});
+                defer sidebox.deinit();
+
+                for (0..20) |i| {
+                    dvui.label(@src(), "label {d}", .{i}, .{ .id_extra = i });
+                }
             }
-        }
-        top_area.deinit();
-    }
+            side_area.deinit();
 
-    _ = dvui.spacer(@src(), .{ .min_size_content = .all(10) });
+            _ = dvui.spacer(@src(), .{ .min_size_content = .all(10) });
 
-    var hbox3 = dvui.box(@src(), .horizontal, .{ .expand = .horizontal });
+            {
+                var scontainer = dvui.ScrollContainerWidget.init(@src(), siMain, .{ .scroll_area = &main_area, .frame_viewport = fv, .event_rect = main_area.data().borderRectScale().r }, .{ .expand = .both });
+                scontainer.install();
+                defer scontainer.deinit();
+                scontainer.processEvents();
+                scontainer.processVelocity();
 
-    var side_area = dvui.scrollArea(@src(), .{ .scroll_info = siLeft, .frame_viewport = .{ .y = fv.y }, .vertical_bar = .hide, .process_events_after = false }, .{ .min_size_content = .{ .w = left_side_width, .h = 200 }, .expand = .vertical });
-    {
-        // inside side area
-        var sidebox = dvui.box(@src(), .vertical, .{});
-        defer sidebox.deinit();
-
-        for (0..20) |i| {
-            dvui.label(@src(), "label {d}", .{i}, .{ .id_extra = i });
-        }
-    }
-    side_area.deinit();
-
-    _ = dvui.spacer(@src(), .{ .min_size_content = .all(10) });
-
-    var scontainer = dvui.ScrollContainerWidget.init(@src(), siMain, .{ .scroll_area = &main_area, .frame_viewport = fv, .event_rect = main_area.data().borderRectScale().r }, .{ .expand = .both });
-    scontainer.install();
-    scontainer.processEvents();
-    scontainer.processVelocity();
-
-    {
-        // inside main area
-        var mainbox = dvui.box(@src(), .vertical, .{});
-        var mainbox2 = dvui.box(@src(), .horizontal, .{});
-        for (0..20) |i| {
-            dvui.label(@src(), "label {d}", .{i}, .{ .id_extra = i });
-        }
-        mainbox2.deinit();
-        for (1..20) |i| {
-            dvui.label(@src(), "label {d}", .{i}, .{ .id_extra = i });
-        }
-        mainbox.deinit();
-    }
-    scontainer.deinit();
-    hbox3.deinit();
-    main_area.deinit();
+                {
+                    // inside main area
+                    var mainbox = dvui.box(@src(), .vertical, .{});
+                    defer mainbox.deinit();
+                    {
+                        var mainbox2 = dvui.box(@src(), .horizontal, .{});
+                        defer mainbox2.deinit();
+                        for (0..20) |i| {
+                            dvui.label(@src(), "label {d}", .{i}, .{ .id_extra = i });
+                        }
+                    }
+                    for (1..20) |i| {
+                        dvui.label(@src(), "label {d}", .{i}, .{ .id_extra = i });
+                    }
+                } // mainbox
+            } // scontainer
+        } // hbox3
+    } // main_area
 
     // sync siTop and siMain horizontal
     if (siTop.viewport.x != fv.x) siMain.viewport.x = siTop.viewport.x;

--- a/src/Examples/styling.zig
+++ b/src/Examples/styling.zig
@@ -94,17 +94,18 @@ pub fn styling() void {
 
         // We are using two boxes here so the box shadow can have different corner_radius values.
 
-        var vbox = dvui.box(@src(), .vertical, .{ .margin = dvui.Rect.all(30), .min_size_content = .{ .w = 200, .h = 100 }, .corner_radius = dvui.Rect.all(5), .background = true, .border = if (border.*) dvui.Rect.all(1) else null, .box_shadow = .{ .color = .fromColor(backbox_color), .corner_radius = dvui.Rect.all(radius.*), .shrink = shrink.*, .offset = offset.*, .blur = blur.*, .alpha = alpha.* } });
-        dvui.label(@src(), "Box shadows", .{}, .{ .gravity_x = 0.5 });
-        _ = dvui.checkbox(@src(), border, "border", .{});
-        _ = dvui.sliderEntry(@src(), "radius: {d:0.0}", .{ .value = radius, .min = 0, .max = 50, .interval = 1 }, .{ .gravity_x = 0.5 });
-        _ = dvui.sliderEntry(@src(), "blur: {d:0.1}", .{ .value = blur, .min = 0, .max = 50, .interval = 0.1 }, .{ .gravity_x = 0.5 });
-        _ = dvui.sliderEntry(@src(), "shrink: {d:0.0}", .{ .value = shrink, .min = -10, .max = 50, .interval = 1 }, .{ .gravity_x = 0.5 });
-        _ = dvui.sliderEntry(@src(), "x: {d:0.0}", .{ .value = &offset.x, .min = -20, .max = 20, .interval = 1 }, .{ .gravity_x = 0.5 });
-        _ = dvui.sliderEntry(@src(), "y: {d:0.0}", .{ .value = &offset.y, .min = -20, .max = 20, .interval = 1 }, .{ .gravity_x = 0.5 });
-        _ = dvui.sliderEntry(@src(), "alpha: {d:0.2}", .{ .value = alpha, .min = 0, .max = 1, .interval = 0.01 }, .{ .gravity_x = 0.5 });
-        vbox.deinit();
-
+        {
+            var vbox = dvui.box(@src(), .vertical, .{ .margin = dvui.Rect.all(30), .min_size_content = .{ .w = 200, .h = 100 }, .corner_radius = dvui.Rect.all(5), .background = true, .border = if (border.*) dvui.Rect.all(1) else null, .box_shadow = .{ .color = .fromColor(backbox_color), .corner_radius = dvui.Rect.all(radius.*), .shrink = shrink.*, .offset = offset.*, .blur = blur.*, .alpha = alpha.* } });
+            defer vbox.deinit();
+            dvui.label(@src(), "Box shadows", .{}, .{ .gravity_x = 0.5 });
+            _ = dvui.checkbox(@src(), border, "border", .{});
+            _ = dvui.sliderEntry(@src(), "radius: {d:0.0}", .{ .value = radius, .min = 0, .max = 50, .interval = 1 }, .{ .gravity_x = 0.5 });
+            _ = dvui.sliderEntry(@src(), "blur: {d:0.1}", .{ .value = blur, .min = 0, .max = 50, .interval = 0.1 }, .{ .gravity_x = 0.5 });
+            _ = dvui.sliderEntry(@src(), "shrink: {d:0.0}", .{ .value = shrink, .min = -10, .max = 50, .interval = 1 }, .{ .gravity_x = 0.5 });
+            _ = dvui.sliderEntry(@src(), "x: {d:0.0}", .{ .value = &offset.x, .min = -20, .max = 20, .interval = 1 }, .{ .gravity_x = 0.5 });
+            _ = dvui.sliderEntry(@src(), "y: {d:0.0}", .{ .value = &offset.y, .min = -20, .max = 20, .interval = 1 }, .{ .gravity_x = 0.5 });
+            _ = dvui.sliderEntry(@src(), "alpha: {d:0.2}", .{ .value = alpha, .min = 0, .max = 1, .interval = 0.01 }, .{ .gravity_x = 0.5 });
+        }
         {
             var vbox2 = dvui.box(@src(), .vertical, .{ .margin = .{ .y = 30 } });
             defer vbox2.deinit();

--- a/src/Examples/text_entry.zig
+++ b/src/Examples/text_entry.zig
@@ -4,7 +4,6 @@ var text_entry_password_buf_obf_enable: bool = true;
 var text_entry_multiline_allocator_buf: [1000]u8 = undefined;
 var text_entry_multiline_fba = std.heap.FixedBufferAllocator.init(&text_entry_multiline_allocator_buf);
 var text_entry_multiline_buf: []u8 = &.{};
-var text_entry_multiline_initialized = false;
 var text_entry_multiline_break = false;
 
 /// ![image](Examples-text_entry.png)
@@ -142,9 +141,8 @@ pub fn textEntryWidgets(demo_win_id: dvui.WidgetId) void {
             },
         );
 
-        if (!text_entry_multiline_initialized) {
-            text_entry_multiline_initialized = true;
-            te.textTyped("This multiline text\nentry can scroll\nin both directions.", false);
+        if (dvui.firstFrame(te.data().id)) {
+            te.textSet("This multiline text\nentry can scroll\nin both directions.", false);
         }
 
         const bytes = te.len;
@@ -296,7 +294,7 @@ pub fn textEntryWidgets(demo_win_id: dvui.WidgetId) void {
         };
 
         const combo = dvui.comboBox(@src(), .{}, .{});
-
+        defer combo.deinit();
         // filter suggestions to match the start of the entry
         if (combo.te.text_changed) blk: {
             const arena = dvui.currentWindow().lifo();
@@ -317,7 +315,6 @@ pub fn textEntryWidgets(demo_win_id: dvui.WidgetId) void {
         if (combo.entries(dvui.dataGetSlice(null, combo.te.data().id, "suggestions", [][]const u8) orelse entries)) |index| {
             dvui.log.debug("Combo entry index picked: {d}", .{index});
         }
-        combo.deinit();
     }
 
     {

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -269,8 +269,10 @@ pub fn init(
         .windows => {
             // zig fmt: off
                 try self.keybinds.putNoClobber(self.gpa, "cut",        .{ .key = .x, .control = true });
-                try self.keybinds.putNoClobber(self.gpa, "copy",       .{ .key = .c, .control = true });
-                try self.keybinds.putNoClobber(self.gpa, "paste",      .{ .key = .v, .control = true });
+                try self.keybinds.putNoClobber(self.gpa, "copy",       .{ .key = .c, .control = true, .also = "copy_1" });
+                try self.keybinds.putNoClobber(self.gpa, "copy_1",       .{ .key = .insert, .control = true, .shift = false, .alt = false, .command = false });
+                try self.keybinds.putNoClobber(self.gpa, "paste",      .{ .key = .v, .control = true, .also = "paste_1" });
+                try self.keybinds.putNoClobber(self.gpa, "paste_1",       .{ .key = .insert, .control = false, .shift = true, .alt = false, .command = false });
                 try self.keybinds.putNoClobber(self.gpa, "select_all", .{ .key = .a, .control = true });
 
                 // use with mod.matchBind


### PR DESCRIPTION
I noticed a strange line in the Calculator example that didn't match modern zig.

While fixing that I made it behave a bit more like a calculator:
1) Starting a new operation before pressing = now works.
2) Round the display output to 6 decimal places, to avoid FP-precision issues. 
3) Clear current calculation if digit is pressed and there is no current operation. e.g. typing a number directly after =, N or %.
4) Replaced C-like sizeof(array)/sizeof(array[0]) with array.len

Still does not correctly display leading zeros until a non-zero digit is pressed e.g. 0.00004 does not display until the 4 is entered. But I can live with that.

Leaving this open while I look through the rest of the examples. (To be clear, I'm looking for obviously un-zig or un-dvui  code. Not trying to re-write everyone's example code).