### PR TITLE
Backend  textureUpdate  implemented for sdl3 + texture caching logic

### DIFF
--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -9,7 +9,7 @@ const Backend = @This();
 pub const Common = @import("backends/common.zig");
 
 pub const GenericError = std.mem.Allocator.Error || error{BackendError};
-pub const TextureError = GenericError || error{ TextureCreate, TextureRead };
+pub const TextureError = GenericError || error{ TextureCreate, TextureRead, TextureUpdate, NotImplemented };
 
 /// The current implementation used
 pub const kind = Implementation.kind;
@@ -75,9 +75,18 @@ pub fn textureCreate(self: Backend, pixels: [*]const u8, width: u32, height: u32
     return self.impl.textureCreate(pixels, width, height, interpolation);
 }
 
+/// Update a `dvui.Texture` from premultiplied alpha `pixels` in RGBA.  The
+/// passed in texture must be created  with textureCreate
+pub fn textureUpdate(self: Backend, texture: dvui.Texture, pixels: [*]const u8) TextureError!void {
+    // we can handle backends that dont support textureUpdate by using destroy and create again!
+    if (comptime !@hasDecl(Implementation, "textureUpdate")) return TextureError.NotImplemented;
+    return self.impl.textureUpdate(texture, pixels);
+}
+
 /// Destroy `texture` made with `textureCreate`. After this call, this texture
 /// pointer will not be used by dvui.
 pub fn textureDestroy(self: Backend, texture: dvui.Texture) void {
+    // std.debug.print("destroy ptr {} w: {}, h:{}\n", .{ @intFromPtr(texture.ptr), texture.width, texture.height });
     return self.impl.textureDestroy(texture);
 }
 

--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -79,8 +79,9 @@ pub fn textureCreate(self: Backend, pixels: [*]const u8, width: u32, height: u32
 /// passed in texture must be created  with textureCreate
 pub fn textureUpdate(self: Backend, texture: dvui.Texture, pixels: [*]const u8) TextureError!void {
     // we can handle backends that dont support textureUpdate by using destroy and create again!
-    if (comptime !@hasDecl(Implementation, "textureUpdate")) return TextureError.NotImplemented;
-    return self.impl.textureUpdate(texture, pixels);
+    if (comptime !@hasDecl(Implementation, "textureUpdate")) return TextureError.NotImplemented else {
+        return self.impl.textureUpdate(texture, pixels);
+    }
 }
 
 /// Destroy `texture` made with `textureCreate`. After this call, this texture

--- a/src/Color.zig
+++ b/src/Color.zig
@@ -5,6 +5,8 @@ const Color = @This();
 const dvui = @import("dvui.zig");
 const ColorsFromTheme = dvui.Options.ColorsFromTheme;
 
+const tvg = @import("svg2tvg");
+
 r: u8 = 0xff,
 g: u8 = 0xff,
 b: u8 = 0xff,
@@ -420,8 +422,8 @@ pub const PMAImage = struct {
                 var col: [4]u8 = undefined;
                 for (&col, slice) |*a, s| a.* = s;
             }
-            fn conv(dcol: dvui.Color) dvui.tvg.Color {
-                return dvui.tvg.Color{
+            fn conv(dcol: dvui.Color) tvg.Color {
+                return tvg.Color{
                     .r = @as(f32, @floatFromInt(dcol.r)) / 255.0,
                     .g = @as(f32, @floatFromInt(dcol.g)) / 255.0,
                     .b = @as(f32, @floatFromInt(dcol.b)) / 255.0,
@@ -440,13 +442,13 @@ pub const PMAImage = struct {
         };
         var fb = std.io.fixedBufferStream(tvg_bytes);
 
-        var ow_stroke: ?dvui.tvg.Color = null;
+        var ow_stroke: ?tvg.Color = null;
         if (icon_opts.stroke_color) |cx| ow_stroke = ImageAdapter.conv(cx);
-        var ow_fill: ?dvui.tvg.Color = null;
+        var ow_fill: ?tvg.Color = null;
         var disable_fill = false;
         if (ow_fill != null and ow_fill.?.a == 0.0) disable_fill = true;
         if (icon_opts.fill_color) |cx| ow_fill = ImageAdapter.conv(cx);
-        dvui.tvg.renderStream(render_alloc, &img, fb.reader(), .{
+        tvg.renderStream(render_alloc, &img, fb.reader(), .{
             .overwrite_stroke_width = icon_opts.stroke_width,
             .overwrite_stroke = ow_stroke,
             .overwrite_fill = ow_fill,

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -761,8 +761,12 @@ pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, width: u32, height:
 }
 
 pub fn textureUpdate(_: *SDLBackend, texture: dvui.Texture, pixels: [*]const u8) !void {
-    const tx: [*c]c.SDL_Texture = @alignCast(@ptrCast(texture.ptr));
-    if (!c.SDL_UpdateTexture(tx, null, pixels, @intCast(texture.width * 4))) return error.TextureUpdate;
+    if (comptime sdl3) {
+        const tx: [*c]c.SDL_Texture = @alignCast(@ptrCast(texture.ptr));
+        if (!c.SDL_UpdateTexture(tx, null, pixels, @intCast(texture.width * 4))) return error.TextureUpdate;
+    } else {
+        return dvui.Backend.TextureError.NotImplemented;
+    }
 }
 
 pub fn textureCreateTarget(self: *SDLBackend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.TextureTarget {

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -760,6 +760,11 @@ pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, width: u32, height:
     return dvui.Texture{ .ptr = texture, .width = width, .height = height };
 }
 
+pub fn textureUpdate(_: *SDLBackend, texture: dvui.Texture, pixels: [*]const u8) !void {
+    const tx: [*c]c.SDL_Texture = @alignCast(@ptrCast(texture.ptr));
+    if (!c.SDL_UpdateTexture(tx, null, pixels, @intCast(texture.width * 4))) return error.TextureUpdate;
+}
+
 pub fn textureCreateTarget(self: *SDLBackend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.TextureTarget {
     if (!sdl3) switch (interpolation) {
         .nearest => _ = c.SDL_SetHint(c.SDL_HINT_RENDER_SCALE_QUALITY, "nearest"),

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -20,7 +20,7 @@
 const builtin = @import("builtin");
 const std = @import("std");
 pub const backend = @import("backend");
-pub const tvg = @import("svg2tvg");
+const tvg = @import("svg2tvg");
 
 pub const math = std.math;
 pub const fnv = std.hash.Fnv1a_64;
@@ -5326,7 +5326,7 @@ pub const ImageSource = union(enum) {
         return h.final();
     }
 
-    /// Will get the texture from cache or create it if it doesn't already exist;
+    /// Will get the texture from cache or create it if it doesn't already exist
     ///
     /// Only valid between `Window.begin` and `Window.end`
     pub fn getTexture(self: ImageSource) !Texture {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -20,7 +20,7 @@
 const builtin = @import("builtin");
 const std = @import("std");
 pub const backend = @import("backend");
-const tvg = @import("svg2tvg");
+pub const tvg = @import("svg2tvg");
 
 pub const math = std.math;
 pub const fnv = std.hash.Fnv1a_64;
@@ -1080,23 +1080,55 @@ pub const Texture = struct {
 
     pub const CacheKey = u64;
 
-    pub fn fromImageFile(name: []const u8, image_bytes: []const u8, interpolation: enums.TextureInterpolation) (Backend.TextureError || StbImageError)!Texture {
-        //std.debug.print("regenerating texture for imageFile\n", .{});
-        var w: c_int = undefined;
-        var h: c_int = undefined;
-        var channels_in_file: c_int = undefined;
-        const data = c.stbi_load_from_memory(image_bytes.ptr, @as(c_int, @intCast(image_bytes.len)), &w, &h, &channels_in_file, 4);
-        if (data == null) {
-            log.warn("imageTexture stbi_load error on image \"{s}\": {s}\n", .{ name, c.stbi_failure_reason() });
-            return StbImageError.stbImageError;
+    /// Update a texture that was created with `textureCreate`. or fromImageSource
+    ///
+    /// The dimensions of the image must match the initial dimensions!
+    /// Only valid to call while the underlying Texture is not destroyed!
+    ///
+    /// Only valid between `Window.begin` and `Window.end`.
+    pub fn updateContent(self: *Texture, src: ImageSource) !void {
+        switch (src) {
+            .imageFile => |f| {
+                const img = try Color.PMAImage.fromImageFile(f.name, f.bytes);
+                try textureUpdate(self, img.pma, f.interpolation);
+            },
+            .pixels => |px| {
+                const copy = try currentWindow().arena().dupe(u8, px.rgba);
+                defer currentWindow().arena().free(copy);
+                const pma = Color.PMA.sliceFromRGBA(copy);
+                try textureUpdate(self, pma, px.interpolation);
+            },
+            .pixelsPMA => |px| {
+                try textureUpdate(self, px.rgba, px.interpolation);
+            },
+            .texture => |_| @panic("this is not supported currently"),
         }
-        defer c.stbi_image_free(data);
-
-        return try textureCreate(Color.PMA.sliceFromRGBA(data[0..@intCast(w * h * @sizeOf(Color.PMA))]), @intCast(w), @intCast(h), interpolation);
+    }
+    /// creates a new Texture from an ImageSource
+    ///
+    /// Only valid between `Window.begin` and `Window.end`.
+    pub fn fromImageSource(source: ImageSource) !Texture {
+        return switch (source) {
+            .imageFile => |f| try Texture.fromImageFile(f.name, f.bytes, f.interpolation),
+            .pixelsPMA => |px| try Texture.fromPixelsPMA(px.rgba, px.width, px.height, px.interpolation),
+            .pixels => |px| blk: {
+                // Using arena here instead of lifo as this buffer is likely to be large and we
+                // prefer that lifo doesn't reallocate as often. Arena is intended for larger,
+                // one of allocations and we can still free the buffer here
+                const copy = try currentWindow().arena().dupe(u8, px.rgba);
+                defer currentWindow().arena().free(copy);
+                break :blk try Texture.fromPixelsPMA(Color.PMA.sliceFromRGBA(copy), px.width, px.height, px.interpolation);
+            },
+            .texture => |t| t,
+        };
     }
 
-    pub fn fromPixelsPMA(pma: []dvui.Color.PMA, width: u32, height: u32, interpolation: enums.TextureInterpolation) Backend.TextureError!Texture {
-        //std.debug.print("regenerating texture for pixelsPMA\n", .{});
+    pub fn fromImageFile(name: []const u8, image_bytes: []const u8, interpolation: enums.TextureInterpolation) (Backend.TextureError || StbImageError)!Texture {
+        const img = Color.PMAImage.fromImageFile(name, image_bytes) catch return StbImageError.stbImageError;
+        return try textureCreate(img.pma, img.width, img.height, interpolation);
+    }
+
+    pub fn fromPixelsPMA(pma: []const dvui.Color.PMA, width: u32, height: u32, interpolation: enums.TextureInterpolation) Backend.TextureError!Texture {
         return try dvui.textureCreate(pma, width, height, interpolation);
     }
 
@@ -1104,57 +1136,10 @@ pub const Texture = struct {
     ///
     /// Only valid between `Window.begin`and `Window.end`.
     pub fn fromTvgFile(name: []const u8, tvg_bytes: []const u8, height: u32, icon_opts: IconRenderOptions) (Backend.TextureError || TvgError)!Texture {
-        const ImageAdapter = struct {
-            pixels: []u8,
-            width: u32,
-            height: u32,
-            pub fn setPixel(self: *@This(), x: usize, y: usize, col: [4]u8) void {
-                const idx = (y * self.height + x) * 4;
-                for (0..4) |i| self.pixels[idx + i] = col[i];
-            }
-            pub fn getPixel(self: *@This(), x: usize, y: usize) [4]u8 {
-                const idx = y * self.height + x;
-                const slice = self.pixels[idx * 4 .. (idx + 1) * 4];
-                var col: [4]u8 = undefined;
-                for (&col, slice) |*a, s| a.* = s;
-            }
-            fn conv(dcol: dvui.Color) tvg.Color {
-                return tvg.Color{
-                    .r = @as(f32, @floatFromInt(dcol.r)) / 255.0,
-                    .g = @as(f32, @floatFromInt(dcol.g)) / 255.0,
-                    .b = @as(f32, @floatFromInt(dcol.b)) / 255.0,
-                    .a = @as(f32, @floatFromInt(dcol.a)) / 255.0,
-                };
-            }
-        };
-
         const cw = currentWindow();
-        const img_raw_data = try cw.lifo().alloc(u8, height * height * 4);
-        defer cw.lifo().free(img_raw_data);
-        @memset(img_raw_data, 0);
-        var img = ImageAdapter{
-            .pixels = img_raw_data,
-            .width = height,
-            .height = height,
-        };
-        var fb = std.io.fixedBufferStream(tvg_bytes);
-
-        var ow_stroke: ?tvg.Color = null;
-        if (icon_opts.stroke_color) |cx| ow_stroke = ImageAdapter.conv(cx);
-        var ow_fill: ?tvg.Color = null;
-        var disable_fill = false;
-        if (ow_fill != null and ow_fill.?.a == 0.0) disable_fill = true;
-        if (icon_opts.fill_color) |cx| ow_fill = ImageAdapter.conv(cx);
-        tvg.renderStream(cw.arena(), &img, fb.reader(), .{
-            .overwrite_stroke_width = icon_opts.stroke_width,
-            .overwrite_stroke = ow_stroke,
-            .overwrite_fill = ow_fill,
-            .disable_fill = disable_fill,
-        }) catch |err| {
-            log.warn("iconTexture Tinyvg error {!} rendering icon {s} at height {d}\n", .{ err, name, height });
-            return TvgError.tvgError;
-        };
-        return try textureCreate(@ptrCast(img.pixels), @intCast(img.width), @intCast(img.height), .linear);
+        const img = Color.PMAImage.fromTvgFile(name, cw.lifo(), cw.arena(), tvg_bytes, height, icon_opts) catch return TvgError.tvgError;
+        defer cw.lifo().free(img.pma);
+        return try textureCreate(img.pma, img.width, img.height, .linear);
     }
 };
 
@@ -5245,7 +5230,7 @@ pub const ImageSource = union(enum) {
         // Optional name/filename for debugging
         name: []const u8 = "imageFile",
         interpolation: enums.TextureInterpolation = .linear,
-        invalidation_strategy: InvalidationStrategy = .ptr,
+        invalidate: InvalidationStrategy = .ptr,
     },
 
     /// bytes of an premultiplied rgba u8 array in row major order
@@ -5254,7 +5239,7 @@ pub const ImageSource = union(enum) {
         width: u32,
         height: u32,
         interpolation: enums.TextureInterpolation = .linear,
-        invalidation_strategy: InvalidationStrategy = .ptr,
+        invalidate: InvalidationStrategy = .ptr,
     },
 
     /// bytes of a non premultiplied rgba u8 array in row major order, will
@@ -5266,7 +5251,7 @@ pub const ImageSource = union(enum) {
         width: u32,
         height: u32,
         interpolation: enums.TextureInterpolation = .linear,
-        invalidation_strategy: InvalidationStrategy = .ptr,
+        invalidate: InvalidationStrategy = .ptr,
     },
 
     /// When providing a texture directly, `hash` will return 0 and it will
@@ -5295,83 +5280,70 @@ pub const ImageSource = union(enum) {
     /// the texture cache.
     pub fn hash(self: ImageSource) u64 {
         var h = fnv.init();
+        // .always hashes ptr (for uniqueness) and image dimensions so we can update the texture if dimensions stay the same
+        const img_dimensions = imageSize(self) catch Size{ .w = 0, .h = 0 };
+        var dim: [2]u32 = .{ @intFromFloat(img_dimensions.w), @intFromFloat(img_dimensions.h) };
+        const img_dim_bytes = std.mem.asBytes(&dim);
+
         switch (self) {
             .imageFile => |file| {
-                switch (file.invalidation_strategy) {
+                switch (file.invalidate) {
                     .ptr => h.update(std.mem.asBytes(&file.bytes.ptr)),
                     .bytes => h.update(file.bytes),
-                    .always => return 0,
+                    .always => {
+                        h.update(std.mem.asBytes(&file.bytes.ptr));
+                        h.update(img_dim_bytes);
+                    },
                 }
                 h.update(std.mem.asBytes(&@intFromEnum(file.interpolation)));
             },
             .pixelsPMA => |pixels| {
-                switch (pixels.invalidation_strategy) {
-                    .ptr => h.update(std.mem.asBytes(&pixels.rgba.ptr)),
+                switch (pixels.invalidate) {
+                    .ptr, .always => h.update(std.mem.asBytes(&pixels.rgba.ptr)),
                     .bytes => h.update(@ptrCast(pixels.rgba)),
-                    .always => return 0,
                 }
                 h.update(std.mem.asBytes(&@intFromEnum(pixels.interpolation)));
-                h.update(std.mem.asBytes(&pixels.width));
-                h.update(std.mem.asBytes(&pixels.height));
+                h.update(img_dim_bytes);
             },
             .pixels => |pixels| {
-                switch (pixels.invalidation_strategy) {
-                    .ptr => h.update(std.mem.asBytes(&pixels.rgba.ptr)),
+                switch (pixels.invalidate) {
+                    .ptr, .always => h.update(std.mem.asBytes(&pixels.rgba.ptr)),
                     .bytes => h.update(std.mem.sliceAsBytes(pixels.rgba)),
-                    .always => return 0,
                 }
                 h.update(std.mem.asBytes(&@intFromEnum(pixels.interpolation)));
-                h.update(std.mem.asBytes(&pixels.width));
-                h.update(std.mem.asBytes(&pixels.height));
+                h.update(img_dim_bytes);
             },
             .texture => return 0,
         }
         return h.final();
     }
 
-    /// Will get the texture from cache or create it if it doesn't already exist
+    /// Will get the texture from cache or create it if it doesn't already exist;
     ///
     /// Only valid between `Window.begin` and `Window.end`
     pub fn getTexture(self: ImageSource) !Texture {
         const key = self.hash();
-        return switch (self) {
-            .imageFile => |file| (if (file.invalidation_strategy == .always) null else textureGetCached(key)) orelse {
-                const texture = try Texture.fromImageFile(file.name, file.bytes, file.interpolation);
-                if (file.invalidation_strategy == .always) {
-                    textureDestroyLater(texture);
-                } else {
-                    textureAddToCache(key, texture);
-                }
-                return texture;
-            },
-            .pixelsPMA => |pixels| (if (pixels.invalidation_strategy == .always) null else textureGetCached(key)) orelse {
-                const texture = try Texture.fromPixelsPMA(pixels.rgba, pixels.width, pixels.height, pixels.interpolation);
-                // std.debug.print("regenerating texture for pixelsPMA\n", .{});
-                if (pixels.invalidation_strategy == .always) {
-                    textureDestroyLater(texture);
-                } else {
-                    textureAddToCache(key, texture);
-                }
-                return texture;
-            },
-            .pixels => |pixels| (if (pixels.invalidation_strategy == .always) null else textureGetCached(key)) orelse {
-                // Using arena here instead of lifo as this buffer is likely to be large and we
-                // prefer that lifo doesn't reallocate as often. Arena is intended for larger,
-                // one of allocations and we can still free the buffer here
-                // const copy = try currentWindow().arena().dupe(u8, pixels.rgba);
-                // defer currentWindow().arena().free(copy);
-                const copy = pixels.rgba;
-                // std.debug.print("regenerating texture for pixels\n", .{});
-                const texture = try Texture.fromPixelsPMA(Color.PMA.sliceFromRGBA(copy), pixels.width, pixels.height, pixels.interpolation);
-                if (pixels.invalidation_strategy == .always) {
-                    textureDestroyLater(texture);
-                } else {
-                    textureAddToCache(key, texture);
-                }
-                return texture;
-            },
-            .texture => |tex| tex,
+        const invalidate = switch (self) {
+            .imageFile => |f| f.invalidate,
+            .pixels => |px| px.invalidate,
+            .pixelsPMA => |px| px.invalidate,
+            // return texture directly
+            .texture => |tex| return tex,
         };
+        if (textureGetCached(key)) |cached_texture| {
+            // if invalidate = always, we update the texture using updateContent for efficency, otherwise return the cached Texture
+            if (invalidate == .always) {
+                var tex_mut = cached_texture;
+                try tex_mut.updateContent(self);
+                return tex_mut;
+            } else return cached_texture;
+        } else {
+            // cache was empty we create a new Texture
+            const new_texture = try Texture.fromImageSource(self);
+            textureAddToCache(key, new_texture);
+            std.log.warn("added {}, w: {}, h: {} to the cache", .{ key, new_texture.width, new_texture.height });
+            return new_texture;
+        }
     }
 };
 
@@ -6946,6 +6918,25 @@ pub fn textureCreate(pixels: []const Color.PMA, width: u32, height: u32, interpo
         log.err("Texture was created with an incorrect amount of pixels, expected {d} but got {d} (w: {d}, h: {d})", .{ pixels.len, width * height, width, height });
     }
     return currentWindow().backend.textureCreate(@ptrCast(pixels.ptr), width, height, interpolation);
+}
+
+/// Update a texture that was created with `textureCreate`.
+///
+/// this is only valid to call while the Texture is not destroyed!
+///
+/// Only valid between `Window.begin` and `Window.end`.
+pub fn textureUpdate(Self: *Texture, pma: []const dvui.Color.PMA, interpolation: enums.TextureInterpolation) !void {
+    if (pma.len != Self.width * Self.height) @panic("Texture size and supplied Content did not match");
+    currentWindow().backend.textureUpdate(Self.*, @ptrCast(pma.ptr)) catch |err| {
+        // texture update not supported by backend, destroy and create texture
+        if (err == Backend.TextureError.NotImplemented) {
+            const new_tex = try textureCreate(pma, Self.width, Self.height, interpolation);
+            textureDestroyLater(Self.*);
+            Self.* = new_tex;
+        } else {
+            return err;
+        }
+    };
 }
 
 /// Create a texture that can be rendered with `renderTexture` and drawn to

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5349,7 +5349,6 @@ pub const ImageSource = union(enum) {
             // cache was empty we create a new Texture
             const new_texture = try Texture.fromImageSource(self);
             textureAddToCache(key, new_texture);
-            std.log.warn("added {}, w: {}, h: {} to the cache", .{ key, new_texture.width, new_texture.height });
             return new_texture;
         }
     }

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1094,7 +1094,7 @@ pub const Texture = struct {
     /// Only valid to call while the underlying Texture is not destroyed!
     ///
     /// Only valid between `Window.begin` and `Window.end`.
-    pub fn updateContent(self: *Texture, src: ImageSource) !void {
+    pub fn updateImageSource(self: *Texture, src: ImageSource) !void {
         switch (src) {
             .imageFile => |f| {
                 const img = try Color.PMAImage.fromImageFile(f.name, f.bytes);
@@ -5291,7 +5291,7 @@ pub const ImageSource = union(enum) {
         // .always hashes ptr (for uniqueness) and image dimensions so we can update the texture if dimensions stay the same
         const img_dimensions = imageSize(self) catch Size{ .w = 0, .h = 0 };
         var dim: [2]u32 = .{ @intFromFloat(img_dimensions.w), @intFromFloat(img_dimensions.h) };
-        const img_dim_bytes = std.mem.asBytes(&dim);
+        const img_dim_bytes = std.mem.asBytes(&dim); // hashing u32 here instead of float because of unstable bit representation in floating point numbers
 
         switch (self) {
             .imageFile => |file| {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5339,10 +5339,10 @@ pub const ImageSource = union(enum) {
             .texture => |tex| return tex,
         };
         if (textureGetCached(key)) |cached_texture| {
-            // if invalidate = always, we update the texture using updateContent for efficency, otherwise return the cached Texture
+            // if invalidate = always, we update the texture using updateImageSource for efficency, otherwise return the cached Texture
             if (invalidate == .always) {
                 var tex_mut = cached_texture;
-                try tex_mut.updateContent(self);
+                try tex_mut.updateImageSource(self);
                 return tex_mut;
             } else return cached_texture;
         } else {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1110,9 +1110,7 @@ pub const Texture = struct {
             height: u32,
             pub fn setPixel(self: *@This(), x: usize, y: usize, col: [4]u8) void {
                 const idx = (y * self.height + x) * 4;
-                for (0..4) |i| {
-                    self.pixels[idx + i] = col[i];
-                }
+                for (0..4) |i| self.pixels[idx + i] = col[i];
             }
             pub fn getPixel(self: *@This(), x: usize, y: usize) [4]u8 {
                 const idx = y * self.height + x;
@@ -1145,9 +1143,7 @@ pub const Texture = struct {
         if (icon_opts.stroke_color) |cx| ow_stroke = ImageAdapter.conv(cx);
         var ow_fill: ?tvg.Color = null;
         var disable_fill = false;
-        if (ow_fill != null and ow_fill.?.a == 0.0) {
-            disable_fill = true;
-        }
+        if (ow_fill != null and ow_fill.?.a == 0.0) disable_fill = true;
         if (icon_opts.fill_color) |cx| ow_fill = ImageAdapter.conv(cx);
         tvg.renderStream(cw.arena(), &img, fb.reader(), .{
             .overwrite_stroke_width = icon_opts.stroke_width,
@@ -5362,8 +5358,9 @@ pub const ImageSource = union(enum) {
                 // Using arena here instead of lifo as this buffer is likely to be large and we
                 // prefer that lifo doesn't reallocate as often. Arena is intended for larger,
                 // one of allocations and we can still free the buffer here
-                const copy = try currentWindow().arena().dupe(u8, pixels.rgba);
-                defer currentWindow().arena().free(copy);
+                // const copy = try currentWindow().arena().dupe(u8, pixels.rgba);
+                // defer currentWindow().arena().free(copy);
+                const copy = pixels.rgba;
                 // std.debug.print("regenerating texture for pixels\n", .{});
                 const texture = try Texture.fromPixelsPMA(Color.PMA.sliceFromRGBA(copy), pixels.width, pixels.height, pixels.interpolation);
                 if (pixels.invalidation_strategy == .always) {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5238,7 +5238,7 @@ pub const ImageSource = union(enum) {
         // Optional name/filename for debugging
         name: []const u8 = "imageFile",
         interpolation: enums.TextureInterpolation = .linear,
-        invalidate: InvalidationStrategy = .ptr,
+        invalidation: InvalidationStrategy = .ptr,
     },
 
     /// bytes of an premultiplied rgba u8 array in row major order
@@ -5247,7 +5247,7 @@ pub const ImageSource = union(enum) {
         width: u32,
         height: u32,
         interpolation: enums.TextureInterpolation = .linear,
-        invalidate: InvalidationStrategy = .ptr,
+        invalidation: InvalidationStrategy = .ptr,
     },
 
     /// bytes of a non premultiplied rgba u8 array in row major order, will
@@ -5259,7 +5259,7 @@ pub const ImageSource = union(enum) {
         width: u32,
         height: u32,
         interpolation: enums.TextureInterpolation = .linear,
-        invalidate: InvalidationStrategy = .ptr,
+        invalidation: InvalidationStrategy = .ptr,
     },
 
     /// When providing a texture directly, `hash` will return 0 and it will
@@ -5295,7 +5295,7 @@ pub const ImageSource = union(enum) {
 
         switch (self) {
             .imageFile => |file| {
-                switch (file.invalidate) {
+                switch (file.invalidation) {
                     .ptr => h.update(std.mem.asBytes(&file.bytes.ptr)),
                     .bytes => h.update(file.bytes),
                     .always => {
@@ -5306,7 +5306,7 @@ pub const ImageSource = union(enum) {
                 h.update(std.mem.asBytes(&@intFromEnum(file.interpolation)));
             },
             .pixelsPMA => |pixels| {
-                switch (pixels.invalidate) {
+                switch (pixels.invalidation) {
                     .ptr, .always => h.update(std.mem.asBytes(&pixels.rgba.ptr)),
                     .bytes => h.update(@ptrCast(pixels.rgba)),
                 }
@@ -5314,7 +5314,7 @@ pub const ImageSource = union(enum) {
                 h.update(img_dim_bytes);
             },
             .pixels => |pixels| {
-                switch (pixels.invalidate) {
+                switch (pixels.invalidation) {
                     .ptr, .always => h.update(std.mem.asBytes(&pixels.rgba.ptr)),
                     .bytes => h.update(std.mem.sliceAsBytes(pixels.rgba)),
                 }
@@ -5332,9 +5332,9 @@ pub const ImageSource = union(enum) {
     pub fn getTexture(self: ImageSource) !Texture {
         const key = self.hash();
         const invalidate = switch (self) {
-            .imageFile => |f| f.invalidate,
-            .pixels => |px| px.invalidate,
-            .pixelsPMA => |px| px.invalidate,
+            .imageFile => |f| f.invalidation,
+            .pixels => |px| px.invalidation,
+            .pixelsPMA => |px| px.invalidation,
             // return texture directly
             .texture => |tex| return tex,
         };


### PR DESCRIPTION
this pr:
- adds another fn to the Backend: textureUpdate which is optional to implement in the Backend for now
- in dvui.zig added textureUpdate (which calls backend.textureUpdate)  similar to textureCreate for direct access
- in Color.zig added struct PMAImage which consists of a []PMA, width and height
- moved fns that convert ImageFile or tvgFile to []PMA slice are moved to PMAImage
- dvui.Texture: new fn fromImageSource()
- dvui.Texture: new fn updateImageSource() to update its Content with an ImageSource
- changed the logic around caching textures to use the new textureUpdate