### PR TITLE
Don't use `Options` for `Theme` styles

### DIFF
--- a/src/Examples/basic_widgets.zig
+++ b/src/Examples/basic_widgets.zig
@@ -319,7 +319,7 @@ pub fn dropdownAdvanced() void {
             var hbox2 = dvui.box(@src(), .horizontal, .{ .expand = .both });
             defer hbox2.deinit();
 
-            var opts: Options = if (mi.show_active) dvui.themeGet().style_accent else .{};
+            var opts: Options = if (mi.show_active) dvui.themeGet().accent() else .{};
 
             dvui.icon(
                 @src(),
@@ -347,7 +347,7 @@ pub fn dropdownAdvanced() void {
             var vbox = dvui.box(@src(), .vertical, .{ .expand = .both });
             defer vbox.deinit();
 
-            var opts: Options = if (mi.show_active) dvui.themeGet().style_accent else .{};
+            var opts: Options = if (mi.show_active) dvui.themeGet().accent() else .{};
 
             _ = dvui.image(@src(), .{ .source = .{ .imageFile = .{ .bytes = zig_favicon, .name = "zig favicon" } } }, opts.override(.{ .gravity_x = 0.5 }));
             dvui.labelNoFmt(@src(), "image above text", .{}, opts.override(.{ .gravity_x = 0.5, .padding = .{} }));

--- a/src/Examples/struct_ui.zig
+++ b/src/Examples/struct_ui.zig
@@ -31,54 +31,53 @@ pub fn structUI() void {
         dvui.structEntryAlloc(@src(), dvui.currentWindow().gpa, Top, &Top.instance, .{ .margin = .{ .x = 10 } });
     }
 
-    // This broke when I added Options.data_out, and I don't know why
-    //if (dvui.expander(@src(), "Edit Current Theme", .{}, .{ .expand = .horizontal })) {
-    //    themeEditor();
-    //}
+    if (dvui.expander(@src(), "Edit Current Theme", .{}, .{ .expand = .horizontal })) {
+        themeEditor();
+    }
 }
 
 /// ![image](Examples-themeEditor.png)
-//pub fn themeEditor() void {
-//    var b2 = dvui.box(@src(), .vertical, .{ .expand = .horizontal, .margin = .{ .x = 10 } });
-//    defer b2.deinit();
-//
-//    const color_field_options = dvui.StructFieldOptions(dvui.Color){ .fields = .{
-//        .r = .{ .min = 0, .max = 255, .widget_type = .slider },
-//        .g = .{ .min = 0, .max = 255, .widget_type = .slider },
-//        .b = .{ .min = 0, .max = 255, .widget_type = .slider },
-//        .a = .{ .disabled = true },
-//    } };
-//
-//    dvui.structEntryEx(@src(), "dvui.Theme", dvui.Theme, dvui.themeGet(), .{
-//        .use_expander = false,
-//        .label_override = "",
-//        .fields = .{
-//            .name = .{ .disabled = true },
-//            .dark = .{ .widget_type = .toggle },
-//            .style_err = .{ .disabled = true },
-//            .style_accent = .{ .disabled = true },
-//            .font_body = .{ .disabled = true },
-//            .font_heading = .{ .disabled = true },
-//            .font_caption = .{ .disabled = true },
-//            .font_caption_heading = .{ .disabled = true },
-//            .font_title = .{ .disabled = true },
-//            .font_title_1 = .{ .disabled = true },
-//            .font_title_2 = .{ .disabled = true },
-//            .font_title_3 = .{ .disabled = true },
-//            .font_title_4 = .{ .disabled = true },
-//            .color_accent = color_field_options,
-//            .color_err = color_field_options,
-//            .color_text = color_field_options,
-//            .color_text_press = color_field_options,
-//            .color_fill = color_field_options,
-//            .color_fill_window = color_field_options,
-//            .color_fill_control = color_field_options,
-//            .color_fill_hover = color_field_options,
-//            .color_fill_press = color_field_options,
-//            .color_border = color_field_options,
-//        },
-//    });
-//}
+pub fn themeEditor() void {
+    var b2 = dvui.box(@src(), .vertical, .{ .expand = .horizontal, .margin = .{ .x = 10 } });
+    defer b2.deinit();
+
+    const color_field_options = dvui.StructFieldOptions(dvui.Color){ .fields = .{
+        .r = .{ .min = 0, .max = 255, .widget_type = .slider },
+        .g = .{ .min = 0, .max = 255, .widget_type = .slider },
+        .b = .{ .min = 0, .max = 255, .widget_type = .slider },
+        .a = .{ .disabled = true },
+    } };
+
+    dvui.structEntryEx(@src(), "dvui.Theme", dvui.Theme, dvui.themeGet(), .{
+        .use_expander = false,
+        .label_override = "",
+        .fields = .{
+            .name = .{ .disabled = true },
+            .dark = .{ .widget_type = .toggle },
+            .style_err = .{ .disabled = true },
+            .style_accent = .{ .disabled = true },
+            .font_body = .{ .disabled = true },
+            .font_heading = .{ .disabled = true },
+            .font_caption = .{ .disabled = true },
+            .font_caption_heading = .{ .disabled = true },
+            .font_title = .{ .disabled = true },
+            .font_title_1 = .{ .disabled = true },
+            .font_title_2 = .{ .disabled = true },
+            .font_title_3 = .{ .disabled = true },
+            .font_title_4 = .{ .disabled = true },
+            .color_accent = color_field_options,
+            .color_err = color_field_options,
+            .color_text = color_field_options,
+            .color_text_press = color_field_options,
+            .color_fill = color_field_options,
+            .color_fill_window = color_field_options,
+            .color_fill_control = color_field_options,
+            .color_fill_hover = color_field_options,
+            .color_fill_press = color_field_options,
+            .color_border = color_field_options,
+        },
+    });
+}
 
 pub fn themeSerialization() void {
     var serialize_box = dvui.box(@src(), .vertical, .{ .expand = .horizontal, .margin = .{ .x = 10 } });

--- a/src/Examples/styling.zig
+++ b/src/Examples/styling.zig
@@ -8,8 +8,8 @@ pub fn styling() void {
         var hbox = dvui.box(@src(), .horizontal, .{});
         defer hbox.deinit();
 
-        _ = dvui.button(@src(), "Accent", .{}, dvui.themeGet().style_accent);
-        _ = dvui.button(@src(), "Error", .{}, dvui.themeGet().style_err);
+        _ = dvui.button(@src(), "Accent", .{}, dvui.themeGet().accent());
+        _ = dvui.button(@src(), "Error", .{}, dvui.themeGet().err());
         _ = dvui.button(@src(), "Window", .{}, .{ .color_fill = .fill_window });
         _ = dvui.button(@src(), "Content", .{}, .{ .color_fill = .fill });
         _ = dvui.button(@src(), "Control", .{}, .{});

--- a/src/Theme.zig
+++ b/src/Theme.zig
@@ -50,13 +50,35 @@ font_title_3: Font,
 font_title_4: Font,
 
 // used for highlighting menu/dropdown items
-style_accent: Options,
+style_accent: ColorStyles,
 
 // used for a button to perform dangerous actions
-style_err: Options,
+style_err: ColorStyles,
 
 // if true, need to free the strings in deinit()
 allocated_strings: bool = false,
+
+pub const ColorStyles = struct {
+    color_accent: ?Options.ColorOrName = null,
+    color_text: ?Options.ColorOrName = null,
+    color_text_press: ?Options.ColorOrName = null,
+    color_fill: ?Options.ColorOrName = null,
+    color_fill_hover: ?Options.ColorOrName = null,
+    color_fill_press: ?Options.ColorOrName = null,
+    color_border: ?Options.ColorOrName = null,
+
+    pub fn asOptions(self: ColorStyles) Options {
+        return .{
+            .color_accent = self.color_accent,
+            .color_text = self.color_text,
+            .color_text_press = self.color_text_press,
+            .color_fill = self.color_fill,
+            .color_fill_hover = self.color_fill_hover,
+            .color_fill_press = self.color_fill_press,
+            .color_border = self.color_border,
+        };
+    }
+};
 
 pub fn deinit(self: *Theme, gpa: std.mem.Allocator) void {
     if (self.allocated_strings) {
@@ -87,6 +109,16 @@ pub fn fontSizeAdd(self: *Theme, delta: f32) Theme {
     ret.font_title_4.size += delta;
 
     return ret;
+}
+
+/// Gets the accent style `Options`
+pub fn accent(self: *const Theme) Options {
+    return self.style_accent.asOptions();
+}
+
+/// Gets the error style `Options`
+pub fn err(self: *const Theme) Options {
+    return self.style_err.asOptions();
 }
 
 pub fn picker(src: std.builtin.SourceLocation, opts: Options) bool {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5126,7 +5126,7 @@ pub fn menuItemLabel(src: std.builtin.SourceLocation, label_str: []const u8, ini
     }
 
     if (mi.show_active) {
-        labelopts = labelopts.override(themeGet().style_accent);
+        labelopts = labelopts.override(themeGet().accent());
     }
 
     labelNoFmt(@src(), label_str, .{}, labelopts);
@@ -5149,7 +5149,7 @@ pub fn menuItemIcon(src: std.builtin.SourceLocation, name: []const u8, tvg_bytes
     }
 
     if (mi.show_active) {
-        iconopts = iconopts.override(themeGet().style_accent);
+        iconopts = iconopts.override(themeGet().accent());
     }
 
     icon(@src(), name, tvg_bytes, .{}, iconopts);
@@ -6299,7 +6299,7 @@ pub fn checkmark(checked: bool, focused: bool, rs: RectScale, pressed: bool, hov
 
     var options = opts;
     if (checked) {
-        options = opts.override(themeGet().style_accent);
+        options = opts.override(themeGet().accent());
         rs.r.insetAll(0.5 * rs.s).fill(cornerRad, .{ .color = options.color(fill) });
     } else {
         rs.r.insetAll(rs.s).fill(cornerRad, .{ .color = options.color(fill) });
@@ -6386,7 +6386,7 @@ pub fn radioCircle(active: bool, focused: bool, rs: RectScale, pressed: bool, ho
 
     var options = opts;
     if (active) {
-        options = opts.override(themeGet().style_accent);
+        options = opts.override(themeGet().accent());
         r.insetAll(0.5 * rs.s).fill(cornerRad, .{ .color = options.color(.fill) });
     } else {
         r.insetAll(rs.s).fill(cornerRad, .{ .color = opts.color(fill) });

--- a/src/themes/Adwaita.zig
+++ b/src/themes/Adwaita.zig
@@ -49,7 +49,7 @@ pub const light = light: {
         .color_fill_press = (Color.HSLuv{ .s = 0, .l = 72 }).color(),
         .color_border = (Color.HSLuv{ .s = 0, .l = 63 }).color(),
 
-        .style_accent = Options{
+        .style_accent = .{
             .color_accent = .{ .color = light_accent_accent },
             .color_text = .{ .color = Color.white },
             .color_text_press = .{ .color = Color.white },
@@ -59,7 +59,7 @@ pub const light = light: {
             .color_border = .{ .color = light_accent_border },
         },
 
-        .style_err = Options{
+        .style_err = .{
             .color_accent = .{ .color = light_err_accent },
             .color_text = .{ .color = Color.white },
             .color_text_press = .{ .color = Color.white },
@@ -112,7 +112,7 @@ pub const dark = dark: {
         .color_fill_press = dark_fill_hsl.lighten(30).color(),
         .color_border = dark_fill_hsl.lighten(39).color(),
 
-        .style_accent = Options{
+        .style_accent = .{
             .color_accent = .{ .color = dark_accent_accent },
             .color_text = .{ .color = Color.white },
             .color_text_press = .{ .color = Color.white },
@@ -122,7 +122,7 @@ pub const dark = dark: {
             .color_border = .{ .color = dark_accent_border },
         },
 
-        .style_err = Options{
+        .style_err = .{
             .color_accent = .{ .color = dark_err_accent },
             .color_text = .{ .color = Color.white },
             .color_text_press = .{ .color = Color.white },

--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -181,7 +181,7 @@ pub fn addChoiceLabel(self: *DropdownWidget, label_text: []const u8) bool {
 
     var opts = self.options.strip();
     if (mi.show_active) {
-        opts = opts.override(dvui.themeGet().style_accent);
+        opts = opts.override(dvui.themeGet().accent());
     }
 
     dvui.labelNoFmt(@src(), label_text, .{}, opts);


### PR DESCRIPTION
This is as partial fix for #472

Most of the issue in #472 originated from cyclical pointers in `Options` introduced by the `data_out` field. There is no good reason for `Theme` to hold `Options` directly in the first place, except maybe duplicated field definitions. This adds a new type for only color styles that the `Theme` can use, which allows the `themeEditor` to work as before. This is not a true fix for the issues in #472, but it's an improvement to the types of `Theme`. 