### PR TITLE
refactor Event Handling, consistent API around Window.extra_frames_needed?

### DIFF
--- a/src/Event.zig
+++ b/src/Event.zig
@@ -27,7 +27,7 @@ evt: union(enum) {
 /// matched this event, using `dvui.matchEvent` or similar.
 /// This makes it possible to see which widget handled the event.
 pub fn handle(self: *Event, src: std.builtin.SourceLocation, wd: *const dvui.WidgetData) void {
-    if (dvui.currentWindow().debug.logEvents(null)) {
+    if (dvui.currentWindow().debug().logEvents(null)) {
         var action: []const u8 = "";
         switch (self.evt) {
             .mouse => action = @tagName(self.evt.mouse.action),

--- a/src/Examples/debugging.zig
+++ b/src/Examples/debugging.zig
@@ -12,7 +12,7 @@ pub fn debuggingErrors() void {
     dvui.label(@src(), "- text, icons, and images rounded to nearest pixel", .{}, .{ .margin = .{ .x = 10 } });
     dvui.label(@src(), "- text rendered at the closest smaller font (not stretched)", .{}, .{ .margin = .{ .x = 10 } });
 
-    _ = dvui.checkbox(@src(), &dvui.currentWindow().debug.touch_simulate_events, "Convert mouse events to touch", .{});
+    _ = dvui.checkbox(@src(), &dvui.currentWindow().debug().touch_simulate_events, "Convert mouse events to touch", .{});
     dvui.label(@src(), "- mouse drag will scroll", .{}, .{ .margin = .{ .x = 10 } });
     dvui.label(@src(), "- mouse click in text layout/entry shows touch draggables and menu", .{}, .{ .margin = .{ .x = 10 } });
 

--- a/src/Examples/scroll_canvas.zig
+++ b/src/Examples/scroll_canvas.zig
@@ -372,7 +372,7 @@ pub fn scrollCanvas() void {
 
         if (!done) {
             // still dragging, draw a half-opaque box to show we are dragging
-            const dr = Rect.Physical.fromPoint(dvui.currentWindow().mouse_pt.diff(.{ .x = 10, .y = 10 })).toSize(.all(20));
+            const dr = Rect.Physical.fromPoint(dvui.currentWindow().mouse_pt().diff(.{ .x = 10, .y = 10 })).toSize(.all(20));
             dr.fill(.{}, .{ .color = dvui.Color.lime.opacity(0.5) });
         }
     }

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -27,7 +27,7 @@ rect_scale: ?RectScale = null,
 pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Options) WidgetData {
     const parent = dvui.parentGet();
     const id = parent.extendId(src, opts.idExtra());
-    const options = if (dvui.currentWindow().debug.options_override.get(id)) |val| val.@"0" else opts;
+    const options = if (dvui.currentWindow().debug().options_override.get(id)) |val| val.@"0" else opts;
     const min_size = options.min_sizeGet().min(options.max_sizeGet());
 
     const ms = dvui.minSize(id, min_size);
@@ -100,32 +100,32 @@ pub fn register(self: *WidgetData) void {
         hasher.update(std.mem.asBytes(&(self.id == focused_widget_id)));
     }
 
-    if (cw.debug.target == .focused and self.id == focused_widget_id) {
-        cw.debug.widget_id = self.id;
+    if ((cw.debug()).target == .focused and self.id == focused_widget_id) {
+        cw.debug().widget_id = self.id;
     }
 
-    if (cw.debug.target.mouse() or self.id == cw.debug.widget_id) {
+    if (cw.debug().target.mouse() or self.id == cw.debug().widget_id) {
         var rs = self.rectScale();
 
-        if (cw.debug.target.mouse() and
-            rs.r.contains(cw.mouse_pt) and
+        if (cw.debug().target.mouse() and
+            rs.r.contains(cw.mouse_pt()) and
             // prevents stuff in scroll area outside viewport being caught
-            dvui.clipGet().contains(cw.mouse_pt) and
+            dvui.clipGet().contains(cw.mouse_pt()) and
             // prevents stuff in lower subwindows being caught
-            cw.windowFor(cw.mouse_pt) == dvui.subwindowCurrentId())
+            cw.windowFor(cw.mouse_pt()) == dvui.subwindowCurrentId())
         {
-            cw.debug.under_mouse_stack.append(cw.gpa, .{
+            cw.debug().under_mouse_stack.append(cw.gpa, .{
                 .id = self.id,
                 // Fallback must be empty so that freeing the name will be valid
                 .name = cw.gpa.dupe(u8, self.options.name orelse "") catch "",
             }) catch |err| {
                 dvui.logError(@src(), err, "Could not add debug info for widgets under mouse position. Widget {x} {s}", .{ self.id, self.options.name orelse "???" });
             };
-            cw.debug.widget_id = self.id;
+            cw.debug().widget_id = self.id;
         }
 
-        if (self.id == cw.debug.widget_id) {
-            if (cw.debug.widget_panic) {
+        if (self.id == cw.debug().widget_id) {
+            if (cw.debug().widget_panic) {
                 @panic("Debug Window Panic");
             }
 
@@ -134,8 +134,8 @@ pub fn register(self: *WidgetData) void {
                 min_size = ms;
             }
 
-            cw.debug.target_wd = self.*;
-            cw.debug.target_wd.?.parent = undefined;
+            cw.debug().target_wd = self.*;
+            cw.debug().target_wd.?.parent = undefined;
 
             const clipr = dvui.clipGet();
             // clip to whole window so we always see the outline
@@ -308,7 +308,7 @@ pub fn minSizeSetAndRefresh(self: *WidgetData) void {
         if (kv.used) {
             const name: []const u8 = self.options.name orelse "???";
             dvui.log.err("{s}:{d} duplicate widget id {x} (widget \"{s}\" highlighted in red); you may need to pass .{{.id_extra=<loop index>}} as widget options (see https://github.com/david-vanderson/dvui/blob/master/readme-implementation.md#widget-ids )\n", .{ self.src.file, self.src.line, self.id, name });
-            cw.debug.widget_id = self.id;
+            cw.debug().widget_id = self.id;
         }
     }
 }

--- a/src/widgets/CacheWidget.zig
+++ b/src/widgets/CacheWidget.zig
@@ -33,9 +33,9 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
         .init_opts = init_opts,
         .hash = dvui.hashIdKey(wd.id, "_tex"),
         .tex_uv = dvui.dataGet(null, wd.id, "_tex_uv", Size) orelse .{},
-        .refresh_prev_value = dvui.currentWindow().extra_frames_needed,
+        .refresh_prev_value = dvui.currentWindow().event_state.extra_frames_needed,
     };
-    dvui.currentWindow().extra_frames_needed = 0;
+    dvui.currentWindow().event_state.extra_frames_needed = 0;
     if (dvui.dataGet(null, self.wd.id, "_unsupported", bool) orelse false) self.state = .unsupported;
     return self;
 }
@@ -158,12 +158,12 @@ pub fn deinit(self: *CacheWidget) void {
     defer dvui.widgetFree(self);
     const cw = dvui.currentWindow();
     if (self.state == .ok and self.uncached()) {
-        if (dvui.currentWindow().extra_frames_needed == 0) {
+        if (dvui.currentWindow().event_state.extra_frames_needed == 0) {
             dvui.dataSet(null, self.data().id, "_cache_now", true);
             dvui.refresh(null, @src(), self.data().id);
         }
     }
-    cw.extra_frames_needed = @max(cw.extra_frames_needed, self.refresh_prev_value);
+    cw.event_state.extra_frames_needed = @max(cw.event_state.extra_frames_needed, self.refresh_prev_value);
 
     if (self.old_clip) |clip| {
         dvui.clipSet(clip);

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -136,7 +136,7 @@ pub fn shown(self: *FloatingTooltipWidget) bool {
             },
             .sticky => {
                 if (dvui.firstFrame(self.data().id)) {
-                    const mp = dvui.currentWindow().mouse_pt.toNatural();
+                    const mp = dvui.currentWindow().mouse_pt().toNatural();
                     dvui.dataSet(null, self.data().id, "_sticky_pt", mp);
                 } else {
                     const mp = dvui.dataGet(null, self.data().id, "_sticky_pt", dvui.Point.Natural) orelse dvui.Point.Natural{};

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -144,8 +144,8 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
         if (self.auto_size) {
             // Track if any of our children called refresh(), and in deinit we
             // will turn off auto_size if none of them did.
-            self.auto_size_refresh_prev_value = dvui.currentWindow().extra_frames_needed;
-            dvui.currentWindow().extra_frames_needed = 0;
+            self.auto_size_refresh_prev_value = dvui.currentWindow().event_state.extra_frames_needed;
+            dvui.currentWindow().event_state.extra_frames_needed = 0;
 
             const ms = Size.min(Size.max(min_size, self.options.min_sizeGet()), .cast(dvui.windowRect().size()));
             self.wd.rect.w = ms.w;
@@ -182,7 +182,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
                 while (nudge) {
                     nudge = false;
                     // don't check against subwindows[0] - that's that main window
-                    for (cw.subwindows.items[1..]) |subw| {
+                    for (cw.subwindows().items[1..]) |subw| {
                         if (subw.id != self.wd.id and subw.rect.topLeft().equals(self.data().rect.topLeft())) {
                             self.wd.rect.x += 24;
                             self.wd.rect.y += 24;
@@ -542,10 +542,10 @@ pub fn deinit(self: *FloatingWindowWidget) void {
     self.layout.deinit();
 
     if (self.auto_size_refresh_prev_value) |pv| {
-        if (dvui.currentWindow().extra_frames_needed == 0) {
+        if (dvui.currentWindow().event_state.extra_frames_needed == 0) {
             self.auto_size = false;
         }
-        dvui.currentWindow().extra_frames_needed = @max(dvui.currentWindow().extra_frames_needed, pv);
+        dvui.currentWindow().event_state.extra_frames_needed = @max(dvui.currentWindow().event_state.extra_frames_needed, pv);
     }
 
     if (self.init_options.process_events_in_deinit) {

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -268,7 +268,7 @@ pub fn init(src: std.builtin.SourceLocation, cols: WidthsOrNum, init_opts: InitO
             // If the grid is keep track of col widths then keep a copy of the starting col widths.
             self.starting_col_widths = dvui.currentWindow().arena().alloc(f32, self.col_widths.len) catch |err| default: {
                 dvui.logError(@src(), err, "GridWidget {x} could not allocate column widths", .{self.data().id});
-                dvui.currentWindow().debug.widget_id = self.data().id;
+                dvui.currentWindow().debug().widget_id = self.data().id;
                 break :default null;
             };
             if (self.starting_col_widths) |starting| {
@@ -374,7 +374,7 @@ pub fn headerCell(self: *GridWidget, src: std.builtin.SourceLocation, col_num: u
     if (self.hscroll == null) {
         if (self.bscroll != null) {
             dvui.log.debug("GridWidget {x} all header cells must be created before any body cells. Header will be placed in body.\n", .{self.data().id});
-            dvui.currentWindow().debug.widget_id = self.bscroll.?.data().id;
+            dvui.currentWindow().debug().widget_id = self.bscroll.?.data().id;
         } else {
             self.headerScrollAreaCreate();
         }

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -38,7 +38,7 @@ pub fn init(src: std.builtin.SourceLocation, comptime fmt: []const u8, args: any
         const str = std.fmt.allocPrint(cw.lifo(), fmt, args) catch |err| {
             const newid = dvui.parentGet().extendId(src, opts.idExtra());
             dvui.logError(@src(), err, "id {x} (highlighted in red) could not print its content", .{newid});
-            dvui.currentWindow().debug.widget_id = newid;
+            dvui.currentWindow().debug().widget_id = newid;
             break :blk .{ fmt, null };
         };
         // We need to use `long_term_arena` because otherwise we
@@ -46,7 +46,7 @@ pub fn init(src: std.builtin.SourceLocation, comptime fmt: []const u8, args: any
         const utf8 = dvui.toUtf8(cw.arena(), str) catch |err| {
             const newid = dvui.parentGet().extendId(src, opts.idExtra());
             dvui.logError(@src(), err, "id {x} (highlighted in red) could not allocate valid utf8 slice", .{newid});
-            dvui.currentWindow().debug.widget_id = newid;
+            dvui.currentWindow().debug().widget_id = newid;
             // We contained invalid utf8, so textSize will fail later
             break :blk .{ str, cw.lifo() };
         };
@@ -87,7 +87,7 @@ pub fn initNoFmtAllocator(src: std.builtin.SourceLocation, label_str: []const u8
 
 fn logAndHighlight(src: std.builtin.SourceLocation, opts: Options, err: anyerror) void {
     const newid = dvui.parentGet().extendId(src, opts.idExtra());
-    dvui.currentWindow().debug.widget_id = newid;
+    dvui.currentWindow().debug().widget_id = newid;
     dvui.log.err("{s}:{d} LabelWidget id {x} (highlighted in red) init() got {!}", .{ src.file, src.line, newid, err });
 }
 

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -177,8 +177,8 @@ pub fn processEvent(self: *MenuWidget, e: *Event) void {
                     if (dvui.dataGet(null, self.data().id, "_child_popup", Rect.Physical)) |r| {
                         const center = Point.Physical{ .x = r.x + r.w / 2, .y = r.y + r.h / 2 };
                         const cw = dvui.currentWindow();
-                        const to_center = center.diff(cw.mouse_pt_prev);
-                        const movement = cw.mouse_pt.diff(cw.mouse_pt_prev);
+                        const to_center = center.diff(cw.mouse_pt_prev());
+                        const movement = cw.mouse_pt().diff(cw.mouse_pt_prev());
                         const dot_prod = movement.x * to_center.x + movement.y * to_center.y;
                         const cos = dot_prod / (to_center.length() * movement.length());
                         if (std.math.acos(cos) < std.math.pi / 3.0) {

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -247,7 +247,7 @@ pub fn rectFor(self: *ScrollContainerWidget, id: dvui.WidgetId, min_size: Size, 
         // If you are reading this, make sure that children of scrollArea() are
         // not expanded in the scrollArea's layout direction, or that only the
         // last child is.
-        dvui.currentWindow().debug.widget_id = id;
+        dvui.currentWindow().debug().widget_id = id;
         dvui.log.debug("{s}:{d} got child {x} after expanded child", .{ @src().file, @src().line, id });
     } else if (e.isVertical()) {
         self.seen_expanded_child = true;


### PR DESCRIPTION
this PR will be an attempt to untangle Event handling logic from Window. WIP
status:
- refactor: all fields that are touched by input event handling (the `addEventXYZ` functions) are now in a seperate struct called EventState
- Window has a field `event_state: EventState`
- changed event list to be a fixed Capacity List, the Capacity is configurable by the User. this has the benefit of bounded memory usage and bounded worst case performance at the cost of more memory allocated upfront.
- EventState uses its own arena for duped strings that is reset with `EventState.endFrame(...)`

Reasoning: 
- this makes it easier to understand what state in `Window` is actually coupled to input event handling
- it seperates Window logic from Event handling logic which makes Event Handling more flexibel

Discussion
- I came across a lot of widgets that read fields of the Window struct or even modify them in their logic
- I think it would be beneficial to provide an api for the things these widgets need, to uncouple them from the Event Handling / Window Implementation, this also would make it easier to understand what these widgets doing with respect to the Event/Window state