### PR TITLE
Theme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,4 +302,6 @@ if (theme_dark) {
 ```
 The theme's color_accent is also used to show keyboard focus.
 
+The default theme will attempt to follow the system dark or light mode, or it can be set in the `Window` init options or by setting the `Window.theme` field directly. See the app and standalone examples for how to set the default theme. 
+
 See [implementation details](readme-implementation.md) for more information.

--- a/README.md
+++ b/README.md
@@ -295,10 +295,9 @@ dvui.ButtonWidget.defaults.background = false;
 Themes can be changed between frames or even within a frame.  The theme controls the fonts and colors referenced by font_style and named colors.
 ```zig
 if (theme_dark) {
-    win.theme = win.themes.get("Adwaita Dark").?;
-}
-else {
-    win.theme = win.themes.get("Adwaita Light").?;
+    win.theme = dvui.Theme.builtin.adwaita_dark;
+} else {
+    win.theme = dvui.Theme.builtin.adwaita_light;
 }
 ```
 The theme's color_accent is also used to show keyboard focus.

--- a/examples/app.zig
+++ b/examples/app.zig
@@ -41,6 +41,14 @@ var orig_content_scale: f32 = 1.0;
 pub fn AppInit(win: *dvui.Window) !void {
     orig_content_scale = win.content_scale;
     //try dvui.addFont("NOTO", @embedFile("../src/fonts/NotoSansKR-Regular.ttf"), null);
+
+    if (false) {
+        // If you need to set a theme based on the users preferred color scheme, do it here
+        win.theme = switch (win.backend.preferredColorScheme() orelse .light) {
+            .light => dvui.Theme.builtin.adwaita_light,
+            .dark => dvui.Theme.builtin.adwaita_dark,
+        };
+    }
 }
 
 // Run as app is shutting down before dvui.Window.deinit()

--- a/examples/dx11-standalone.zig
+++ b/examples/dx11-standalone.zig
@@ -51,6 +51,15 @@ pub fn main() !void {
         .vsync = vsync,
         .title = "DVUI DX11 Standalone Example",
         .icon = window_icon_png, // can also call setIconFromFileContent()
+        .dvui_window_init_options = .{
+            // you can set the default theme here in the init options
+            // PS: we need to pass undefined as the backend pointer because we haven't created the
+            //     backend yet. The pointer is unused for color scheme in the dx11 backend
+            .theme = switch (Backend.preferredColorScheme(undefined) orelse .light) {
+                .light => dvui.Theme.builtin.adwaita_light,
+                .dark => dvui.Theme.builtin.adwaita_dark,
+            },
+        },
     });
     defer first_backend.deinit();
 

--- a/examples/raylib-standalone.zig
+++ b/examples/raylib-standalone.zig
@@ -40,7 +40,13 @@ pub fn main() !void {
     backend.log_events = true;
 
     // init dvui Window (maps onto a single OS window)
-    var win = try dvui.Window.init(@src(), gpa, backend.backend(), .{});
+    var win = try dvui.Window.init(@src(), gpa, backend.backend(), .{
+        // you can set the default theme here in the init options
+        .theme = switch (backend.preferredColorScheme() orelse .light) {
+            .light => dvui.Theme.builtin.adwaita_light,
+            .dark => dvui.Theme.builtin.adwaita_dark,
+        },
+    });
     defer win.deinit();
 
     main_loop: while (true) {

--- a/examples/sdl-standalone.zig
+++ b/examples/sdl-standalone.zig
@@ -49,7 +49,13 @@ pub fn main() !void {
     _ = Backend.c.SDL_EnableScreenSaver();
 
     // init dvui Window (maps onto a single OS window)
-    var win = try dvui.Window.init(@src(), gpa, backend.backend(), .{});
+    var win = try dvui.Window.init(@src(), gpa, backend.backend(), .{
+        // you can set the default theme here in the init options
+        .theme = switch (backend.preferredColorScheme() orelse .light) {
+            .light => dvui.Theme.builtin.adwaita_light,
+            .dark => dvui.Theme.builtin.adwaita_dark,
+        },
+    });
     defer win.deinit();
 
     var interrupted = false;

--- a/src/Theme.zig
+++ b/src/Theme.zig
@@ -9,32 +9,35 @@ const Theme = @This();
 
 name: []const u8,
 
-// widgets can use this if they need to adjust colors
+/// widgets can use this if they need to adjust colors
 dark: bool,
 
+/// alpha value to apply to all colors and rendering
 alpha: f32 = 1.0,
 
-// used for focus
+/// used for focus highlighting
 color_accent: Color,
 
 color_err: Color,
 
-// text/foreground color
+/// text/foreground color
 color_text: Color,
 
-// text/foreground color when widget is pressed
+/// text/foreground color when widget is pressed
 color_text_press: Color,
 
-// background color for displaying lots of text
+/// background color for displaying lots of text
 color_fill: Color,
 
-// background color for containers that have other widgets inside
+/// background color for containers that have other widgets inside
 color_fill_window: Color,
 
-// background color for controls like buttons
+/// background color for controls like buttons
 color_fill_control: Color,
 
+/// background color while hovering over controls like buttons
 color_fill_hover: Color,
+/// background color while pressing down on controls like buttons
 color_fill_press: Color,
 
 color_border: Color,
@@ -49,13 +52,13 @@ font_title_2: Font,
 font_title_3: Font,
 font_title_4: Font,
 
-// used for highlighting menu/dropdown items
+/// used for highlighting menu/dropdown items
 style_accent: ColorStyles,
 
-// used for a button to perform dangerous actions
+/// used for buttons to perform dangerous actions
 style_err: ColorStyles,
 
-// if true, need to free the strings in deinit()
+/// if true, all strings in `Theme` will be freed in `deinit`
 allocated_strings: bool = false,
 
 pub const ColorStyles = struct {

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -76,6 +76,10 @@ secs_since_last_frame: f32 = 0,
 extra_frames_needed: u8 = 0,
 clipRect: dvui.Rect.Physical = .{},
 
+/// The currently active theme where colors and fonts will be sourced.
+/// This field is intended to be assigned to directly.
+///
+/// See `dvui.themeSet`
 theme: Theme,
 
 /// Uses `gpa` allocator


### PR DESCRIPTION
Final additions for #490

This adds a couple of changes related to themes:
- Makes the existing comments in `Theme` proper doc comments
- Add doc comment to `Window.theme` field that describes how to set it and how it's allowed to be changed
- Update the readme to explain how default themes are chosen and to not use the theme hashmap that was removed in #494
- Add the code to set the theme to the standalone and app examples