### PR TITLE
Id refactor

### DIFF
--- a/readme-implementation.md
+++ b/readme-implementation.md
@@ -140,7 +140,7 @@ If `Options.rect` is set, the widget is directly specifying its position and siz
 `subwindow` is the term dvui uses for floating windows/dialogs/popups/etc.  They are dvui widgets and are not detachable or moveable outside the OS window.
 
 ### Widget IDs
-Each widget gets a `WidgetId` (fancy u64) by combining:
+Each widget gets an `Id` (fancy u64) by combining:
 - parent's id (see https://github.com/david-vanderson/dvui/blob/main/README.md#parent-child-and-nesting )
 - @src() passed to widget
 - `.id_extra` field of Options passed to widget (defaults to 0)

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -3,7 +3,7 @@ options_editor_open: bool = false,
 options_override_list_open: bool = false,
 
 /// 0 means no widget is selected
-widget_id: dvui.WidgetId = .zero,
+widget_id: dvui.Id = .zero,
 target: DebugTarget = .none,
 
 /// All functions using the parent are invalid
@@ -12,10 +12,10 @@ target_wd: ?dvui.WidgetData = null,
 /// Uses `gpa` allocator
 ///
 /// The name slice is also duplicated by the `gpa` allocator
-under_mouse_stack: std.ArrayListUnmanaged(struct { id: dvui.WidgetId, name: []const u8 }) = .empty,
+under_mouse_stack: std.ArrayListUnmanaged(struct { id: dvui.Id, name: []const u8 }) = .empty,
 
 /// Uses `gpa` allocator
-options_override: std.AutoHashMapUnmanaged(dvui.WidgetId, struct { Options, std.builtin.SourceLocation }) = .empty,
+options_override: std.AutoHashMapUnmanaged(dvui.Id, struct { Options, std.builtin.SourceLocation }) = .empty,
 
 toggle_mutex: std.Thread.Mutex = .{},
 log_refresh: bool = false,
@@ -259,7 +259,7 @@ pub fn show(self: *Debug) void {
 
         var it = self.options_override.iterator();
         var i: usize = 0;
-        var remove_override_id: ?dvui.WidgetId = null;
+        var remove_override_id: ?dvui.Id = null;
         while (it.next()) |entry| : (i += 1) {
             const id = entry.key_ptr.*;
             const options, const src = entry.value_ptr.*;
@@ -388,7 +388,7 @@ pub fn optionsEditor(self: *Options, wd: *const dvui.WidgetData) bool {
     return changed;
 }
 
-fn copyOptionsToClipboard(src: std.builtin.SourceLocation, id: dvui.WidgetId, options: Options) void {
+fn copyOptionsToClipboard(src: std.builtin.SourceLocation, id: dvui.Id, options: Options) void {
     dvui.log.debug("Copied Options struct for {s}:{d}", .{ src.file, src.line });
     dvui.toast(@src(), .{ .message = "Options copied to clipboard" });
 
@@ -401,7 +401,7 @@ fn copyOptionsToClipboard(src: std.builtin.SourceLocation, id: dvui.WidgetId, op
     dvui.clipboardTextSet(out.items);
 }
 
-fn layoutPage(self: *Options, id: dvui.WidgetId) bool {
+fn layoutPage(self: *Options, id: dvui.Id) bool {
     var changed = false;
 
     const corner_radius_was_null = self.corner_radius == null;
@@ -738,7 +738,7 @@ fn layoutPage(self: *Options, id: dvui.WidgetId) bool {
     return changed;
 }
 
-fn stylePage(self: *Options, id: dvui.WidgetId) bool {
+fn stylePage(self: *Options, id: dvui.Id) bool {
     var changed = false;
 
     var row = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });

--- a/src/Event.zig
+++ b/src/Event.zig
@@ -10,8 +10,8 @@ handled: bool = false,
 
 /// For key events these represents focus. For mouse events widgetId represents
 /// capture, windowId unused.
-target_windowId: ?dvui.WidgetId = null,
-target_widgetId: ?dvui.WidgetId = null,
+target_windowId: ?dvui.Id = null,
+target_widgetId: ?dvui.Id = null,
 
 // num increments within a frame, used in focusRemainingEvents
 num: u16 = 0,
@@ -119,7 +119,7 @@ pub const Mouse = struct {
     mod: enums.Mod,
 
     p: dvui.Point.Physical,
-    floating_win: dvui.WidgetId,
+    floating_win: dvui.Id,
 };
 
 test {

--- a/src/Examples/StrokeTest.zig
+++ b/src/Examples/StrokeTest.zig
@@ -59,7 +59,7 @@ pub fn data(self: *Self) *dvui.WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *Self, id: dvui.WidgetId, min_size: dvui.Size, e: dvui.Options.Expand, g: dvui.Options.Gravity) dvui.Rect {
+pub fn rectFor(self: *Self, id: dvui.Id, min_size: dvui.Size, e: dvui.Options.Expand, g: dvui.Options.Gravity) dvui.Rect {
     _ = id;
     return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }

--- a/src/Examples/animations.zig
+++ b/src/Examples/animations.zig
@@ -287,7 +287,7 @@ pub fn animatingWindowRect(src: std.builtin.SourceLocation, rect: *Rect, show_fl
 }
 
 const AnimatingDialog = struct {
-    pub fn dialogDisplay(id: dvui.WidgetId) !void {
+    pub fn dialogDisplay(id: dvui.Id) !void {
         const modal = dvui.dataGet(null, id, "_modal", bool) orelse unreachable;
         const title = dvui.dataGetSlice(null, id, "_title", []u8) orelse unreachable;
         const message = dvui.dataGetSlice(null, id, "_message", []u8) orelse unreachable;
@@ -364,7 +364,7 @@ const AnimatingDialog = struct {
         }
     }
 
-    pub fn after(id: dvui.WidgetId, response: enums.DialogResponse) !void {
+    pub fn after(id: dvui.Id, response: enums.DialogResponse) !void {
         _ = id;
         std.log.debug("You clicked \"{s}\"", .{@tagName(response)});
     }

--- a/src/Examples/dialogs.zig
+++ b/src/Examples/dialogs.zig
@@ -2,7 +2,7 @@ var progress_mutex = std.Thread.Mutex{};
 var progress_val: f32 = 0.0;
 
 /// ![image](Examples-dialogs.png)
-pub fn dialogs(demo_win_id: dvui.WidgetId) void {
+pub fn dialogs(demo_win_id: dvui.Id) void {
     {
         var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
         defer hbox.deinit();
@@ -24,7 +24,7 @@ pub fn dialogs(demo_win_id: dvui.WidgetId) void {
         }
 
         const dialogsFollowup = struct {
-            fn callafter(id: dvui.WidgetId, response: enums.DialogResponse) !void {
+            fn callafter(id: dvui.Id, response: enums.DialogResponse) !void {
                 _ = id;
                 var buf: [100]u8 = undefined;
                 const text = std.fmt.bufPrint(&buf, "You clicked \"{s}\" in the previous dialog", .{@tagName(response)}) catch unreachable;
@@ -221,7 +221,7 @@ fn background_dialog(win: *dvui.Window, delay_ns: u64) void {
     dvui.dialog(@src(), .{}, .{ .window = win, .modal = false, .title = "Background Dialog", .message = "This non modal dialog was added from a non-GUI thread." });
 }
 
-fn background_toast(win: *dvui.Window, delay_ns: u64, subwindow_id: ?dvui.WidgetId) void {
+fn background_toast(win: *dvui.Window, delay_ns: u64, subwindow_id: ?dvui.Id) void {
     std.time.sleep(delay_ns);
     dvui.refresh(win, @src(), null);
     dvui.toast(@src(), .{ .window = win, .subwindow_id = subwindow_id, .message = "Toast came from a non-GUI thread" });

--- a/src/Examples/menus.zig
+++ b/src/Examples/menus.zig
@@ -243,7 +243,7 @@ pub fn focus() void {
 
             if (dvui.button(@src(), "Focus Next textEntry", .{}, .{})) {
                 // grab id from previous frame
-                if (dvui.dataGet(null, uniqueId, "next_text_entry_id", dvui.WidgetId)) |id| {
+                if (dvui.dataGet(null, uniqueId, "next_text_entry_id", dvui.Id)) |id| {
                     dvui.focusWidget(id, null, null);
                 }
             }

--- a/src/Examples/reorder_tree.zig
+++ b/src/Examples/reorder_tree.zig
@@ -325,7 +325,7 @@ const tree_palette = &[_]dvui.Color{
     .{ .r = 0x4b, .g = 0x5b, .b = 0xab, .a = 0xff },
 };
 
-fn exampleRemoveTreeEntry(directory: []const u8, entries: *MutableTreeEntry.Children, old_directory: []const u8, uniqueId: dvui.WidgetId) void {
+fn exampleRemoveTreeEntry(directory: []const u8, entries: *MutableTreeEntry.Children, old_directory: []const u8, uniqueId: dvui.Id) void {
     for (entries.items, 0..) |*e, i| {
         const alloc = dvui.currentWindow().lifo();
         const abs_path = std.fs.path.join(alloc, &.{ directory, e.name }) catch "";
@@ -341,7 +341,7 @@ fn exampleRemoveTreeEntry(directory: []const u8, entries: *MutableTreeEntry.Chil
     }
 }
 
-fn examplePlaceTreeEntry(directory: []const u8, entries: *MutableTreeEntry.Children, new_directory: []const u8, uniqueId: dvui.WidgetId) void {
+fn examplePlaceTreeEntry(directory: []const u8, entries: *MutableTreeEntry.Children, new_directory: []const u8, uniqueId: dvui.Id) void {
     if (std.mem.containsAtLeast(u8, new_directory, 1, directory)) {
         if (dvui.dataGetPtr(null, uniqueId, "removed_entry", MutableTreeEntry)) |removed_entry| {
             const alloc = dvui.currentWindow().lifo();
@@ -452,7 +452,7 @@ const example_file_structure: []const ConstTreeEntry = &[_]ConstTreeEntry{
     },
 };
 
-fn exampleFileTreeSearch(directory: []const u8, base_entries: *MutableTreeEntry.Children, entries: *MutableTreeEntry.Children, tree: *dvui.TreeWidget, uniqueId: dvui.WidgetId, color_id: *usize, branch_options: dvui.Options, expander_options: dvui.Options) !void {
+fn exampleFileTreeSearch(directory: []const u8, base_entries: *MutableTreeEntry.Children, entries: *MutableTreeEntry.Children, tree: *dvui.TreeWidget, uniqueId: dvui.Id, color_id: *usize, branch_options: dvui.Options, expander_options: dvui.Options) !void {
     var id_extra: usize = 0;
     for (entries.items) |*entry| {
         id_extra += 1;
@@ -555,7 +555,7 @@ fn exampleFileTreeSearch(directory: []const u8, base_entries: *MutableTreeEntry.
 /// This is needed because we want to automatically deallocate when we are done
 fn keepExampleFileTreeDataAlive(const_file_tree: []const ConstTreeEntry) void {
     for (const_file_tree) |const_entry| {
-        const id: dvui.WidgetId = @enumFromInt(dvui.hashIdKey(@enumFromInt(@intFromPtr(const_file_tree.ptr)), const_entry.name));
+        const id: dvui.Id = @enumFromInt(dvui.hashIdKey(@enumFromInt(@intFromPtr(const_file_tree.ptr)), const_entry.name));
         const child_slice = dvui.dataGetSlice(null, id, "child_slice", []MutableTreeEntry) orelse @panic("File tree slice did not exist");
         std.mem.doNotOptimizeAway(child_slice);
         if (const_entry.children.len > 0) {
@@ -566,7 +566,7 @@ fn keepExampleFileTreeDataAlive(const_file_tree: []const ConstTreeEntry) void {
 
 fn exampleFileTreeSetup(const_file_tree: []const ConstTreeEntry, mutable_file_tree: *MutableTreeEntry.Children) void {
     for (const_file_tree) |const_entry| {
-        const id: dvui.WidgetId = @enumFromInt(dvui.hashIdKey(@enumFromInt(@intFromPtr(const_file_tree.ptr)), const_entry.name));
+        const id: dvui.Id = @enumFromInt(dvui.hashIdKey(@enumFromInt(@intFromPtr(const_file_tree.ptr)), const_entry.name));
         // Allocate a data slice with the max amount of children possible which will be kept alive later.
         dvui.dataSetSliceCopies(null, id, "child_slice", &[1]MutableTreeEntry{undefined}, example_file_structure_max_children);
         var mutable_entry = MutableTreeEntry{
@@ -621,9 +621,9 @@ pub fn fileTree(src: std.builtin.SourceLocation, root_directory: []const u8, tre
     recurseFiles(root_directory, tree, uniqueId, branch_options, expander_options) catch std.debug.panic("Failed to recurse files", .{});
 }
 
-fn recurseFiles(root_directory: []const u8, outer_tree: *dvui.TreeWidget, uniqueId: dvui.WidgetId, branch_options: dvui.Options, expander_options: dvui.Options) !void {
+fn recurseFiles(root_directory: []const u8, outer_tree: *dvui.TreeWidget, uniqueId: dvui.Id, branch_options: dvui.Options, expander_options: dvui.Options) !void {
     const recursor = struct {
-        fn search(directory: []const u8, tree: *dvui.TreeWidget, uid: dvui.WidgetId, color_id: *usize, branch_opts: dvui.Options, expander_opts: dvui.Options) !void {
+        fn search(directory: []const u8, tree: *dvui.TreeWidget, uid: dvui.Id, color_id: *usize, branch_opts: dvui.Options, expander_opts: dvui.Options) !void {
             var dir = std.fs.cwd().openDir(directory, .{ .access_sub_paths = true, .iterate = true }) catch return;
             defer dir.close();
 

--- a/src/Examples/reorder_tree.zig
+++ b/src/Examples/reorder_tree.zig
@@ -555,7 +555,7 @@ fn exampleFileTreeSearch(directory: []const u8, base_entries: *MutableTreeEntry.
 /// This is needed because we want to automatically deallocate when we are done
 fn keepExampleFileTreeDataAlive(const_file_tree: []const ConstTreeEntry) void {
     for (const_file_tree) |const_entry| {
-        const id: dvui.Id = @enumFromInt(dvui.hashIdKey(@enumFromInt(@intFromPtr(const_file_tree.ptr)), const_entry.name));
+        const id = dvui.Id.update(@enumFromInt(@intFromPtr(const_file_tree.ptr)), const_entry.name);
         const child_slice = dvui.dataGetSlice(null, id, "child_slice", []MutableTreeEntry) orelse @panic("File tree slice did not exist");
         std.mem.doNotOptimizeAway(child_slice);
         if (const_entry.children.len > 0) {
@@ -566,7 +566,7 @@ fn keepExampleFileTreeDataAlive(const_file_tree: []const ConstTreeEntry) void {
 
 fn exampleFileTreeSetup(const_file_tree: []const ConstTreeEntry, mutable_file_tree: *MutableTreeEntry.Children) void {
     for (const_file_tree) |const_entry| {
-        const id: dvui.Id = @enumFromInt(dvui.hashIdKey(@enumFromInt(@intFromPtr(const_file_tree.ptr)), const_entry.name));
+        const id = dvui.Id.update(@enumFromInt(@intFromPtr(const_file_tree.ptr)), const_entry.name);
         // Allocate a data slice with the max amount of children possible which will be kept alive later.
         dvui.dataSetSliceCopies(null, id, "child_slice", &[1]MutableTreeEntry{undefined}, example_file_structure_max_children);
         var mutable_entry = MutableTreeEntry{

--- a/src/Examples/text_entry.zig
+++ b/src/Examples/text_entry.zig
@@ -7,7 +7,7 @@ var text_entry_multiline_buf: []u8 = &.{};
 var text_entry_multiline_break = false;
 
 /// ![image](Examples-text_entry.png)
-pub fn textEntryWidgets(demo_win_id: dvui.WidgetId) void {
+pub fn textEntryWidgets(demo_win_id: dvui.Id) void {
     var left_alignment = dvui.Alignment.init(@src(), 0);
     defer left_alignment.deinit();
 

--- a/src/Widget.zig
+++ b/src/Widget.zig
@@ -72,8 +72,9 @@ pub fn data(self: Widget) *WidgetData {
     return self.vtable.data(self.ptr).validate();
 }
 
+/// Calls `dvui.Id.extendId` on the this widgets id
 pub fn extendId(self: Widget, src: std.builtin.SourceLocation, id_extra: usize) dvui.Id {
-    return dvui.hashSrc(self.data().id, src, id_extra);
+    return self.data().id.extendId(src, id_extra);
 }
 
 pub fn rectFor(self: Widget, id: Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {

--- a/src/Widget.zig
+++ b/src/Widget.zig
@@ -7,7 +7,7 @@ const Rect = dvui.Rect;
 const RectScale = dvui.RectScale;
 const Size = dvui.Size;
 const WidgetData = dvui.WidgetData;
-const WidgetId = dvui.WidgetId;
+const Id = dvui.Id;
 
 const Widget = @This();
 
@@ -16,7 +16,7 @@ vtable: *const VTable,
 
 const VTable = struct {
     data: *const fn (ptr: *anyopaque) *WidgetData,
-    rectFor: *const fn (ptr: *anyopaque, id: WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect,
+    rectFor: *const fn (ptr: *anyopaque, id: Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect,
     screenRectScale: *const fn (ptr: *anyopaque, r: Rect) RectScale,
     minSizeForChild: *const fn (ptr: *anyopaque, s: Size) void,
 };
@@ -24,7 +24,7 @@ const VTable = struct {
 pub fn init(
     pointer: anytype,
     comptime dataFn: fn (ptr: @TypeOf(pointer)) *WidgetData,
-    comptime rectForFn: fn (ptr: @TypeOf(pointer), id: WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect,
+    comptime rectForFn: fn (ptr: @TypeOf(pointer), id: Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect,
     comptime screenRectScaleFn: fn (ptr: @TypeOf(pointer), r: Rect) RectScale,
     comptime minSizeForChildFn: fn (ptr: @TypeOf(pointer), s: Size) void,
 ) Widget {
@@ -39,7 +39,7 @@ pub fn init(
             return @call(.always_inline, dataFn, .{self});
         }
 
-        fn rectForImpl(ptr: *anyopaque, id: WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+        fn rectForImpl(ptr: *anyopaque, id: Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
             const self = @as(Ptr, @ptrCast(@alignCast(ptr)));
             return @call(.always_inline, rectForFn, .{ self, id, min_size, e, g });
         }
@@ -72,11 +72,11 @@ pub fn data(self: Widget) *WidgetData {
     return self.vtable.data(self.ptr).validate();
 }
 
-pub fn extendId(self: Widget, src: std.builtin.SourceLocation, id_extra: usize) dvui.WidgetId {
+pub fn extendId(self: Widget, src: std.builtin.SourceLocation, id_extra: usize) dvui.Id {
     return dvui.hashSrc(self.data().id, src, id_extra);
 }
 
-pub fn rectFor(self: Widget, id: WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: Widget, id: Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     return self.vtable.rectFor(self.ptr, id, min_size, e, g);
 }
 

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -7,7 +7,7 @@ const Rect = dvui.Rect;
 const RectScale = dvui.RectScale;
 const Size = dvui.Size;
 const Widget = dvui.Widget;
-const WidgetId = dvui.WidgetId;
+const Id = dvui.Id;
 const WidgetData = @This();
 
 pub const InitOptions = struct {
@@ -15,7 +15,7 @@ pub const InitOptions = struct {
     subwindow: bool = false,
 };
 
-id: WidgetId,
+id: Id,
 parent: Widget,
 init_options: InitOptions,
 rect: Rect,
@@ -320,7 +320,7 @@ pub fn minSizeReportToParent(self: *const WidgetData) void {
 }
 
 pub fn validate(self: *const WidgetData) *WidgetData {
-    std.debug.assert(self.id != WidgetId.undef); // Indicates a use after deinit() error.
+    std.debug.assert(self.id != Id.undef); // Indicates a use after deinit() error.
     return @constCast(self);
 }
 

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -1,4 +1,4 @@
-/**@typedef {BigInt} WidgetId */
+/**@typedef {BigInt} Id */
 
 /**
  * @param {number} ms Number of milliseconds to sleep
@@ -205,7 +205,7 @@ class Dvui {
 
     // Used for file uploads. Only valid for one frame
     filesCacheModified = false;
-    /** @type {Map<WidgetId, FileList>} */
+    /** @type {Map<Id, FileList>} */
     filesCache = new Map();
 
     //let par = document.createElement("p");

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -736,28 +736,28 @@ pub fn setCursor(self: *WebBackend, cursor: dvui.enums.Cursor) void {
     }
 }
 
-pub fn openFilePicker(id: dvui.WidgetId, accept: ?[]const u8, multiple: bool) void {
+pub fn openFilePicker(id: dvui.Id, accept: ?[]const u8, multiple: bool) void {
     const accept_final = accept orelse "";
     wasm.wasm_open_file_picker(id.asU64(), accept_final.ptr, accept_final.len, multiple);
 }
 
-pub fn getFileName(id: dvui.WidgetId, file_index: usize) ?[:0]const u8 {
+pub fn getFileName(id: dvui.Id, file_index: usize) ?[:0]const u8 {
     const ptr = wasm.wasm_get_file_name(id.asU64(), file_index);
     if (@intFromPtr(ptr) <= 0) return null;
     return std.mem.sliceTo(ptr, 0);
 }
 
-pub fn getFileSize(id: dvui.WidgetId, file_index: usize) ?usize {
+pub fn getFileSize(id: dvui.Id, file_index: usize) ?usize {
     const size: isize = wasm.wasm_get_file_size(id.asU64(), file_index);
     if (size <= 0) return null;
     return @intCast(size);
 }
 
-pub fn readFileData(id: dvui.WidgetId, file_index: usize, data: [*]u8) void {
+pub fn readFileData(id: dvui.Id, file_index: usize, data: [*]u8) void {
     wasm.wasm_read_file_data(id.asU64(), file_index, data);
 }
 
-pub fn getNumberOfFilesAvailable(id: dvui.WidgetId) usize {
+pub fn getNumberOfFilesAvailable(id: dvui.Id) usize {
     return wasm.wasm_get_number_of_files_available(id.asU64());
 }
 

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -197,9 +197,13 @@ pub const Id = enum(u64) {
     }
 
     pub fn asU64(self: Id) u64 {
-        return @intCast(@intFromEnum(self));
+        return @intFromEnum(self);
     }
 
+    /// ALWAYS prefer using `asU64` unless a `usize` is required as it could
+    /// loose precision and uniqueness on non-64bit platforms (like wasm32).
+    ///
+    /// Using an `Id` as `Options.id_extra` would be a valid use of this function
     pub fn asUsize(self: Id) usize {
         // usize might be u32 (like on wasm32)
         return @truncate(@intFromEnum(self));

--- a/src/selection.zig
+++ b/src/selection.zig
@@ -6,7 +6,7 @@
 const std = @import("std");
 const dvui = @import("dvui.zig");
 const WidgetData = dvui.WidgetData;
-const WidgetId = dvui.WidgetId;
+const Id = dvui.Id;
 const Rect = dvui.Rect;
 
 pub const SelectAllState = enum {
@@ -113,7 +113,7 @@ pub const MultiSelectMouse = struct {
 /// Helper for select all support via the "select_all" keyboard binding.
 pub const SelectAllKeyboard = struct {
     selection_changed: bool = false,
-    last_focused_in_frame: WidgetId = .zero,
+    last_focused_in_frame: Id = .zero,
 
     /// reset() should be called immediately before the first "selectable" is created.
     /// If using with a GridWidget, call reset before the first body cell is created.

--- a/src/widgets/AnimateWidget.zig
+++ b/src/widgets/AnimateWidget.zig
@@ -116,7 +116,7 @@ pub fn data(self: *AnimateWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *AnimateWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *AnimateWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
     return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }

--- a/src/widgets/BoxWidget.zig
+++ b/src/widgets/BoxWidget.zig
@@ -42,7 +42,7 @@ packed_children: f32 = 0,
 total_weight: f32 = 0,
 child_rect: Rect = Rect{},
 child_positioned: bool = false,
-child_id: if (builtin.mode == .Debug) dvui.WidgetId else void,
+child_id: if (builtin.mode == .Debug) dvui.Id else void,
 ratio_extra: f32 = 0,
 ran_off: bool = false,
 pixels_per_w: f32 = 0,
@@ -106,7 +106,7 @@ pub fn data(self: *BoxWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *BoxWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *BoxWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     if (builtin.mode == .Debug) {
         if (self.child_id != .zero) {
             dvui.logError(@src(), error.BadOrder, "rectFor called before previous widget called minSizeForChild", .{});

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -95,7 +95,7 @@ pub fn data(self: *ButtonWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *ButtonWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *ButtonWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
     return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }

--- a/src/widgets/CacheWidget.zig
+++ b/src/widgets/CacheWidget.zig
@@ -31,7 +31,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     var self = CacheWidget{
         .wd = wd,
         .init_opts = init_opts,
-        .hash = dvui.hashIdKey(wd.id, "_tex"),
+        .hash = wd.id.update("_tex").asU64(),
         .tex_uv = dvui.dataGet(null, wd.id, "_tex_uv", Size) orelse .{},
         .refresh_prev_value = dvui.currentWindow().extra_frames_needed,
     };

--- a/src/widgets/CacheWidget.zig
+++ b/src/widgets/CacheWidget.zig
@@ -139,7 +139,7 @@ pub fn data(self: *CacheWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *CacheWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *CacheWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
     return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -319,9 +319,12 @@ pub fn hueSlider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hue
 }
 
 pub fn getHueSelectorTexture(dir: dvui.enums.Direction) dvui.Backend.TextureError!dvui.Texture {
-    const hue_texture_id = dvui.hashIdKey(@enumFromInt(@as(u64, @intFromEnum(dir))), "hue_selector_texture");
+    var h = dvui.fnv.init();
+    h.update("hue");
+    h.update(std.mem.asBytes(&dir));
+    const id = h.final();
     const cw = dvui.currentWindow();
-    const res = try cw.texture_cache.getOrPut(cw.gpa, hue_texture_id);
+    const res = try cw.texture_cache.getOrPut(cw.gpa, id);
     if (!res.found_existing) {
         const width: u32, const height: u32 = switch (dir) {
             .horizontal => .{ hue_selector_colors.len, 1 },
@@ -333,9 +336,12 @@ pub fn getHueSelectorTexture(dir: dvui.enums.Direction) dvui.Backend.TextureErro
 }
 
 pub fn getValueSaturationTexture(hue: f32) dvui.Backend.TextureError!dvui.Texture {
-    const hue_texture_id = dvui.hashIdKey(@enumFromInt(@as(u64, @intFromFloat(hue * 10000))), "value_saturation_texture");
+    var h = dvui.fnv.init();
+    h.update("value");
+    h.update(std.mem.asBytes(&(hue * 10000)));
+    const id = h.final();
     const cw = dvui.currentWindow();
-    const res = try cw.texture_cache.getOrPut(cw.gpa, hue_texture_id);
+    const res = try cw.texture_cache.getOrPut(cw.gpa, id);
     if (!res.found_existing) {
         var pixels: [4]Color.PMA = .{ .white, .cast(Color.HSV.toColor(.{ .h = hue })), .black, .black };
         // set top right corner to the max value of that hue

--- a/src/widgets/ContextWidget.zig
+++ b/src/widgets/ContextWidget.zig
@@ -21,7 +21,7 @@ wd: WidgetData,
 init_options: InitOptions,
 
 prev_menu_root: ?dvui.MenuWidget.Root = null,
-winId: dvui.WidgetId,
+winId: dvui.Id,
 focused: bool = false,
 activePt: Point.Natural = .{},
 
@@ -79,7 +79,7 @@ pub fn data(self: *ContextWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *ContextWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *ContextWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
     dvui.log.debug("{s}:{d} ContextWidget should not have normal child widgets, only menu stuff", .{ self.data().src.file, self.data().src.line });
     return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);

--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -11,7 +11,7 @@ drop: ?FloatingMenuWidget = null,
 drop_first_frame: bool = false,
 /// SAFETY: Will always be set by `addChoice` before use
 drop_mi: MenuItemWidget = undefined,
-drop_mi_id: ?dvui.WidgetId = null,
+drop_mi_id: ?dvui.Id = null,
 drop_mi_index: usize = 0,
 drop_height: f32 = 0,
 drop_adjust: f32 = 0,

--- a/src/widgets/FlexBoxWidget.zig
+++ b/src/widgets/FlexBoxWidget.zig
@@ -59,7 +59,7 @@ pub fn data(self: *FlexBoxWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *FlexBoxWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *FlexBoxWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
     _ = e;
     _ = g;

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -52,8 +52,8 @@ prev_rendering: bool = undefined,
 wd: WidgetData,
 /// options is for our embedded ScrollAreaWidget
 options: Options,
-prev_windowId: dvui.WidgetId = .zero,
-prev_last_focus: dvui.WidgetId = undefined,
+prev_windowId: dvui.Id = .zero,
+prev_last_focus: dvui.Id = undefined,
 parent_popup: ?*FloatingMenuWidget = null,
 have_popup_child: bool = false,
 init_options: InitOptions,
@@ -190,7 +190,7 @@ pub fn data(self: *FloatingMenuWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *FloatingMenuWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *FloatingMenuWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
     return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -53,7 +53,7 @@ parent_tooltip: ?*FloatingTooltipWidget = null,
 prev_rendering: bool = undefined,
 wd: WidgetData,
 /// SAFETY: Set by `install`
-prev_windowId: dvui.WidgetId = undefined,
+prev_windowId: dvui.Id = undefined,
 /// SAFETY: Set by `install`
 prevClip: Rect.Physical = undefined,
 scale_val: f32,
@@ -207,7 +207,7 @@ pub fn data(self: *FloatingTooltipWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *FloatingTooltipWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *FloatingTooltipWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
     return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }

--- a/src/widgets/FloatingWidget.zig
+++ b/src/widgets/FloatingWidget.zig
@@ -19,7 +19,7 @@ pub var defaults: Options = .{
 prev_rendering: bool = undefined,
 wd: WidgetData,
 /// SAFETY: Set by `install`
-prev_windowId: dvui.WidgetId = undefined,
+prev_windowId: dvui.Id = undefined,
 /// SAFETY: Set by `install`
 prevClip: Rect.Physical = undefined,
 scale_val: f32,
@@ -87,7 +87,7 @@ pub fn data(self: *FloatingWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *FloatingWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *FloatingWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
     return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -79,7 +79,7 @@ options: Options,
 /// SAFETY: Set by `install`
 prev_windowInfo: dvui.subwindowCurrentSetReturn = undefined,
 /// SAFETY: Set by `install`
-prev_last_focus: dvui.WidgetId = undefined,
+prev_last_focus: dvui.Id = undefined,
 /// SAFETY: Set by `install`
 layout: BoxWidget = undefined,
 /// SAFETY: Set by `install`
@@ -527,7 +527,7 @@ pub fn data(self: *FloatingWindowWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *FloatingWindowWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *FloatingWindowWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
     return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -30,7 +30,7 @@ const Cursor = dvui.enums.Cursor;
 const MaxSize = Options.MaxSize;
 const ScrollInfo = dvui.ScrollInfo;
 const WidgetData = dvui.WidgetData;
-const WidgetId = dvui.WidgetId;
+const Id = dvui.Id;
 const Event = dvui.Event;
 const BoxWidget = dvui.BoxWidget;
 const ScrollAreaWidget = dvui.ScrollAreaWidget;
@@ -955,7 +955,7 @@ pub const KeyboardNavigation = struct {
     cursor: Cell = .{ .col_num = 0, .row_num = 0 },
 
     /// Internal use.
-    last_focused_widget: WidgetId = .zero,
+    last_focused_widget: Id = .zero,
 
     /// Call this once per frame before the grid body cells are created.
     pub fn processEvents(self: *KeyboardNavigation, grid: *GridWidget) void {

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -138,7 +138,7 @@ pub fn data(self: *const MenuItemWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *MenuItemWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *MenuItemWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
     return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }
@@ -279,7 +279,7 @@ test "menuItem click sets last_focused_id_this_frame" {
     defer t.deinit();
 
     const fns = struct {
-        var last_focused_id_set: ?dvui.WidgetId = null;
+        var last_focused_id_set: ?dvui.Id = null;
 
         fn frame() !dvui.App.Result {
             var m = dvui.menu(@src(), .vertical, .{ .padding = .all(10), .tag = "menu" });

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -59,15 +59,15 @@ pub var defaults: Options = .{
 
 pub const InitOptions = struct {
     dir: enums.Direction,
-    parentSubwindowId: ?dvui.WidgetId = null,
+    parentSubwindowId: ?dvui.Id = null,
 };
 
 wd: WidgetData,
 
 init_opts: InitOptions,
-winId: dvui.WidgetId,
+winId: dvui.Id,
 parentMenu: ?*MenuWidget = null,
-last_focus: dvui.WidgetId,
+last_focus: dvui.Id,
 /// SAFETY: Set in `install`
 box: BoxWidget = undefined,
 
@@ -155,7 +155,7 @@ pub fn data(self: *MenuWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *MenuWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *MenuWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
     return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }

--- a/src/widgets/OverlayWidget.zig
+++ b/src/widgets/OverlayWidget.zig
@@ -35,7 +35,7 @@ pub fn data(self: *OverlayWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *OverlayWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *OverlayWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
     return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -224,7 +224,7 @@ pub fn data(self: *PanedWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *PanedWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) dvui.Rect {
+pub fn rectFor(self: *PanedWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) dvui.Rect {
     _ = id;
     var r = self.data().contentRect().justSize();
     var margin = self.handle_thick / 2 + self.init_opts.handle_margin;

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -60,7 +60,7 @@ pub fn data(self: *ReorderWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *ReorderWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *ReorderWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
     return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }
@@ -342,7 +342,7 @@ pub const Reorderable = struct {
         return self.wd.validate();
     }
 
-    pub fn rectFor(self: *Reorderable, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+    pub fn rectFor(self: *Reorderable, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
         _ = id;
         return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
     }

--- a/src/widgets/ScaleWidget.zig
+++ b/src/widgets/ScaleWidget.zig
@@ -137,7 +137,7 @@ pub fn data(self: *ScaleWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *ScaleWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *ScaleWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     const s = if (self.scale.* > 0)
         1.0 / self.scale.*
     else

--- a/src/widgets/ScrollAreaWidget.zig
+++ b/src/widgets/ScrollAreaWidget.zig
@@ -31,7 +31,7 @@ pub const InitOpts = struct {
     vertical_bar: ScrollInfo.ScrollBarMode = .auto,
     horizontal: ?ScrollInfo.ScrollMode = null, // .none is default
     horizontal_bar: ScrollInfo.ScrollBarMode = .auto,
-    focus_id: ?dvui.WidgetId = null, // clicking on a scrollbar will focus this id, or the scroll container if null
+    focus_id: ?dvui.Id = null, // clicking on a scrollbar will focus this id, or the scroll container if null
     frame_viewport: ?dvui.Point = null,
     lock_visible: bool = false,
     process_events_after: bool = true,
@@ -93,7 +93,7 @@ pub fn installScrollBars(self: *ScrollAreaWidget) void {
     self.hbox.install();
     self.hbox.drawBackground();
 
-    const focus_target = self.init_opts.focus_id orelse dvui.dataGet(null, self.hbox.data().id, "_scroll_id", dvui.WidgetId);
+    const focus_target = self.init_opts.focus_id orelse dvui.dataGet(null, self.hbox.data().id, "_scroll_id", dvui.Id);
 
     const crect = self.hbox.data().contentRect();
 

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -21,13 +21,13 @@ pub var defaults: Options = .{
 pub const InitOptions = struct {
     scroll_info: *ScrollInfo,
     direction: enums.Direction = .vertical,
-    focus_id: ?dvui.WidgetId = null,
+    focus_id: ?dvui.Id = null,
 };
 
 wd: WidgetData,
 grabRect: Rect = Rect{},
 si: *ScrollInfo,
-focus_id: ?dvui.WidgetId = null,
+focus_id: ?dvui.Id = null,
 dir: enums.Direction,
 highlight: bool = false,
 

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -44,7 +44,7 @@ pub const InitOptions = struct {
 wd: WidgetData,
 si: *ScrollInfo,
 init_opts: InitOptions,
-last_focus: dvui.WidgetId,
+last_focus: dvui.Id,
 parentScroll: ?*ScrollContainerWidget = null,
 
 // si.viewport.x/y might be updated in the middle of a frame, this prevents
@@ -56,10 +56,10 @@ prevClip: Rect.Physical = .{},
 nextVirtualSize: Size = Size{},
 seen_expanded_child: bool = false,
 
-first_visible_id: dvui.WidgetId = .zero,
+first_visible_id: dvui.Id = .zero,
 first_visible_offset: Point = Point{}, // offset of top left of first visible widget from viewport
 
-inject_capture_id: ?dvui.WidgetId = null,
+inject_capture_id: ?dvui.Id = null,
 seen_scroll_drag: bool = false,
 
 finger_down: bool = false,
@@ -112,7 +112,7 @@ pub fn install(self: *ScrollContainerWidget) void {
     self.frame_viewport = self.init_opts.frame_viewport orelse self.si.viewport.topLeft();
     if (self.init_opts.lock_visible) {
         // we don't want to see anything until we find first_visible_id
-        self.first_visible_id = dvui.dataGet(null, self.data().id, "_fv_id", dvui.WidgetId) orelse .zero;
+        self.first_visible_id = dvui.dataGet(null, self.data().id, "_fv_id", dvui.Id) orelse .zero;
         self.first_visible_offset = dvui.dataGet(null, self.data().id, "_fv_offset", Point) orelse .{};
         self.frame_viewport = .{ .x = -10000, .y = -10000 };
     }
@@ -231,7 +231,7 @@ pub fn data(self: *ScrollContainerWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *ScrollContainerWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *ScrollContainerWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     // todo: do horizontal properly
     if (self.seen_expanded_child) {
         // Having one expanded child makes sense - could be taking the rest of

--- a/src/widgets/SuggestionWidget.zig
+++ b/src/widgets/SuggestionWidget.zig
@@ -1,6 +1,6 @@
 pub const SuggestionWidget = @This();
 
-id: dvui.WidgetId,
+id: dvui.Id,
 /// Is for the floating menu widget that might open
 options: Options,
 init_options: InitOptions,
@@ -19,7 +19,7 @@ pub var defaults: Options = .{
 
 pub const InitOptions = struct {
     rs: RectScale,
-    text_entry_id: dvui.WidgetId,
+    text_entry_id: dvui.Id,
 };
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) SuggestionWidget {

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -339,7 +339,7 @@ pub fn data(self: *TextEntryWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *TextEntryWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *TextEntryWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
     return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
 }

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -1472,7 +1472,7 @@ pub fn data(self: *TextLayoutWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *TextLayoutWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *TextLayoutWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
 
     // For corner widgets, they might want to be closer to the border than the

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -60,7 +60,7 @@ pub fn data(self: *TreeWidget) *WidgetData {
     return &self.wd;
 }
 
-pub fn rectFor(self: *TreeWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *TreeWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     _ = id;
     return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
 }
@@ -378,7 +378,7 @@ pub const Branch = struct {
         return &self.wd;
     }
 
-    pub fn rectFor(self: *Branch, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+    pub fn rectFor(self: *Branch, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
         _ = id;
         return dvui.placeIn(self.wd.contentRect().justSize(), min_size, e, g);
     }

--- a/src/widgets/VirtualParentWidget.zig
+++ b/src/widgets/VirtualParentWidget.zig
@@ -36,7 +36,7 @@ pub fn data(self: *VirtualParentWidget) *WidgetData {
     return self.wd.validate();
 }
 
-pub fn rectFor(self: *VirtualParentWidget, id: dvui.WidgetId, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+pub fn rectFor(self: *VirtualParentWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
     const ret = self.data().parent.rectFor(id, min_size, e, g);
     if (self.child_rect_union) |u| {
         self.child_rect_union = u.unionWith(ret);


### PR DESCRIPTION
`WidgetId` was used for more than just widgets and the code to translate from `u64` to `WidgetId` was very messy.

This renames `WidgetId` to just `Id` and moves `hashSrc` (renamed to `extendId` as that is the intended use) and `hashIdKey` (renamed to `update` to match the hash update function which it just calls directly) to it. This makes `Id` more generally useful and the removed the distinction of when you get and id and when you get just a `u64` hash.