### PR TITLE
Make Menu behaviours match common UIs

### DIFF
--- a/src/Examples/menus.zig
+++ b/src/Examples/menus.zig
@@ -61,6 +61,7 @@ pub fn menus() void {
                 _ = dvui.menuItemLabel(@src(), "Dummy Long", .{}, .{ .expand = .horizontal });
                 _ = dvui.menuItemLabel(@src(), "Dummy Super Long", .{}, .{ .expand = .horizontal });
             }
+            if (dvui.menuItemLabel(@src(), "Log", .{}, .{ .expand = .horizontal })) |_| {}
         }
 
         dvui.labelNoFmt(@src(), "Right click for a context menu", .{}, .{ .gravity_x = 1.0 });

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -92,6 +92,10 @@ pub fn register(self: *WidgetData) void {
         }
     }
 
+    if (self.id == dvui.focusedWidgetIdInCurrentSubwindow()) {
+        cw.last_focused_id_in_subwindow = self.id;
+    }
+
     if (dvui.testing.widget_hasher) |*hasher| {
         hasher.update(std.mem.asBytes(&self.init_options));
         hasher.update(std.mem.asBytes(&self.options.hash()));

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -29,6 +29,7 @@ subwindow_currentRect: Rect.Natural = .{},
 focused_subwindowId: Id = .zero,
 
 last_focused_id_this_frame: Id = .zero,
+last_focused_id_in_subwindow: Id = .zero,
 last_registered_id_this_frame: Id = .zero,
 scroll_to_focused: bool = false,
 

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -984,6 +984,7 @@ pub fn begin(
     self.cursor_requested = null;
     self.text_input_rect = null;
     self.last_focused_id_this_frame = .zero;
+    self.last_focused_id_in_subwindow = .zero;
 
     self.debug.reset(self.gpa);
 

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1407,6 +1407,7 @@ pub fn focusWidget(id: ?Id, subwindow_id: ?Id, event_num: ?u16) void {
 
                     if (cw.last_registered_id_this_frame == wid) {
                         cw.last_focused_id_this_frame = wid;
+                        cw.last_focused_id_in_subwindow = wid;
                     } else {
                         // walk parent chain
                         var wd = cw.data().parent.data();
@@ -1414,6 +1415,7 @@ pub fn focusWidget(id: ?Id, subwindow_id: ?Id, event_num: ?u16) void {
                         while (true) : (wd = wd.parent.data()) {
                             if (wd.id == wid) {
                                 cw.last_focused_id_this_frame = wid;
+                                cw.last_focused_id_in_subwindow = wid;
                                 break;
                             }
 
@@ -1482,6 +1484,13 @@ pub fn lastFocusedIdInFrameSince(prev: Id) ?Id {
     } else {
         return null;
     }
+}
+
+/// Last widget id we saw in the current subwindow that was focused.
+///
+/// Only valid between `Window.begin`and `Window.end`.
+pub fn lastFocusedIdInSubwindow() Id {
+    return currentWindow().last_focused_id_in_subwindow;
 }
 
 /// Set cursor the app should use if not already set this frame.

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -124,13 +124,15 @@ pub fn install(self: *FloatingMenuWidget) void {
         const ms = dvui.minSize(self.data().id, self.options.min_sizeGet());
         self.data().rect = self.data().rect.toSize(ms);
         self.data().rect = .cast(dvui.placeOnScreen(dvui.windowRect(), self.init_options.from, avoid, .cast(self.data().rect)));
+        if (dvui.dataGet(null, self.data().id, "_check_focus", void) != null) {
+            dvui.dataRemove(null, self.data().id, "_check_focus");
+            if (dvui.MenuWidget.current() == null or !dvui.MenuWidget.current().?.mouse_mode or self.data().rectScale().r.contains(dvui.currentWindow().mouse_pt)) {
+                dvui.focusSubwindow(self.data().id, null);
+            }
+        }
     } else {
         self.data().rect = .cast(dvui.placeOnScreen(dvui.windowRect(), self.init_options.from, avoid, .cast(self.data().rect)));
-
-        // first frame, focus unless we are in a menu being driven by the mouse
-        if (dvui.MenuWidget.current() == null or !dvui.MenuWidget.current().?.mouse_mode) {
-            dvui.focusSubwindow(self.data().id, null);
-        }
+        dvui.dataSet(null, self.data().id, "_check_focus", {});
 
         // need a second frame to fit contents (FocusWindow calls refresh but
         // here for clarity)

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -202,11 +202,6 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
                         // Toggle the submenu closed
                         menu().?.submenus_activated = false;
                         menu().?.submenus_in_child = false;
-                        // Need to reset focus so that hovering doesn't reopen the submenu
-                        // TODO: Should we retain the tab/focus order here? Focusing the menu
-                        //       doesn't fix taborder and focusing the item allows it to open
-                        //       immidietly again on hover.
-                        dvui.focusWidget(null, null, e.num);
                         dvui.refresh(null, @src(), self.data().id);
                     }
                 } else if (self.data().id == dvui.focusedWidgetIdInCurrentSubwindow()) {

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -214,7 +214,11 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
                     dvui.MenuWidget.current().?.mouse_mode = true;
                     self.mouse_over = true;
 
-                    if (dvui.draggingName("_mi_mouse_down")) {
+                    if (dvui.draggingName("_mi_mouse_down") or
+                        // If we have a submenu and there is an active submenu, allow for hovering
+                        // no move focus to a sibling submenu
+                        (self.init_opts.submenu and dvui.MenuWidget.current().?.has_child_popup))
+                    {
                         // we shouldn't have gotten this event if the motion
                         // was towards a submenu (caught in MenuWidget)
                         dvui.focusSubwindow(null, null); // focuses the window we are in

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -215,9 +215,12 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
                     self.mouse_over = true;
 
                     if (dvui.draggingName("_mi_mouse_down") or
-                        // If we have a submenu and there is an active submenu, allow for hovering
-                        // no move focus to a sibling submenu
-                        (self.init_opts.submenu and dvui.MenuWidget.current().?.has_child_popup))
+                        // If we are not the root menu, there is a menu open so hovering should
+                        // move focus and potentially open submenus
+                        !dvui.MenuWidget.current().?.isRootMenu() or
+                        // ...but if the root menu has an active item, allow for hovering to move
+                        // focus within the menu, opening any sibling submenus in the process
+                        dvui.MenuWidget.current().?.has_active_item)
                     {
                         // we shouldn't have gotten this event if the motion
                         // was towards a submenu (caught in MenuWidget)

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -108,7 +108,8 @@ pub fn matchEvent(self: *MenuItemWidget, e: *Event) bool {
 
 pub fn processEvents(self: *MenuItemWidget) void {
     // keep this flag alive for the .mouse.release event
-    _ = dvui.dataGet(null, self.data().id, "_just_opened", void);
+    // NOTE: This gets clear on release in `MenuWidget.processEventsAfter`
+    _ = dvui.dataGet(null, menu().?.data().id, "_mi_submenu_opened", void);
     const evts = dvui.events();
     for (evts) |*e| {
         if (!self.matchEvent(e))
@@ -174,11 +175,9 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
                 // This is how dropdowns are triggered.
                 e.handle(@src(), self.data());
                 if (self.init_opts.submenu) {
-                    if (!menu().?.submenus_activated) {
-                        // We will open so we set some data to remember that
-                        // this press open the submenu
-                        dvui.dataSet(null, self.data().id, "_just_opened", {});
-                    }
+                    // We will open so we set some data to remember that
+                    // this press opened the submenu
+                    dvui.dataSet(null, menu().?.data().id, "_mi_submenu_opened", {});
                     menu().?.submenus_activated = true;
                     menu().?.submenus_in_child = true;
                 }
@@ -199,7 +198,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
                 e.handle(@src(), self.data());
                 if (self.init_opts.submenu) {
                     // Only the root menu is toggleable, all other submenus work on hover
-                    if (menu().?.isRootMenu() and dvui.dataGet(null, self.data().id, "_just_opened", void) == null) {
+                    if (menu().?.isRootMenu() and dvui.dataGet(null, menu().?.data().id, "_mi_submenu_opened", void) == null) {
                         // Toggle the submenu closed
                         menu().?.submenus_activated = false;
                         menu().?.submenus_in_child = false;
@@ -215,7 +214,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
                     dvui.refresh(null, @src(), self.data().id);
                 }
                 // clear out the flag for the next press event
-                dvui.dataRemove(null, self.data().id, "_just_opened");
+                // dvui.dataRemove(null, menu().?.data().id, "_mi_submenu_opened");
 
                 if (dvui.captured(self.data().id)) {
                     // should only happen with touch

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -73,7 +73,7 @@ box: BoxWidget = undefined,
 
 // whether submenus should be open
 submenus_activated: bool = false,
-has_child_popup: bool = false,
+has_active_item: bool = false,
 
 // whether submenus in a child menu should default to open (for mouse interactions, not for keyboard)
 submenus_in_child: bool = false,
@@ -101,7 +101,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
         self.submenus_activated = pm.submenus_in_child;
     }
 
-    if (dvui.dataGet(null, self.wd.id, "_has_popup", bool)) |has_popup| self.has_child_popup = has_popup;
+    if (dvui.dataGet(null, self.wd.id, "_has_active_item", bool)) |has_active_item| self.has_active_item = has_active_item;
     if (dvui.dataGet(null, self.wd.id, "_mouse_mode", bool)) |mouse_mode| self.mouse_mode = mouse_mode;
 
     return self;
@@ -147,6 +147,10 @@ pub fn close_chain(self: *MenuWidget, reason: CloseReason) void {
             dvui.focusSubwindow(self.init_opts.parentSubwindowId, null);
         }
     }
+}
+
+pub fn isRootMenu(self: *MenuWidget) bool {
+    return self.parentMenu == null;
 }
 
 pub fn widget(self: *MenuWidget) Widget {
@@ -274,7 +278,7 @@ pub fn deinit(self: *MenuWidget) void {
     self.box.deinit();
     dvui.dataSet(null, self.data().id, "_mouse_mode", self.mouse_mode);
     dvui.dataSet(null, self.data().id, "_sub_act", self.submenus_activated);
-    dvui.dataSet(null, self.data().id, "_has_popup", self.child_popup_rect != null);
+    dvui.dataSet(null, self.data().id, "_has_active_item", self.child_popup_rect != null or dvui.lastFocusedIdInFrameSince(self.last_focus) != null);
     if (self.child_popup_rect) |r| {
         dvui.dataSet(null, self.data().id, "_child_popup", r);
     }

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -73,6 +73,7 @@ box: BoxWidget = undefined,
 
 // whether submenus should be open
 submenus_activated: bool = false,
+has_child_popup: bool = false,
 
 // whether submenus in a child menu should default to open (for mouse interactions, not for keyboard)
 submenus_in_child: bool = false,
@@ -100,6 +101,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
         self.submenus_activated = pm.submenus_in_child;
     }
 
+    if (dvui.dataGet(null, self.wd.id, "_has_popup", bool)) |has_popup| self.has_child_popup = has_popup;
     if (dvui.dataGet(null, self.wd.id, "_mouse_mode", bool)) |mouse_mode| self.mouse_mode = mouse_mode;
 
     return self;
@@ -272,6 +274,7 @@ pub fn deinit(self: *MenuWidget) void {
     self.box.deinit();
     dvui.dataSet(null, self.data().id, "_mouse_mode", self.mouse_mode);
     dvui.dataSet(null, self.data().id, "_sub_act", self.submenus_activated);
+    dvui.dataSet(null, self.data().id, "_has_popup", self.child_popup_rect != null);
     if (self.child_popup_rect) |r| {
         dvui.dataSet(null, self.data().id, "_child_popup", r);
     }

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -294,7 +294,7 @@ pub fn deinit(self: *MenuWidget) void {
     self.box.deinit();
     dvui.dataSet(null, self.data().id, "_mouse_mode", self.mouse_mode);
     dvui.dataSet(null, self.data().id, "_sub_act", self.submenus_activated);
-    dvui.dataSet(null, self.data().id, "_has_active_item", self.child_popup_rect != null or dvui.lastFocusedIdInFrameSince(self.last_focus) != null);
+    dvui.dataSet(null, self.data().id, "_has_active_item", self.child_popup_rect != null);
     if (self.child_popup_rect) |r| {
         dvui.dataSet(null, self.data().id, "_child_popup", r);
     }

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -210,6 +210,10 @@ pub fn processEventsAfter(self: *MenuWidget) void {
 
     const evts = dvui.events();
     for (evts) |*e| {
+        if (e.evt == .mouse and e.evt.mouse.action == .release) {
+            // The mouse button was released so clear out the opened flag
+            dvui.dataRemove(null, self.data().id, "_mi_submenu_opened");
+        }
         if (!dvui.eventMatch(e, .{ .id = self.data().id, .focus_id = focus_id, .r = self.data().borderRectScale().r }))
             continue;
 

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -226,16 +226,22 @@ pub fn processEventsAfter(self: *MenuWidget) void {
                             self.mouse_mode = false;
                             if (self.init_opts.dir == .vertical) {
                                 e.handle(@src(), self.data());
-                                // TODO: don't do this if focus would move outside the menu
                                 dvui.tabIndexPrev(e.num);
+                                if (dvui.focusedWidgetId() == null) {
+                                    // We stepped past the last item, cycle around
+                                    dvui.tabIndexPrev(e.num);
+                                }
                             }
                         },
                         .down => {
                             self.mouse_mode = false;
                             if (self.init_opts.dir == .vertical) {
                                 e.handle(@src(), self.data());
-                                // TODO: don't do this if focus would move outside the menu
                                 dvui.tabIndexNext(e.num);
+                                if (dvui.focusedWidgetId() == null) {
+                                    // We stepped past the last item, cycle around
+                                    dvui.tabIndexNext(e.num);
+                                }
                             }
                         },
                         .left => {
@@ -250,16 +256,22 @@ pub fn processEventsAfter(self: *MenuWidget) void {
                                 }
                             } else {
                                 e.handle(@src(), self.data());
-                                // TODO: don't do this if focus would move outside the menu
                                 dvui.tabIndexPrev(e.num);
+                                if (dvui.focusedWidgetId() == null) {
+                                    // We stepped past the last item, cycle around
+                                    dvui.tabIndexPrev(e.num);
+                                }
                             }
                         },
                         .right => {
                             self.mouse_mode = false;
                             if (self.init_opts.dir == .horizontal) {
                                 e.handle(@src(), self.data());
-                                // TODO: don't do this if focus would move outside the menu
                                 dvui.tabIndexNext(e.num);
+                                if (dvui.focusedWidgetId() == null) {
+                                    // We stepped past the last item, cycle around
+                                    dvui.tabIndexNext(e.num);
+                                }
                             }
                         },
                         else => {},

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -133,6 +133,7 @@ pub fn close(self: *MenuWidget) void {
 
 pub fn close_chain(self: *MenuWidget, reason: CloseReason) void {
     self.submenus_activated = false;
+    self.has_active_item = false;
     // close all submenus in the chain
     if (self.parentMenu) |pm| {
         pm.close_chain(reason);
@@ -294,7 +295,7 @@ pub fn deinit(self: *MenuWidget) void {
     self.box.deinit();
     dvui.dataSet(null, self.data().id, "_mouse_mode", self.mouse_mode);
     dvui.dataSet(null, self.data().id, "_sub_act", self.submenus_activated);
-    dvui.dataSet(null, self.data().id, "_has_active_item", self.child_popup_rect != null);
+    dvui.dataSet(null, self.data().id, "_has_active_item", self.child_popup_rect != null or (self.has_active_item and dvui.lastFocusedIdInFrameSince(self.last_focus) != null));
     if (self.child_popup_rect) |r| {
         dvui.dataSet(null, self.data().id, "_child_popup", r);
     }

--- a/src/widgets/SuggestionWidget.zig
+++ b/src/widgets/SuggestionWidget.zig
@@ -6,7 +6,7 @@ options: Options,
 init_options: InitOptions,
 
 /// SAFETY: Set in `install`
-menu: *MenuWidget = undefined,
+menu: MenuWidget = undefined,
 drop: ?*FloatingMenuWidget = null,
 drop_mi: ?MenuItemWidget = null,
 drop_mi_index: usize = 0,
@@ -33,7 +33,8 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *SuggestionWidget) void {
-    self.menu = dvui.menu(@src(), .horizontal, .{ .rect = .{}, .id_extra = self.options.idExtra() });
+    self.menu = dvui.MenuWidget.init(@src(), .{ .dir = .horizontal, .close_without_focused_child = false }, .{ .rect = .{}, .id_extra = self.options.idExtra() });
+    self.menu.install();
 }
 
 // Use this to see if dropped will return true without installing the


### PR DESCRIPTION
Closes: #506

I hope this fixes the behaviour that @br07h3rj observed in a satisfactory way. In summary you still need one down press to active a submenu, but once it's active only hovering is needed so swap between siblings.

This does not automatically open menus on hover, which was intentionally removed in 395b7c6, but allows for any menu that is already active to moved between available submenus on hover.