### PR TITLE
PanedWidget handle multiple widgets per pane

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -201,9 +201,6 @@ pub fn demo() void {
     }
 
     if (paned.showSecond()) {
-        var vbox = dvui.box(@src(), .{}, .{ .expand = .both });
-        defer vbox.deinit();
-
         {
             var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
             defer hbox.deinit();

--- a/src/Examples/theming.zig
+++ b/src/Examples/theming.zig
@@ -19,9 +19,6 @@ pub fn theming() void {
     defer paned.deinit();
 
     if (paned.showFirst()) {
-        const vbox = dvui.box(@src(), .{}, .{ .expand = .both, .margin = .{ .y = 10 } });
-        defer vbox.deinit();
-
         {
             const hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });
             defer hbox.deinit();
@@ -61,7 +58,7 @@ pub fn theming() void {
             }
         }
 
-        const active_page = dvui.dataGetPtrDefault(null, vbox.data().id, "Page", ThemeEditingPage, .Colors);
+        const active_page = dvui.dataGetPtrDefault(null, paned.data().id, "Page", ThemeEditingPage, .Colors);
         {
             var tabs = dvui.TabsWidget.init(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });
             tabs.install();

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -7434,15 +7434,15 @@ pub const BasicLayout = struct {
                 if (e.isVertical()) {
                     self.seen_expanded = true;
                 }
-                r.y = self.pos;
-                r.h = @max(0, r.h - r.y);
+                r.y += self.pos;
+                r.h = @max(0, r.h - self.pos);
             },
             .horizontal => {
                 if (e.isHorizontal()) {
                     self.seen_expanded = true;
                 }
-                r.x = self.pos;
-                r.w = @max(0, r.w - r.x);
+                r.x += self.pos;
+                r.w = @max(0, r.w - self.pos);
             },
         }
 


### PR DESCRIPTION
Closes #500

`PanedWidget` now uses `dvui.BasicLayout`, similar to `Window` and `ScaleWidget`, to stack multiple widgets vertically in each pane. This removed the need for a wrapping box for multiple child widget.