### PR TITLE
Removed Auto-Select First Entry in Menu

### DIFF
--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -39,11 +39,6 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     const options = defaults.override(opts);
     const wd = WidgetData.init(src, .{}, options);
 
-    if (dvui.focusedWidgetIdInCurrentSubwindow() == null and menu().?.floating()) {
-        // if nothing is focused in this floating menu, then focus the first item we see
-        dvui.focusWidget(wd.id, null, null);
-    }
-
     return .{
         .wd = wd,
         .init_opts = init_opts,


### PR DESCRIPTION
I found one last thing I don't like about the menu behavior. (There's always one more.) Auto-selecting the first entry in the menu is an unusual feature and removing it doesn't seem to break anything as far as I can tell. Is there a reason this is needed?