### PR TITLE
Better cross widget dragging

### DIFF
--- a/src/Event.zig
+++ b/src/Event.zig
@@ -21,6 +21,15 @@ evt: union(enum) {
     text: Text,
 },
 
+pub fn format(self: *const Event, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+    try std.fmt.format(writer, "Event({d}){{{s} ", .{ self.num, @tagName(self.evt) });
+    switch (self.evt) {
+        .mouse => |me| try std.fmt.format(writer, "{s}}}", .{@tagName(me.action)}),
+        .key => |ke| try std.fmt.format(writer, "{s}}}", .{@tagName(ke.action)}),
+        .text => try std.fmt.format(writer, "}}", .{}),
+    }
+}
+
 /// Mark the event as handled
 ///
 /// In general, the `dvui.WidgetData` passed here should be the same one that
@@ -28,13 +37,7 @@ evt: union(enum) {
 /// This makes it possible to see which widget handled the event.
 pub fn handle(self: *Event, src: std.builtin.SourceLocation, wd: *const dvui.WidgetData) void {
     if (dvui.currentWindow().debug.logEvents(null)) {
-        var action: []const u8 = "";
-        switch (self.evt) {
-            .mouse => action = @tagName(self.evt.mouse.action),
-            .key => action = @tagName(self.evt.key.action),
-            else => {},
-        }
-        dvui.log.debug("{s}:{d} {s} {s} event (num {d}) handled by {s} ({x})", .{ src.file, src.line, @tagName(self.evt), action, self.num, wd.options.name orelse "???", wd.id });
+        dvui.log.debug("{s}:{d} {} handled by {s} ({x})", .{ src.file, src.line, self, wd.options.name orelse "???", wd.id });
     }
     self.handled = true;
 }

--- a/src/Examples/reorder_tree.zig
+++ b/src/Examples/reorder_tree.zig
@@ -246,7 +246,7 @@ pub fn reorderListsAdvanced(cross_drag: bool) void {
 
         dvui.label(@src(), "Drag to add : {d}", .{g.strings_len}, .{});
 
-        if (dvui.ReorderWidget.draggable(@src(), .{ .top_left = hbox2.data().rectScale().r.topLeft() }, .{ .expand = .vertical, .gravity_x = 1.0, .min_size_content = dvui.Size.all(22), .gravity_y = 0.5 })) |p| {
+        if (dvui.ReorderWidget.draggable(@src(), .{ .rect = hbox2.data().rectScale().r }, .{ .expand = .vertical, .gravity_x = 1.0, .min_size_content = dvui.Size.all(22), .gravity_y = 0.5 })) |p| {
             // add to list, but will be removed if not dropped onto a list slot
             g.strings[g.strings_len] = g.strings_template[g.strings_len];
             added_idx = g.strings_len;
@@ -317,7 +317,7 @@ pub fn reorderListsAdvanced(cross_drag: bool) void {
 
         dvui.label(@src(), "{s}", .{s}, .{});
 
-        if (dvui.ReorderWidget.draggable(@src(), .{ .top_left = reorderable.data().rectScale().r.topLeft() }, .{ .expand = .vertical, .gravity_x = 1.0, .min_size_content = dvui.Size.all(22), .gravity_y = 0.5 })) |p| {
+        if (dvui.ReorderWidget.draggable(@src(), .{ .rect = reorderable.data().rectScale().r }, .{ .expand = .vertical, .gravity_x = 1.0, .min_size_content = dvui.Size.all(22), .gravity_y = 0.5 })) |p| {
             // marking all events for capture, this will only be a problem if some
             // mouse events (in the same frame) came before this drag, and would
             // have interacted with a widget that hasn't run yet

--- a/src/Examples/reorder_tree.zig
+++ b/src/Examples/reorder_tree.zig
@@ -4,9 +4,52 @@ const reorderLayout = enum {
     flex,
 };
 
+const g_simple = struct {
+    var dir_entry: usize = 0;
+    var strings = [6][]const u8{ "zero", "one", "two", "three", "four", "five" };
+};
+
+const g_advanced = struct {
+    var strings_template = [6][]const u8{ "A zero", "A one", "A two", "A three", "A four", "A five" };
+    var strings = [6][]const u8{ "A zero", "A one", "A two", "A three", "", "" };
+    var strings_len: usize = 4;
+
+    pub fn reorder(removed_idx: ?usize, insert_before_idx: ?usize) void {
+        if (removed_idx) |ri| {
+            if (insert_before_idx) |ibi| {
+                // save this index
+                const removed = strings[ri];
+                if (ri < ibi) {
+                    // moving down, shift others up
+                    for (ri..ibi - 1) |i| {
+                        strings[i] = strings[i + 1];
+                    }
+                    strings[ibi - 1] = removed;
+                } else {
+                    // moving up, shift others down
+                    for (ibi..ri, 0..) |_, i| {
+                        strings[ri - i] = strings[ri - i - 1];
+                    }
+                    strings[ibi] = removed;
+                }
+            } else {
+                // just removing, shift others up
+                for (ri..strings_len - 1) |i| {
+                    strings[i] = strings[i + 1];
+                }
+                strings_len -= 1;
+            }
+        }
+    }
+};
+
+var g_cross_drag_from: ?enum { simple, advanced } = null;
+var g_cross_drag_item: ?usize = null;
+
 pub fn reorderLists() void {
     const uniqueId = dvui.parentGet().extendId(@src(), 0);
     const layo = dvui.dataGetPtrDefault(null, uniqueId, "reorderLayout", reorderLayout, .horizontal);
+    const cross_drag = dvui.dataGetPtrDefault(null, uniqueId, "cross_drag", bool, false);
 
     if (dvui.expander(@src(), "Simple", .{ .default_expanded = true }, .{ .expand = .horizontal })) {
         var vbox = dvui.box(@src(), .{}, .{ .margin = .{ .x = 10 } });
@@ -32,15 +75,17 @@ pub fn reorderLists() void {
             dvui.label(@src(), "to reorder.", .{}, .{});
         }
 
-        reorderListsSimple(layo.*);
+        reorderListsSimple(layo.*, cross_drag.*);
     }
 
     if (dvui.expander(@src(), "Advanced", .{}, .{ .expand = .horizontal })) {
-        var vbox = dvui.box(@src(), .{}, .{ .margin = .{ .x = 10 } });
+        var vbox = dvui.box(@src(), .{}, .{ .margin = .{ .x = 10 }, .expand = .horizontal, .min_size_content = .width(500) });
         defer vbox.deinit();
 
+        _ = dvui.checkbox(@src(), cross_drag, "Allow drags between simple/advanced", .{});
+
         dvui.label(@src(), "Drag off list to remove.", .{}, .{});
-        reorderListsAdvanced();
+        reorderListsAdvanced(cross_drag.*);
     }
 
     if (dvui.expander(@src(), "Tree", .{ .default_expanded = true }, .{ .expand = .horizontal })) {
@@ -89,12 +134,8 @@ pub fn reorderLists() void {
     }
 }
 
-pub fn reorderListsSimple(lay: reorderLayout) void {
-    const g = struct {
-        var dir_entry: usize = 0;
-        var strings = [6][]const u8{ "zero", "one", "two", "three", "four", "five" };
-    };
-
+pub fn reorderListsSimple(lay: reorderLayout, cross_drag: bool) void {
+    const g = g_simple;
     var removed_idx: ?usize = null;
     var insert_before_idx: ?usize = null;
 
@@ -107,7 +148,7 @@ pub fn reorderListsSimple(lay: reorderLayout) void {
     }
 
     // reorder widget must wrap entire list
-    var reorder = dvui.reorder(@src(), .{ .min_size_content = .{ .w = 120 }, .background = true, .border = dvui.Rect.all(1), .padding = dvui.Rect.all(4) });
+    var reorder = dvui.reorder(@src(), .{ .drag_name = if (cross_drag) "demo-reorder-cross-drag" else null }, .{ .min_size_content = .{ .w = 120 }, .background = true, .border = dvui.Rect.all(1), .padding = dvui.Rect.all(4) });
     defer reorder.deinit();
 
     // this box determines layout of list - could be any layout widget
@@ -129,10 +170,18 @@ pub fn reorderListsSimple(lay: reorderLayout) void {
         var reorderable = reorder.reorderable(@src(), .{}, .{ .id_extra = i, .expand = .horizontal, .min_size_content = dvui.Options.sizeM(8, 1) });
         defer reorderable.deinit();
 
+        if (reorderable.floating()) {
+            // happens every frame something is being dragged from this list
+            g_cross_drag_item = i;
+            g_cross_drag_from = .simple;
+        }
+
         if (reorderable.removed()) {
             removed_idx = i; // this entry is being dragged
+            dvui.log.debug("simple removed {d}", .{i});
         } else if (reorderable.insertBefore()) {
             insert_before_idx = i; // this entry was dropped onto
+            dvui.log.debug("simple insertBefore {d}", .{i});
         }
 
         // actual content of the list entry
@@ -149,58 +198,50 @@ pub fn reorderListsSimple(lay: reorderLayout) void {
     // show a final slot that allows dropping an entry at the end of the list
     if (reorder.finalSlot()) {
         insert_before_idx = g.strings.len; // entry was dropped into the final slot
+        dvui.log.debug("simple insertBefore last slot {d}", .{insert_before_idx.?});
     }
 
-    // returns true if the slice was reordered
-    _ = dvui.ReorderWidget.reorderSlice([]const u8, &g.strings, removed_idx, insert_before_idx);
+    if (insert_before_idx) |ibi| {
+        if (removed_idx) |ri| {
+            // item was dragged and dropped onto same list
+            dvui.log.debug("simple same list", .{});
+            dvui.ReorderWidget.reorderSlice([]const u8, &g.strings, ri, ibi);
+            g_cross_drag_item = null;
+            g_cross_drag_from = null;
+            removed_idx = null; // prevent removing below
+        } else {
+            // item dropped from a different list
+            dvui.log.debug("simple drop {d}, no action", .{ibi});
+        }
+    }
+
+    if (removed_idx) |_| {
+        if (g_cross_drag_item) |_| {
+            // do nothing
+            dvui.log.debug("simple list removed, no action", .{});
+            g_cross_drag_item = null;
+            g_cross_drag_from = null;
+        }
+    }
 }
 
-pub fn reorderListsAdvanced() void {
-    const g = struct {
-        var strings_template = [6][]const u8{ "zero", "one", "two", "three", "four", "five" };
-        var strings = [6][]const u8{ "zero", "one", "two", "three", "", "" };
-        var strings_len: usize = 4;
-
-        pub fn reorder(removed_idx: ?usize, insert_before_idx: ?usize) void {
-            if (removed_idx) |ri| {
-                if (insert_before_idx) |ibi| {
-                    // save this index
-                    const removed = strings[ri];
-                    if (ri < ibi) {
-                        // moving down, shift others up
-                        for (ri..ibi - 1) |i| {
-                            strings[i] = strings[i + 1];
-                        }
-                        strings[ibi - 1] = removed;
-                    } else {
-                        // moving up, shift others down
-                        for (ibi..ri, 0..) |_, i| {
-                            strings[ri - i] = strings[ri - i - 1];
-                        }
-                        strings[ibi] = removed;
-                    }
-                } else {
-                    // just removing, shift others up
-                    for (ri..strings_len - 1) |i| {
-                        strings[i] = strings[i + 1];
-                    }
-                    strings_len -= 1;
-                }
-            }
-        }
-    };
-
-    var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+pub fn reorderListsAdvanced(cross_drag: bool) void {
+    const g = g_advanced;
+    var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });
     defer hbox.deinit();
+
+    if (g_cross_drag_item) |cdi| {
+        dvui.label(@src(), "Dragging {d}\nfrom {s}", .{ cdi, @tagName(g_cross_drag_from.?) }, .{ .gravity_x = 1.0 });
+    }
 
     // template you can drag to add to list
     var added_idx: ?usize = null;
     var added_idx_p: ?dvui.Point.Physical = null;
 
     if (g.strings_len == g.strings.len) {
-        dvui.label(@src(), "List Full", .{}, .{ .gravity_x = 1.0 });
+        dvui.label(@src(), "List Full", .{}, .{ .gravity_x = 0.5 });
     } else {
-        var hbox2 = dvui.box(@src(), .{ .dir = .horizontal }, .{ .gravity_x = 1.0, .border = dvui.Rect.all(1), .margin = dvui.Rect.all(4), .background = true, .style = .window });
+        var hbox2 = dvui.box(@src(), .{ .dir = .horizontal }, .{ .gravity_x = 0.5, .border = dvui.Rect.all(1), .margin = dvui.Rect.all(4), .background = true, .style = .window });
         defer hbox2.deinit();
 
         dvui.label(@src(), "Drag to add : {d}", .{g.strings_len}, .{});
@@ -218,7 +259,7 @@ pub fn reorderListsAdvanced() void {
     var insert_before_idx: ?usize = null;
 
     // reorder widget must wrap entire list
-    var reorder = dvui.reorder(@src(), .{ .min_size_content = .{ .w = 120 }, .background = true, .border = dvui.Rect.all(1), .padding = dvui.Rect.all(4) });
+    var reorder = dvui.reorder(@src(), .{ .drag_name = if (cross_drag) "demo-reorder-cross-drag" else null }, .{ .min_size_content = .{ .w = 120 }, .background = true, .border = dvui.Rect.all(1), .padding = dvui.Rect.all(4) });
     defer reorder.deinit();
 
     // determines layout of list
@@ -239,7 +280,11 @@ pub fn reorderListsAdvanced() void {
         var reorderable = dvui.Reorderable.init(@src(), reorder, .{ .reorder_id = i, .draw_target = false, .reinstall = false }, .{ .id_extra = i, .expand = .horizontal });
         defer reorderable.deinit();
 
-        if (!reorderable.floating()) {
+        if (reorderable.floating()) {
+            // happens every frame something is being dragged from this list
+            g_cross_drag_item = i;
+            g_cross_drag_from = .advanced;
+        } else {
             if (seen_non_floating) {
                 // we've had a non floating one already, and we are non floating, so add a separator
                 _ = dvui.separator(@src(), .{ .id_extra = i, .expand = .horizontal, .margin = dvui.Rect.all(6) });
@@ -289,6 +334,7 @@ pub fn reorderListsAdvanced() void {
 
         if (reorderable.insertBefore()) {
             insert_before_idx = g.strings_len;
+            dvui.log.debug("advanced insertBefore last slot {d}", .{insert_before_idx.?});
         }
 
         if (reorderable.targetRectScale()) |rs| {
@@ -297,7 +343,36 @@ pub fn reorderListsAdvanced() void {
         }
     }
 
-    g.reorder(removed_idx, insert_before_idx);
+    if (insert_before_idx) |ibi| {
+        if (removed_idx) |ri| {
+            // item was dragged and dropped onto same list
+            dvui.log.debug("advanced same list", .{});
+            g.reorder(ri, ibi);
+            g_cross_drag_item = null;
+            g_cross_drag_from = null;
+            removed_idx = null; // prevent removing below
+        } else {
+            // item dropped from a different list
+            dvui.log.debug("advanced drop {d}", .{ibi});
+            if (g.strings_len == g.strings.len) {
+                dvui.log.debug("advanced drop full", .{});
+            } else {
+                // add to end and then reorder
+                g.strings[g.strings_len] = g_simple.strings[g_cross_drag_item.?];
+                g.strings_len += 1;
+                g.reorder(g.strings_len - 1, ibi);
+                // g_cross_drag_item/from will be nulled when the other list gets removed()
+            }
+        }
+    }
+
+    if (removed_idx) |ri| {
+        // do nothing
+        dvui.log.debug("advanced list removed", .{});
+        g.reorder(ri, null);
+        g_cross_drag_item = null;
+        g_cross_drag_from = null;
+    }
 }
 
 pub fn reorderTree(uniqueId: dvui.Id) void {

--- a/src/Examples/reorder_tree.zig
+++ b/src/Examples/reorder_tree.zig
@@ -178,10 +178,8 @@ pub fn reorderListsSimple(lay: reorderLayout, cross_drag: bool) void {
 
         if (reorderable.removed()) {
             removed_idx = i; // this entry is being dragged
-            dvui.log.debug("simple removed {d}", .{i});
         } else if (reorderable.insertBefore()) {
             insert_before_idx = i; // this entry was dropped onto
-            dvui.log.debug("simple insertBefore {d}", .{i});
         }
 
         // actual content of the list entry

--- a/src/Examples/reorder_tree.zig
+++ b/src/Examples/reorder_tree.zig
@@ -58,12 +58,12 @@ pub fn reorderLists() void {
 
             var label_opts: dvui.Options = .{ .padding = .all(20), .margin = .all(20), .border = .all(1) };
 
-            if (dvui.draggingName("tree_drag")) {
+            if (dvui.dragName("tree_drag")) {
                 label_opts.background = true;
                 label_opts.color_fill = dvui.themeGet().color(.content, .fill_hover);
 
                 for (dvui.events()) |*e| {
-                    if (!dvui.eventMatch(e, .{ .id = vbox.data().id, .r = vbox.data().borderRectScale().r, .dragging_name = "tree_drag" })) continue;
+                    if (!dvui.eventMatch(e, .{ .id = vbox.data().id, .r = vbox.data().borderRectScale().r, .drag_name = "tree_drag" })) continue;
 
                     if (e.evt == .mouse and e.evt.mouse.action == .position) {
                         label_opts.color_fill = dvui.themeGet().color(.content, .fill_press);
@@ -306,7 +306,7 @@ pub fn reorderTree(uniqueId: dvui.Id) void {
         uniqueId,
         .{
             .enable_reordering = true,
-            .dragging_name = "tree_drag",
+            .drag_name = "tree_drag",
         },
         .{
             .background = true,

--- a/src/Examples/scroll_canvas.zig
+++ b/src/Examples/scroll_canvas.zig
@@ -65,7 +65,7 @@ pub fn scrollCanvas() void {
 
     const evts = dvui.events();
 
-    const dragging_box = dvui.draggingName("box_transfer");
+    const dragging_box = dvui.dragName("box_transfer");
     if (dragging_box) {
         // draw a half-opaque box to show we are dragging
         // put it in a floating widget so it draws above stuff we do later
@@ -241,7 +241,7 @@ pub fn scrollCanvas() void {
 
         // Check if a drag is over or dropped on this box
         for (evts) |*e| {
-            if (!dvui.eventMatch(e, .{ .id = dragBox.data().id, .r = dragBox.data().borderRectScale().r, .dragging_name = "box_transfer" })) {
+            if (!dvui.eventMatch(e, .{ .id = dragBox.data().id, .r = dragBox.data().borderRectScale().r, .drag_name = "box_transfer" })) {
                 continue;
             }
 

--- a/src/Examples/scroll_canvas.zig
+++ b/src/Examples/scroll_canvas.zig
@@ -74,7 +74,7 @@ pub fn scrollCanvas() void {
         var fwd: dvui.WidgetData = undefined;
 
         const mouse_point = dvui.currentWindow().mouse_pt.toNatural().diff(.{ .x = 10, .y = 10 });
-        var fw = dvui.FloatingWidget.init(@src(), .{ .mouse_events = false }, .{ .rect = Rect.fromPoint(.cast(mouse_point)), .min_size_content = .all(20), .background = true, .color_fill = dvui.Color.teal.opacity(0.5), .data_out = &fwd });
+        var fw = dvui.FloatingWidget.init(@src(), .{ .mouse_events = false }, .{ .rect = Rect.fromPoint(.cast(mouse_point)), .min_size_content = .all(20), .background = true, .color_fill = dvui.themeGet().focus.opacity(0.5), .data_out = &fwd });
         fw.install();
         fw.deinit();
 
@@ -105,8 +105,8 @@ pub fn scrollCanvas() void {
             .style = .window,
             .border = .{ .h = 1, .w = 1, .x = 1, .y = 1 },
             .corner_radius = .{ .h = 5, .w = 5, .x = 5, .y = 5 },
-            .color_border = if (dragging_box) .teal else null,
-            .box_shadow = .{ .color = if (dragging_box) .teal else .black },
+            .color_border = if (dragging_box) dvui.themeGet().focus else null,
+            .box_shadow = .{},
         });
 
         const boxRect = dragBox.data().rectScale().r;
@@ -261,7 +261,7 @@ pub fn scrollCanvas() void {
                         dvui.cursorSet(.crosshair);
                         // the drag is hovered above us, draw to indicate that
                         const rs = dragBox.data().contentRectScale();
-                        rs.r.fill(dragBox.data().options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = dvui.Color.teal.opacity(0.2) });
+                        rs.r.fill(dragBox.data().options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = dvui.themeGet().focus.opacity(0.2) });
                     }
                 },
                 else => {},

--- a/src/Examples/scroll_canvas.zig
+++ b/src/Examples/scroll_canvas.zig
@@ -240,31 +240,33 @@ pub fn scrollCanvas() void {
         }
 
         // Check if a drag is over or dropped on this box
-        for (evts) |*e| {
-            if (!dvui.eventMatch(e, .{ .id = dragBox.data().id, .r = dragBox.data().borderRectScale().r, .drag_name = "box_transfer" })) {
-                continue;
-            }
+        if (dragging_box) {
+            for (evts) |*e| {
+                if (!dvui.eventMatch(e, .{ .id = dragBox.data().id, .r = dragBox.data().borderRectScale().r, .drag_name = "box_transfer" })) {
+                    continue;
+                }
 
-            switch (e.evt) {
-                .mouse => |me| {
-                    if (me.action == .release and me.button.pointer()) {
-                        e.handle(@src(), dragBox.data());
-                        dvui.dragEnd();
-                        dvui.refresh(null, @src(), dragBox.data().id);
+                switch (e.evt) {
+                    .mouse => |me| {
+                        if (me.action == .release and me.button.pointer()) {
+                            e.handle(@src(), dragBox.data());
+                            dvui.dragEnd();
+                            dvui.refresh(null, @src(), dragBox.data().id);
 
-                        if (drag_box_window.* != i) {
-                            // move box to new home
-                            box_contents[drag_box_window.*] -= 1;
-                            box_contents[1 - drag_box_window.*] += 1;
+                            if (drag_box_window.* != i) {
+                                // move box to new home
+                                box_contents[drag_box_window.*] -= 1;
+                                box_contents[1 - drag_box_window.*] += 1;
+                            }
+                        } else if (me.action == .position) {
+                            dvui.cursorSet(.crosshair);
+                            // the drag is hovered above us, draw to indicate that
+                            const rs = dragBox.data().contentRectScale();
+                            rs.r.fill(dragBox.data().options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = dvui.themeGet().focus.opacity(0.2) });
                         }
-                    } else if (me.action == .position) {
-                        dvui.cursorSet(.crosshair);
-                        // the drag is hovered above us, draw to indicate that
-                        const rs = dragBox.data().contentRectScale();
-                        rs.r.fill(dragBox.data().options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = dvui.themeGet().focus.opacity(0.2) });
-                    }
-                },
-                else => {},
+                    },
+                    else => {},
+                }
             }
         }
 

--- a/src/Examples/scroll_canvas.zig
+++ b/src/Examples/scroll_canvas.zig
@@ -240,33 +240,31 @@ pub fn scrollCanvas() void {
         }
 
         // Check if a drag is over or dropped on this box
-        if (dragging_box) {
-            for (evts) |*e| {
-                if (!dvui.eventMatch(e, .{ .id = dragBox.data().id, .r = dragBox.data().borderRectScale().r, .dragging_name = "box_transfer" })) {
-                    continue;
-                }
+        for (evts) |*e| {
+            if (!dvui.eventMatch(e, .{ .id = dragBox.data().id, .r = dragBox.data().borderRectScale().r, .dragging_name = "box_transfer" })) {
+                continue;
+            }
 
-                switch (e.evt) {
-                    .mouse => |me| {
-                        if (me.action == .release and me.button.pointer()) {
-                            e.handle(@src(), dragBox.data());
-                            dvui.dragEnd();
-                            dvui.refresh(null, @src(), dragBox.data().id);
+            switch (e.evt) {
+                .mouse => |me| {
+                    if (me.action == .release and me.button.pointer()) {
+                        e.handle(@src(), dragBox.data());
+                        dvui.dragEnd();
+                        dvui.refresh(null, @src(), dragBox.data().id);
 
-                            if (drag_box_window.* != i) {
-                                // move box to new home
-                                box_contents[drag_box_window.*] -= 1;
-                                box_contents[1 - drag_box_window.*] += 1;
-                            }
-                        } else if (me.action == .position) {
-                            dvui.cursorSet(.crosshair);
-                            // the drag is hovered above us, draw to indicate that
-                            const rs = dragBox.data().contentRectScale();
-                            rs.r.fill(dragBox.data().options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = dvui.Color.teal.opacity(0.2) });
+                        if (drag_box_window.* != i) {
+                            // move box to new home
+                            box_contents[drag_box_window.*] -= 1;
+                            box_contents[1 - drag_box_window.*] += 1;
                         }
-                    },
-                    else => {},
-                }
+                    } else if (me.action == .position) {
+                        dvui.cursorSet(.crosshair);
+                        // the drag is hovered above us, draw to indicate that
+                        const rs = dragBox.data().contentRectScale();
+                        rs.r.fill(dragBox.data().options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = dvui.Color.teal.opacity(0.2) });
+                    }
+                },
+                else => {},
             }
         }
 

--- a/src/Examples/scroll_canvas.zig
+++ b/src/Examples/scroll_canvas.zig
@@ -224,7 +224,6 @@ pub fn scrollCanvas() void {
                                 dvui.scrollDrag(.{
                                     .mouse_pt = e.evt.mouse.p,
                                     .screen_rect = dragBox.data().rectScale().r,
-                                    .capture_id = dragBox.data().id,
                                 });
                             }
                         }

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -67,6 +67,7 @@ drag_state: enum {
 drag_pt: Point.Physical = .{},
 drag_offset: Point.Physical = .{},
 drag_name: ?[]const u8 = null,
+drag_size: Size.Physical = .{},
 
 frame_time_ns: i128 = 0,
 loop_wait_target: ?i128 = null,

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -157,6 +157,7 @@ pub const Subwindow = struct {
     used: bool = true,
     modal: bool = false,
     stay_above_parent_window: ?Id = null,
+    mouse_events: bool = true,
 };
 
 const SavedData = struct {
@@ -1075,7 +1076,7 @@ pub fn begin(
 
     //dvui.log.debug("window size {d} x {d} renderer size {d} x {d} scale {d}", .{ self.data().rect.w, self.data().rect.h, self.rect_pixels.w, self.rect_pixels.h, self.natural_scale });
 
-    dvui.subwindowAdd(self.data().id, self.data().rect, self.rect_pixels, false, null);
+    dvui.subwindowAdd(self.data().id, self.data().rect, self.rect_pixels, false, null, true);
 
     _ = dvui.subwindowCurrentSet(self.data().id, .cast(self.data().rect));
 
@@ -1167,7 +1168,7 @@ pub fn windowFor(self: *const Self, p: Point.Physical) Id {
     var i = self.subwindows.items.len;
     while (i > 0) : (i -= 1) {
         const sw = &self.subwindows.items[i - 1];
-        if (sw.modal or sw.rect_pixels.contains(p)) {
+        if (sw.mouse_events and (sw.modal or sw.rect_pixels.contains(p))) {
             return sw.id;
         }
     }

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -66,7 +66,7 @@ drag_state: enum {
 } = .none,
 drag_pt: Point.Physical = .{},
 drag_offset: Point.Physical = .{},
-drag_name: []const u8 = "",
+drag_name: ?[]const u8 = null,
 
 frame_time_ns: i128 = 0,
 loop_wait_target: ?i128 = null,
@@ -1590,10 +1590,11 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
     for (evts) |*e| {
         if (self.drag_state == .dragging and e.evt == .mouse and e.evt.mouse.action == .release) {
             if (self.debug.logEvents(null)) {
-                log.debug("clearing drag ({s}) for unhandled mouse release", .{self.drag_name});
+                log.debug("Clearing drag ({?s}) for unhandled mouse release", .{self.drag_name});
             }
             self.drag_state = .none;
-            self.drag_name = "";
+            self.drag_name = null;
+            dvui.refresh(null, @src(), null);
         }
 
         if (!dvui.eventMatch(e, .{ .id = self.data().id, .r = self.rect_pixels, .cleanup = true }))

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1620,13 +1620,7 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
     if (self.debug.logEvents(null)) {
         for (evts) |*e| {
             if (e.handled) continue;
-            var action: []const u8 = "";
-            switch (e.evt) {
-                .mouse => action = @tagName(e.evt.mouse.action),
-                .key => action = @tagName(e.evt.key.action),
-                else => {},
-            }
-            log.debug("Unhandled {s} {s} event (num {d})", .{ @tagName(e.evt), action, e.num });
+            log.debug("Unhandled {}", .{e});
         }
     }
 

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2398,7 +2398,7 @@ pub const DragStartOptions = struct {
     /// locate where to move the point of interest.
     offset: Point.Physical = .{},
 
-    /// Used for cross-widget dragging.  See `draggingName`.
+    /// Used for cross-widget dragging.  See `dragName`.
     name: ?[]const u8 = null,
 };
 
@@ -2499,7 +2499,7 @@ pub fn dragging(p: Point.Physical, name: ?[]const u8) ?Point.Physical {
 /// Use to know when a cross-widget drag is in progress.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn draggingName(name: []const u8) bool {
+pub fn dragName(name: []const u8) bool {
     const cw = currentWindow();
     return cw.drag_state == .dragging and cw.drag_name != null and std.mem.eql(u8, name, cw.drag_name.?);
 }
@@ -3279,8 +3279,8 @@ pub const EventMatchOptions = struct {
     /// Physical pixel rect used to match pointer events.
     r: Rect.Physical,
 
-    /// During a drag, only match pointer events if this is the draggingName.
-    dragging_name: ?[]const u8 = null,
+    /// During a drag, only match pointer events if this is the dragName.
+    drag_name: ?[]const u8 = null,
 
     /// true means match all focus-based events routed to the subwindow with
     /// id.  This is how subwindows catch things like tab if no widget in that
@@ -3311,12 +3311,12 @@ pub fn eventMatch(e: *Event, opts: EventMatchOptions) bool {
         return false;
     }
 
-    if (opts.dragging_name != null) {
+    if (opts.drag_name != null) {
         const cw = currentWindow();
         if (cw.drag_state != .dragging or (cw.drag_state == .dragging and cw.drag_name == null)) {
             // asked for cross-widget drag but none is happening
             if (builtin.mode == .Debug and opts.debug) {
-                log.debug("eventMatch {} dragging name ({?s}) given but no named drag happening", .{ e, opts.dragging_name });
+                log.debug("eventMatch {} drag_name ({?s}) given but no named drag happening", .{ e, opts.drag_name });
             }
             return false;
         }
@@ -3361,10 +3361,10 @@ pub fn eventMatch(e: *Event, opts: EventMatchOptions) bool {
             }
 
             const cw = currentWindow();
-            if (cw.drag_state == .dragging and cw.drag_name != null and (opts.dragging_name == null or !std.mem.eql(u8, cw.drag_name.?, opts.dragging_name.?))) {
+            if (cw.drag_state == .dragging and cw.drag_name != null and (opts.drag_name == null or !std.mem.eql(u8, cw.drag_name.?, opts.drag_name.?))) {
                 // a cross-widget drag is happening that we don't know about
                 if (builtin.mode == .Debug and opts.debug) {
-                    log.debug("eventMatch {} dragging name ({?s}) didn't match given ({?s})", .{ e, cw.drag_name, opts.dragging_name });
+                    log.debug("eventMatch {} drag_name ({?s}) given but current drag is ({?s})", .{ e, opts.drag_name, cw.drag_name });
                 }
                 return false;
             }

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -3482,10 +3482,9 @@ pub fn clicked(wd: *const WidgetData, opts: ClickOptions) bool {
                         }
                     }
                 } else if (me.action == .position) {
-                    // TODO: Should this mark this event as handled? If the click_rect
-                    //       is above another widget with hover effects or click behaviour,
-                    //       we don't want that widget to highlight as if the next click
-                    //       would apply to it.
+                    // Usually you don't want to mark .position events as
+                    // handled, so that multiple widgets can all do hover
+                    // highlighting.
 
                     // a single .position mouse event is at the end of each
                     // frame, so this means the mouse ended above us

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -3624,10 +3624,6 @@ pub const ScrollDragOptions = struct {
     // rect in screen coords of the widget doing the drag (scrolling will stop
     // if it wouldn't show more of this rect)
     screen_rect: dvui.Rect.Physical,
-
-    // id of the widget that has mouse capture during the drag (needed to
-    // inject synthetic motion events into the next frame to keep scrolling)
-    capture_id: dvui.Id,
 };
 
 /// Bubbled from inside a scrollarea to ensure scrolling while dragging

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -3311,6 +3311,17 @@ pub fn eventMatch(e: *Event, opts: EventMatchOptions) bool {
         return false;
     }
 
+    if (opts.dragging_name != null) {
+        const cw = currentWindow();
+        if (cw.drag_state != .dragging or (cw.drag_state == .dragging and cw.drag_name == null)) {
+            // asked for cross-widget drag but none is happening
+            if (builtin.mode == .Debug and opts.debug) {
+                log.debug("eventMatch {} dragging name ({?s}) given but no named drag happening", .{ e, opts.dragging_name });
+            }
+            return false;
+        }
+    }
+
     switch (e.evt) {
         .key, .text => {
             if (e.target_windowId) |wid| {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2303,7 +2303,7 @@ pub fn renderTriangles(triangles: Triangles, tex: ?Texture) Backend.GenericError
 /// tagged with.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn subwindowAdd(id: Id, rect: Rect, rect_pixels: Rect.Physical, modal: bool, stay_above_parent_window: ?Id) void {
+pub fn subwindowAdd(id: Id, rect: Rect, rect_pixels: Rect.Physical, modal: bool, stay_above_parent_window: ?Id, mouse_events: bool) void {
     const cw = currentWindow();
     for (cw.subwindows.items) |*sw| {
         if (id == sw.id) {
@@ -2313,6 +2313,7 @@ pub fn subwindowAdd(id: Id, rect: Rect, rect_pixels: Rect.Physical, modal: bool,
             sw.rect_pixels = rect_pixels;
             sw.modal = modal;
             sw.stay_above_parent_window = stay_above_parent_window;
+            sw.mouse_events = mouse_events;
 
             if (sw.render_cmds.items.len > 0 or sw.render_cmds_after.items.len > 0) {
                 log.warn("subwindowAdd {x} is clearing some drawing commands (did you try to draw between subwindowCurrentSet and subwindowAdd?)\n", .{id});
@@ -2331,6 +2332,7 @@ pub fn subwindowAdd(id: Id, rect: Rect, rect_pixels: Rect.Physical, modal: bool,
         .rect_pixels = rect_pixels,
         .modal = modal,
         .stay_above_parent_window = stay_above_parent_window,
+        .mouse_events = mouse_events,
     };
     if (stay_above_parent_window) |subwin_id| {
         // it wants to be above subwin_id

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -4914,9 +4914,9 @@ pub fn cache(src: std.builtin.SourceLocation, init_opts: CacheWidget.InitOptions
     return ret;
 }
 
-pub fn reorder(src: std.builtin.SourceLocation, opts: Options) *ReorderWidget {
+pub fn reorder(src: std.builtin.SourceLocation, init_opts: ReorderWidget.InitOptions, opts: Options) *ReorderWidget {
     var ret = widgetAlloc(ReorderWidget);
-    ret.* = ReorderWidget.init(src, opts);
+    ret.* = ReorderWidget.init(src, init_opts, opts);
     ret.install();
     ret.processEvents();
     return ret;

--- a/src/structEntry.zig
+++ b/src/structEntry.zig
@@ -613,7 +613,7 @@ pub fn sliceFieldWidget(
     var removed_idx: ?usize = null;
     var insert_before_idx: ?usize = null;
 
-    var reorder = dvui.reorder(@src(), .{
+    var reorder = dvui.reorder(@src(), .{}, .{
         .min_size_content = .{ .w = 120 },
         .background = true,
         .border = dvui.Rect.all(1),
@@ -668,8 +668,11 @@ pub fn sliceFieldWidget(
         insert_before_idx = result.*.len; // entry was dropped into the final slot
     }
 
-    // returns true if the slice was reordered
-    _ = dvui.ReorderWidget.reorderSlice(Child, result.*, removed_idx, insert_before_idx);
+    if (insert_before_idx) |ibi| {
+        if (removed_idx) |ri| {
+            dvui.ReorderWidget.reorderSlice(Child, result.*, ri, ibi);
+        }
+    }
 
     //if (alloc) {
     switch (treatment) {

--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -134,7 +134,6 @@ pub fn dropped(self: *DropdownWidget) bool {
                         dvui.scrollDrag(.{
                             .mouse_pt = e.evt.mouse.p,
                             .screen_rect = drop.menu.data().rectScale().r,
-                            .capture_id = drop.wd.id,
                         });
                     } else if (e.evt.mouse.action == .position) {
                         dvui.currentWindow().inject_motion_event = true;

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -144,7 +144,7 @@ pub fn install(self: *FloatingMenuWidget) void {
     const rs = self.data().rectScale();
 
     self.prev_windowId = dvui.subwindowCurrentSet(self.data().id, null).id;
-    dvui.subwindowAdd(self.data().id, self.data().rect, rs.r, false, null);
+    dvui.subwindowAdd(self.data().id, self.data().rect, rs.r, false, null, true);
     dvui.captureMouseMaintain(.{ .id = self.data().id, .rect = rs.r, .subwindow_id = self.data().id });
 
     // first break out of whatever clip we were in (so box shadows work, since

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -184,7 +184,7 @@ pub fn install(self: *FloatingTooltipWidget) void {
 
     const rs = self.data().rectScale();
 
-    dvui.subwindowAdd(self.data().id, self.data().rect, rs.r, false, self.prev_windowId);
+    dvui.subwindowAdd(self.data().id, self.data().rect, rs.r, false, self.prev_windowId, true);
     dvui.captureMouseMaintain(.{ .id = self.data().id, .rect = rs.r, .subwindow_id = self.data().id });
 
     // first clip to the whole window to break out of whatever clipping we

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -255,7 +255,7 @@ pub fn install(self: *FloatingWindowWidget) void {
 
 pub fn drawBackground(self: *FloatingWindowWidget) void {
     const rs = self.data().rectScale();
-    dvui.subwindowAdd(self.data().id, self.data().rect, rs.r, self.init_options.modal, if (self.init_options.stay_above_parent_window) self.prev_windowInfo.id else null);
+    dvui.subwindowAdd(self.data().id, self.data().rect, rs.r, self.init_options.modal, if (self.init_options.stay_above_parent_window) self.prev_windowInfo.id else null, true);
     dvui.captureMouseMaintain(.{ .id = self.data().id, .rect = rs.r, .subwindow_id = self.data().id });
 
     if (self.init_options.modal and !dvui.firstFrame(self.data().id)) {

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -97,10 +97,6 @@ pub fn minSizeForChild(self: *ReorderWidget, s: Size) void {
 }
 
 pub fn matchEvent(self: *ReorderWidget, event: *dvui.Event) bool {
-    if (dvui.captured(self.wd.id) or dvui.dragName(self.init_opts.drag_name)) {
-        return true;
-    }
-
     return dvui.eventMatch(event, .{ .id = self.wd.id, .r = self.data().borderRectScale().r, .drag_name = self.init_opts.drag_name });
 }
 

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -173,6 +173,7 @@ pub fn deinit(self: *ReorderWidget) void {
 pub fn dragStart(self: *ReorderWidget, reorder_id: usize, p: dvui.Point.Physical, event_num: u16) void {
     self.id_reorderable = reorder_id;
     self.drag_point = p;
+    self.found_slot = true;
     dvui.captureMouse(self.data(), event_num);
     if (self.init_opts.drag_name) |dn| {
         // set drag_name to start cross-widget drag

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -250,7 +250,7 @@ pub const Reorderable = struct {
                 self.data().register();
                 dvui.parentSet(self.widget());
 
-                self.floating_widget = dvui.FloatingWidget.init(@src(), .{ .rect = Rect.fromPoint(.cast(topleft.toNatural())), .min_size_content = self.reorder.reorderable_size });
+                self.floating_widget = dvui.FloatingWidget.init(@src(), .{ .mouse_events = false }, .{ .rect = Rect.fromPoint(.cast(topleft.toNatural())), .min_size_content = self.reorder.reorderable_size });
                 self.floating_widget.?.install();
             } else {
                 if (self.init_options.last_slot) {

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -10,22 +10,35 @@ const WidgetData = dvui.WidgetData;
 
 const ReorderWidget = @This();
 
+pub const InitOptions = struct {
+    /// If not null, drags give up mouse capture and set this drag name
+    drag_name: ?[]const u8 = null,
+};
+
 wd: WidgetData,
+init_opts: InitOptions,
 id_reorderable: ?usize = null, // matches Reorderable.reorder_id
-drag_point: ?dvui.Point.Physical = null,
+drag_point: ?dvui.Point.Physical = null, // non null if we started the drag
 drag_ending: bool = false,
 reorderable_size: Size = .{},
 found_slot: bool = false,
 
-pub fn init(src: std.builtin.SourceLocation, opts: Options) ReorderWidget {
+pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) ReorderWidget {
     const defaults = Options{ .name = "Reorder" };
     const wd = WidgetData.init(src, .{}, defaults.override(opts));
-    return .{
+    var self: ReorderWidget = .{
         .wd = wd,
+        .init_opts = init_opts,
         .id_reorderable = dvui.dataGet(null, wd.id, "_id_reorderable", usize),
         .drag_point = dvui.dataGet(null, wd.id, "_drag_point", dvui.Point.Physical),
         .reorderable_size = dvui.dataGet(null, wd.id, "_reorderable_size", dvui.Size) orelse .{},
     };
+    if (init_opts.drag_name) |dn| {
+        if (self.drag_point != null and !dvui.dragName(dn)) {
+            self.drag_ending = true;
+        }
+    }
+    return self;
 }
 
 pub fn install(self: *ReorderWidget) void {
@@ -36,7 +49,11 @@ pub fn install(self: *ReorderWidget) void {
 }
 
 pub fn needFinalSlot(self: *ReorderWidget) bool {
-    return self.drag_point != null and !self.found_slot;
+    if (self.drag_ending or dvui.captured(self.wd.id) or (self.init_opts.drag_name != null and dvui.dragName(self.init_opts.drag_name.?))) {
+        return !self.found_slot and self.data().borderRectScale().r.contains(dvui.currentWindow().mouse_pt);
+    }
+
+    return false;
 }
 
 pub fn finalSlot(self: *ReorderWidget) bool {
@@ -73,8 +90,30 @@ pub fn minSizeForChild(self: *ReorderWidget, s: Size) void {
     self.data().minSizeMax(self.data().options.padSize(s));
 }
 
-pub fn matchEvent(self: *ReorderWidget, e: *dvui.Event) bool {
-    return dvui.eventMatchSimple(e, self.data());
+pub fn matchEvent(self: *ReorderWidget, event: *dvui.Event) bool {
+    if (dvui.captured(self.wd.id) or (self.init_opts.drag_name != null and dvui.dragName(self.init_opts.drag_name.?))) {
+        // passively listen to mouse motion
+        for (dvui.events()) |*e| {
+            if (e.evt == .mouse and e.evt.mouse.action == .motion) {
+                if (self.drag_point != null) {
+                    self.drag_point = e.evt.mouse.p;
+
+                    dvui.scrollDrag(.{
+                        .mouse_pt = e.evt.mouse.p,
+                        .screen_rect = self.wd.rectScale().r,
+                    });
+                }
+            }
+        }
+    }
+
+    if (self.init_opts.drag_name) |dn| {
+        if (dvui.dragName(dn)) {
+            return dvui.eventMatch(event, .{ .id = self.wd.id, .r = self.data().borderRectScale().r, .drag_name = dn });
+        }
+    }
+
+    return dvui.eventMatchSimple(event, self.data());
 }
 
 pub fn processEvents(self: *ReorderWidget) void {
@@ -88,24 +127,17 @@ pub fn processEvents(self: *ReorderWidget) void {
 }
 
 pub fn processEvent(self: *ReorderWidget, e: *dvui.Event) void {
-    if (dvui.captured(self.data().id)) {
-        switch (e.evt) {
-            .mouse => |me| {
-                if ((me.action == .press or me.action == .release) and me.button.pointer()) {
-                    self.drag_ending = true;
-                    dvui.captureMouse(null, e.num);
-                    dvui.dragEnd();
-                    dvui.refresh(null, @src(), self.data().id);
-                } else if (me.action == .motion) {
-                    self.drag_point = me.p;
-                    dvui.scrollDrag(.{
-                        .mouse_pt = me.p,
-                        .screen_rect = self.data().rectScale().r,
-                    });
-                }
-            },
-            else => {},
-        }
+    switch (e.evt) {
+        .mouse => |me| {
+            if (me.action == .release and me.button.pointer()) {
+                e.handle(@src(), self.data());
+                dvui.log.debug("drag ending", .{});
+                self.drag_ending = true;
+                dvui.captureMouse(null, e.num);
+                dvui.dragEnd();
+            }
+        },
+        else => {},
     }
 }
 
@@ -114,6 +146,7 @@ pub fn deinit(self: *ReorderWidget) void {
     if (self.drag_ending) {
         self.id_reorderable = null;
         self.drag_point = null;
+        dvui.refresh(null, @src(), self.data().id);
     }
 
     if (self.id_reorderable) |idr| {
@@ -139,8 +172,12 @@ pub fn deinit(self: *ReorderWidget) void {
 pub fn dragStart(self: *ReorderWidget, reorder_id: usize, p: dvui.Point.Physical, event_num: u16) void {
     self.id_reorderable = reorder_id;
     self.drag_point = p;
-    self.found_slot = true;
     dvui.captureMouse(self.data(), event_num);
+    if (self.init_opts.drag_name) |dn| {
+        // have to call dragStart to set the drag name
+        dvui.dragStart(p, .{ .name = dn });
+        dvui.captureMouse(null, 0);
+    }
 }
 
 pub const draggableInitOptions = struct {
@@ -213,13 +250,13 @@ pub const Reorderable = struct {
 
     wd: WidgetData,
     reorder: *ReorderWidget,
-    init_options: InitOptions,
+    init_options: Reorderable.InitOptions,
     options: Options,
     installed: bool = false,
     floating_widget: ?dvui.FloatingWidget = null,
     target_rs: ?dvui.RectScale = null,
 
-    pub fn init(src: std.builtin.SourceLocation, reorder: *ReorderWidget, init_opts: InitOptions, opts: Options) Reorderable {
+    pub fn init(src: std.builtin.SourceLocation, reorder: *ReorderWidget, init_opts: Reorderable.InitOptions, opts: Options) Reorderable {
         const defaults = Options{ .name = "Reorderable" };
         const options = defaults.override(opts);
         return .{
@@ -242,9 +279,9 @@ pub const Reorderable = struct {
 
     pub fn install(self: *Reorderable) void {
         self.installed = true;
-        if (self.reorder.drag_point) |dp| {
-            const topleft = dp.plus(dvui.dragOffset());
-            if (self.reorder.id_reorderable.? == (self.init_options.reorder_id orelse self.data().id.asUsize())) {
+        if (self.reorder.drag_ending or dvui.captured(self.reorder.data().id) or (self.reorder.init_opts.drag_name != null and dvui.dragName(self.reorder.init_opts.drag_name.?))) {
+            const topleft = dvui.currentWindow().mouse_pt.plus(dvui.dragOffset());
+            if (self.reorder.drag_point != null and self.reorder.id_reorderable.? == (self.init_options.reorder_id orelse self.data().id.asUsize())) {
                 // we are being dragged - put in floating widget
                 self.data().register();
                 dvui.parentSet(self.widget());
@@ -293,8 +330,7 @@ pub const Reorderable = struct {
     }
 
     pub fn removed(self: *Reorderable) bool {
-        // if drag_ending is true, id_reorderable is non-null
-        if (self.reorder.drag_ending and self.reorder.id_reorderable.? == (self.init_options.reorder_id orelse self.data().id.asUsize())) {
+        if (self.reorder.drag_ending and self.reorder.drag_point != null and self.reorder.id_reorderable.? == (self.init_options.reorder_id orelse self.data().id.asUsize())) {
             return true;
         }
 
@@ -369,30 +405,24 @@ pub const Reorderable = struct {
     }
 };
 
-pub fn reorderSlice(comptime T: type, slice: []T, removed_idx: ?usize, insert_before_idx: ?usize) bool {
-    if (removed_idx) |ri| {
-        if (insert_before_idx) |ibi| {
-            // save this index
-            const removed = slice[ri];
-            if (ri < ibi) {
-                // moving down, shift others up
-                for (ri..ibi - 1) |i| {
-                    slice[i] = slice[i + 1];
-                }
-                slice[ibi - 1] = removed;
-            } else {
-                // moving up, shift others down
-                for (ibi..ri, 0..) |_, i| {
-                    slice[ri - i] = slice[ri - i - 1];
-                }
-                slice[ibi] = removed;
-            }
+pub fn reorderSlice(comptime T: type, slice: []T, removed_idx: usize, insert_before_idx: usize) void {
+    const ri = removed_idx;
+    const ibi = insert_before_idx;
 
-            return true;
+    const removed = slice[ri];
+    if (ri < ibi) {
+        // moving down, shift others up
+        for (ri..ibi - 1) |i| {
+            slice[i] = slice[i + 1];
         }
+        slice[ibi - 1] = removed;
+    } else {
+        // moving up, shift others down
+        for (ibi..ri, 0..) |_, i| {
+            slice[ri - i] = slice[ri - i - 1];
+        }
+        slice[ibi] = removed;
     }
-
-    return false;
 }
 
 test {

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -113,7 +113,7 @@ pub fn processEvents(self: *ReorderWidget) void {
 pub fn processEvent(self: *ReorderWidget, e: *dvui.Event) void {
     switch (e.evt) {
         .mouse => |me| {
-            // if we are the drag source, passively listen to all mouse events
+            // if we are the drag source, update where the mouse is and possibly scroll
             if (self.drag_point != null and me.action == .motion) {
                 self.drag_point = e.evt.mouse.p;
 

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -55,7 +55,7 @@ fn dragging(self: *ReorderWidget) bool {
 }
 
 pub fn needFinalSlot(self: *ReorderWidget) bool {
-    if (self.dragging() and !self.data().borderRectScale().r.intersect(dvui.dragRect()).empty()) {
+    if (self.dragging() and self.data().borderRectScale().r.contains(dvui.currentWindow().mouse_pt)) {
         return !self.found_slot;
     }
 
@@ -129,7 +129,7 @@ pub fn processEvent(self: *ReorderWidget, e: *dvui.Event) void {
 
             // detect a drag end that is over us
             // if nobody catches it, dvui.Window will end the drag on an unhandled mouse up
-            if (self.dragging() and !self.data().borderRectScale().r.intersect(dvui.dragRect()).empty()) {
+            if (self.dragging() and self.data().borderRectScale().r.contains(dvui.currentWindow().mouse_pt)) {
                 if (me.action == .release and me.button.pointer()) {
                     e.handle(@src(), self.data());
                     self.drag_ending = true;
@@ -298,7 +298,7 @@ pub const Reorderable = struct {
                 }
                 const rs = self.data().rectScale();
 
-                if (!self.reorder.found_slot and !rs.r.intersect(dvui.dragRect()).empty()) {
+                if (!self.reorder.found_slot and rs.r.contains(dvui.currentWindow().mouse_pt)) {
                     // user is dragging something over this rect
                     self.target_rs = rs;
                     self.reorder.found_slot = true;

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -101,7 +101,6 @@ pub fn processEvent(self: *ReorderWidget, e: *dvui.Event) void {
                     dvui.scrollDrag(.{
                         .mouse_pt = me.p,
                         .screen_rect = self.data().rectScale().r,
-                        .capture_id = self.data().id,
                     });
                 }
             },

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -60,7 +60,6 @@ seen_expanded_child: bool = false,
 first_visible_id: dvui.Id = .zero,
 first_visible_offset: Point = Point{}, // offset of top left of first visible widget from viewport
 
-inject_capture_id: ?dvui.Id = null,
 seen_scroll_drag: bool = false,
 
 finger_down: bool = false,
@@ -368,7 +367,7 @@ pub fn processScrollDrag(
 
         // if we are scrolling, then we need a motion event next
         // frame so that the child widget can adjust selection
-        self.inject_capture_id = sd.capture_id;
+        dvui.currentWindow().inject_motion_event = true;
     }
 
     self.seen_scroll_drag = true;
@@ -600,17 +599,6 @@ pub fn deinit(self: *ScrollContainerWidget) void {
     dvui.dataSet(null, self.data().id, "_fv_id", self.first_visible_id);
     dvui.dataSet(null, self.data().id, "_fv_offset", self.first_visible_offset);
     dvui.dataSet(null, self.data().id, "_finger_down", self.finger_down);
-
-    if (self.inject_capture_id) |ci| {
-        // Only do this if the widget that called the scrollDrag still has
-        // mouse capture at this point.  Mouse could have moved, called
-        // scrollDrag, then released - in that case we don't want to inject a
-        // motion event next frame.
-        if (dvui.captured(ci)) {
-            // inject a mouse motion event into next frame
-            dvui.currentWindow().inject_motion_event = true;
-        }
-    }
 
     const padded = self.data().options.padSize(self.nextVirtualSize);
     switch (self.si.horizontal) {

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -336,7 +336,6 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
                         dvui.scrollDrag(.{
                             .mouse_pt = e.evt.mouse.p,
                             .screen_rect = self.data().rectScale().r,
-                            .capture_id = self.data().id,
                         });
                     }
                 }
@@ -406,7 +405,6 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
                         dvui.scrollDrag(.{
                             .mouse_pt = e.evt.mouse.p,
                             .screen_rect = self.data().rectScale().r,
-                            .capture_id = self.data().id,
                         });
                     }
                 }
@@ -1646,7 +1644,6 @@ pub fn processEvent(self: *TextLayoutWidget, e: *Event) void {
                         dvui.scrollDrag(.{
                             .mouse_pt = me.p,
                             .screen_rect = self.data().rectScale().r,
-                            .capture_id = self.data().id,
                         });
                     } else {
                         // user intended to scroll with a finger swipe

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -303,7 +303,7 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
             rect.w = size;
             rect.h = size;
 
-            var fc = dvui.FloatingWidget.init(@src(), .{ .rect = rect });
+            var fc = dvui.FloatingWidget.init(@src(), .{}, .{ .rect = rect });
             fc.install();
 
             var offset: Point.Physical = dvui.dataGet(null, fc.data().id, "_offset", Point.Physical) orelse .{};
@@ -373,7 +373,7 @@ pub fn install(self: *TextLayoutWidget, opts: struct { focused: ?bool = null, sh
             rect.w = size;
             rect.h = size;
 
-            var fc = dvui.FloatingWidget.init(@src(), .{ .rect = rect });
+            var fc = dvui.FloatingWidget.init(@src(), .{}, .{ .rect = rect });
             fc.install();
 
             var offset: Point.Physical = dvui.dataGet(null, fc.data().id, "_offset", Point.Physical) orelse .{};
@@ -1418,7 +1418,7 @@ pub fn addTextDone(self: *TextLayoutWidget, opts: Options) void {
 
 pub fn touchEditing(self: *TextLayoutWidget) ?*FloatingWidget {
     if (self.touch_editing and self.te_show_context_menu and self.focus_at_start and self.data().visible()) {
-        self.te_floating = dvui.FloatingWidget.init(@src(), .{});
+        self.te_floating = dvui.FloatingWidget.init(@src(), .{}, .{});
 
         const r = dvui.windowRectScale().rectFromPhysical(dvui.clipGet());
         if (dvui.minSizeGet(self.te_floating.data().id)) |_| {

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -211,6 +211,7 @@ pub const Branch = struct {
 
                 self.floating_widget = dvui.FloatingWidget.init(
                     @src(),
+                    .{ .mouse_events = false },
                     .{ .rect = Rect.fromPoint(.cast(topleft.toNatural())), .min_size_content = self.tree.branch_size },
                 );
                 self.floating_widget.?.install();

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -102,7 +102,6 @@ pub fn processEvent(self: *TreeWidget, e: *dvui.Event) void {
                     dvui.scrollDrag(.{
                         .mouse_pt = me.p,
                         .screen_rect = self.wd.rectScale().r,
-                        .capture_id = self.wd.id,
                     });
                 }
             },

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -20,6 +20,9 @@ init_options: InitOptions = undefined,
 
 pub const InitOptions = struct {
     enable_reordering: bool = true,
+
+    /// If not null, drags give up mouse capture and set this dragging name
+    dragging_name: ?[]const u8 = null,
 };
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) TreeWidget {
@@ -30,6 +33,11 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
     self.id_branch = dvui.dataGet(null, self.wd.id, "_id_branch", usize) orelse null;
     self.drag_point = dvui.dataGet(null, self.wd.id, "_drag_point", dvui.Point.Physical) orelse null;
     self.branch_size = dvui.dataGet(null, self.wd.id, "_branch_size", dvui.Size) orelse dvui.Size{};
+    if (init_opts.dragging_name) |dn| {
+        if (self.drag_point != null and !dvui.draggingName(dn)) {
+            self.drag_ending = true;
+        }
+    }
     return self;
 }
 
@@ -73,8 +81,28 @@ pub fn minSizeForChild(self: *TreeWidget, s: Size) void {
     self.wd.minSizeMax(self.wd.options.padSize(s));
 }
 
-pub fn matchEvent(self: *TreeWidget, e: *dvui.Event) bool {
-    return dvui.eventMatchSimple(e, self.data());
+pub fn matchEvent(self: *TreeWidget, event: *dvui.Event) bool {
+    if (dvui.captured(self.wd.id) or (self.init_options.dragging_name != null and dvui.draggingName(self.init_options.dragging_name.?))) {
+        // passively listen to mouse motion
+        for (dvui.events()) |*e| {
+            if (e.evt == .mouse and e.evt.mouse.action == .motion) {
+                self.drag_point = e.evt.mouse.p;
+
+                dvui.scrollDrag(.{
+                    .mouse_pt = e.evt.mouse.p,
+                    .screen_rect = self.wd.rectScale().r,
+                });
+            }
+        }
+    }
+
+    if (self.init_options.dragging_name) |dn| {
+        if (dvui.draggingName(dn)) {
+            return dvui.eventMatch(event, .{ .id = self.wd.id, .r = self.data().borderRectScale().r, .dragging_name = dn });
+        }
+    }
+
+    return dvui.eventMatchSimple(event, self.data());
 }
 
 pub fn processEvents(self: *TreeWidget) void {
@@ -88,21 +116,15 @@ pub fn processEvents(self: *TreeWidget) void {
 }
 
 pub fn processEvent(self: *TreeWidget, e: *dvui.Event) void {
-    if (dvui.captured(self.wd.id)) {
+    if (dvui.captured(self.wd.id) or (self.init_options.dragging_name != null and dvui.draggingName(self.init_options.dragging_name.?))) {
         switch (e.evt) {
             .mouse => |me| {
                 if ((me.action == .press or me.action == .release) and me.button.pointer()) {
+                    e.handle(@src(), self.data());
                     self.drag_ending = true;
                     dvui.captureMouse(null, e.num);
                     dvui.dragEnd();
                     dvui.refresh(null, @src(), self.wd.id);
-                } else if (me.action == .motion) {
-                    self.drag_point = me.p;
-
-                    dvui.scrollDrag(.{
-                        .mouse_pt = me.p,
-                        .screen_rect = self.wd.rectScale().r,
-                    });
                 }
             },
             else => {},
@@ -117,6 +139,7 @@ pub fn deinit(self: *TreeWidget) void {
     if (self.drag_ending) {
         self.id_branch = null;
         self.drag_point = null;
+        dvui.refresh(null, @src(), self.wd.id);
     }
 
     if (self.id_branch) |idr| {
@@ -143,6 +166,12 @@ pub fn dragStart(self: *TreeWidget, branch_id: usize, p: dvui.Point.Physical) vo
     self.id_branch = branch_id;
     self.drag_point = p;
     dvui.captureMouse(self.data(), 0);
+    if (self.init_options.dragging_name) |dn| {
+        // have to call dragStart because dragPreStart was called inside Button
+        // which didn't have the dragging name
+        dvui.dragStart(p, .{ .name = dn });
+        dvui.captureMouse(null, 0);
+    }
 }
 
 pub fn branch(self: *TreeWidget, src: std.builtin.SourceLocation, init_opts: Branch.InitOptions, opts: Options) *Branch {
@@ -290,16 +319,11 @@ pub const Branch = struct {
 
                 switch (e.evt) {
                     .mouse => |me| {
-                        if (me.action == .press and me.button.pointer()) {
-                            e.handle(@src(), self.button.data());
-                            dvui.captureMouse(self.button.data(), e.num);
-                            const top_left = self.button.wd.rectScale().r.topLeft();
-                            dvui.dragPreStart(me.p, .{ .offset = top_left });
-                        } else if (me.action == .motion) {
+                        if (me.action == .motion) {
                             if (dvui.captured(self.button.wd.id)) {
                                 e.handle(@src(), self.button.data());
                                 if (dvui.dragging(me.p, null)) |_| {
-                                    self.tree.dragStart(self.wd.id.asUsize(), me.p); // reorder grabs capture
+                                    self.tree.dragStart(self.wd.id.asUsize(), me.p);
 
                                     break :loop;
                                 }

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -166,8 +166,7 @@ pub fn dragStart(self: *TreeWidget, branch_id: usize, p: dvui.Point.Physical) vo
     self.drag_point = p;
     dvui.captureMouse(self.data(), 0);
     if (self.init_options.drag_name) |dn| {
-        // have to call dragStart because dragPreStart was called inside Button
-        // which didn't have the dragging name
+        // have to call dragStart to set the drag name
         dvui.dragStart(p, .{ .name = dn });
         dvui.captureMouse(null, 0);
     }


### PR DESCRIPTION
Fixes #516

When @foxnne tried to do cross-widget dragging for real, we didn't have enough support.  This adds:
* eventMatch() dragging_name parameter
  * used for opting in to a named (cross-widget) drag
* FloatingWidget mouse_events option
  * if a floating widget is being used to visually show a cross-widget drag, then mouse events need to go through it to the subwindow below
  * this allows a widget under the floating one to receive mouse position and release to end the drag

I've updated the scroll_canvas demo.

Still working on adding a demo showing drag-n-drop from a Tree to another widget, and between two Reorderables.