### PR TITLE
Fix grid demo display issues

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -218,7 +218,7 @@ pub fn demo() void {
         }
         defer if (scroll) |s| s.deinit();
 
-        var vbox = dvui.box(@src(), .{}, .{ .padding = dvui.Rect.all(4) });
+        var vbox = dvui.box(@src(), .{}, .{ .padding = dvui.Rect.all(4), .expand = .both });
         defer vbox.deinit();
 
         switch (demo_active) {


### PR DESCRIPTION
Fixes issues caused by d0426421f605856475398d50ee2b48a46fee9def's introduction of a new vbox to contain each demo.

The vbox didn't expand, so virtual scrolling grid's don't know how much space they have to display rows.
The Layouts and data demo was using parent height to determine the size of the grid. This has been changed to layout the bottom panel before the grid.
- Make vbox surrounding all demos .expand = both so grids can expand
- Cleanup layouts and data example to layout bottom panel first
- Cleanup variable row heights demo to centre labels again.

