### PR TITLE
Adapt PNG encoder to `std.Io.Writer`

### DIFF
--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -7341,12 +7341,12 @@ pub const Picture = struct {
     }
 
     /// Encode texture as png.  Call after `stop` before `deinit`.
-    pub fn png(self: *Picture, allocator: std.mem.Allocator) Backend.TextureError![]u8 {
-        const pma_pixels = try dvui.textureReadTarget(allocator, self.texture);
+    pub fn png(self: *Picture, writer: *std.Io.Writer) !void {
+        const pma_pixels = try dvui.textureReadTarget(currentWindow().lifo(), self.texture);
         const pixels = Color.PMA.sliceToRGBA(pma_pixels);
-        defer allocator.free(pixels);
+        defer currentWindow().lifo().free(pixels);
 
-        return try dvui.pngEncode(allocator, pixels, self.texture.width, self.texture.height, .{});
+        try PNGEncoder.write(writer, pixels, self.texture.width, self.texture.height);
     }
 
     /// Draw recorded texture and destroy it.
@@ -7360,122 +7360,168 @@ pub const Picture = struct {
     }
 };
 
-pub const pngEncodeOptions = struct {
-    /// Physical size of image, pixels per meter added to png pHYs chunk.
+/// Physical size of image, pixels per meter added to png pHYs chunk.
+/// Use `writeWithResolution` to specify the resolution, or `write`
+/// for dvui to set it based on the windows resolution
+pub const PNGEncoder = struct {
     /// 0 => don't write the pHYs chunk
-    /// null => dvui will use 72 dpi (2834.64 px/m) times `windowNaturalScale`
-    resolution: ?u32 = null,
-};
-
-/// Make a png encoded image from RGBA pixels.
-///
-/// Gives bytes of a png file (allocated by arena).
-pub fn pngEncode(arena: std.mem.Allocator, pixels: []u8, width: u32, height: u32, opts: pngEncodeOptions) std.mem.Allocator.Error![]u8 {
-    var len: c_int = undefined;
-    const png_bytes = c.stbi_write_png_to_mem(pixels.ptr, @intCast(width * 4), @intCast(width), @intCast(height), 4, &len);
-    defer {
-        if (wasm) {
-            backend.dvui_c_free(png_bytes);
-        } else {
-            c.free(png_bytes);
-        }
-    }
-
-    // 4 bytes: length of data
-    // 4 bytes: "pHYs"
-    // 9 bytes: data (2 4-byte numbers + 1 byte units)
-    // 4 bytes: crc
-    const pHYs_size = 4 + 4 + 9 + 4;
-    var extra: usize = pHYs_size;
-    var p_buf: [pHYs_size]u8 = undefined;
-    var res: u32 = 0;
-    if (opts.resolution) |r| {
-        res = r;
-    } else {
-        res = @intFromFloat(@round(windowNaturalScale() * 72.0 / 0.0254));
-    }
-
-    if (res == 0) {
-        extra = 0;
-    } else {
-        std.mem.writeInt(u32, p_buf[0..][0..4], 9, .big); // length of data
-        @memcpy(p_buf[4..][0..4], "pHYs");
-        std.mem.writeInt(u32, p_buf[8..][0..4], res, .big); // res horizontal
-        std.mem.writeInt(u32, p_buf[12..][0..4], res, .big); // res vertical
-        p_buf[16] = 1; // 1 => pixels/meter
-
-        // crc includes "pHYs" and data
-        std.mem.writeInt(u32, p_buf[17..][0..4], png_crc32(p_buf[4..][0..13]), .big);
-    }
-
-    var ret = try arena.alloc(u8, @as(usize, @intCast(len)) + extra);
-
-    // find byte index of end of IDHR chunk
-    const idhr_data_len: u32 = std.mem.readInt(u32, png_bytes[8..][0..4], .big);
+    resolution: u32 = 0,
+    output: *std.Io.Writer,
 
     // 8 bytes PNG magic bytes
     // 4 bytes length of IDHR data
     // 4 bytes "IDHR"
-    // IDHR data
-    // 4 bytes IDHR crc
-    const split: u32 = 8 + 4 + 4 + idhr_data_len + 4;
+    bytes_remaining_until_next_state: u32 = 8,
+    state: enum(u2) {
+        waiting_for_idhr_len,
+        /// Waiting for one u32 of len data
+        reading_idhr_len,
+        /// Should wait for len + crc (one u32)
+        skipping_idhr_content,
+        has_inserted_chunks,
+    } = .waiting_for_idhr_len,
 
-    @memcpy(ret[0..split], png_bytes[0..split]);
-    if (res != 0) {
-        @memcpy(ret[split..][0..extra], &p_buf);
+    /// Atleast this many bytes is needed to write the pHYs header
+    pub const min_buffer_size = pHYs_header_size;
+    const pHYs_len = 9;
+    const pHYs_header_size = pHYs_len + 4; // includes "pHYs"
+
+    /// dvui will set the resolution of 72 dpi (2834.64 px/m) times `windowNaturalScale`
+    pub fn write(output: *std.Io.Writer, pixels: []u8, width: u32, height: u32) !void {
+        try writeWithResolution(output, pixels, width, height, @intFromFloat(@round(windowNaturalScale() * 72.0 / 0.0254)));
     }
-    @memcpy(ret[split + extra ..], png_bytes[split..@as(usize, @intCast(len))]);
 
-    return ret;
-}
-
-/// Calculate a PNG crc value.
-///
-/// Code from stb_image_write.h
-pub fn png_crc32(buf: []u8) u32 {
-    // zig fmt: off
-    const crc_table = [256]u32 {
-      0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419, 0x706AF48F, 0xE963A535, 0x9E6495A3,
-      0x0eDB8832, 0x79DCB8A4, 0xE0D5E91E, 0x97D2D988, 0x09B64C2B, 0x7EB17CBD, 0xE7B82D07, 0x90BF1D91,
-      0x1DB71064, 0x6AB020F2, 0xF3B97148, 0x84BE41DE, 0x1ADAD47D, 0x6DDDE4EB, 0xF4D4B551, 0x83D385C7,
-      0x136C9856, 0x646BA8C0, 0xFD62F97A, 0x8A65C9EC, 0x14015C4F, 0x63066CD9, 0xFA0F3D63, 0x8D080DF5,
-      0x3B6E20C8, 0x4C69105E, 0xD56041E4, 0xA2677172, 0x3C03E4D1, 0x4B04D447, 0xD20D85FD, 0xA50AB56B,
-      0x35B5A8FA, 0x42B2986C, 0xDBBBC9D6, 0xACBCF940, 0x32D86CE3, 0x45DF5C75, 0xDCD60DCF, 0xABD13D59,
-      0x26D930AC, 0x51DE003A, 0xC8D75180, 0xBFD06116, 0x21B4F4B5, 0x56B3C423, 0xCFBA9599, 0xB8BDA50F,
-      0x2802B89E, 0x5F058808, 0xC60CD9B2, 0xB10BE924, 0x2F6F7C87, 0x58684C11, 0xC1611DAB, 0xB6662D3D,
-      0x76DC4190, 0x01DB7106, 0x98D220BC, 0xEFD5102A, 0x71B18589, 0x06B6B51F, 0x9FBFE4A5, 0xE8B8D433,
-      0x7807C9A2, 0x0F00F934, 0x9609A88E, 0xE10E9818, 0x7F6A0DBB, 0x086D3D2D, 0x91646C97, 0xE6635C01,
-      0x6B6B51F4, 0x1C6C6162, 0x856530D8, 0xF262004E, 0x6C0695ED, 0x1B01A57B, 0x8208F4C1, 0xF50FC457,
-      0x65B0D9C6, 0x12B7E950, 0x8BBEB8EA, 0xFCB9887C, 0x62DD1DDF, 0x15DA2D49, 0x8CD37CF3, 0xFBD44C65,
-      0x4DB26158, 0x3AB551CE, 0xA3BC0074, 0xD4BB30E2, 0x4ADFA541, 0x3DD895D7, 0xA4D1C46D, 0xD3D6F4FB,
-      0x4369E96A, 0x346ED9FC, 0xAD678846, 0xDA60B8D0, 0x44042D73, 0x33031DE5, 0xAA0A4C5F, 0xDD0D7CC9,
-      0x5005713C, 0x270241AA, 0xBE0B1010, 0xC90C2086, 0x5768B525, 0x206F85B3, 0xB966D409, 0xCE61E49F,
-      0x5EDEF90E, 0x29D9C998, 0xB0D09822, 0xC7D7A8B4, 0x59B33D17, 0x2EB40D81, 0xB7BD5C3B, 0xC0BA6CAD,
-      0xEDB88320, 0x9ABFB3B6, 0x03B6E20C, 0x74B1D29A, 0xEAD54739, 0x9DD277AF, 0x04DB2615, 0x73DC1683,
-      0xE3630B12, 0x94643B84, 0x0D6D6A3E, 0x7A6A5AA8, 0xE40ECF0B, 0x9309FF9D, 0x0A00AE27, 0x7D079EB1,
-      0xF00F9344, 0x8708A3D2, 0x1E01F268, 0x6906C2FE, 0xF762575D, 0x806567CB, 0x196C3671, 0x6E6B06E7,
-      0xFED41B76, 0x89D32BE0, 0x10DA7A5A, 0x67DD4ACC, 0xF9B9DF6F, 0x8EBEEFF9, 0x17B7BE43, 0x60B08ED5,
-      0xD6D6A3E8, 0xA1D1937E, 0x38D8C2C4, 0x4FDFF252, 0xD1BB67F1, 0xA6BC5767, 0x3FB506DD, 0x48B2364B,
-      0xD80D2BDA, 0xAF0A1B4C, 0x36034AF6, 0x41047A60, 0xDF60EFC3, 0xA867DF55, 0x316E8EEF, 0x4669BE79,
-      0xCB61B38C, 0xBC66831A, 0x256FD2A0, 0x5268E236, 0xCC0C7795, 0xBB0B4703, 0x220216B9, 0x5505262F,
-      0xC5BA3BBE, 0xB2BD0B28, 0x2BB45A92, 0x5CB36A04, 0xC2D7FFA7, 0xB5D0CF31, 0x2CD99E8B, 0x5BDEAE1D,
-      0x9B64C2B0, 0xEC63F226, 0x756AA39C, 0x026D930A, 0x9C0906A9, 0xEB0E363F, 0x72076785, 0x05005713,
-      0x95BF4A82, 0xE2B87A14, 0x7BB12BAE, 0x0CB61B38, 0x92D28E9B, 0xE5D5BE0D, 0x7CDCEFB7, 0x0BDBDF21,
-      0x86D3D2D4, 0xF1D4E242, 0x68DDB3F8, 0x1FDA836E, 0x81BE16CD, 0xF6B9265B, 0x6FB077E1, 0x18B74777,
-      0x88085AE6, 0xFF0F6A70, 0x66063BCA, 0x11010B5C, 0x8F659EFF, 0xF862AE69, 0x616BFFD3, 0x166CCF45,
-      0xA00AE278, 0xD70DD2EE, 0x4E048354, 0x3903B3C2, 0xA7672661, 0xD06016F7, 0x4969474D, 0x3E6E77DB,
-      0xAED16A4A, 0xD9D65ADC, 0x40DF0B66, 0x37D83BF0, 0xA9BCAE53, 0xDEBB9EC5, 0x47B2CF7F, 0x30B5FFE9,
-      0xBDBDF21C, 0xCABAC28A, 0x53B39330, 0x24B4A3A6, 0xBAD03605, 0xCDD70693, 0x54DE5729, 0x23D967BF,
-      0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94, 0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B, 0x2D02EF8D
-    };
-    // zig fmt: on
-
-    var crc: u32 = ~@as(u32, 0);
-    for (buf) |ch| {
-        crc = (crc >> 8) ^ crc_table[ch ^ (crc & 0xff)];
+    /// `resolution == 0` => don't write the pHYs chunk
+    pub fn writeWithResolution(output: *std.Io.Writer, pixels: []u8, width: u32, height: u32, resolution: u32) !void {
+        std.debug.assert(output.buffer.len >= min_buffer_size);
+        var png_encoder = PNGEncoder{
+            .resolution = resolution,
+            .output = output,
+        };
+        const res = c.stbi_write_png_to_func(
+            &stbi_write_png_callback,
+            &png_encoder,
+            @intCast(width),
+            @intCast(height),
+            c.STBI_rgb_alpha,
+            pixels.ptr,
+            @intCast(width * 4),
+        );
+        if (res == 0) return StbImageError.stbImageError;
     }
-    return ~crc;
-}
+
+    fn writePHYs(self: *PNGEncoder) !void {
+        if (self.resolution == 0) return;
+
+        try self.output.writeInt(u32, pHYs_len, .big); // length of data
+        // Ensure that all the following data will be buffered
+        try self.output.rebase(0, pHYs_header_size);
+
+        const end_before = self.output.end;
+        try self.output.writeAll("pHYs");
+        try self.output.writeInt(u32, self.resolution, .big); // res horizontal
+        try self.output.writeInt(u32, self.resolution, .big); // res vertical
+        try self.output.writeByte(1); // 1 => pixels/meter
+        std.debug.assert(self.output.end - end_before == pHYs_header_size);
+
+        const header = self.output.buffered()[self.output.end - pHYs_header_size ..];
+        // crc includes "pHYs" and data
+        try self.output.writeInt(u32, png_crc32(header), .big);
+    }
+
+    fn callback(self: *PNGEncoder, data_in: []const u8) !void {
+        var data = data_in;
+        if (self.bytes_remaining_until_next_state > 0) {
+            while (data.len >= self.bytes_remaining_until_next_state) {
+                try self.output.writeAll(data[0..self.bytes_remaining_until_next_state]);
+                data = data[self.bytes_remaining_until_next_state..];
+                // We have passed all the bytes we wanted to
+                switch (self.state) {
+                    .waiting_for_idhr_len => {
+                        self.state = .reading_idhr_len;
+                        self.bytes_remaining_until_next_state = @sizeOf(u32);
+                        // Ensure the value fits in the buffer for reading
+                        try self.output.rebase(0, @sizeOf(u32));
+                    },
+                    .reading_idhr_len => {
+                        const len_buf = self.output.buffered()[self.output.end - @sizeOf(u32) ..];
+                        const idhr_len = std.mem.readInt(u32, len_buf[0..@sizeOf(u32)], .big);
+                        self.state = .skipping_idhr_content;
+                        // 4 bytes for "IDHR" + one u32 for crc
+                        self.bytes_remaining_until_next_state = 4 + idhr_len + @sizeOf(u32);
+                    },
+                    .skipping_idhr_content => {
+                        try self.writePHYs();
+                        self.state = .has_inserted_chunks;
+                        self.bytes_remaining_until_next_state = 0;
+                        break;
+                    },
+                    // If the extra chunks have been written, so the loop should've exited before this
+                    .has_inserted_chunks => unreachable,
+                }
+            } else {
+                self.bytes_remaining_until_next_state -|= @intCast(data.len);
+            }
+        }
+        try self.output.writeAll(data);
+    }
+
+    fn stbi_write_png_callback(ctx: ?*anyopaque, data_ptr: ?*anyopaque, len: c_int) callconv(.c) void {
+        const self: *PNGEncoder = @ptrCast(@alignCast(ctx.?));
+        const data: []const u8 = @as([*]const u8, @ptrCast(@alignCast(data_ptr.?)))[0..@intCast(len)];
+        for (data) |b| {
+            self.callback(&.{b}) catch |err| logError(@src(), err, "Failed to write png data to output", .{});
+        }
+    }
+
+    /// Calculate a PNG crc value.
+    ///
+    /// Code from stb_image_write.h
+    pub fn png_crc32(buf: []u8) u32 {
+        // zig fmt: off
+        const crc_table = [256]u32 {
+        0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419, 0x706AF48F, 0xE963A535, 0x9E6495A3,
+        0x0eDB8832, 0x79DCB8A4, 0xE0D5E91E, 0x97D2D988, 0x09B64C2B, 0x7EB17CBD, 0xE7B82D07, 0x90BF1D91,
+        0x1DB71064, 0x6AB020F2, 0xF3B97148, 0x84BE41DE, 0x1ADAD47D, 0x6DDDE4EB, 0xF4D4B551, 0x83D385C7,
+        0x136C9856, 0x646BA8C0, 0xFD62F97A, 0x8A65C9EC, 0x14015C4F, 0x63066CD9, 0xFA0F3D63, 0x8D080DF5,
+        0x3B6E20C8, 0x4C69105E, 0xD56041E4, 0xA2677172, 0x3C03E4D1, 0x4B04D447, 0xD20D85FD, 0xA50AB56B,
+        0x35B5A8FA, 0x42B2986C, 0xDBBBC9D6, 0xACBCF940, 0x32D86CE3, 0x45DF5C75, 0xDCD60DCF, 0xABD13D59,
+        0x26D930AC, 0x51DE003A, 0xC8D75180, 0xBFD06116, 0x21B4F4B5, 0x56B3C423, 0xCFBA9599, 0xB8BDA50F,
+        0x2802B89E, 0x5F058808, 0xC60CD9B2, 0xB10BE924, 0x2F6F7C87, 0x58684C11, 0xC1611DAB, 0xB6662D3D,
+        0x76DC4190, 0x01DB7106, 0x98D220BC, 0xEFD5102A, 0x71B18589, 0x06B6B51F, 0x9FBFE4A5, 0xE8B8D433,
+        0x7807C9A2, 0x0F00F934, 0x9609A88E, 0xE10E9818, 0x7F6A0DBB, 0x086D3D2D, 0x91646C97, 0xE6635C01,
+        0x6B6B51F4, 0x1C6C6162, 0x856530D8, 0xF262004E, 0x6C0695ED, 0x1B01A57B, 0x8208F4C1, 0xF50FC457,
+        0x65B0D9C6, 0x12B7E950, 0x8BBEB8EA, 0xFCB9887C, 0x62DD1DDF, 0x15DA2D49, 0x8CD37CF3, 0xFBD44C65,
+        0x4DB26158, 0x3AB551CE, 0xA3BC0074, 0xD4BB30E2, 0x4ADFA541, 0x3DD895D7, 0xA4D1C46D, 0xD3D6F4FB,
+        0x4369E96A, 0x346ED9FC, 0xAD678846, 0xDA60B8D0, 0x44042D73, 0x33031DE5, 0xAA0A4C5F, 0xDD0D7CC9,
+        0x5005713C, 0x270241AA, 0xBE0B1010, 0xC90C2086, 0x5768B525, 0x206F85B3, 0xB966D409, 0xCE61E49F,
+        0x5EDEF90E, 0x29D9C998, 0xB0D09822, 0xC7D7A8B4, 0x59B33D17, 0x2EB40D81, 0xB7BD5C3B, 0xC0BA6CAD,
+        0xEDB88320, 0x9ABFB3B6, 0x03B6E20C, 0x74B1D29A, 0xEAD54739, 0x9DD277AF, 0x04DB2615, 0x73DC1683,
+        0xE3630B12, 0x94643B84, 0x0D6D6A3E, 0x7A6A5AA8, 0xE40ECF0B, 0x9309FF9D, 0x0A00AE27, 0x7D079EB1,
+        0xF00F9344, 0x8708A3D2, 0x1E01F268, 0x6906C2FE, 0xF762575D, 0x806567CB, 0x196C3671, 0x6E6B06E7,
+        0xFED41B76, 0x89D32BE0, 0x10DA7A5A, 0x67DD4ACC, 0xF9B9DF6F, 0x8EBEEFF9, 0x17B7BE43, 0x60B08ED5,
+        0xD6D6A3E8, 0xA1D1937E, 0x38D8C2C4, 0x4FDFF252, 0xD1BB67F1, 0xA6BC5767, 0x3FB506DD, 0x48B2364B,
+        0xD80D2BDA, 0xAF0A1B4C, 0x36034AF6, 0x41047A60, 0xDF60EFC3, 0xA867DF55, 0x316E8EEF, 0x4669BE79,
+        0xCB61B38C, 0xBC66831A, 0x256FD2A0, 0x5268E236, 0xCC0C7795, 0xBB0B4703, 0x220216B9, 0x5505262F,
+        0xC5BA3BBE, 0xB2BD0B28, 0x2BB45A92, 0x5CB36A04, 0xC2D7FFA7, 0xB5D0CF31, 0x2CD99E8B, 0x5BDEAE1D,
+        0x9B64C2B0, 0xEC63F226, 0x756AA39C, 0x026D930A, 0x9C0906A9, 0xEB0E363F, 0x72076785, 0x05005713,
+        0x95BF4A82, 0xE2B87A14, 0x7BB12BAE, 0x0CB61B38, 0x92D28E9B, 0xE5D5BE0D, 0x7CDCEFB7, 0x0BDBDF21,
+        0x86D3D2D4, 0xF1D4E242, 0x68DDB3F8, 0x1FDA836E, 0x81BE16CD, 0xF6B9265B, 0x6FB077E1, 0x18B74777,
+        0x88085AE6, 0xFF0F6A70, 0x66063BCA, 0x11010B5C, 0x8F659EFF, 0xF862AE69, 0x616BFFD3, 0x166CCF45,
+        0xA00AE278, 0xD70DD2EE, 0x4E048354, 0x3903B3C2, 0xA7672661, 0xD06016F7, 0x4969474D, 0x3E6E77DB,
+        0xAED16A4A, 0xD9D65ADC, 0x40DF0B66, 0x37D83BF0, 0xA9BCAE53, 0xDEBB9EC5, 0x47B2CF7F, 0x30B5FFE9,
+        0xBDBDF21C, 0xCABAC28A, 0x53B39330, 0x24B4A3A6, 0xBAD03605, 0xCDD70693, 0x54DE5729, 0x23D967BF,
+        0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94, 0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B, 0x2D02EF8D
+        };
+        // zig fmt: on
+
+        var crc: u32 = ~@as(u32, 0);
+        for (buf) |ch| {
+            crc = (crc >> 8) ^ crc_table[ch ^ (crc & 0xff)];
+        }
+        return ~crc;
+    }
+};
 
 pub fn plot(src: std.builtin.SourceLocation, plot_opts: PlotWidget.InitOptions, opts: Options) *PlotWidget {
     var ret = widgetAlloc(PlotWidget);


### PR DESCRIPTION
Depends on #529

This removes the need to buffer the entire png in memory when writing to a file. The plot example has been updated accordingly.

Using `std.Io.Writer` for `Backend.textureReadTarget` isn't really an improvement because many of the underlying graphics apis still need a complete buffer to write in to, which would mean an additional memcpy. The current solution provides optimal buffering with regards to the graphics api compatibility.