### PR TITLE
Replace stateful showCursor with Cursor.hidden

### DIFF
--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -135,13 +135,6 @@ pub fn preferredColorScheme(self: Backend) ?dvui.enums.ColorScheme {
     return self.impl.preferredColorScheme();
 }
 
-/// Show/hide the cursor.
-///
-/// Returns the previous state of the cursor, `true` meaning shown
-pub fn cursorShow(self: Backend, value: ?bool) GenericError!bool {
-    return self.impl.cursorShow(value);
-}
-
 /// Called by `dvui.refresh` when it is called from a background
 /// thread.  Used to wake up the gui thread.  It only has effect if you
 /// are using `dvui.Window.waitTime` or some other method of waiting until

--- a/src/backends/raylib.zig
+++ b/src/backends/raylib.zig
@@ -438,26 +438,34 @@ pub fn openURL(self: *RaylibBackend, url: []const u8) !void {
 }
 
 pub fn setCursor(self: *RaylibBackend, cursor: dvui.enums.Cursor) void {
-    if (cursor != self.cursor_last) {
-        self.cursor_last = cursor;
-
-        const raylib_cursor = switch (cursor) {
-            .arrow => c.MOUSE_CURSOR_ARROW,
-            .ibeam => c.MOUSE_CURSOR_IBEAM,
-            .wait => c.MOUSE_CURSOR_DEFAULT, // raylib doesn't have this
-            .wait_arrow => c.MOUSE_CURSOR_DEFAULT, // raylib doesn't have this
-            .crosshair => c.MOUSE_CURSOR_CROSSHAIR,
-            .arrow_nw_se => c.MOUSE_CURSOR_RESIZE_NWSE,
-            .arrow_ne_sw => c.MOUSE_CURSOR_RESIZE_NESW,
-            .arrow_w_e => c.MOUSE_CURSOR_RESIZE_EW,
-            .arrow_n_s => c.MOUSE_CURSOR_RESIZE_NS,
-            .arrow_all => c.MOUSE_CURSOR_RESIZE_ALL,
-            .bad => c.MOUSE_CURSOR_NOT_ALLOWED,
-            .hand => c.MOUSE_CURSOR_POINTING_HAND,
-        };
-
-        c.SetMouseCursor(raylib_cursor);
+    if (cursor == self.cursor_last) return;
+    defer self.cursor_last = cursor;
+    const new_shown_state = if (cursor == .hidden) false else if (self.cursor_last == .hidden) true else null;
+    if (new_shown_state) |new_state| {
+        if (self.cursorShow(new_state) == new_state) {
+            log.err("Cursor shown state was out of sync", .{});
+        }
+        // Return early if we are hiding
+        if (new_state == false) return;
     }
+
+    const raylib_cursor = switch (cursor) {
+        .arrow => c.MOUSE_CURSOR_ARROW,
+        .ibeam => c.MOUSE_CURSOR_IBEAM,
+        .wait => c.MOUSE_CURSOR_DEFAULT, // raylib doesn't have this
+        .wait_arrow => c.MOUSE_CURSOR_DEFAULT, // raylib doesn't have this
+        .crosshair => c.MOUSE_CURSOR_CROSSHAIR,
+        .arrow_nw_se => c.MOUSE_CURSOR_RESIZE_NWSE,
+        .arrow_ne_sw => c.MOUSE_CURSOR_RESIZE_NESW,
+        .arrow_w_e => c.MOUSE_CURSOR_RESIZE_EW,
+        .arrow_n_s => c.MOUSE_CURSOR_RESIZE_NS,
+        .arrow_all => c.MOUSE_CURSOR_RESIZE_ALL,
+        .bad => c.MOUSE_CURSOR_NOT_ALLOWED,
+        .hand => c.MOUSE_CURSOR_POINTING_HAND,
+        .hidden => unreachable,
+    };
+
+    c.SetMouseCursor(raylib_cursor);
 }
 
 pub fn preferredColorScheme(_: *RaylibBackend) ?dvui.enums.ColorScheme {

--- a/src/backends/testing.zig
+++ b/src/backends/testing.zig
@@ -9,7 +9,6 @@ size: dvui.Size.Natural,
 size_pixels: dvui.Size.Physical,
 time: i128 = 0,
 clipboard: ?[]const u8 = null,
-cursor_shown: bool = true,
 
 pub const kind: dvui.enums.Backend = .testing;
 
@@ -145,13 +144,6 @@ pub fn openURL(_: *TestingBackend, _: []const u8) std.mem.Allocator.Error!void {
 
 pub fn preferredColorScheme(_: *TestingBackend) ?dvui.enums.ColorScheme {
     return null;
-}
-
-pub fn cursorShow(self: *TestingBackend, value: ?bool) bool {
-    defer if (value) |val| {
-        self.cursor_shown = val;
-    };
-    return self.cursor_shown;
 }
 
 /// Called by dvui.refresh() when it is called from a background

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -741,8 +741,6 @@ class Dvui {
                 }
             },
             wasm_cursor: (name_ptr, name_len) => {
-                // Don't overwrite cursor if it is hidden
-                if (this.gl.canvas.style.cursor === "none") return;
                 let cursor_name = utf8decoder.decode(
                     new Uint8Array(
                         this.instance.exports.memory.buffer,
@@ -751,15 +749,6 @@ class Dvui {
                     ),
                 );
                 this.gl.canvas.style.cursor = cursor_name;
-            },
-            wasm_cursor_show: (value) => {
-                const prev = this.gl.canvas.style.cursor !== "none";
-                if (value == 0) {
-                    this.gl.canvas.style.cursor = "none";
-                } else if (value == 1) {
-                    this.gl.canvas.style.cursor = "default";
-                }
-                return prev;
             },
             wasm_text_input: (x, y, w, h) => {
                 if (w > 0 && h > 0) {

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -55,7 +55,6 @@ pub const wasm = if (!builtin.is_test) struct {
     pub extern "dvui" fn wasm_renderGeometry(texture: u32, index_ptr: [*]const u8, index_len: usize, vertex_ptr: [*]const u8, vertex_len: usize, sizeof_vertex: u8, offset_pos: u8, offset_col: u8, offset_uv: u8, clip: u8, x: i32, y: i32, w: i32, h: i32) void;
 
     pub extern "dvui" fn wasm_cursor(name: [*]const u8, name_len: usize) void;
-    pub extern "dvui" fn wasm_cursor_show(value: i8) bool;
     pub extern "dvui" fn wasm_text_input(x: f32, y: f32, w: f32, h: f32) void;
     pub extern "dvui" fn wasm_open_url(ptr: [*]const u8, len: usize) void;
     pub extern "dvui" fn wasm_preferred_color_scheme() u8;
@@ -113,9 +112,6 @@ pub const wasm = if (!builtin.is_test) struct {
     pub fn wasm_renderGeometry(_: u32, _: [*]const u8, _: usize, _: [*]const u8, _: usize, _: u8, _: u8, _: u8, _: u8, _: u8, _: i32, _: i32, _: i32, _: i32) void {}
 
     pub fn wasm_cursor(_: [*]const u8, _: usize) void {}
-    pub fn wasm_cursor_show(_: i8) bool {
-        return undefined;
-    }
     pub fn wasm_text_input(_: f32, _: f32, _: f32, _: f32) void {}
     pub fn wasm_open_url(_: [*]const u8, _: usize) void {}
     pub fn wasm_preferred_color_scheme() u8 {
@@ -710,10 +706,6 @@ pub fn downloadData(name: []const u8, data: []const u8) !void {
     wasm.wasm_download_data(name.ptr, name.len, data.ptr, data.len);
 }
 
-pub fn cursorShow(_: *WebBackend, value: ?bool) bool {
-    return wasm.wasm_cursor_show(if (value) |val| @intFromBool(val) else -1);
-}
-
 /// This can be used to request a new frame directly.
 ///
 /// If you need to request a frame from the JavaScript side, use
@@ -723,25 +715,25 @@ pub fn refresh(_: *WebBackend) void {
 }
 
 pub fn setCursor(self: *WebBackend, cursor: dvui.enums.Cursor) void {
-    if (cursor != self.cursor_last) {
-        self.cursor_last = cursor;
+    if (cursor == self.cursor_last) return;
+    defer self.cursor_last = cursor;
 
-        const name: []const u8 = switch (cursor) {
-            .arrow => "default",
-            .ibeam => "text",
-            .wait => "wait",
-            .wait_arrow => "progress",
-            .crosshair => "crosshair",
-            .arrow_nw_se => "nwse-resize",
-            .arrow_ne_sw => "nesw-resize",
-            .arrow_w_e => "ew-resize",
-            .arrow_n_s => "ns-resize",
-            .arrow_all => "move",
-            .bad => "not-allowed",
-            .hand => "pointer",
-        };
-        wasm.wasm_cursor(name.ptr, name.len);
-    }
+    const name: []const u8 = switch (cursor) {
+        .arrow => "default",
+        .ibeam => "text",
+        .wait => "wait",
+        .wait_arrow => "progress",
+        .crosshair => "crosshair",
+        .arrow_nw_se => "nwse-resize",
+        .arrow_ne_sw => "nesw-resize",
+        .arrow_w_e => "ew-resize",
+        .arrow_n_s => "ns-resize",
+        .arrow_all => "move",
+        .bad => "not-allowed",
+        .hand => "pointer",
+        .hidden => "none",
+    };
+    wasm.wasm_cursor(name.ptr, name.len);
 }
 
 pub fn openFilePicker(id: dvui.Id, accept: ?[]const u8, multiple: bool) void {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1524,18 +1524,6 @@ pub fn cursorSet(cursor: enums.Cursor) void {
     }
 }
 
-/// Shows or hides the cursor, `true` meaning it's shown.
-///
-/// The previous value will be returned
-///
-/// Only valid between `Window.begin`and `Window.end`.
-pub fn cursorShow(value: ?bool) bool {
-    return currentWindow().backend.cursorShow(value) catch |err| {
-        logError(@src(), err, "Could not change cursor visibility", .{});
-        return true;
-    };
-}
-
 /// A collection of points that make up a shape that can later be rendered to the screen.
 ///
 /// This is the basic tool to create rectangles and more complex polygons to later be

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -378,6 +378,7 @@ pub const Cursor = enum(u8) {
     arrow_all,
     bad,
     hand,
+    hidden,
 };
 
 pub const ColorScheme = enum { light, dark };


### PR DESCRIPTION
Closes #540

This requires that most backends cache the previous state of the cursor, which most already did. Most the backends `showCursor` functions still remain, but they're no longer intended to be called directly and is handled by the `setCursor` system. The stateful-ness of each backend is now contained to the backend itself and the user just needs to call `dvui.setCursor`, with `dvui.showCursor` being removed, and the correct state will be presented at the end of the frame.