### PR TITLE
ShrinkingArenaAllocator:  Handle alignment padding when freeing

### DIFF
--- a/src/shrinking_arena_allocator.zig
+++ b/src/shrinking_arena_allocator.zig
@@ -170,7 +170,10 @@ pub fn ShrinkingArenaAllocator(comptime opts: InitOptions) type {
 
             // Extend the allocated length to the previous freed allocation
             // to account for padding between allocations
-            const index_adjustment = if (self.last_freed_ptr) |ptr| ptr -| (@intFromPtr(memory.ptr) + memory.len) else 0;
+            const index_adjustment = if (self.last_freed_ptr) |ptr|
+                @min(ptr -| (@intFromPtr(memory.ptr) + memory.len), Alignment.@"32".toByteUnits())
+            else
+                0;
             if (self.arena.state.end_index > index_adjustment) {
                 self.arena.state.end_index -= index_adjustment;
             }


### PR DESCRIPTION
Relates to #545

This fixes the issue of varying alignments making calls to free fail. We can now guarantee to only need  one call to free.

Because of svg2tvg using a 16 byte aligned buffer we are forced to set the maximum to 16, unless we create a wrapper arena allocator everywhere we call into the library (which isn't unreasonable). The max alignment can be easily changed in that case.