### PR TITLE
WidgetData: Only use fade if scale is 1

### DIFF
--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -201,7 +201,10 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct { fill_color: ?
 
             const rs = self.borderRectScale();
             if (!rs.r.empty()) {
-                rs.r.fill(self.options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = self.options.color(.border), .fade = 1.0 });
+                rs.r.fill(self.options.corner_radiusGet().scale(rs.s, Rect.Physical), .{
+                    .color = self.options.color(.border),
+                    .fade = if (self.rectScale().s > 1.0) 0.0 else 1.0,
+                });
             }
         }
     }
@@ -209,7 +212,10 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct { fill_color: ?
     if (bg) {
         const rs = self.backgroundRectScale();
         if (!rs.r.empty()) {
-            rs.r.fill(self.options.corner_radiusGet().scale(rs.s, Rect.Physical), .{ .color = opts.fill_color orelse self.options.color(.fill), .fade = 1.0 });
+            rs.r.fill(self.options.corner_radiusGet().scale(rs.s, Rect.Physical), .{
+                .color = opts.fill_color orelse self.options.color(.fill),
+                .fade = if (self.rectScale().s > 1.0) 0.0 else 1.0,
+            });
         }
     }
 }


### PR DESCRIPTION
Hi! 

Please let me know if this is incorrect, but I wanted to take a look at using fade only if its a low-dpi screen, as this fixes the border showing 1 px when it shouldn't, like we spoke about a while back on the tree widget. 

Thanks!