### PR TITLE
textLayout speed on screen

### DIFF
--- a/src/Examples/debugging.zig
+++ b/src/Examples/debugging.zig
@@ -7,6 +7,8 @@ pub fn debuggingErrors() void {
         _ = dvui.sliderEntry(@src(), "{d:0.1}", .{ .value = &dvui.scroll_speed, .min = 0.1, .max = 50, .interval = 0.1 }, .{});
     }
 
+    _ = dvui.checkbox(@src(), &dvui.kerning, "Kerning", .{});
+
     _ = dvui.checkbox(@src(), &dvui.currentWindow().snap_to_pixels, "Snap to pixels", .{});
     dvui.label(@src(), "on non-hdpi screens watch the window title \"DVUI Demo\"", .{}, .{ .margin = .{ .x = 10 } });
     dvui.label(@src(), "- text, icons, and images rounded to nearest pixel", .{}, .{ .margin = .{ .x = 10 } });

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1189,14 +1189,21 @@ pub fn fontCacheInit(ttf_bytes: []const u8, font: Font, name: []const u8) FontEr
         const f2_linegap = SF * @as(f32, @floatFromInt(face2_linegap));
         const height = ascent - f2_descent + f2_linegap;
 
-        return FontCacheEntry{
+        var ret = FontCacheEntry{
             .face = face,
             .name = name,
             .scaleFactor = SF,
             .height = @ceil(height),
             .ascent = @floor(ascent),
             .glyph_info = std.AutoHashMap(u32, GlyphInfo).init(currentWindow().gpa),
+            .glyph_info_ascii = undefined,
         };
+
+        for (0..ret.glyph_info_ascii.len) |i| {
+            ret.glyph_info_ascii[i] = try ret.glyphInfoGenerate(@intCast(i));
+        }
+
+        return ret;
     }
 }
 

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -1196,7 +1196,7 @@ fn addTextEx(self: *TextLayoutWidget, text: []const u8, action: AddTextExAction,
         }
 
         { // Scope here is for deallocating rtxt before handling copying to clipboard on the arena
-            const rs = self.screenRectScale(Rect{ .x = self.insert_pt.x, .y = self.insert_pt.y, .w = width, .h = @max(0, self.data().contentRect().h - self.insert_pt.y) });
+            const rs = self.screenRectScale(Rect{ .x = self.insert_pt.x, .y = self.insert_pt.y, .w = s.w, .h = @min(s.h, self.data().contentRect().h - self.insert_pt.y) });
             //std.debug.print("renderText: {} {s}\n", .{ rs.r, txt[0..end] });
             var rtxt = if (newline) txt[0 .. end - 1] else txt[0..end];
 

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -485,7 +485,7 @@ fn findPoint(p: Point, r: Rect, bytes_seen: usize, txt: []const u8, options: Opt
         // found it - p is in this rect
         const how_far = p.x - r.x;
         var pt_end: usize = undefined;
-        _ = options.fontGet().textSizeEx(txt, how_far, &pt_end, .nearest);
+        _ = options.fontGet().textSizeEx(txt, .{ .max_width = how_far, .end_idx = &pt_end, .end_metric = .nearest });
         return .{ .byte = bytes_seen + pt_end, .affinity = if (pt_end == txt.len) .before else .after };
     }
 
@@ -997,6 +997,8 @@ fn addTextEx(self: *TextLayoutWidget, text: []const u8, action: AddTextExAction,
         }
     }
 
+    var kern_buf: [10]u32 = @splat(0);
+
     text_loop: while (txt.len > 0) {
         var linestart: f32 = 0;
 
@@ -1035,7 +1037,7 @@ fn addTextEx(self: *TextLayoutWidget, text: []const u8, action: AddTextExAction,
         var end: usize = undefined;
 
         // get slice of text that fits within width or ends with newline
-        var s = options.fontGet().textSizeEx(txt, if (self.break_lines) width else null, &end, .before);
+        var s = options.fontGet().textSizeEx(txt, .{ .max_width = if (self.break_lines) width else null, .end_idx = &end, .end_metric = .before, .kern_out = &kern_buf });
 
         // ensure we always get at least 1 codepoint so we make progress
         if (end == 0) {
@@ -1058,7 +1060,7 @@ fn addTextEx(self: *TextLayoutWidget, text: []const u8, action: AddTextExAction,
                 const spaceIdx = std.mem.lastIndexOfLinear(u8, txt[0 .. end + 1], " ");
                 if (spaceIdx) |si| {
                     end = si + 1;
-                    s = options.fontGet().textSize(txt[0..end]);
+                    s = options.fontGet().textSizeEx(txt[0..end], .{ .end_metric = .before, .kern_in = &kern_buf });
                     break :blk; // this part will fit
                 }
 
@@ -1138,7 +1140,7 @@ fn addTextEx(self: *TextLayoutWidget, text: []const u8, action: AddTextExAction,
                         // point is in this text
                         const how_far = p.x - rs.x;
                         var pt_end: usize = undefined;
-                        _ = options.fontGet().textSizeEx(txt, how_far, &pt_end, .nearest);
+                        _ = options.fontGet().textSizeEx(txt, .{ .max_width = how_far, .end_idx = &pt_end, .end_metric = .nearest });
                         sel_bytes[i] = self.bytes_seen + pt_end;
                         self.sel_pts[i] = null;
                     } else {
@@ -1221,6 +1223,7 @@ fn addTextEx(self: *TextLayoutWidget, text: []const u8, action: AddTextExAction,
                 .sel_start = self.selection.start -| self.bytes_seen,
                 .sel_end = self.selection.end -| self.bytes_seen,
                 .sel_color = (opts.color_accent orelse (dvui.themeGet().text_select orelse dvui.themeGet().color(.highlight, .fill))).opacity(0.75),
+                .kern_in = &kern_buf,
             }) catch |err| {
                 dvui.logError(@src(), err, "Failed to render text: {s}", .{rtxt});
             };


### PR DESCRIPTION
Part of #539 

This addresses some performance problems with textLayout when showing a lot of text on the screen.  It does not address how to skip non-visible text.

* fixes the bug where performance degrades as you were scrolled lower
* for me this about doubles the speed of processing visible text in Debug mode:
  * for ~24K ascii chars visible, went from 7fps -> 14fps
* ReleaseFast sees less improvement (maybe 55fps->65fps)

What I learned is that performance (at least in Debug) is dominated by:
* looking up GlyphInfo for each codepoint
* looking up kerning for each codepoint pair

For GlyphInfo we are now cheating by prebaking all ascii characters.  I wonder if there is a better way to do this, either by making GlyphInfo smaller, or having a better lookup datastructure.

For kerning we are reusing most of the information from textSize in renderText.  The key here is assuming that non-zero kerning pairs are rare.  Maybe something like a bloom filter would work better, if we could get the kerning table straight from the font.
