### PR TITLE
minor fixes to saveImage() and struct_ui

### DIFF
--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -1121,7 +1121,7 @@ pub fn findMatchingStructOption(T: type, struct_options: anytype) ?StructOptions
 /// Stores all strings currently allocated by struct_ui.
 /// K: a pointer to the string field.
 /// V: The string slice.
-pub var string_map: std.AutoArrayHashMapUnmanaged(*const []const u8, []const u8) = .empty;
+pub var string_map: std.AutoHashMapUnmanaged(*const []const u8, []const u8) = .empty;
 
 /// Returns a 'gpa' backing type with required allocator.
 pub fn stringBackingAllocator() StringBackingType {

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -334,7 +334,7 @@ pub fn saveImage(self: *Self, frame: dvui.App.frameFunction, rect: ?dvui.Rect.Ph
 
     var dir = try std.fs.cwd().makeOpenPath(self.image_dir.?, .{});
     defer dir.close();
-    const file = try dir.openFile(filename, .{});
+    const file = try dir.createFile(filename, .{});
     defer file.close();
     var buf: [512]u8 = undefined;
     var writer = file.writer(&buf);


### PR DESCRIPTION
- Fix issue with -generate-images=true failing with file not found 
- struct_ui now uses an AutoHashMap for strings instead of the array version