### PR TITLE
Example: reorder_tree: Persist open branch state when tree is not pro…

### DIFF
--- a/src/Examples/reorder_tree.zig
+++ b/src/Examples/reorder_tree.zig
@@ -46,6 +46,10 @@ const g_advanced = struct {
 var g_cross_drag_from: ?enum { simple, advanced } = null;
 var g_cross_drag_item: ?usize = null;
 
+var reorder_tree_buffer: [2048]u8 = undefined;
+var reorder_tree_fba = std.heap.FixedBufferAllocator.init(&reorder_tree_buffer);
+var reorder_tree_open_branches = std.AutoHashMap(dvui.Id, void).init(reorder_tree_fba.allocator());
+
 pub fn reorderLists() void {
     const uniqueId = dvui.parentGet().extendId(@src(), 0);
     const layo = dvui.dataGetPtrDefault(null, uniqueId, "reorderLayout", reorderLayout, .horizontal);
@@ -578,7 +582,15 @@ fn exampleFileTreeSearch(directory: []const u8, base_entries: *MutableTreeEntry.
             .expand = .horizontal,
         };
 
-        const branch = tree.branch(@src(), .{ .expanded = false }, branch_opts_override.override(branch_options));
+        // Check our branch id, which is updated from our entry name making it a stable ID
+        // If our branch exists in our tracking map, we know it's expanded
+        var expanded = false;
+        const branch_id = tree.data().id.update(entry.name);
+        if (reorder_tree_open_branches.contains(branch_id)) {
+            expanded = true;
+        }
+
+        const branch = tree.branch(@src(), .{ .expanded = expanded }, branch_opts_override.override(branch_options));
         defer branch.deinit();
 
         const alloc = dvui.currentWindow().lifo();
@@ -638,6 +650,11 @@ fn exampleFileTreeSearch(directory: []const u8, base_entries: *MutableTreeEntry.
             };
 
             if (branch.expander(@src(), .{ .indent = 14 }, expander_opts_override.override(expander_options))) {
+                // The expander is open, so we need to add the branch to our tracking map
+                reorder_tree_open_branches.put(branch_id, {}) catch {
+                    dvui.log.debug("Failed to track branch state!", .{});
+                };
+
                 exampleFileTreeSearch(
                     abs_path,
                     base_entries,
@@ -648,6 +665,9 @@ fn exampleFileTreeSearch(directory: []const u8, base_entries: *MutableTreeEntry.
                     branch_options,
                     expander_options,
                 ) catch std.debug.panic("Failed to recurse files", .{});
+            } else {
+                // Here, the expander is not open, so we need to removed the branch from tracking map
+                _ = reorder_tree_open_branches.remove(branch_id);
             }
 
             color_id.* = color_id.* + 1;

--- a/src/Examples/reorder_tree.zig
+++ b/src/Examples/reorder_tree.zig
@@ -46,6 +46,8 @@ const g_advanced = struct {
 var g_cross_drag_from: ?enum { simple, advanced } = null;
 var g_cross_drag_item: ?usize = null;
 
+// These allocations are only necessary for the tree example to have persistent state of open branches
+// when a parent branch is closed or the tree is not processed.
 var reorder_tree_buffer: [2048]u8 = undefined;
 var reorder_tree_fba = std.heap.FixedBufferAllocator.init(&reorder_tree_buffer);
 var reorder_tree_open_branches = std.AutoHashMap(dvui.Id, void).init(reorder_tree_fba.allocator());


### PR DESCRIPTION
…cessed

Please let me know if you'd rather go any other way on this, for now it just felt most appropriate that if an application wishes to persist that data, that the application is responsible for storing that state and passing it along to `expanded` in the branch's `init_options`. 

Since the tree is largely very generic right now, I think trying to wrap in persistent state into the widget just complicates things where-as handling it externally is quite simple.

Please let me know of any changes you'd like to make or any additional comments to make things more clear!

Closes #560.