### PR TITLE
TreeWidget: Add `init_option`s to branch, adding a vertical ov…

### DIFF
--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -192,8 +192,10 @@ pub const Branch = struct {
         // if non-null, must be unique among reorderables in a single reorder
         branch_id: ?usize = null,
 
-        // if true, branch expander will have a dropdown animation
-        animate: bool = true,
+        // If animation duration is greater than 0, the expander will animate accordingly
+        animation_duration: i32 = 400_000,
+
+        animation_easing: *const dvui.easing.EasingFn = dvui.easing.outBack,
     };
 
     wd: WidgetData = undefined,
@@ -360,8 +362,8 @@ pub const Branch = struct {
         };
 
         if (self.expanded) {
-            if (self.init_options.animate)
-                self.anim = dvui.animate(@src(), .{ .duration = 500_000, .easing = dvui.easing.outBack, .kind = .vertical }, .{});
+            if (self.init_options.animation_duration > 0)
+                self.anim = dvui.animate(@src(), .{ .duration = self.init_options.animation_duration, .easing = self.init_options.animation_easing, .kind = .vertical }, .{});
 
             self.expander_vbox = dvui.BoxWidget.init(src, .{ .dir = .vertical }, defaults.override(opts));
             self.expander_vbox.install();

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -361,7 +361,7 @@ pub const Branch = struct {
 
         if (self.expanded) {
             if (self.init_options.animate)
-                self.anim = dvui.animate(@src(), .{ .duration = 250_000, .easing = dvui.easing.outBack, .kind = .vertical }, .{});
+                self.anim = dvui.animate(@src(), .{ .duration = 500_000, .easing = dvui.easing.outBack, .kind = .vertical }, .{});
 
             self.expander_vbox = dvui.BoxWidget.init(src, .{ .dir = .vertical }, defaults.override(opts));
             self.expander_vbox.install();

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -191,6 +191,9 @@ pub const Branch = struct {
         // if null, uses widget id
         // if non-null, must be unique among reorderables in a single reorder
         branch_id: ?usize = null,
+
+        // if true, branch expander will have a dropdown animation
+        animate: bool = true,
     };
 
     wd: WidgetData = undefined,
@@ -206,6 +209,7 @@ pub const Branch = struct {
     target_rs: ?dvui.RectScale = null,
     expanded: bool = false,
     can_expand: bool = false,
+    anim: ?*dvui.AnimateWidget = null,
 
     pub fn init(src: std.builtin.SourceLocation, reorder: *TreeWidget, init_opts: Branch.InitOptions, opts: Options) Branch {
         var self = Branch{};
@@ -356,6 +360,9 @@ pub const Branch = struct {
         };
 
         if (self.expanded) {
+            if (self.init_options.animate)
+                self.anim = dvui.animate(@src(), .{ .duration = 250_000, .easing = dvui.easing.outBack, .kind = .vertical }, .{});
+
             self.expander_vbox = dvui.BoxWidget.init(src, .{ .dir = .vertical }, defaults.override(opts));
             self.expander_vbox.install();
             self.expander_vbox.drawBackground();
@@ -423,8 +430,12 @@ pub const Branch = struct {
         defer self.* = undefined;
 
         if (self.can_expand) {
-            if (self.expanded)
+            if (self.expanded) {
                 self.expander_vbox.deinit();
+                if (self.anim) |a| {
+                    a.deinit();
+                }
+            }
 
             dvui.dataSet(null, self.wd.id, "_expanded", self.expanded);
         } else {


### PR DESCRIPTION
…ershoot animation

This is just for fun, but I think it makes the tree widget feel interactive and fun, and replays the animation when the tree resets. I'd love to include this in my app if it's an acceptable change. 

Edit: Wanted to go ahead and make this easy to customize, so now it accepts a duration and easing for the expansion animation