### PR TITLE
TreeWidget: Fix animation/box options, AnimateWidget: Add `.none` option to disable animation

### DIFF
--- a/src/Examples/animations.zig
+++ b/src/Examples/animations.zig
@@ -95,7 +95,7 @@ pub fn animations() void {
 
             dvui.labelNoFmt(@src(), "Animate", .{}, .{ .gravity_y = 0.5 });
 
-            _ = dvui.dropdown(@src(), &.{ "alpha", "horizontal", "vertical" }, &global.animation_choice, .{});
+            _ = dvui.dropdown(@src(), &.{ "alpha", "horizontal", "vertical", "none" }, &global.animation_choice, .{});
 
             dvui.labelNoFmt(@src(), "easing", .{}, .{ .gravity_y = 0.5 });
 
@@ -155,6 +155,7 @@ pub fn animations() void {
                 0 => .alpha,
                 1 => .horizontal,
                 2 => .vertical,
+                3 => .none,
                 else => unreachable,
             };
             var animator = dvui.animate(@src(), .{ .kind = kind, .duration = global.duration, .easing = global.easing }, .{ .expand = .both, .gravity_x = if (global.center) 0.5 else 0.0, .gravity_y = if (global.center) 0.5 else 0.0 });

--- a/src/Examples/reorder_tree.zig
+++ b/src/Examples/reorder_tree.zig
@@ -657,6 +657,13 @@ fn exampleFileTreeSearch(directory: []const u8, base_entries: *MutableTreeEntry.
                     dvui.log.debug("Failed to track branch state!", .{});
                 };
 
+                var box = dvui.box(@src(), .{ .dir = .vertical }, .{
+                    .expand = .horizontal,
+                    .background = false,
+                    .gravity_y = 1.0,
+                });
+                defer box.deinit();
+
                 exampleFileTreeSearch(
                     abs_path,
                     base_entries,

--- a/src/widgets/AnimateWidget.zig
+++ b/src/widgets/AnimateWidget.zig
@@ -37,15 +37,17 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *AnimateWidget) void {
-    if (dvui.firstFrame(self.data().id)) {
-        // start begin animation
-        self.start();
-    }
+    if (self.init_opts.kind != .none) {
+        if (dvui.firstFrame(self.data().id)) {
+            // start begin animation
+            self.start();
+        }
 
-    if (dvui.animationGet(self.data().id, "_end")) |a| {
-        self.val = a.value();
-    } else if (dvui.animationGet(self.data().id, "_start")) |a| {
-        self.val = a.value();
+        if (dvui.animationGet(self.data().id, "_end")) |a| {
+            self.val = a.value();
+        } else if (dvui.animationGet(self.data().id, "_start")) |a| {
+            self.val = a.value();
+        }
     }
 
     if (self.val) |v| {

--- a/src/widgets/AnimateWidget.zig
+++ b/src/widgets/AnimateWidget.zig
@@ -19,6 +19,7 @@ pub const InitOptions = struct {
 };
 
 pub const Kind = enum {
+    none,
     alpha,
     vertical,
     horizontal,
@@ -49,6 +50,7 @@ pub fn install(self: *AnimateWidget) void {
 
     if (self.val) |v| {
         switch (self.init_opts.kind) {
+            .none => {},
             .alpha => {
                 self.prev_alpha = dvui.alpha(v);
             },
@@ -133,6 +135,7 @@ pub fn deinit(self: *AnimateWidget) void {
     defer self.* = undefined;
     if (self.val) |v| {
         switch (self.init_opts.kind) {
+            .none => {},
             .alpha => {
                 dvui.alphaSet(self.prev_alpha);
             },

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -361,24 +361,21 @@ pub const Branch = struct {
             .margin = .{ .x = init_opts.indent },
         };
 
-        const anim_defaults = Options{
-            .name = "ExpanderAnimation",
-            .expand = opts.expand,
-        };
-
         if (self.expanded) {
-            if (self.init_options.animation_duration > 0)
-                self.anim = dvui.animate(
-                    @src(),
-                    .{
-                        .duration = self.init_options.animation_duration,
-                        .easing = self.init_options.animation_easing,
-                        .kind = .vertical,
-                    },
-                    anim_defaults.override(opts.strip()),
-                );
+            self.anim = dvui.animate(
+                @src(),
+                .{
+                    .duration = self.init_options.animation_duration,
+                    .easing = self.init_options.animation_easing,
+                    .kind = if (self.init_options.animation_duration > 0) .vertical else .none,
+                },
+                defaults.override(opts),
+            );
 
-            self.expander_vbox = dvui.BoxWidget.init(src, .{ .dir = .vertical }, defaults.override(opts));
+            // Always expand the inner box to fill the animation
+            const expander_opts = dvui.Options{ .expand = .both };
+
+            self.expander_vbox = dvui.BoxWidget.init(src, .{ .dir = .vertical }, expander_opts.override(opts.strip()));
             self.expander_vbox.install();
             self.expander_vbox.drawBackground();
 

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -361,9 +361,22 @@ pub const Branch = struct {
             .margin = .{ .x = init_opts.indent },
         };
 
+        const anim_defaults = Options{
+            .name = "ExpanderAnimation",
+            .expand = opts.expand,
+        };
+
         if (self.expanded) {
             if (self.init_options.animation_duration > 0)
-                self.anim = dvui.animate(@src(), .{ .duration = self.init_options.animation_duration, .easing = self.init_options.animation_easing, .kind = .vertical }, .{});
+                self.anim = dvui.animate(
+                    @src(),
+                    .{
+                        .duration = self.init_options.animation_duration,
+                        .easing = self.init_options.animation_easing,
+                        .kind = .vertical,
+                    },
+                    anim_defaults.override(opts.strip()),
+                );
 
             self.expander_vbox = dvui.BoxWidget.init(src, .{ .dir = .vertical }, defaults.override(opts));
             self.expander_vbox.install();


### PR DESCRIPTION
This was an oversight from my previous PR. Please let me know if any other options need to be forwarded to the animation, but I think we want it to mostly remain empty other than expansion and let the underlying expander box handle the options.