### PR TITLE
TreeWidget: No longer rely on setting border non-uniform...

### DIFF
--- a/src/Examples/reorder_tree.zig
+++ b/src/Examples/reorder_tree.zig
@@ -393,6 +393,7 @@ pub fn reorderTree(uniqueId: dvui.Id) void {
             .background = true,
             .border = dvui.Rect.all(1),
             .padding = dvui.Rect.all(4),
+            .corner_radius = dvui.Rect.all(4),
         },
         .{
             .padding = dvui.Rect.all(1),
@@ -945,7 +946,7 @@ fn recurseFiles(root_directory: []const u8, outer_tree: *dvui.TreeWidget, unique
         .color_fill = dvui.themeGet().color(.window, .fill),
         .color_border = tree_palette[0],
         .expand = .horizontal,
-        .corner_radius = .all(8),
+        .corner_radius = root_branch.button.wd.options.corner_radius,
         .background = true,
         .box_shadow = .{
             .color = .black,

--- a/src/Examples/reorder_tree.zig
+++ b/src/Examples/reorder_tree.zig
@@ -398,7 +398,6 @@ pub fn reorderTree(uniqueId: dvui.Id) void {
             .padding = dvui.Rect.all(1),
         },
         .{
-            .border = .{ .x = 1 },
             .corner_radius = dvui.Rect.all(4),
             .box_shadow = .{
                 .color = .black,
@@ -946,9 +945,8 @@ fn recurseFiles(root_directory: []const u8, outer_tree: *dvui.TreeWidget, unique
         .color_fill = dvui.themeGet().color(.window, .fill),
         .color_border = tree_palette[0],
         .expand = .horizontal,
-        .corner_radius = root_branch.button.wd.options.corner_radius,
+        .corner_radius = .all(8),
         .background = true,
-        .border = .{ .x = 1 },
         .box_shadow = .{
             .color = .black,
             .offset = .{ .x = -5, .y = 5 },

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -379,6 +379,34 @@ pub const Branch = struct {
             self.expander_vbox.install();
             self.expander_vbox.drawBackground();
 
+            {
+                var path = dvui.Path.Builder.init(dvui.currentWindow().lifo());
+                defer path.deinit();
+
+                const r = self.expander_vbox.wd.rectScale().r;
+                const radii = opts.corner_radiusGet().scale(self.expander_vbox.wd.rectScale().s, dvui.Rect.Physical);
+
+                // Top left corner arc
+                path.addArc(
+                    .{ .x = r.x + radii.x, .y = r.y + radii.y },
+                    radii.x,
+                    std.math.pi * 1.5,
+                    std.math.pi,
+                    false,
+                );
+
+                // Bottom left corner arc
+                path.addArc(
+                    .{ .x = r.x + radii.x, .y = r.y + r.h - radii.y },
+                    radii.x,
+                    std.math.pi,
+                    std.math.pi * 0.5,
+                    false,
+                );
+
+                path.build().stroke(.{ .thickness = 1, .color = opts.color(.border) });
+            }
+
             // Since our items are padded, we need to add some extra space to the top
             _ = dvui.spacer(@src(), .{ .min_size_content = .{ .h = self.options.paddingGet().y * 2.0 } });
         }


### PR DESCRIPTION
...(`.{ .x = 1 }`) for the expander box border, and instead draw a stroke

The rounded edge can be controlled with the expander's border opts, zero radius will draw straight lines. This should now look basically the same except the ends of the arcs wont "fade" like they did before, but I really don't think thats a detail worth worrying about.

<img width="1312" height="944" alt="Screenshot 2025-09-24 at 1 57 34 PM" src="https://github.com/user-attachments/assets/4cd955c1-bc7f-4947-b0d4-e1b55cf11e7a" />

