### PR TITLE
Refactor data and texture cache

### DIFF
--- a/src/Data.zig
+++ b/src/Data.zig
@@ -1,0 +1,223 @@
+mutex: std.Thread.Mutex = .{},
+storage: Storage = .empty,
+trash: Trash = .empty,
+
+pub const Data = @This();
+
+pub const Key = dvui.Id;
+
+pub const Storage = dvui.TrackingAutoHashMap(Key, SavedData, .get_and_put);
+pub const Trash = std.ArrayListUnmanaged(SavedData);
+
+const SavedData = struct {
+    alignment: u8,
+    data: []u8,
+
+    debug: DebugInfo,
+
+    pub const Kind = enum(u1) {
+        /// Store the data pointer to by the slice
+        single_item,
+        /// Store the slice as ptr and len (not copying the data)
+        slice,
+    };
+
+    pub const DebugInfo = if (builtin.mode == .Debug) struct {
+        name: []const u8,
+        kind: Kind,
+
+        fn eq(self: DebugInfo, other: DebugInfo) bool {
+            return std.mem.eql(u8, self.name, other.name) and self.kind == other.kind;
+        }
+
+        pub fn format(self: DebugInfo, writer: *std.Io.Writer) !void {
+            try writer.print("{[name]s} ({[kind]t})", self);
+        }
+    } else void;
+
+    pub fn free(self: *const SavedData, gpa: std.mem.Allocator) void {
+        if (self.data.len != 0) {
+            gpa.rawFree(
+                self.data,
+                std.mem.Alignment.fromByteUnits(self.alignment),
+                @returnAddress(),
+            );
+        }
+    }
+};
+
+fn Slice(S: type) type {
+    const dt = @typeInfo(S);
+    return if (dt == .pointer and dt.pointer.size == .slice)
+        if (dt.pointer.sentinel()) |s|
+            [:s]dt.pointer.child
+        else
+            []dt.pointer.child
+    else if (dt == .pointer and dt.pointer.size == .one and @typeInfo(dt.pointer.child) == .array)
+        if (@typeInfo(dt.pointer.child).array.sentinel()) |s|
+            [:s]@typeInfo(dt.pointer.child).array.child
+        else
+            []@typeInfo(dt.pointer.child).array.child
+    else
+        @compileError("Data.Slice needs a slice or pointer to array, given " ++ @typeName(S));
+}
+
+pub fn set(self: *Data, gpa: std.mem.Allocator, key: Key, data: anytype) std.mem.Allocator.Error!void {
+    const value, _ = try self.getOrPutT(gpa, key, @TypeOf(data));
+    value.* = data;
+}
+
+pub fn setSlice(self: *Data, gpa: std.mem.Allocator, key: Key, data: anytype) std.mem.Allocator.Error!void {
+    return setSliceCopies(self, gpa, key, data, 1);
+}
+pub fn setSliceCopies(self: *Data, gpa: std.mem.Allocator, key: Key, data: anytype, num_copies: usize) std.mem.Allocator.Error!void {
+    const S = @TypeOf(data);
+    if (num_copies == 0) return;
+    const sentinel = @typeInfo(Slice(S)).pointer.sentinel();
+    const slice, _ = try self.getOrPutSliceT(gpa, key, Slice(S), data.len * num_copies + @intFromBool(sentinel != null), true);
+    for (0..num_copies) |i| {
+        @memcpy(slice[i * data.len ..][0..data.len], data);
+    }
+    if (sentinel) |s| slice[data.len] = s;
+}
+
+pub fn getPtr(self: *Data, key: Key, comptime T: type) ?*T {
+    return @ptrCast(@alignCast(self.get(key, if (SavedData.DebugInfo == void) {} else .{ .name = @typeName(T), .kind = .single_item })));
+}
+pub fn getPtrDefault(self: *Data, gpa: std.mem.Allocator, key: Key, comptime T: type, default: T) std.mem.Allocator.Error!*T {
+    const value, const existing = try self.getOrPutT(gpa, key, T);
+    if (!existing) value.* = default;
+    return value;
+}
+
+pub fn getSlice(self: *Data, key: Key, comptime S: type) ?Slice(S) {
+    return @ptrCast(@alignCast(self.get(key, if (SavedData.DebugInfo == void) {} else .{ .name = @typeName(@typeInfo(S).pointer.child), .kind = .slice })));
+}
+pub fn getSliceDefault(self: *Data, gpa: std.mem.Allocator, key: Key, comptime S: type, default: []const @typeInfo(S).pointer.child) std.mem.Allocator.Error!Slice(S) {
+    const sentinel = @typeInfo(Slice(S)).pointer.sentinel();
+    const slice, const existing = try self.getOrPutSliceT(gpa, key, Slice(S), default.len, false);
+    if (!existing) {
+        @memcpy(slice, default);
+        if (sentinel) |s| slice[default.len] = s;
+    }
+    return slice;
+}
+
+fn getOrPutT(self: *Data, gpa: std.mem.Allocator, key: Key, comptime T: type) std.mem.Allocator.Error!struct { *T, bool } {
+    const bytes, const existing = try self.getOrPut(
+        gpa,
+        key,
+        @sizeOf(T),
+        @alignOf(T),
+        true,
+        if (SavedData.DebugInfo == void) {} else .{ .name = @typeName(T), .kind = .single_item },
+    );
+    return .{ @ptrCast(@alignCast(bytes)), existing };
+}
+fn getOrPutSliceT(self: *Data, gpa: std.mem.Allocator, key: Key, comptime S: type, len: usize, replace_existing: bool) std.mem.Allocator.Error!struct { S, bool } {
+    const st = @typeInfo(S);
+    const T = st.pointer.child;
+    const bytes, const existing = try self.getOrPut(
+        gpa,
+        key,
+        @sizeOf(T) * len + @intFromBool(st.pointer.sentinel() != null),
+        st.pointer.alignment,
+        replace_existing,
+        if (SavedData.DebugInfo == void) {} else .{ .name = @typeName(T), .kind = .slice },
+    );
+    return .{ @ptrCast(@alignCast(bytes)), existing };
+}
+
+/// Returns the backing byte slice and a boolean indicating if we found an existing entry
+pub fn getOrPut(self: *Data, gpa: std.mem.Allocator, key: Key, len: usize, alignment: u8, replace_existing: bool, debug: SavedData.DebugInfo) std.mem.Allocator.Error!struct { []u8, bool } {
+    self.mutex.lock();
+    defer self.mutex.unlock();
+
+    if (replace_existing) try self.trash.ensureUnusedCapacity(gpa, 1);
+    const entry = try self.storage.getOrPut(gpa, key);
+    errdefer _ = self.storage.remove(key);
+
+    const should_trash = replace_existing and entry.found_existing and entry.value_ptr.data.len != len;
+    if (should_trash) {
+        // log.debug("dataSet: already had data for id {x} key {s}, freeing previous data\n", .{ id, key });
+        if (@TypeOf(debug) != void) {
+            if (!debug.eq(entry.value_ptr.debug)) {
+                std.debug.panic("Date.getOrPut: stored type {f} doesn't match asked for type {f}", .{ entry.value_ptr.debug, debug });
+            }
+        }
+        self.trash.appendAssumeCapacity(entry.value_ptr.*);
+    }
+    if (!entry.found_existing or should_trash) {
+        entry.value_ptr.* = .{
+            .alignment = alignment,
+            .data = if (len == 0) &.{} else if (gpa.rawAlloc(len, .fromByteUnits(alignment), @returnAddress())) |ptr| ptr[0..len] else return std.mem.Allocator.Error.OutOfMemory,
+            .debug = debug,
+        };
+    }
+    return .{ entry.value_ptr.data, entry.found_existing };
+}
+
+/// returns the backing byte slice if we have one
+pub fn get(self: *Data, key: Key, debug: SavedData.DebugInfo) ?[]u8 {
+    self.mutex.lock();
+    defer self.mutex.unlock();
+
+    if (self.storage.getPtr(key)) |sd| {
+        if (@TypeOf(debug) != void) {
+            if (!debug.eq(sd.debug)) {
+                std.debug.panic("Data.get: stored type {f} doesn't match asked for type {f}", .{ sd.debug, debug });
+            }
+        }
+        return sd.data;
+    } else {
+        return null;
+    }
+}
+
+pub fn remove(self: *Data, gpa: std.mem.Allocator, key: Key) std.mem.Allocator.Error!void {
+    self.mutex.lock();
+    defer self.mutex.unlock();
+    try self.trash.ensureUnusedCapacity(gpa, 1);
+
+    if (self.storage.fetchRemove(key)) |dd| {
+        self.trash.appendAssumeCapacity(dd.value);
+    }
+}
+
+/// Destroys all unused and trashed textures since the last
+/// call to `reset`
+pub fn reset(self: *Data, gpa: std.mem.Allocator) std.mem.Allocator.Error!void {
+    const keys = try self.storage.reset(gpa);
+    defer gpa.free(keys);
+    self.mutex.lock();
+    defer self.mutex.unlock();
+    errdefer comptime unreachable;
+    for (keys) |key| {
+        self.storage.fetchRemove(key).?.value.free(gpa);
+    }
+    for (self.trash.items) |sd| {
+        sd.free(gpa);
+    }
+    self.trash.clearRetainingCapacity();
+}
+
+pub fn deinit(self: *Data, gpa: std.mem.Allocator) void {
+    defer self.* = undefined;
+    var it = self.storage.iterator();
+    while (it.next()) |entry| {
+        entry.value_ptr.free(gpa);
+    }
+    self.storage.deinit(gpa);
+    for (self.trash.items) |sd| {
+        sd.free(gpa);
+    }
+    self.trash.deinit(gpa);
+}
+
+const std = @import("std");
+const builtin = @import("builtin");
+const dvui = @import("./dvui.zig");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -97,11 +97,8 @@ button_order: dvui.enums.DialogButtonOrder = .cancel_ok,
 min_sizes: dvui.TrackingAutoHashMap(Id, Size, .put_only) = .empty,
 /// Uses `gpa` allocator
 tags: dvui.TrackingAutoHashMap([]const u8, dvui.TagData, .put_only) = .empty,
-data_mutex: std.Thread.Mutex = .{},
 /// Uses `gpa` allocator
-datas: dvui.TrackingAutoHashMap(Id, SavedData, .get_and_put) = .empty,
-/// Uses `arena` allocator
-datas_trash: std.ArrayListUnmanaged(SavedData) = .empty,
+data_store: dvui.Data = .{},
 /// Uses `gpa` allocator
 animations: dvui.TrackingAutoHashMap(Id, Animation, .get_and_put) = .empty,
 /// Uses `gpa` allocator
@@ -158,24 +155,6 @@ pub const Subwindow = struct {
     modal: bool = false,
     stay_above_parent_window: ?Id = null,
     mouse_events: bool = true,
-};
-
-const SavedData = struct {
-    alignment: u8,
-    data: []u8,
-
-    type_str: if (builtin.mode == .Debug) []const u8 else void = undefined,
-    copy_slice: if (builtin.mode == .Debug) bool else void = undefined,
-
-    pub fn free(self: *const SavedData, allocator: std.mem.Allocator) void {
-        if (self.data.len != 0) {
-            allocator.rawFree(
-                self.data,
-                std.mem.Alignment.fromByteUnits(self.alignment),
-                @returnAddress(),
-            );
-        }
-    }
 };
 
 pub const InitOptions = struct {
@@ -364,18 +343,9 @@ pub fn init(
 }
 
 pub fn deinit(self: *Self) void {
-    for (self.datas_trash.items) |sd| {
-        sd.free(self.gpa);
-    }
-    self.datas_trash.deinit(self.arena());
+    self.data_store.deinit(self.gpa);
 
     self.texture_cache.deinit(self.gpa, self.backend);
-
-    {
-        var it = self.datas.iterator();
-        while (it.next()) |item| item.value_ptr.free(self.gpa);
-        self.datas.deinit(self.gpa);
-    }
 
     self.debug.deinit(self.gpa);
 
@@ -995,7 +965,7 @@ pub fn begin(
 
     self.debug.reset(self.gpa);
 
-    self.datas_trash = .empty;
+    try self.data_store.reset(self.gpa);
     try self.texture_cache.reset(self.lifo(), self.backend);
 
     {
@@ -1037,18 +1007,6 @@ pub fn begin(
             self.gpa.free(name);
         }
         //std.debug.print("tags {d}\n", .{self.tags.count()});
-    }
-
-    {
-        self.data_mutex.lock();
-        defer self.data_mutex.unlock();
-        const deadData = try self.datas.reset(self.lifo());
-        defer self.lifo().free(deadData);
-        for (deadData) |id| {
-            var sd = self.datas.fetchRemove(id).?;
-            sd.value.free(self.gpa);
-        }
-        //std.debug.print("datas {d}\n", .{self.datas.count()});
     }
 
     // Swap current and previous tab index lists
@@ -1288,110 +1246,6 @@ pub fn renderCommands(self: *Self, queue: []const dvui.RenderCommand) !void {
     }
 }
 
-/// data is copied into internal storage
-pub fn dataSetAdvanced(self: *Self, id: Id, key: []const u8, data_in: anytype, comptime copy_slice: bool, num_copies: usize) void {
-    const hash = id.update(key);
-
-    const dt = @typeInfo(@TypeOf(data_in));
-    const dt_type_str = @typeName(@TypeOf(data_in));
-    const bytes: []const u8 = if (copy_slice) blk: {
-        var bytes = std.mem.sliceAsBytes(data_in);
-        if (dt.pointer.sentinel() != null) {
-            bytes.len += @sizeOf(dt.pointer.child);
-        }
-        break :blk bytes;
-    } else std.mem.asBytes(&data_in);
-
-    const alignment = comptime blk: {
-        if (copy_slice) {
-            break :blk dt.pointer.alignment;
-        } else {
-            break :blk @alignOf(@TypeOf(data_in));
-        }
-    };
-
-    self.data_mutex.lock();
-    defer self.data_mutex.unlock();
-
-    const entry = self.datas.getOrPut(self.gpa, hash) catch |err| {
-        dvui.logError(@src(), err, "id {x} key {s}", .{ id, key });
-        return;
-    };
-
-    const is_same_size = entry.value_ptr.data.len == bytes.len * num_copies;
-    const should_trash = entry.found_existing and !is_same_size;
-    if (should_trash) {
-        // log.debug("dataSet: already had data for id {x} key {s}, freeing previous data\n", .{ id, key });
-        if (builtin.mode == .Debug) {
-            if (!std.mem.eql(u8, entry.value_ptr.type_str, @typeName(@TypeOf(data_in))) or entry.value_ptr.copy_slice != copy_slice) {
-                std.debug.panic(
-                    "dataSetAdvanced: stored type {s} (slice {any}) doesn't match asked for type {s} (slice {any})",
-                    .{ entry.value_ptr.type_str, entry.value_ptr.copy_slice, @typeName(@TypeOf(data_in)), copy_slice },
-                );
-            }
-        }
-        self.datas_trash.append(self.arena(), entry.value_ptr.*) catch |err| {
-            // Remove from map so it dataGet doesn't return an undefined value
-            _ = self.datas.remove(hash);
-            dvui.logError(@src(), err, "Previous data could not be added to the trash, id {x} key {s}", .{ id, key });
-            return;
-        };
-    }
-    if (!entry.found_existing or should_trash) {
-        entry.value_ptr.* = .{
-            .alignment = alignment,
-            .data = self.gpa.allocWithOptions(u8, bytes.len * num_copies, .fromByteUnits(alignment), null) catch |err| switch (err) {
-                error.OutOfMemory => {
-                    dvui.logError(@src(), err, "id {x} key {s}", .{ id, key });
-                    return;
-                },
-            },
-        };
-        if (builtin.mode == .Debug) {
-            entry.value_ptr.type_str = dt_type_str;
-            entry.value_ptr.copy_slice = copy_slice;
-        }
-    }
-
-    // Set data
-    for (0..num_copies) |i| {
-        @memcpy(entry.value_ptr.data[i * bytes.len ..][0..bytes.len], bytes);
-    }
-}
-
-/// returns the backing byte slice if we have one
-pub fn dataGetInternal(self: *Self, id: Id, key: []const u8, comptime T: type, slice: bool) ?[]u8 {
-    const hash = id.update(key);
-
-    self.data_mutex.lock();
-    defer self.data_mutex.unlock();
-
-    if (self.datas.getPtr(hash)) |sd| {
-        if (builtin.mode == .Debug) {
-            if (!std.mem.eql(u8, sd.type_str, @typeName(T)) or sd.copy_slice != slice) {
-                std.debug.panic("dataGetInternal: stored type {s} (slice {any}) doesn't match asked for type {s} (slice {any})", .{ sd.type_str, sd.copy_slice, @typeName(T), slice });
-            }
-        }
-        return sd.data;
-    } else {
-        return null;
-    }
-}
-
-pub fn dataRemove(self: *Self, id: Id, key: []const u8) void {
-    const hash = id.update(key);
-
-    self.data_mutex.lock();
-    defer self.data_mutex.unlock();
-
-    if (self.datas.fetchRemove(hash)) |dd| {
-        self.datas_trash.append(self.arena(), dd.value) catch |err| {
-            dvui.logError(@src(), err, "Previous data could not be added to the trash, id {x} key {s}", .{ id, key });
-            return;
-        };
-    }
-}
-
 ///  Add a dialog to be displayed on the GUI thread during `Window.end`.
 ///
 ///  See `dvui.dialogAdd` for higher level api.
@@ -1560,13 +1414,6 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
 
     // Call this before freeing data so backend can use data allocated during frame.
     try self.backend.end();
-
-    // log.debug("Datas trash {d}", .{self.datas_trash.items.len});
-    for (self.datas_trash.items) |sd| {
-        sd.free(self.gpa);
-    }
-    // Set to empty because it's allocated on the arena and will be freed there
-    self.datas_trash = .empty;
 
     // events may have been tagged with a focus widget that never showed up
     const evts = dvui.events();

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -166,6 +166,8 @@ pub const Alignment = layout.Alignment;
 pub const PlaceOnScreenAvoid = layout.PlaceOnScreenAvoid;
 pub const placeOnScreen = layout.placeOnScreen;
 
+pub const Data = @import("Data.zig");
+
 pub const wasm = (builtin.target.cpu.arch == .wasm32 or builtin.target.cpu.arch == .wasm64);
 pub const useFreeType = !wasm;
 
@@ -1996,6 +1998,11 @@ pub const hashSrc = void;
 /// DEPRECATED: See `dvui.Id.update`
 pub const hashIdKey = void;
 
+// Used for all the data functions
+fn currentOverrideOrPanic(win: ?*Window) *Window {
+    return win orelse current_window orelse @panic("dataSet current_window was null, pass a *Window as first parameter if calling from other thread or outside window.begin()/end()");
+}
+
 /// Set key/value pair for given id.
 ///
 /// Can be called from any thread.
@@ -2010,7 +2017,10 @@ pub const hashIdKey = void;
 ///
 /// If you want to store the contents of a slice, use `dataSetSlice`.
 pub fn dataSet(win: ?*Window, id: Id, key: []const u8, data: anytype) void {
-    dataSetAdvanced(win, id, key, data, false, 1);
+    const w = currentOverrideOrPanic(win);
+    (w.data_store.set(w.gpa, id.update(key), data)) catch |err| {
+        dvui.logError(@src(), err, "id {x} key {s}", .{ id, key });
+    };
 }
 
 /// Set key/value pair for given id, copying the slice contents. Can be passed
@@ -2026,30 +2036,20 @@ pub fn dataSet(win: ?*Window, id: Id, key: []const u8, data: anytype) void {
 /// If called from non-GUI thread or outside `Window.begin`/`Window.end`, you must
 /// pass a pointer to the `Window` you want to add the data to.
 pub fn dataSetSlice(win: ?*Window, id: Id, key: []const u8, data: anytype) void {
-    dataSetSliceCopies(win, id, key, data, 1);
+    const w = currentOverrideOrPanic(win);
+    (w.data_store.setSlice(w.gpa, id.update(key), data)) catch |err| {
+        dvui.logError(@src(), err, "id {x} key {s}", .{ id, key });
+    };
 }
 
 /// Same as `dataSetSlice`, but will copy data `num_copies` times all concatenated
 /// into a single slice.  Useful to get dvui to allocate a specific number of
 /// entries that you want to fill in after.
 pub fn dataSetSliceCopies(win: ?*Window, id: Id, key: []const u8, data: anytype, num_copies: usize) void {
-    const dt = @typeInfo(@TypeOf(data));
-    if (dt == .pointer and dt.pointer.size == .slice) {
-        if (dt.pointer.sentinel()) |s| {
-            dataSetAdvanced(win, id, key, @as([:s]dt.pointer.child, @constCast(data)), true, num_copies);
-        } else {
-            dataSetAdvanced(win, id, key, @as([]dt.pointer.child, @constCast(data)), true, num_copies);
-        }
-    } else if (dt == .pointer and dt.pointer.size == .one and @typeInfo(dt.pointer.child) == .array) {
-        const child_type = @typeInfo(dt.pointer.child);
-        if (child_type.array.sentinel()) |s| {
-            dataSetAdvanced(win, id, key, @as([:s]child_type.array.child, @constCast(data)), true, num_copies);
-        } else {
-            dataSetAdvanced(win, id, key, @as([]child_type.array.child, @constCast(data)), true, num_copies);
-        }
-    } else {
-        @compileError("dataSetSlice needs a slice or pointer to array, given " ++ @typeName(@TypeOf(data)));
-    }
+    const w = currentOverrideOrPanic(win);
+    (w.data_store.setSliceCopies(w.gpa, id.update(key), data, num_copies)) catch |err| {
+        dvui.logError(@src(), err, "id {x} key {s}", .{ id, key });
+    };
 }
 
 /// Set key/value pair for given id.
@@ -2065,15 +2065,10 @@ pub fn dataSetSliceCopies(win: ?*Window, id: Id, key: []const u8, data: anytype,
 /// contents are copied into internal storage. If false, only the slice itself
 /// (ptr and len) and stored.
 pub fn dataSetAdvanced(win: ?*Window, id: Id, key: []const u8, data: anytype, comptime copy_slice: bool, num_copies: usize) void {
-    if (win) |w| {
-        // we are being called from non gui thread or outside begin()/end()
-        w.dataSetAdvanced(id, key, data, copy_slice, num_copies);
+    if (copy_slice) {
+        return dataSetSliceCopies(win, id, key, data, num_copies);
     } else {
-        if (current_window) |cw| {
-            cw.dataSetAdvanced(id, key, data, copy_slice, num_copies);
-        } else {
-            @panic("dataSet current_window was null, pass a *Window as first parameter if calling from other thread or outside window.begin()/end()");
-        }
+        return dataSet(win, id, key, data);
     }
 }
 
@@ -2088,11 +2083,8 @@ pub fn dataSetAdvanced(win: ?*Window, id: Id, key: []const u8, data: anytype, co
 ///
 /// If you want to get the contents of a stored slice, use `dataGetSlice`.
 pub fn dataGet(win: ?*Window, id: Id, key: []const u8, comptime T: type) ?T {
-    if (dataGetInternal(win, id, key, T, false)) |bytes| {
-        return @as(*T, @ptrCast(@alignCast(bytes.ptr))).*;
-    } else {
-        return null;
-    }
+    const w = currentOverrideOrPanic(win);
+    return if (w.data_store.getPtr(id.update(key), T)) |v| v.* else null;
 }
 
 /// Retrieve the value for given key associated with id.  If no value was stored, store default and then return it.
@@ -2106,10 +2098,9 @@ pub fn dataGet(win: ?*Window, id: Id, key: []const u8, comptime T: type) ?T {
 ///
 /// If you want to get the contents of a stored slice, use `dataGetSlice`.
 pub fn dataGetDefault(win: ?*Window, id: Id, key: []const u8, comptime T: type, default: T) T {
-    if (dataGetInternal(win, id, key, T, false)) |bytes| {
-        return @as(*T, @ptrCast(@alignCast(bytes.ptr))).*;
-    } else {
-        dataSet(win, id, key, default);
+    const w = currentOverrideOrPanic(win);
+    if (w.data_store.getPtr(id.update(key), T)) |v| return v.* else {
+        w.data_store.set(w.gpa, id.update(key), default);
         return default;
     }
 }
@@ -2131,12 +2122,11 @@ pub fn dataGetDefault(win: ?*Window, id: Id, key: []const u8, comptime T: type, 
 ///
 /// If you want to get the contents of a stored slice, use `dataGetSlice`.
 pub fn dataGetPtrDefault(win: ?*Window, id: Id, key: []const u8, comptime T: type, default: T) *T {
-    if (dataGetPtr(win, id, key, T)) |ptr| {
-        return ptr;
-    } else {
-        dataSet(win, id, key, default);
-        return dataGetPtr(win, id, key, T).?;
-    }
+    const w = currentOverrideOrPanic(win);
+    return w.data_store.getPtrDefault(w.gpa, id.update(key), T, default) catch |err| {
+        dvui.logError(@src(), err, "id {x} key {s}", .{ id, key });
+        @panic("dataGetPtrDefault failed");
+    };
 }
 
 /// Retrieve a pointer to the value for given key associated with id.
@@ -2154,11 +2144,8 @@ pub fn dataGetPtrDefault(win: ?*Window, id: Id, key: []const u8, comptime T: typ
 ///
 /// If you want to get the contents of a stored slice, use `dataGetSlice`.
 pub fn dataGetPtr(win: ?*Window, id: Id, key: []const u8, comptime T: type) ?*T {
-    if (dataGetInternal(win, id, key, T, false)) |bytes| {
-        return @as(*T, @ptrCast(@alignCast(bytes.ptr)));
-    } else {
-        return null;
-    }
+    const w = currentOverrideOrPanic(win);
+    return w.data_store.getPtr(id.update(key), T);
 }
 
 /// Retrieve slice contents for given key associated with id.
@@ -2177,20 +2164,8 @@ pub fn dataGetPtr(win: ?*Window, id: Id, key: []const u8, comptime T: type) ?*T 
 ///
 /// The slice will always be valid until the next call to `Window.end`.
 pub fn dataGetSlice(win: ?*Window, id: Id, key: []const u8, comptime T: type) ?T {
-    const dt = @typeInfo(T);
-    if (dt != .pointer or dt.pointer.size != .slice) {
-        @compileError("dataGetSlice needs a slice, given " ++ @typeName(T));
-    }
-
-    if (dataGetInternal(win, id, key, T, true)) |bytes| {
-        if (dt.pointer.sentinel()) |sentinel| {
-            return @as([:sentinel]align(@alignOf(dt.pointer.child)) dt.pointer.child, @ptrCast(@alignCast(std.mem.bytesAsSlice(dt.pointer.child, bytes[0 .. bytes.len - @sizeOf(dt.pointer.child)]))));
-        } else {
-            return @as([]align(@alignOf(dt.pointer.child)) dt.pointer.child, @alignCast(std.mem.bytesAsSlice(dt.pointer.child, bytes)));
-        }
-    } else {
-        return null;
-    }
+    const w = currentOverrideOrPanic(win);
+    return w.data_store.getSlice(id.update(key), T);
 }
 
 /// Retrieve slice contents for given key associated with id.
@@ -2209,23 +2184,19 @@ pub fn dataGetSlice(win: ?*Window, id: Id, key: []const u8, comptime T: type) ?T
 ///
 /// The slice will always be valid until the next call to `Window.end`.
 pub fn dataGetSliceDefault(win: ?*Window, id: Id, key: []const u8, comptime T: type, default: []const @typeInfo(T).pointer.child) T {
-    return dataGetSlice(win, id, key, T) orelse blk: {
-        dataSetSlice(win, id, key, default);
-        break :blk dataGetSlice(win, id, key, T).?;
+    const w = currentOverrideOrPanic(win);
+    return w.data_store.getSliceDefault(w.gpa, id.update(key), T, default) catch |err| {
+        dvui.logError(@src(), err, "id {x} key {s}", .{ id, key });
+        @panic("dataGetSliceDefault failed");
     };
 }
 
 // returns the backing slice of bytes if we have it
 pub fn dataGetInternal(win: ?*Window, id: Id, key: []const u8, comptime T: type, slice: bool) ?[]u8 {
-    if (win) |w| {
-        // we are being called from non gui thread or outside begin()/end()
-        return w.dataGetInternal(id, key, T, slice);
+    if (slice) {
+        return dataGetPtr(win, id, key, T);
     } else {
-        if (current_window) |cw| {
-            return cw.dataGetInternal(id, key, T, slice);
-        } else {
-            @panic("dataGet current_window was null, pass a *Window as first parameter if calling from other thread or outside window.begin()/end()");
-        }
+        return dataGetSlice(win, id, key, T);
     }
 }
 
@@ -2237,16 +2208,10 @@ pub fn dataGetInternal(win: ?*Window, id: Id, key: []const u8, comptime T: type,
 /// If called from non-GUI thread or outside `Window.begin`/`Window.end`, you must
 /// pass a pointer to the `Window` you want to add the dialog to.
 pub fn dataRemove(win: ?*Window, id: Id, key: []const u8) void {
-    if (win) |w| {
-        // we are being called from non gui thread or outside begin()/end()
-        return w.dataRemove(id, key);
-    } else {
-        if (current_window) |cw| {
-            return cw.dataRemove(id, key);
-        } else {
-            @panic("dataRemove current_window was null, pass a *Window as first parameter if calling from other thread or outside window.begin()/end()");
-        }
-    }
+    const w = currentOverrideOrPanic(win);
+    return w.data_store.remove(w.gpa, id.update(key)) catch |err| {
+        dvui.logError(@src(), err, "id {x} key {s}", .{ id, key });
+    };
 }
 
 /// Return a rect that fits inside avail given the options. avail wins over

--- a/src/render.zig
+++ b/src/render.zig
@@ -389,12 +389,12 @@ pub fn renderIcon(name: []const u8, tvg_bytes: []const u8, rs: RectScale, opts: 
     h.update(std.mem.asBytes(&icon_opts));
     const hash = h.final();
 
-    const texture = Texture.Cache.get(hash) orelse blk: {
+    const texture = dvui.textureGetCached(hash) orelse blk: {
         const texture = Texture.fromTvgFile(name, tvg_bytes, @intFromFloat(ask_height), icon_opts) catch |err| {
             dvui.logError(@src(), err, "Could not create texture from tvg file \"{s}\"", .{name});
             return;
         };
-        Texture.Cache.add(hash, texture);
+        dvui.textureAddToCache(hash, texture);
         break :blk texture;
     };
 

--- a/src/widgets/CacheWidget.zig
+++ b/src/widgets/CacheWidget.zig
@@ -67,9 +67,7 @@ pub fn install(self: *CacheWidget) void {
         if (dvui.textureGetCached(self.hash)) |t| {
             // if we had a texture, show it this frame because our contents needs a frame to get sizing
             self.drawCachedTexture(t);
-
-            dvui.textureDestroyLater(t);
-            _ = dvui.currentWindow().texture_cache.remove(self.hash);
+            dvui.textureInvalidateCache(self.hash);
 
             // now we've shown the texture, so prevent any widgets from drawing on top of it this frame
             // - can happen if some widgets precalculate their size (like label)

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -323,16 +323,15 @@ pub fn getHueSelectorTexture(dir: dvui.enums.Direction) dvui.Backend.TextureErro
     h.update("hue");
     h.update(std.mem.asBytes(&dir));
     const id = h.final();
-    const cw = dvui.currentWindow();
-    const res = try cw.texture_cache.getOrPut(cw.gpa, id);
-    if (!res.found_existing) {
+    if (dvui.textureGetCached(id)) |cached| return cached else {
         const width: u32, const height: u32 = switch (dir) {
             .horizontal => .{ hue_selector_colors.len, 1 },
             .vertical => .{ 1, hue_selector_colors.len },
         };
-        res.value_ptr.* = try dvui.textureCreate(&hue_selector_colors, width, height, .linear);
+        const texture = try dvui.textureCreate(&hue_selector_colors, width, height, .linear);
+        dvui.textureAddToCache(id, texture);
+        return texture;
     }
-    return res.value_ptr.*;
 }
 
 pub fn getValueSaturationTexture(hue: f32) dvui.Backend.TextureError!dvui.Texture {
@@ -340,14 +339,13 @@ pub fn getValueSaturationTexture(hue: f32) dvui.Backend.TextureError!dvui.Textur
     h.update("value");
     h.update(std.mem.asBytes(&(hue * 10000)));
     const id = h.final();
-    const cw = dvui.currentWindow();
-    const res = try cw.texture_cache.getOrPut(cw.gpa, id);
-    if (!res.found_existing) {
+    if (dvui.textureGetCached(id)) |cached| return cached else {
         var pixels: [4]Color.PMA = .{ .white, .cast(Color.HSV.toColor(.{ .h = hue })), .black, .black };
         // set top right corner to the max value of that hue
-        res.value_ptr.* = try dvui.textureCreate(&pixels, 2, 2, .linear);
+        const texture = try dvui.textureCreate(&pixels, 2, 2, .linear);
+        dvui.textureAddToCache(id, texture);
+        return texture;
     }
-    return res.value_ptr.*;
 }
 
 const hue_selector_colors: [7]Color.PMA = .{ .red, .yellow, .lime, .cyan, .blue, .magenta, .red };


### PR DESCRIPTION
This splits out the old `datas` and the texture cache into separate files that no longer have any logic in `dvui.zig` or depends on `dvui.currentWindow()`. Both of these structs handle their "trash" and any potential locking.

Separating other parts of `Window` and the `dvui.zig` file will get harder as there are some functions that depend on random fields. For example, splitting out events and the event adding functions would still require some reference back to the `debug` field on `Window` to add debug touch events. 

One solution to the splitting issue is that the other separate files use `const win = @fieldParentPtr("events", self)` to still allow this behaviour but still separating the different responsibilities. I think this is a decent solution for the event list, subwindows (with `RenderCommand` that needs some window fields), font cache (already takes `*Window` in it's init function so this isn't that far from reality) and dragging (needs the window natural scale) .

The goal is to make `dvui.zig` just an entry point of the api that calls the more specific apis with some conveniences, like using `currentWindow()` for you. It should not include the implementations for these functions as these should be grouped into some logical place with functions within the same domain etc. The widget helper functions, `dvui.box` etc, should also be moved to their respective widgets files (probably in a nested struct called `Helpers` or similar, potentially in a separate file, to not mix them with the widgets api).