### PR TITLE
TrackingAutoHashMap: remove unused values with an iterator

### DIFF
--- a/src/Data.zig
+++ b/src/Data.zig
@@ -186,14 +186,12 @@ pub fn remove(self: *Data, gpa: std.mem.Allocator, key: Key) std.mem.Allocator.E
 
 /// Destroys all unused and trashed textures since the last
 /// call to `reset`
-pub fn reset(self: *Data, gpa: std.mem.Allocator) std.mem.Allocator.Error!void {
-    const keys = try self.storage.reset(gpa);
-    defer gpa.free(keys);
+pub fn reset(self: *Data, gpa: std.mem.Allocator) void {
     self.mutex.lock();
     defer self.mutex.unlock();
-    errdefer comptime unreachable;
-    for (keys) |key| {
-        self.storage.fetchRemove(key).?.value.free(gpa);
+    var it = self.storage.iterator();
+    while (it.next_resetting()) |kv| {
+        kv.value.free(gpa);
     }
     for (self.trash.items) |sd| {
         sd.free(gpa);

--- a/src/Texture.zig
+++ b/src/Texture.zig
@@ -66,12 +66,10 @@ pub const Cache = struct {
     ///
     /// `allocator` is only used for the returned slice and can be
     /// different from the one used for calls to `add`
-    pub fn reset(self: *Cache, allocator: std.mem.Allocator, backend: dvui.Backend) std.mem.Allocator.Error!void {
-        const keys = try self.cache.reset(allocator);
-        defer allocator.free(keys);
-        errdefer comptime unreachable;
-        for (keys) |key| {
-            backend.textureDestroy(self.cache.fetchRemove(key).?.value);
+    pub fn reset(self: *Cache, backend: dvui.Backend) void {
+        var it = self.cache.iterator();
+        while (it.next_resetting()) |kv| {
+            backend.textureDestroy(kv.value);
         }
         for (self.trash.items) |tex| {
             backend.textureDestroy(tex);


### PR DESCRIPTION
The current std hashmap doesn't invalidate pointers when removing keys, instead just marking the slot as empty. This means that we do not have to allocate to remove the unused entries, which removes a point of failure and simplifies the reset logic.