### PR TITLE
textlayout: enforce valid utf-8 before handling caching

### DIFF
--- a/src/Examples/debugging.zig
+++ b/src/Examples/debugging.zig
@@ -40,6 +40,9 @@ pub fn debuggingErrors() void {
         var b = dvui.box(@src(), .{}, .{ .expand = .horizontal, .margin = .{ .x = 10 } });
         defer b.deinit();
         dvui.labelNoFmt(@src(), "this \xFFtext\xFF includes some \xFF invalid utf-8\xFF\xFF\xFF which is replaced with \xFF", .{}, .{});
+        const tl = dvui.textLayout(@src(), .{ .cache_layout = true }, .{});
+        defer tl.deinit();
+        tl.addText("Some \xFFinvalid utf-8 \xc3 in a text layout", .{});
     }
 
     if (dvui.expander(@src(), "Scroll child after expanded child (will log error)", .{}, .{ .expand = .horizontal })) {


### PR DESCRIPTION
Fixes #607

Some parts of this function was using the non-validated input text. Now everything should use the valid utf-8, with a small performance penalty for caching that now still has to validate the utf-8. This fixes the assert trigger at https://github.com/RedPhoenixQ/dvui/blob/textlayout-use-utf8/src/widgets/TextLayoutWidget.zig#L1620.