### PR TITLE
AccessKit: additional widget support

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,10 +328,13 @@ DVUI has varying support for different kinds of accessibility infrastructure.  C
 * Language Input
   * IME (Input Method Editor) works in SDL and web backends
 
-* Audio Output
-  * accesskit integration for screen readers and alternate input events
-  * add `-Daccesskit` to `zig build`
-  * see `Options.role` and `Options.label`
-  * this is still new, please report problems and missing widget support
+* High Contrast Themes
+  * dvui's themes can support this
+  * no current OS integration
 
+* Screen Reading and Alternate Input
+  * [AccessKit](https://accesskit.dev/) integration
+  * add `-Daccesskit` to `zig build`
+  * uses `Options.role` and `Options.label`
+  * see [readme-accessibility](readme-accessibility.md) for more information
 

--- a/readme-accessibility.md
+++ b/readme-accessibility.md
@@ -1,0 +1,225 @@
+# Accessibility in DVUI
+
+## What is accessibility?
+
+Most modern operating system provide an accessibility API to assist users who cannot use standard computer I/O devices to interact with applications.
+
+These users often interact via 'screen reader' that can read text and other accessibility labels from the application. Some readers will also provide the user with a way to perform actions on an application, such as clicking a button, or setting the text in a text box. Others will rely on the keyboard navigation features provided by the application.
+
+DVUI implements accessibility through the AccessKit (link) toolkit, which provides a common interface to the operating system-specific accessibility APIs.
+
+To ensure our DVUI applications are enjoyed by as many users as possible, I would encourage you to treat accessibility as a first-class requirement for your application and to test it just as you would any other feature. 
+
+## Any other benefits. Any downsides?
+
+Incorporating accessibility makes your UI application scriptable. Each widget that has a node in the accessibility tree which publishes its current value along with the set of actions it can perform. By using your platform's accessibility API, you can write automated tests and allows users to script common usage scenarios.
+
+Outside of the additional executable size from including the AccessKit library, there is very little performance impact from supporting AccessKit. (Essentially, two additional if statements per widget) 
+
+The overhead incurred with creating AccessKit nodes is only incurred when the operating system's accessibility API is activated by a screen reader or similar application.
+
+## Enabling AccessKit in DVUI
+
+AccessKit can be included as either a static or dynamic link library. Use -Daccesskit=static or -Daccesskit=shared to enable AccessKit support. 
+
+Not all combinations of backends and operating systems are currently supported. 
+- Linux - Coming soon.
+- Windows - Support for all backends, except raylib static due to symbol clashes.
+- MacOS - Support for SDL2, SDL3 and Raylib.
+- Web - Not currently supported by AccessKit but is planning to do so. 
+
+When you compile you application with AccessKit enabled, most of the accessibility work is taken care of for you and your users will gain most of the benefits of accessibility support. However, DVUI doesn't know your application's intent or any semantic details about the UX, so it is not possible to automate everything. 
+
+As an example, you may have a set of radio buttons, but DVUI has no way to know if those radio buttons all belong to the same radio group.
+
+For the radio button example, you can give DVUI and AccessKit some additional information by setting the 
+role option on the box surrounding the radio buttons to `.role = .radio_group`.  This will let AccessKit know that all child radio buttons within the box all belong to the same radio group. You might also choose to supply a `.label` to give the user more information about the meaning of the radio group.
+
+There are other AccessKit APIs that let you provide more details to the accessibility API. See [Widget users](#widget-users) for more details on how to use the AccessKit API.
+
+```
+{
+    var hbox = dvui.box(@src(), 
+        .{ .dir = .horizontal }, 
+        .role = .radio_group, 
+        .label = . { .text = "Make a choice"} },
+    );
+    defer hbox.deinit();
+    
+    if (dvui.radio(@src(), radio_choice == choice1), "Choice 1", .{ .id_extra = i })) {
+        radio_choice = choice1;
+    }
+    if (dvui.radio(@src(), radio_choice == choice2), "Choice 2", .{ .id_extra = i })) {
+        radio_choice = choice2;
+    }
+}
+```
+## Testing for accessibility
+
+As all accessibility APIs are operating system specific, different tools are required to test on each platform.
+
+### Testing accessibility on Windows
+
+The basic test you should do is to open the Narrator using `ctrl-win-enter` (The same keyboard shortcut closes it). Perform the following steps:
+1) Make sure the reader highlights a widget when you first click on the window. 
+    - If no widget is focused and the whole window stays highlighted, you need to default the focus to a widget whenever the window is first opened using `dvui.focusWidget()` or similar.
+2) Press `caps-r` to read the screen. The reader should read all controls and their displayed content.
+    - If the reader is reading from controls that should be skipped (e.g. the down triangle in a custom dropdown), set .role = .none in the widget creation options for the image.
+    - If the reader is skipping a widget that should be added, set .role to an appropriate value for that widget. 
+    - Check that fields are labelled correctly (e.g. associating a label for a text box). DVUI has some heuristics to pick up this label but use the .label = .for or .by in the widget options to properly associate labels is preferred.
+3) Tab through each widget. 
+    - Make sure each focusable widget has an appropriate `.tab_index` (either manually assigned or generated) and has a sensible position in the tab order.
+    - Make sure the reader highlights each widget and reads out the correct value.
+4) Pay special attention to images and icons. Make sure to add a `.label` option to give descriptive labels to these widgets.
+
+The above steps only test reading from the screen. Actions can also be testing.
+1) Download, install and run [Accessibility Insights](https://accessibilityinsights.io/)
+2) Click on each widget
+3) Look in the bottom right pane for a list of values and actions applicable to each widget.
+    - If you don't see an action for an actionable widget and it is a DVUI widget, raise an issue.
+    - If it is your widget, use `AccessKit.nodeAddAction()` and other relevant API to add the appropriate actions.
+    - The best way to understand what actions are available for which roles is to look at the rust source code.
+
+See [AccessKit - Tips for application developers](https://github.com/AccessKit/accesskit/blob/main/README-APPLICATION-DEVELOPERS.md)
+
+### Testing accessibility on MacOS
+
+See [AccessKit - Tips for application developers](https://github.com/AccessKit/accesskit/blob/main/README-APPLICATION-DEVELOPERS.md)
+
+### Testing accessibility on Linux
+
+See [AccessKit - Tips for application developers](https://github.com/AccessKit/accesskit/blob/main/README-APPLICATION-DEVELOPERS.md)
+
+## DVUI and AccessKit
+
+AccessKit is an accessibility library written in Rust that abstracts the underlying operating system specific accessibility APIs into a unified one.
+
+AccessKit requires:
+1) A tree of "node ids" representing the parent / child relationships and the roles of each node.
+2) A set of updates to those nodes, which contain any data that was changed since the previous update.
+
+As DVUI does not keep state for all widget values, a full set of node id's and a full set of updates is sent at the end of each frame.
+
+The DVUI WidgetId is used as the AccessKit node id. When a widget is created, if 1) Accessibility is active, 2) The Widget has a role and it is not .none, a new AccessKit node will be created via `dvui.accesskit.nodeCreate()`
+Widgets will then set any values or actions against the created node.
+
+Note: AccessKit is still a relatively new and evolving library. Not all platform accessibility features are supported and support for some features may be partially implemented or buggy.
+
+### Multithreading requirements
+
+There is the potential for any callback from AccessKit to be called on the non-gui thread. This includes the initialTreeUpdate, the frameTreeUpdate and the actionHandler. Which thread these are called on varies by operating system, so you should assume they will be called on a separate thread.
+
+Any direct access to the `currentWindow().accesskit` variables should be protected by `currentWindow().accesskit.mutex`. 
+`accesskit.nodes` is safe for `.get` access if used from the gui thread.
+
+### Actions
+
+Actions are input events from the OS accessibility API to perform some function in the GUI, such as focusing a widget, clicking a button or setting a value for a widget. See `AccessKit.Actions` for a full list.
+
+Actions are collected for the current frame in the `action_requests` ArrayList. 
+At the start of the next frame, these action requests are converted to the relevant DVUI events for the requested widget.
+Values are set via the 'text' event with the `replace` field set to true to indicate that the value should replace any existing value held by that widget.
+
+Currently supported Actions are:
+* click
+* set_value (text and numeric types are supported)
+* focus
+
+It is planned to support scrolling actions once the read-only issue with AccessKit scrollbars is resolved.
+
+### Widget creators
+
+Each widget's `install()` should check if an accessibility node was created by using `self.data().accesskit_node()` or equivalent. If this returns non-null, AccessKit functions can be used on the returned node to set any values and events for that widget. Common functions are:
+- `nodeSetValue` / `nodeSetNumericValue` - Used to set the value to be read out by the reader. See rust source code for details on what values can be set for each role.
+- `nodesetToggled` - For checkboxes, radio buttons etc.
+- `nodeAddAction` - Common actions are .click, .focus, .toggle. See rust source code for the actions available for each role.
+
+If your widget can have a value set, then make sure to handle the `text` event to allow that value to be set via a set_value action.
+
+It is safe to use the `accesskit_node()` for a widget that has been deinitialized. e.g. the following code will work. 
+```
+var label_wd: WidgetData = undefined;
+dvui.labelNoFmt(@src(), message, .{}, .{ .background = true, .corner_radius = dvui.Rect.all(1000), .padding = .{ .x = 16, .y = 8, .w = 16, .h = 8 }, .data_out = &label_wd });
+if (label_wd.accesskit_node()) |ak_node| {     
+    AccessKit.nodeSetLive(ak_node, AccessKit.Live.polite);
+}
+```
+
+For cases where you only have access to the widget id. the AccessKit node can be obtained from the `nodes` collection of the `AccessKit` struct. e.g.
+```
+var label_id: Id = ...;
+{
+    if (currentWindow().accesskit.nodes.get(label_id)) |ak_node| {
+        AccessKit.nodeSetLive(ak_node, AccessKit.Live.polite);
+    }
+}
+```
+
+### Widget users
+
+The AccessKit APIs are also available for widget users to customize accessibility information. As above, the AccessKit node can be accessed either from `accesskit_node()` on widget data, or via the `nodes` collection through `currentWindow().accesskit`
+
+An example of using a text box as a number entry box and adding minimum and maximum values. (Note that dvui.textEntryNumber already does this for you)
+
+```
+const te = dvui.textEntry(@src(), .{}, .{ .role = .number_input});
+if (te.data().accesskit_node()) | ak_node | {
+    // Remove the text value already set by textEntry
+    AccessKit.nodeClearValue(ak_node);  
+    AccessKit.nodeSetMinNumericValue(ak_node, 0);
+    AccessKit.nodeSetMaxNumericValue(ak_node, 128);
+    // Set the numeric value.
+    AccessKit.nodeSetNumericValue(ak_node, std.fmt.parseInt(te.getText()) catch 0);
+}
+```
+
+## Current State of Accessibility in DVUI
+
+* A role of `null` means the widget will not be added to the accessibility tree, unless the user passes a `role` for that widget via Options.
+
+| Widget | Role | Read Support | Action Support | TODO? | Details |
+|--------|------|--------------|----------------|-------|---------|
+| AnimateWidget| null | Basic | N/A | N | User can pass .role and .label via options |
+| BoxWidget | null | Basic | N/A | N | User can pass .role and .label via options |
+| ButtonWidget | button | Yes | Yes | N | Focus and Click actions supported |
+| ColorPickerWidget | slider x 4 | Partial | Partial | Y | AccessKit does not currently support 2d-sliders. Other sliders are supported. |
+| DropDownWidget | combo_box / list_item | N | Y | Y | more testing required |
+| FlexBoxWidget | null | Basic | N/A | N | User can pass .role and .label via options |
+| FloatingMenuWidget | none | N/A | N/A | N | Accessibility Handled by Menu / MenuItem|
+| FloatingToolTipWidget | tooltip | Y* | N | N | Tooltips are added only when shown. No support for showing / hiding tooltips |
+| FloatingWidget | N/A | N/A | N/A | N | |
+| FloatingWindowWidget | window | Y | Y | N | Can close via close button. |
+| GridWidget | grid, header, cell | Y? | N/A | Y | Needs more real-world testing. Setting row and col numbers doesn't appear to do anything |
+| IconWidget | image |  Y | N/A | N | |
+| LabelWidget | label |  Y | N/A | N | | 
+| MenuItemWidget | menu_item | Y | Y | Y | Add keyboard shortcuts when supported by dvui | 
+| MenuWidget | menu |  Y | Y | N | |
+| OverlayWidget | null | Basic | N/A | N | User can pass .role and .label via options |
+| PanedWidget | pane |Y | N* | Y | Accesskit currently sets the control as read-only. If this is fixed, implement .text event to set the splitter position. |
+| PlotWidget | .group, .image | N | N/A? | N | Labels image with title of plot. Labels plot widget as a plot. |
+| ReorderWidget | null | N | N | Y | Not currently supported. Unlikely that interaction will work? | 
+| ScaleWidget | null | N/A | N/A | N | Not required |
+| ScrollAreaWidget | scroll_view | Y | N | N | Appears as a pane |
+| ScrollBarWidget | scroll_bar | Y *| N* | Y | Due to bug in AccessKit, is set to read-only and cannot interact. Actual values displayed may not be accurate | 
+| SuggestionsWidget | suggestion, list_item | Y | Y | N | 
+| TabsWidget | .tab_panel, .tab | Y | Y | N | Sets active tabs and allows tab selection |
+| TextEntryWidget | text_input, multiline_text_input | Y* | N* | Y | Text entry should work for "reasonable" amounts of text. SetValue will replace all text. Needs to implement the .text_run role to properly allow users to fully perform text entry and editing. |
+| TextLayoutWidget | label | Y* | N/A | Y | Currently displays only visible text (TBC). Works OK for "reasonable" amounts of text. Does not support sending of formatting information | 
+| TreeWidget | tree, tree_item | Y* | Y | Y | Adds tree and nodes. Implement expand / collapse when supported by AccessKit | 
+| windowHeader | label, button | Y | Y | N | |
+| dialogs | window | Y | Y | Y | All dialogs are displayed as windows, rather than dialogs and modal state is not displayed in accessibility insights. AccessKit currently has limted support for dialogs, so leaving as window until the situation changes and can revisit. |
+| toasts | label | Y? | N/A | ? | These are set as polite annoucements via node_set_live but have not seen this cause anything to be read from the reader. |
+| comboBox | combo_box | Y | Y | N | Displays as combo box and shows list items when dropped |
+| expander | group | Y* | Y* | Y | AccessKit does not currently support expand / collapse |
+| context | ? | ? | ? | ? | Will need to implement "show context menu" action. Which will be mapped to right-click. |
+| gridHeadingSortable | button | Y* | Y | Y | Sets sort state of asc/desc if sorted, but does not come through in accessibility insights. further investigation required |
+| gridHeadingCheckbox | button | Y | Y | N| Labels checkbox as select all / select none. |
+| image | image | Y* | N/A | N | Requires user to label the image with .label |
+| slider | slider | Y | Y | N | Fully supported |
+| progress | progress_indicator | Y | N/A  | N | Fully supported |
+| checkbox | check_box | Y | Y | N | Fully supported |
+| radio | radio_button | Y* | Y | N | Best practice: Create a radio group with a surrounding box|
+| textEntryNumber | number_input | Y | Y | N | Fully supported. Supports min, max and valid/invalid. |
+
+
+

--- a/readme-accessibility.md
+++ b/readme-accessibility.md
@@ -6,17 +6,17 @@ Most modern operating system provide an accessibility API to assist users who ca
 
 These users often interact via 'screen reader' that can read text and other accessibility labels from the application. Some readers will also provide the user with a way to perform actions on an application, such as clicking a button, or setting the text in a text box. Others will rely on the keyboard navigation features provided by the application.
 
-DVUI implements accessibility through the AccessKit (link) toolkit, which provides a common interface to the operating system-specific accessibility APIs.
+DVUI implements accessibility through the [AccessKit](https://github.com/AccessKit/accesskit) toolkit, which provides a common interface to the operating system-specific accessibility APIs.
 
 To ensure our DVUI applications are enjoyed by as many users as possible, I would encourage you to treat accessibility as a first-class requirement for your application and to test it just as you would any other feature. 
 
 ## Any other benefits. Any downsides?
 
-Incorporating accessibility makes your UI application scriptable. Each widget that has a node in the accessibility tree which publishes its current value along with the set of actions it can perform. By using your platform's accessibility API, you can write automated tests and allows users to script common usage scenarios.
+Incorporating accessibility makes your UI application scriptable. Each widget that has a node in the accessibility tree publishes its current value along with the set of actions it can perform. By using your platform's accessibility API, you can write automated tests as well as allowing your users to script common tasks.
 
 Outside of the additional executable size from including the AccessKit library, there is very little performance impact from supporting AccessKit. (Essentially, two additional if statements per widget) 
 
-The overhead incurred with creating AccessKit nodes is only incurred when the operating system's accessibility API is activated by a screen reader or similar application.
+The overhead of creating AccessKit nodes is only incurred when the operating system's accessibility API is activated by a screen reader or similar application.
 
 ## Enabling AccessKit in DVUI
 
@@ -100,8 +100,10 @@ AccessKit requires:
 
 As DVUI does not keep state for all widget values, a full set of node id's and a full set of updates is sent at the end of each frame.
 
-The DVUI WidgetId is used as the AccessKit node id. When a widget is created, if 1) Accessibility is active, 2) The Widget has a role and it is not .none, a new AccessKit node will be created via `dvui.accesskit.nodeCreate()`
+The DVUI WidgetId is used as the AccessKit node id. When a widget is created, if 1) Accessibility is active, 2) The Widget has a role and it is not .none, 3) The widget is at least partially visible or the widget is the focused widget, then a new AccessKit node will be created via `dvui.accesskit.nodeCreate()`
 Widgets will then set any values or actions against the created node.
+
+The visibility check should be removed in future and the nodeSetClipsChildren API should be used for anything that clips contained child widgets. The focused node is always added to the tree, even if it is not visible, meaning it can have the wrong parent. But this stops the screen reader's focus shifting to the main window when the focused widget scrolls off the screen.
 
 Note: AccessKit is still a relatively new and evolving library. Not all platform accessibility features are supported and support for some features may be partially implemented or buggy.
 

--- a/src/AccessKit.zig
+++ b/src/AccessKit.zig
@@ -150,7 +150,7 @@ inline fn nodeCreateFake(_: *AccessKit, _: *dvui.WidgetData, _: Role) ?*Node {
 /// Create a new Node for AccessKit
 /// Returns null if no accessibility information is required for this widget.
 pub fn nodeCreateReal(self: *AccessKit, wd: *dvui.WidgetData, role: Role) ?*Node {
-    if (!wd.visible()) return null;
+    if (!wd.visible() and wd.id != dvui.focusedWidgetId()) return null;
     if (wd.options.role == .none) return null;
 
     {

--- a/src/AccessKit.zig
+++ b/src/AccessKit.zig
@@ -17,7 +17,8 @@ const log = std.log.scoped(.AccessKit);
 adapter: ?AdapterType() = null,
 // The ak_node id for the widget which last had focus this frame.
 focused_id: usize = 0,
-// Note: Any access to `nodes` must be protected by `mutex`.
+// Note: Access to `nodes` must be protected by `mutex`.
+// Safe for read-only access from gui-thread, without mutex.
 nodes: std.AutoArrayHashMapUnmanaged(dvui.Id, *Node) = .empty,
 // Note: Any access to `action_requests` must be protected by `mutex`.
 action_requests: std.ArrayList(ActionRequest) = .empty,
@@ -169,7 +170,8 @@ pub fn nodeCreateReal(self: *AccessKit, wd: *dvui.WidgetData, role: Role) ?*Node
         }
     }
 
-    // std.debug.print("Creating Node for {x} with role {?t} at {s}:{d}\n", .{ wd.id, wd.options.role, wd.src.file, wd.src.line });
+    if (debug_node_tree)
+        std.debug.print("Creating Node for {x} with role {?t} at {s}:{d}\n", .{ wd.id, wd.options.role, wd.src.file, wd.src.line });
 
     const ak_node = nodeNew(role.asU8()) orelse return null;
     wd.ak_node = ak_node;
@@ -220,10 +222,12 @@ pub fn nodeCreateReal(self: *AccessKit, wd: *dvui.WidgetData, role: Role) ?*Node
             if (self.node_to_label == .zero) {
                 self.node_waiting_label = false;
             } else {
-                const for_node = self.nodes.get(self.node_to_label) orelse unreachable;
-                nodePushLabelledBy(for_node, wd.id.asU64());
-                self.node_waiting_label = false;
-                self.node_to_label = .zero;
+                // If the labelled node is no longer visible, it will not be found.
+                if (self.nodes.get(self.node_to_label)) |for_node| {
+                    nodePushLabelledBy(for_node, wd.id.asU64());
+                    self.node_waiting_label = false;
+                    self.node_to_label = .zero;
+                }
             }
         }
         self.prev_label_id = wd.id;
@@ -245,7 +249,8 @@ pub fn nodeParent(wd_in: *dvui.WidgetData) *Node {
     var iter = wd_in.parent.data().iterator();
     while (iter.next()) |wd| {
         if (wd.accesskit_node()) |ak_node| {
-            // std.debug.print("parent node is {x} at {s}:{d}\n", .{ wd.id, wd.src.file, wd.src.line });
+            if (debug_node_tree)
+                std.debug.print("parent node is {x} at {s}:{d}\n", .{ wd.id, wd.src.file, wd.src.line });
             return ak_node;
         }
     }
@@ -298,7 +303,7 @@ fn processActions(self: *AccessKit) void {
                             ActionData.value => break :value std.mem.span(request.data.value.unnamed_0.unnamed_1.value),
                             ActionData.numeric_value => {
                                 var writer: std.io.Writer.Allocating = .init(window.arena());
-                                writer.writer.print("{d:.6}", .{request.data.value.unnamed_0.unnamed_2.numeric_value}) catch break :value "";
+                                writer.writer.print("{d}", .{request.data.value.unnamed_0.unnamed_2.numeric_value}) catch break :value "";
                                 break :value writer.toOwnedSlice() catch break :value "";
                             },
                             else => {
@@ -307,7 +312,7 @@ fn processActions(self: *AccessKit) void {
                         }
                     };
 
-                    _ = window.addEventText(.{ .text = text_value, .target_id = @enumFromInt(request.target) }) catch |err| logEventAddError(@src(), err);
+                    _ = window.addEventText(.{ .text = text_value, .target_id = @enumFromInt(request.target), .replace = true }) catch |err| logEventAddError(@src(), err);
                 }
             },
             else => {},
@@ -1432,3 +1437,5 @@ pub const RoleNoAccessKit = enum {
     list_grid,
     terminal,
 };
+
+const debug_node_tree = false;

--- a/src/Event.zig
+++ b/src/Event.zig
@@ -48,6 +48,7 @@ pub fn handle(self: *Event, src: std.builtin.SourceLocation, wd: *const dvui.Wid
 pub const Text = struct {
     txt: []u8,
     selected: bool = false,
+    replace: bool = false,
 };
 
 pub const Key = struct {

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -134,7 +134,17 @@ pub fn demo() void {
 
         inline for (0..@typeInfo(demoKind).@"enum".fields.len) |i| {
             const e = @as(demoKind, @enumFromInt(i));
-            var bw = dvui.ButtonWidget.init(@src(), .{}, .{ .id_extra = i, .border = Rect.all(1), .background = true, .min_size_content = dvui.Size.all(120), .max_size_content = .size(dvui.Size.all(120)), .margin = Rect.all(5), .style = .content, .tag = "demo_button_" ++ @tagName(e) });
+            var bw = dvui.ButtonWidget.init(@src(), .{}, .{
+                .id_extra = i,
+                .border = Rect.all(1),
+                .background = true,
+                .min_size_content = dvui.Size.all(120),
+                .max_size_content = .size(dvui.Size.all(120)),
+                .margin = Rect.all(5),
+                .style = .content,
+                .tag = "demo_button_" ++ @tagName(e),
+                .label = .{ .text = e.name() },
+            });
             bw.install();
             bw.processEvents();
             bw.drawBackground();

--- a/src/Examples/basic_widgets.zig
+++ b/src/Examples/basic_widgets.zig
@@ -114,9 +114,14 @@ pub fn basicWidgets() void {
         te.deinit();
     }
 
-    inline for (@typeInfo(RadioChoice).@"enum".fields, 0..) |field, i| {
-        if (dvui.radio(@src(), radio_choice == @as(RadioChoice, @enumFromInt(field.value)), "Radio " ++ field.name, .{ .id_extra = i })) {
-            radio_choice = @enumFromInt(field.value);
+    {
+        var vbox = dvui.box(@src(), .{}, .{ .role = .radio_group, .label = .{ .text = "Radio buttons" } });
+        defer vbox.deinit();
+
+        inline for (@typeInfo(RadioChoice).@"enum".fields, 0..) |field, i| {
+            if (dvui.radio(@src(), radio_choice == @as(RadioChoice, @enumFromInt(field.value)), "Radio " ++ field.name, .{ .id_extra = i })) {
+                radio_choice = @enumFromInt(field.value);
+            }
         }
     }
 

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -22,21 +22,7 @@ name: ?[]const u8 = null,
 role: ?dvui.AccessKit.Role = null,
 
 /// Accessibility label, either another widget or text.
-label: ?union(enum) {
-    /// Use the label from a different widget.  This is preferred if there is a
-    /// visible widget that labels this one.
-    by_id: dvui.Id,
-
-    /// Use this label for a different widget.
-    for_id: dvui.Id,
-
-    /// Use the previous or next label widget to label this widget.
-    label_widget: enum { prev, next },
-
-    /// Use this text as the label.  Prefer another option if possible - this
-    /// is for when there is no visible label (like an icon or image).
-    text: []const u8,
-} = null,
+label: ?LabelOpts = null,
 
 /// Pass a pointer to get a copy of the widget's `data` when `register` was
 /// called.  Useful for getting id/rect info out of a higher-level function.
@@ -116,6 +102,22 @@ font_style: ?FontStyle = null,
 
 /// Render a box shadow in `WidgetData.borderAndBackground`.
 box_shadow: ?BoxShadow = null,
+
+pub const LabelOpts = union(enum) {
+    /// Use the label from a different widget.  This is preferred if there is a
+    /// visible widget that labels this one.
+    by_id: dvui.Id,
+
+    /// Use this label for a different widget.
+    for_id: dvui.Id,
+
+    /// Use the previous or next label widget to label this widget.
+    label_widget: enum { prev, next },
+
+    /// Use this text as the label.  Prefer using .by if possible - .text is
+    /// for cases where there is no visible label (like an icon or image).
+    text: []const u8,
+};
 
 pub const Expand = enum {
     none,

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -64,6 +64,10 @@ pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Op
 pub fn register(self: *WidgetData) void {
     self.rect_scale = self.rectScaleFromParent();
 
+    if (self.options.role) |role| {
+        _ = dvui.currentWindow().accesskit.nodeCreate(self, role);
+    }
+
     if (self.options.data_out) |do| {
         do.* = self.*;
     }
@@ -103,10 +107,6 @@ pub fn register(self: *WidgetData) void {
         hasher.update(std.mem.asBytes(&self.options.hash()));
         hasher.update(std.mem.asBytes(&self.rectScale()));
         hasher.update(std.mem.asBytes(&(self.id == focused_widget_id)));
-    }
-
-    if (self.options.role) |role| {
-        _ = dvui.currentWindow().accesskit.nodeCreate(self, role);
     }
 
     if (cw.debug.target == .focused and self.id == focused_widget_id) {

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -504,6 +504,7 @@ pub fn addEventKey(self: *Self, event: Event.Key) std.mem.Allocator.Error!bool {
 pub const AddEventTextOptions = struct {
     text: []const u8,
     selected: bool = false,
+    replace: bool = false,
     target_id: ?dvui.Id = null,
 };
 
@@ -524,6 +525,7 @@ pub fn addEventText(self: *Self, opts: AddEventTextOptions) std.mem.Allocator.Er
             .text = .{
                 .txt = try self.arena().dupe(u8, opts.text),
                 .selected = opts.selected,
+                .replace = opts.replace,
             },
         },
         .target_windowId = self.subwindows.focused_id,

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -3452,6 +3452,7 @@ pub fn button(src: std.builtin.SourceLocation, label_str: []const u8, init_opts:
 }
 
 pub fn buttonIcon(src: std.builtin.SourceLocation, name: []const u8, tvg_bytes: []const u8, init_opts: ButtonWidget.InitOptions, icon_opts: IconRenderOptions, opts: Options) bool {
+    // set label on the button and clear role on icon so they don't duplicate
     const defaults = Options{ .padding = Rect.all(4), .label = .{ .text = name } };
     var bw = ButtonWidget.init(src, init_opts, defaults.override(opts));
     bw.install();
@@ -3465,7 +3466,7 @@ pub fn buttonIcon(src: std.builtin.SourceLocation, name: []const u8, tvg_bytes: 
         name,
         tvg_bytes,
         icon_opts,
-        opts.strip().override(bw.style()).override(.{ .gravity_x = 0.5, .gravity_y = 0.5, .min_size_content = opts.min_size_content, .expand = .ratio, .color_text = opts.color_text }),
+        opts.strip().override(bw.style()).override(.{ .gravity_x = 0.5, .gravity_y = 0.5, .min_size_content = opts.min_size_content, .expand = .ratio, .color_text = opts.color_text, .role = .none }),
     );
 
     const click = bw.clicked();

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -184,6 +184,7 @@ pub fn valueSaturationBox(src: std.builtin.SourceLocation, hsv: *Color.HSV, opts
 pub var hue_slider_defaults: Options = .{
     .name = "Hue Slider",
     .role = .slider,
+    .label = .{ .text = "Hue" },
     .margin = .all(2),
     .min_size_content = .{ .w = 20, .h = 20 },
 };

--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -210,7 +210,12 @@ pub fn addChoice(self: *DropdownWidget) *MenuItemWidget {
         }
     }
 
-    self.drop_mi = MenuItemWidget.init(@src(), .{}, self.options.styleOnly().override(.{ .role = .list_item, .id_extra = self.drop_mi_index, .expand = .horizontal }));
+    self.drop_mi = MenuItemWidget.init(@src(), .{}, self.options.styleOnly().override(.{
+        .role = .list_item,
+        .label = .{ .label_widget = .next },
+        .id_extra = self.drop_mi_index,
+        .expand = .horizontal,
+    }));
     self.drop_mi_id = self.drop_mi.data().id;
     self.drop_mi.install();
     self.drop_mi.processEvents();

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -9,6 +9,7 @@ const RectScale = dvui.RectScale;
 const Size = dvui.Size;
 const Widget = dvui.Widget;
 const WidgetData = dvui.WidgetData;
+const AccessKit = dvui.AccessKit;
 
 const enums = dvui.enums;
 
@@ -162,6 +163,13 @@ pub fn install(self: *PanedWidget) void {
     self.prevClip = dvui.clip(self.data().contentRectScale().r);
 
     dvui.parentSet(self.widget());
+    if (self.data().accesskit_node()) |ak_node| {
+        AccessKit.nodeAddAction(ak_node, AccessKit.Action.focus);
+        AccessKit.nodeAddAction(ak_node, AccessKit.Action.set_value);
+        AccessKit.nodeSetMinNumericValue(ak_node, 0);
+        AccessKit.nodeSetMaxNumericValue(ak_node, 1);
+        AccessKit.nodeSetNumericValue(ak_node, self.split_ratio.*);
+    }
 }
 
 pub fn matchEvent(self: *PanedWidget, e: *Event) bool {

--- a/src/widgets/PlotWidget.zig
+++ b/src/widgets/PlotWidget.zig
@@ -20,6 +20,8 @@ data_max: Data = .{ .x = -std.math.floatMax(f64), .y = -std.math.floatMax(f64) }
 
 pub var defaults: Options = .{
     .name = "Plot",
+    .role = .group,
+    .label = .{ .text = "Plot" },
     .padding = Rect.all(6),
     .background = true,
     .min_size_content = .{ .w = 20, .h = 20 },
@@ -162,7 +164,7 @@ pub fn install(self: *PlotWidget) void {
     //xaxis_padding.deinit();
 
     // data area
-    var data_box = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .both });
+    var data_box = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .both, .role = .image, .label = .{ .text = self.init_options.title orelse "" } });
 
     // mouse hover
     if (self.init_options.mouse_hover) {

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -62,7 +62,8 @@ pub fn install(self: *ScrollBarWidget) void {
     const grabrs = self.data().parent.screenRectScale(self.grabRect);
     self.processEvents(grabrs.r);
 
-    // TODO: I'm pretty sure we can optimize this so that we only set actions and min on "first frame"
+    // Accessibility TODO: Setting value to viewport.x is not correct as it will always show position
+    // as being hte top of the viewport and can't hit 100%.
     if (self.data().accesskit_node()) |ak_node| {
         switch (self.dir) {
             .horizontal => {

--- a/src/widgets/SuggestionWidget.zig
+++ b/src/widgets/SuggestionWidget.zig
@@ -14,6 +14,7 @@ selected_index: usize = 0, // 0 indexed
 activate_selected: bool = false,
 
 pub var defaults: Options = .{
+    .role = .suggestion,
     .name = "Suggestions",
 };
 
@@ -34,7 +35,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 }
 
 pub fn install(self: *SuggestionWidget) void {
-    self.menu = dvui.MenuWidget.init(@src(), .{ .dir = .horizontal, .close_without_focused_child = false }, .{ .rect = .{}, .id_extra = self.options.idExtra() });
+    self.menu = dvui.MenuWidget.init(@src(), .{ .dir = .horizontal, .close_without_focused_child = false }, .{ .role = .none, .rect = .{}, .id_extra = self.options.idExtra() });
     self.menu.install();
 }
 
@@ -90,7 +91,13 @@ pub fn addChoiceLabel(self: *SuggestionWidget, label_str: []const u8) bool {
 }
 
 pub fn addChoice(self: *SuggestionWidget) *MenuItemWidget {
-    self.drop_mi = MenuItemWidget.init(@src(), .{ .highlight_only = true }, .{ .id_extra = self.drop_mi_index, .expand = .horizontal, .padding = .{} });
+    self.drop_mi = MenuItemWidget.init(@src(), .{ .highlight_only = true }, .{
+        .role = .list_item,
+        .label = .{ .label_widget = .next },
+        .id_extra = self.drop_mi_index,
+        .expand = .horizontal,
+        .padding = .{},
+    });
     self.drop_mi.?.install();
     self.drop_mi.?.processEvents();
     if (self.drop_mi.?.data().id == dvui.focusedWidgetId()) {

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -12,6 +12,7 @@ pub var defaults: Options = .{
     .background = false,
     .corner_radius = Rect{},
     .name = "Tabs",
+    .role = .tab_panel,
 };
 
 pub const InitOptions = struct {
@@ -78,8 +79,8 @@ pub fn addTabLabel(self: *TabsWidget, selected: bool, text: []const u8) bool {
 
 pub fn addTab(self: *TabsWidget, selected: bool, opts: Options) *ButtonWidget {
     var tab_defaults: Options = switch (self.init_options.dir) {
-        .horizontal => .{ .id_extra = self.tab_index, .background = true, .corner_radius = .{ .x = 5, .y = 5 }, .margin = .{ .x = 2, .w = 2 } },
-        .vertical => .{ .id_extra = self.tab_index, .background = true, .corner_radius = .{ .x = 5, .h = 5 }, .margin = .{ .y = 2, .h = 2 } },
+        .horizontal => .{ .id_extra = self.tab_index, .background = true, .corner_radius = .{ .x = 5, .y = 5 }, .margin = .{ .x = 2, .w = 2 }, .role = .tab, .label = .{ .label_widget = .next } },
+        .vertical => .{ .id_extra = self.tab_index, .background = true, .corner_radius = .{ .x = 5, .h = 5 }, .margin = .{ .y = 2, .h = 2 }, .role = .tab, .label = .{ .label_widget = .next } },
     };
 
     self.tab_index += 1;
@@ -150,6 +151,9 @@ pub fn addTab(self: *TabsWidget, selected: bool, opts: Options) *ButtonWidget {
             },
         }
     }
+    if (self.tab_button.data().accesskit_node()) |ak_node| {
+        AccessKit.nodeSetSelected(ak_node, selected);
+    }
 
     return &self.tab_button;
 }
@@ -169,6 +173,7 @@ const Point = dvui.Point;
 const BoxWidget = dvui.BoxWidget;
 const ButtonWidget = dvui.ButtonWidget;
 const ScrollAreaWidget = dvui.ScrollAreaWidget;
+const AccessKit = dvui.AccessKit;
 
 const std = @import("std");
 const math = std.math;

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -171,7 +171,7 @@ pub fn install(self: *TextEntryWidget) void {
     const focused = (self.data().id == dvui.lastFocusedIdInFrame());
     if (focused) dvui.currentWindow().last_focused_id_this_frame = .zero;
 
-    self.scroll = ScrollAreaWidget.init(@src(), self.scroll_init_opts, self.data().options.strip().override(.{ .expand = .both }));
+    self.scroll = ScrollAreaWidget.init(@src(), self.scroll_init_opts, self.data().options.strip().override(.{ .role = .none, .expand = .both }));
 
     // scrollbars process mouse events here
     self.scroll.install();
@@ -180,7 +180,7 @@ pub fn install(self: *TextEntryWidget) void {
 
     self.scrollClip = dvui.clipGet();
 
-    self.textLayout = TextLayoutWidget.init(@src(), .{ .break_lines = self.init_opts.break_lines, .kerning = self.init_opts.kerning, .touch_edit_just_focused = false, .cache_layout = self.init_opts.cache_layout }, self.data().options.strip().override(.{ .expand = .both, .padding = self.padding }));
+    self.textLayout = TextLayoutWidget.init(@src(), .{ .break_lines = self.init_opts.break_lines, .kerning = self.init_opts.kerning, .touch_edit_just_focused = false, .cache_layout = self.init_opts.cache_layout }, self.data().options.strip().override(.{ .role = .none, .expand = .both, .padding = self.padding }));
 
     // if textLayout forced cache_layout to false, we need to honor that
     self.init_opts.cache_layout = self.textLayout.cache_layout;
@@ -889,6 +889,9 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event) void {
         .text => |te| {
             e.handle(@src(), self.data());
             var new = std.mem.sliceTo(te.txt, 0);
+            if (te.replace) {
+                self.textLayout.selection.selectAll();
+            }
             if (self.init_opts.multiline) {
                 self.textTyped(new, te.selected);
             } else {

--- a/tools/accesskit_gen.zig
+++ b/tools/accesskit_gen.zig
@@ -83,10 +83,10 @@ pub fn main() !void {
     var debug_allocator: std.heap.DebugAllocator(.{}) = .init;
     const gpa = debug_allocator.allocator();
     var stdout_buffer: [1024]u8 = undefined;
-    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    var stdout_writer = std.fs.File.stdout().writerStreaming(&stdout_buffer);
     const stdout = &stdout_writer.interface;
     defer stdout.flush() catch {}; // Don't forget to flush!
-    var stderr_writer = std.fs.File.stderr().writer(&.{});
+    var stderr_writer = std.fs.File.stderr().writerStreaming(&.{});
     const stderr = &stderr_writer.interface;
 
     if (builtin.os.tag != .windows) {


### PR DESCRIPTION
Supports most DVUI widgets.
- Add readme-accessibility.md
- Add 'replace' option to the text event.
  * Used by accesskit actions to replace existing values e.g. when updating a textbox
- Support for new widgets:
    * toasts
    * suggestions
    * combobox
    * expander
    * tooltip
    * grid headings
    * images
    * progress
    * textEntryNumber
    * ColorPickerWidget
    * GridWidget
    * PanedWidget
    * PlotWidget
    * TabsWidget
    * TreeWidget
- Improved support for
     * slider - set orientation
     * DropDownWidget - list items are now labeled correctly.
     * TextEntryWidget - Implement replace for text event.
- Fixes
    * Create accesskit node earlier in `register()` so that ak_node is available in `data_out`
    * Fix panic when focused node was not visible.
- Other
    * Add basic widget radio buttons to a radio group


@david-vanderson If I remember correctly, you weren't in favour of adding 'replace' to the text event, but I can't see a better way to do it. That's the only change I've made to DVUI core in this PR outside of moving the label options to a named union.

Only lightly tested. Needs a full run-through of the demo app with accessibility enabled. Especially test things that have focus becoming invisible (e.g. scrolling off the screen).