### PR TITLE
AccessKit: Linux support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -583,7 +583,6 @@ fn accessKitPath(b: *std.Build, target: std.Build.ResolvedTarget, ak_dep: *std.B
     }
 }
 
-
 fn accessKitLibName(target: std.Build.ResolvedTarget) []const u8 {
     return if (target.result.os.tag == .windows) "accesskit.dll" //
     else if (target.result.os.tag.isDarwin()) "libaccesskit.dylib" //
@@ -621,6 +620,10 @@ fn addDvuiModule(
         dvui_mod.addIncludePath(ak_dep.path("include"));
         dvui_mod.addLibraryPath(accessKitPath(b, target, ak_dep, opts.accesskit, false));
         dvui_mod.linkSystemLibrary("accesskit", .{});
+
+        if (target.result.os.tag == .linux) {
+            dvui_mod.linkSystemLibrary("unwind", .{});
+        }
     }
 
     const stb_source = "vendor/stb/";

--- a/build.zig
+++ b/build.zig
@@ -548,14 +548,21 @@ const DvuiModuleOptions = struct {
 };
 
 fn accessKitSupported(target: std.Build.ResolvedTarget) bool {
-    if (target.result.os.tag != .windows and !target.result.os.tag.isDarwin()) return false;
-    if (!target.result.cpu.arch.isAARCH64() and !target.result.cpu.arch.isX86()) return false;
-    return true;
+    if (target.result.os.tag == .windows) {
+        return target.result.cpu.arch.isAARCH64() or target.result.cpu.arch.isX86();
+    } else if (target.result.os.tag.isDarwin()) {
+        return target.result.cpu.arch.isAARCH64() or target.result.cpu.arch == .x86_64;
+    } else if (target.result.os.tag == .linux) {
+        return target.result.cpu.arch.isX86();
+    } else {
+        return false;
+    }
 }
 
 fn accessKitPath(b: *std.Build, target: std.Build.ResolvedTarget, ak_dep: *std.Build.Dependency, opt: AccesskitOptions, full_lib_path: bool) std.Build.LazyPath {
     const os_path = if (target.result.os.tag == .windows) "windows" //
         else if (target.result.os.tag.isDarwin()) "macos" //
+        else if (target.result.os.tag == .linux) "linux" //
         else "unsupported";
     const arch_path = if (target.result.cpu.arch.isAARCH64()) "arm64" //
         else if (target.result.cpu.arch == .x86) "x86" //
@@ -564,6 +571,7 @@ fn accessKitPath(b: *std.Build, target: std.Build.ResolvedTarget, ak_dep: *std.B
 
     const abi_path = if (target.result.os.tag == .windows) "msvc" //
         else if (target.result.os.tag.isDarwin()) "" //
+        else if (target.result.os.tag == .linux) "" //
         else "";
 
     const linkage_path = @tagName(opt);
@@ -575,9 +583,11 @@ fn accessKitPath(b: *std.Build, target: std.Build.ResolvedTarget, ak_dep: *std.B
     }
 }
 
+
 fn accessKitLibName(target: std.Build.ResolvedTarget) []const u8 {
     return if (target.result.os.tag == .windows) "accesskit.dll" //
     else if (target.result.os.tag.isDarwin()) "libaccesskit.dylib" //
+    else if (target.result.os.tag == .linux) "libaccesskit.so" //
     else "unsupported";
 }
 

--- a/readme-accessibility.md
+++ b/readme-accessibility.md
@@ -30,9 +30,9 @@ The overhead of creating AccessKit nodes is only incurred when the operating sys
 AccessKit can be included as either a static or dynamic link library. Use `-Daccesskit=static` or `-Daccesskit=shared` to enable AccessKit support. 
 
 Not all combinations of backends and operating systems are currently supported. 
-- Linux - Coming soon.
+- Linux - Supports all backends in for shared and static libraries. SDL2, SDL3 and Raylib.
 - Windows - Support for all backends, except raylib static due to symbol clashes.
-- MacOS - Support for SDL2, SDL3 and Raylib.
+- MacOS - Supports all backends in for shared and static libraries. SDL2, SDL3 and Raylib.
 - Web - Not currently supported by AccessKit but it is planned. 
 
 When you compile you application with AccessKit enabled, most of the accessibility work is taken care of for you and your users will gain most of the benefits of accessibility support. However, DVUI doesn't know your application's intent or any semantic details about the UX, so it is not possible to automate everything. 

--- a/src/AccessKit.zig
+++ b/src/AccessKit.zig
@@ -174,7 +174,6 @@ pub fn nodeCreateReal(self: *AccessKit, wd: *dvui.WidgetData, role: Role) ?*Node
         .on => {},
     }
 
-    //std.debug.print("creating node\n", .{});
     if (debug_node_tree)
         std.debug.print("Creating Node for {x} with role {?t} at {s}:{d}\n", .{ wd.id, wd.options.role, wd.src.file, wd.src.line });
 
@@ -342,7 +341,6 @@ pub fn pushUpdates(self: *AccessKit) void {
     if (builtin.os.tag == .linux)
         c.accesskit_unix_adapter_update_window_focus_state(self.adapter.?, true);
 
-    //std.debug.print("push updates = {t}\n", .{self.status});
     if (self.status != .on) {
         return;
     }
@@ -369,7 +367,6 @@ pub fn pushUpdates(self: *AccessKit) void {
             c.accesskit_macos_queued_events_raise(events);
         }
     } else if (builtin.os.tag == .linux) {
-        //std.debug.print("updating if active\n", .{});
         c.accesskit_unix_adapter_update_if_active(self.adapter.?, frameTreeUpdate, self);
     }
 
@@ -406,7 +403,6 @@ pub fn deinit(self: *AccessKit) void {
 /// Called once per frame (if accessibility is initialized)
 /// Note: This callback is only during the dynamic extent of pushUpdates on the same thread. TODO: verify this.
 pub fn frameTreeUpdate(instance: ?*anyopaque) callconv(.c) ?*TreeUpdate {
-    //std.debug.print("frame tree update\n", .{});
     var self: *AccessKit = @ptrCast(@alignCast(instance));
     const window: *dvui.Window = @alignCast(@fieldParentPtr("accesskit", self));
 
@@ -425,7 +421,6 @@ pub fn frameTreeUpdate(instance: ?*anyopaque) callconv(.c) ?*TreeUpdate {
 /// The initial tree only contains basic window details. These are updated when frameTreeUpdate runs.
 /// Note: This callback can occur on a non-gui thread.
 pub fn initialTreeUpdate(instance: ?*anyopaque) callconv(.c) ?*TreeUpdate {
-    //std.debug.print("init tree update\n", .{});
     var self: *AccessKit = @ptrCast(@alignCast(instance));
     self.mutex.lock();
     defer self.mutex.unlock();

--- a/src/AccessKit.zig
+++ b/src/AccessKit.zig
@@ -82,7 +82,6 @@ pub fn initialize(self: *AccessKit) void {
         //ak.accesskit_macos_add_focus_forwarder_to_window_class("SDLWindow");
         self.adapter = c.accesskit_macos_subclassing_adapter_for_window(macOSWinPtr(window), initialTreeUpdate, self, doAction, self) orelse @panic("null");
     } else if (builtin.os.tag == .linux) {
-        std.debug.print("setting adapter\n", .{});
         self.adapter = c.accesskit_unix_adapter_new(initialTreeUpdate, self, doAction, self, deactivateAccessibility, self) orelse @panic("null");
     } else {
         @panic("Accesskit initialization failed: no supported adapter found");
@@ -175,7 +174,7 @@ pub fn nodeCreateReal(self: *AccessKit, wd: *dvui.WidgetData, role: Role) ?*Node
         .on => {},
     }
 
-std.debug.print("creating node\n", .{});
+    //std.debug.print("creating node\n", .{});
     if (debug_node_tree)
         std.debug.print("Creating Node for {x} with role {?t} at {s}:{d}\n", .{ wd.id, wd.options.role, wd.src.file, wd.src.line });
 
@@ -343,7 +342,7 @@ pub fn pushUpdates(self: *AccessKit) void {
     if (builtin.os.tag == .linux)
         c.accesskit_unix_adapter_update_window_focus_state(self.adapter.?, true);
 
-    std.debug.print("push updates = {t}\n", .{self.status});
+    //std.debug.print("push updates = {t}\n", .{self.status});
     if (self.status != .on) {
         return;
     }
@@ -370,7 +369,7 @@ pub fn pushUpdates(self: *AccessKit) void {
             c.accesskit_macos_queued_events_raise(events);
         }
     } else if (builtin.os.tag == .linux) {
-        std.debug.print("updating if active\n", .{});
+        //std.debug.print("updating if active\n", .{});
         c.accesskit_unix_adapter_update_if_active(self.adapter.?, frameTreeUpdate, self);
     }
 
@@ -407,7 +406,7 @@ pub fn deinit(self: *AccessKit) void {
 /// Called once per frame (if accessibility is initialized)
 /// Note: This callback is only during the dynamic extent of pushUpdates on the same thread. TODO: verify this.
 pub fn frameTreeUpdate(instance: ?*anyopaque) callconv(.c) ?*TreeUpdate {
-    std.debug.print("frame tree update\n", .{});
+    //std.debug.print("frame tree update\n", .{});
     var self: *AccessKit = @ptrCast(@alignCast(instance));
     const window: *dvui.Window = @alignCast(@fieldParentPtr("accesskit", self));
 
@@ -426,7 +425,7 @@ pub fn frameTreeUpdate(instance: ?*anyopaque) callconv(.c) ?*TreeUpdate {
 /// The initial tree only contains basic window details. These are updated when frameTreeUpdate runs.
 /// Note: This callback can occur on a non-gui thread.
 pub fn initialTreeUpdate(instance: ?*anyopaque) callconv(.c) ?*TreeUpdate {
-    std.debug.print("init tree update\n", .{});
+    //std.debug.print("init tree update\n", .{});
     var self: *AccessKit = @ptrCast(@alignCast(instance));
     self.mutex.lock();
     defer self.mutex.unlock();

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1150,6 +1150,56 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
 
             return try win.addEventTouchMotion(.touch0, event.tfinger.x, event.tfinger.y, event.tfinger.dx, event.tfinger.dy);
         },
+        if (sdl3) c.SDL_EVENT_WINDOW_FOCUS_GAINED else c.SDL_WINDOWEVENT_FOCUS_GAINED => {
+            if (self.log_events) {
+                log.debug("event FOCUS_GAINED\n", .{});
+            }
+            if (builtin.os.tag == .linux) {
+                dvui.AccessKit.c.accesskit_unix_adapter_update_window_focus_state(win.accesskit.adapter, true);
+            } else if (builtin.os.tag == .macos) {
+                const events = dvui.AccessKit.c.accesskit_macos_subclassing_adapter_update_view_focus_state(win.accesskit.adapter, true);
+                if (events) |evts| {
+                    dvui.AccessKit.c.accesskit_macos_queued_events_raise(evts);
+                }
+            }
+            return false;
+        },
+        if (sdl3) c.SDL_EVENT_WINDOW_FOCUS_LOST else c.SDL_WINDOWEVENT_FOCUS_LOST => {
+            if (self.log_events) {
+                log.debug("event FOCUS_LOST\n", .{});
+            }
+            if (builtin.os.tag == .linux) {
+                dvui.AccessKit.c.accesskit_unix_adapter_update_window_focus_state(win.accesskit.adapter, false);
+            } else if (builtin.os.tag == .macos) {
+                const events = dvui.AccessKit.c.accesskit_macos_subclassing_adapter_update_view_focus_state(win.accesskit.adapter, false);
+                if (events) |evts| {
+                    dvui.AccessKit.c.accesskit_macos_queued_events_raise(evts);
+                }
+            }
+            return false;
+        },
+        if (sdl3) c.SDL_EVENT_WINDOW_SHOWN else c.SDL_WINDOWEVENT_SHOWN => {
+            if (self.log_events) {
+                log.debug("event WINDOW_SHOWN\n", .{});
+            }
+            if (builtin.os.tag == .linux) {
+                var x: i32 = undefined;
+                var y: i32 = undefined;
+                _ = c.SDL_GetWindowPosition(win.backend.impl.window, &x, &y);
+                var w: i32 = undefined;
+                var h: i32 = undefined;
+                _ = c.SDL_GetWindowSize(win.backend.impl.window, &w, &h);
+                var top: i32 = undefined;
+                var bot: i32 = undefined;
+                var left: i32 = undefined;
+                var right: i32 = undefined;
+                _ = c.SDL_GetWindowBordersSize(win.backend.impl.window, &top, &left, &bot, &right);
+                const outer_bounds: dvui.AccessKit.Rect = .{ .x0 = @floatFromInt(x - left), .y0 = @floatFromInt(y - top), .x1 = @floatFromInt(x + w + right), .y1 = @floatFromInt(y + h + bot) };
+                const inner_bounds: dvui.AccessKit.Rect = .{ .x0 = @floatFromInt(x), .y0 = @floatFromInt(y), .x1 = @floatFromInt(x + w), .y1 = @floatFromInt(y + h) };
+                dvui.AccessKit.c.accesskit_unix_adapter_set_root_window_bounds(win.accesskit.adapter.?, outer_bounds, inner_bounds);
+            }
+            return false;
+        },
         else => {
             if (self.log_events) {
                 log.debug("unhandled SDL event type {any}\n", .{event.type});

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1156,7 +1156,7 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
             }
             if (dvui.accesskit_enabled and builtin.os.tag == .linux) {
                 dvui.AccessKit.c.accesskit_unix_adapter_update_window_focus_state(win.accesskit.adapter, true);
-            } else if (builtin.os.tag == .macos) {
+            } else if (dvui.accesskit_enabled and builtin.os.tag == .macos) {
                 const events = dvui.AccessKit.c.accesskit_macos_subclassing_adapter_update_view_focus_state(win.accesskit.adapter, true);
                 if (events) |evts| {
                     dvui.AccessKit.c.accesskit_macos_queued_events_raise(evts);

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1154,7 +1154,7 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
             if (self.log_events) {
                 log.debug("event FOCUS_GAINED\n", .{});
             }
-            if (builtin.os.tag == .linux) {
+            if (dvui.accesskit_enabled and builtin.os.tag == .linux) {
                 dvui.AccessKit.c.accesskit_unix_adapter_update_window_focus_state(win.accesskit.adapter, true);
             } else if (builtin.os.tag == .macos) {
                 const events = dvui.AccessKit.c.accesskit_macos_subclassing_adapter_update_view_focus_state(win.accesskit.adapter, true);
@@ -1168,9 +1168,9 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
             if (self.log_events) {
                 log.debug("event FOCUS_LOST\n", .{});
             }
-            if (builtin.os.tag == .linux) {
+            if (dvui.accesskit_enabled and builtin.os.tag == .linux) {
                 dvui.AccessKit.c.accesskit_unix_adapter_update_window_focus_state(win.accesskit.adapter, false);
-            } else if (builtin.os.tag == .macos) {
+            } else if (dvui.accesskit_enabled and builtin.os.tag == .macos) {
                 const events = dvui.AccessKit.c.accesskit_macos_subclassing_adapter_update_view_focus_state(win.accesskit.adapter, false);
                 if (events) |evts| {
                     dvui.AccessKit.c.accesskit_macos_queued_events_raise(evts);
@@ -1182,17 +1182,12 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
             if (self.log_events) {
                 log.debug("event WINDOW_SHOWN\n", .{});
             }
-            if (builtin.os.tag == .linux) {
-                var x: i32 = undefined;
-                var y: i32 = undefined;
+            if (dvui.accesskit_enabled and builtin.os.tag == .linux) {
+                var x: i32, var y: i32 = .{ undefined, undefined };
                 _ = c.SDL_GetWindowPosition(win.backend.impl.window, &x, &y);
-                var w: i32 = undefined;
-                var h: i32 = undefined;
+                var w: i32, var h: i32 = .{ undefined, undefined };
                 _ = c.SDL_GetWindowSize(win.backend.impl.window, &w, &h);
-                var top: i32 = undefined;
-                var bot: i32 = undefined;
-                var left: i32 = undefined;
-                var right: i32 = undefined;
+                var top: i32, var bot: i32, var left: i32, var right: i32 = .{ undefined, undefined, undefined, undefined };
                 _ = c.SDL_GetWindowBordersSize(win.backend.impl.window, &top, &left, &bot, &right);
                 const outer_bounds: dvui.AccessKit.Rect = .{ .x0 = @floatFromInt(x - left), .y0 = @floatFromInt(y - top), .x1 = @floatFromInt(x + w + right), .y1 = @floatFromInt(y + h + bot) };
                 const inner_bounds: dvui.AccessKit.Rect = .{ .x0 = @floatFromInt(x), .y0 = @floatFromInt(y), .x1 = @floatFromInt(x + w), .y1 = @floatFromInt(y + h) };

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -3808,14 +3808,7 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
                 e.handle(@src(), b.data());
                 focusWidget(b.data().id, null, e.num);
             }
-
-            if (e.evt == .text) {
-                e.handle(@src(), b.data());
-                text_mode = false;
-                te.textSet(e.evt.text.txt, false);
-                new_val = std.fmt.parseFloat(f32, te_buf[0..te.len]) catch null;
-            }
-
+            
             if (!e.handled) {
                 te.processEvent(e);
             }
@@ -3832,6 +3825,9 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
 
         if (!text_mode) {
             refresh(null, @src(), b.data().id);
+
+            if (init_opts.min) |min| new_val = @max(min, new_val.?);
+            if (init_opts.max) |max| new_val = @min(max, new_val.?);
 
             if (new_val) |nv| {
                 init_opts.value.* = nv;

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -3808,7 +3808,7 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
                 e.handle(@src(), b.data());
                 focusWidget(b.data().id, null, e.num);
             }
-            
+
             if (!e.handled) {
                 te.processEvent(e);
             }
@@ -3826,11 +3826,11 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
         if (!text_mode) {
             refresh(null, @src(), b.data().id);
 
-            if (init_opts.min) |min| new_val = @max(min, new_val.?);
-            if (init_opts.max) |max| new_val = @min(max, new_val.?);
+            if (new_val) |*nv| {
+                if (init_opts.min) |min| nv.* = @max(min, nv.*);
+                if (init_opts.max) |max| nv.* = @min(max, nv.*);
 
-            if (new_val) |nv| {
-                init_opts.value.* = nv;
+                init_opts.value.* = nv.*;
                 ret = true;
             }
         }


### PR DESCRIPTION
Currently working for -Daccesskit=shared on x86_64 linux. 

The static library has unresolved symbol issues. I think because the static library is compiled against libc++ instead of libc. All of the unresolved symbols appear to be related to c++ exception unwinding. Example at end of message. I'll look into this further, to see if we can change the build options.

@DataTriny I'm having an issue in that the initial tree update is always being called, even on a fresh login session, where I've not previously run orca. Which means we're creating accesskit nodes all the time. I don't think it is anything I am doing that would cause this? 

@david-vanderson I wasn't sure whether to move all of the logic for handing the SDL focus and window shown events into AccessKit.zig instead? I initially split it so the SDL logic is in sdl.zig and created some wrappers for the accesskit functions in AccessKit.zig, but that means passing all of the 8 co-ordinate parameters for SDL_EVENT_WINDOW_SHOWN to a function which just passes them directly on to an access kit function. So, I think it all needs to live either in sdl.zig or AccessKit.zig and since it is mostly sdl logic, I left it in sdl.zig. 

```
error: undefined symbol: _Unwind_Resume
    note: referenced by /home/phatc/.cache/zig/p/N-V-__8AAJ37FAuEZXG593uEuYETrkoxDz78QLL32k0GkaYG/lib/linux/x86_64/static/libaccesskit.a(accesskit.accesskit.ed425a1bcbc715c-cgu.0.rcgu.o/):.text._ZN50_$LT$T$u20$as$u20$core..convert..Into$LT$U$GT$$GT$4into17h38dbd7b2c029bd76E
    note: referenced by /home/phatc/.cache/zig/p/N-V-__8AAJ37FAuEZXG593uEuYETrkoxDz78QLL32k0GkaYG/lib/linux/x86_64/static/libaccesskit.a(accesskit.accesskit.ed425a1bcbc715c-cgu.0.rcgu.o/):.text._ZN8blocking7unblock28_$u7b$$u7b$closure$u7d$$u7d$17h06c4e8c728c32277E
    note: referenced by /home/phatc/.cache/zig/p/N-V-__8AAJ37FAuEZXG593uEuYETrkoxDz78QLL32k0GkaYG/lib/linux/x86_64/static/libaccesskit.a(accesskit.accesskit.ed425a1bcbc715c-cgu.0.rcgu.o/):.text._ZN4zbus10connection7builder7Builder6build_28_$u7b$$u7b$closure$u7d$$u7d$17h352ae292f637f83eE
    note: referenced by /home/phatc/.cache/zig/p/N-V-__8AAJ37FAuEZXG593uEuYETrkoxDz78QLL32k0GkaYG/lib/linux/x86_64/static/libaccesskit.a(accesskit.accesskit.ed425a1bcbc715c-cgu.0.rcgu.o/):.text._ZN42_$LT$$RF$T$u20$as$u20$core..fmt..Debug$GT$3fmt17h19b85d05745acdf4E
    note: referenced 114 more times
```

