### PR TITLE
focusGroup: initial implementation

### DIFF
--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -445,8 +445,9 @@ pub fn optionsEditor(self: *Options, wd: *const dvui.WidgetData) bool {
 
     const active_tab = dvui.dataGetPtrDefault(null, vbox.data().id, "Tab", OptionsEditorTab, .layout);
     {
-        var overlay = dvui.overlay(@src(), .{ .expand = .horizontal });
-        defer overlay.deinit();
+        var tabs = dvui.TabsWidget.init(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });
+        tabs.install();
+        defer tabs.deinit();
 
         var button_wd: dvui.WidgetData = undefined;
         if (dvui.buttonIcon(@src(), "Copy Options", dvui.entypo.copy, .{}, .{}, .{ .gravity_x = 1, .data_out = &button_wd })) {
@@ -456,10 +457,6 @@ pub fn optionsEditor(self: *Options, wd: *const dvui.WidgetData) bool {
             .active_rect = button_wd.borderRectScale().r,
             .position = .vertical,
         }, "Copy Options struct to clipboard", .{}, .{});
-
-        var tabs = dvui.TabsWidget.init(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });
-        tabs.install();
-        defer tabs.deinit();
 
         if (tabs.addTabLabel(active_tab.* == .layout, "Layout")) {
             active_tab.* = .layout;

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -371,8 +371,7 @@ pub fn grids() void {
     var tbox = dvui.box(@src(), .{}, .{ .border = Rect.all(1), .expand = .both });
     defer tbox.deinit();
     {
-        var tabs = dvui.TabsWidget.init(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });
-        tabs.install();
+        var tabs = dvui.tabs(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });
         defer tabs.deinit();
         for (0..GridType.num_grids) |tab_num| {
             const this_tab: GridType = @enumFromInt(tab_num);

--- a/src/Examples/basic_widgets.zig
+++ b/src/Examples/basic_widgets.zig
@@ -110,8 +110,8 @@ pub fn basicWidgets() void {
     }
 
     {
-        var vbox = dvui.box(@src(), .{}, .{ .role = .radio_group, .label = .{ .text = "Radio buttons" } });
-        defer vbox.deinit();
+        var group = dvui.radioGroup(@src(), .{ .label = .{ .text = "Radio buttons" } });
+        defer group.deinit();
 
         inline for (@typeInfo(RadioChoice).@"enum".fields, 0..) |field, i| {
             if (dvui.radio(@src(), radio_choice == @as(RadioChoice, @enumFromInt(field.value)), "Radio " ++ field.name, .{ .id_extra = i })) {

--- a/src/Examples/basic_widgets.zig
+++ b/src/Examples/basic_widgets.zig
@@ -110,7 +110,7 @@ pub fn basicWidgets() void {
     }
 
     {
-        var group = dvui.radioGroup(@src(), .{ .label = .{ .text = "Radio buttons" } });
+        var group = dvui.radioGroup(@src(), .{}, .{ .label = .{ .text = "Radio buttons" } });
         defer group.deinit();
 
         inline for (@typeInfo(RadioChoice).@"enum".fields, 0..) |field, i| {

--- a/src/Examples/icon_browser.zig
+++ b/src/Examples/icon_browser.zig
@@ -54,7 +54,7 @@ pub fn iconBrowser(src: std.builtin.SourceLocation, show_flag: *bool, comptime i
     var scroll = dvui.scrollArea(@src(), .{ .scroll_info = &scroll_info }, .{ .expand = .both });
     defer scroll.deinit();
 
-    var group = dvui.focusGroup(@src(), .{ .wrap = false }, .{ .label = .{ .text = "Icons" } });
+    var group = dvui.focusGroup(@src(), .{}, .{ .label = .{ .text = "Icons" } });
     defer group.deinit();
 
     const visibleRect = scroll.si.viewport;

--- a/src/Examples/icon_browser.zig
+++ b/src/Examples/icon_browser.zig
@@ -54,6 +54,9 @@ pub fn iconBrowser(src: std.builtin.SourceLocation, show_flag: *bool, comptime i
     var scroll = dvui.scrollArea(@src(), .{ .scroll_info = &scroll_info }, .{ .expand = .both });
     defer scroll.deinit();
 
+    var group = dvui.focusGroup(@src(), .{ .wrap = false }, .{ .label = .{ .text = "Icons" } });
+    defer group.deinit();
+
     const visibleRect = scroll.si.viewport;
     var cursor: f32 = 0;
     settings.num_rows = 0;
@@ -64,7 +67,7 @@ pub fn iconBrowser(src: std.builtin.SourceLocation, show_flag: *bool, comptime i
         }
         settings.num_rows += 1;
 
-        if (cursor <= (visibleRect.y + visibleRect.h) and (cursor + settings.row_height) >= visibleRect.y) {
+        if (cursor <= (visibleRect.y + visibleRect.h + 100) and (cursor + settings.row_height + 100) >= visibleRect.y) {
             const r = Rect{ .x = 0, .y = cursor, .w = 0, .h = settings.row_height };
             var iconbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .id_extra = i, .expand = .horizontal, .rect = r });
 
@@ -84,7 +87,7 @@ pub fn iconBrowser(src: std.builtin.SourceLocation, show_flag: *bool, comptime i
                 dvui.clipboardTextSet(text);
                 var buf2: [100]u8 = undefined;
                 const toast_text = std.fmt.bufPrint(&buf2, "Copied \"{s}\"", .{text}) catch "Copied <Too much text>";
-                dvui.toast(@src(), .{ .message = toast_text });
+                dvui.toast(@src(), .{ .message = toast_text, .timeout = 1_000_000 });
             }
             dvui.labelNoFmt(@src(), text, .{}, .{ .gravity_y = 0.5 });
 

--- a/src/Examples/layout.zig
+++ b/src/Examples/layout.zig
@@ -156,11 +156,13 @@ pub fn layout() void {
             var vbox = dvui.box(@src(), .{}, .{});
             defer vbox.deinit();
             dvui.label(@src(), "Expand", .{}, .{});
+            var group = dvui.radioGroup(@src(), .{}, .{ .label = .{ .label_widget = .prev } });
             inline for (std.meta.tags(dvui.Options.Expand)) |opt| {
                 if (dvui.radio(@src(), layout_expand == opt, @tagName(opt), .{ .id_extra = @intFromEnum(opt) })) {
                     layout_expand = opt;
                 }
             }
+            group.deinit();
 
             if (Static.img) {
                 dvui.label(@src(), "UVs", .{}, .{});
@@ -179,11 +181,13 @@ pub fn layout() void {
             var vbox = dvui.box(@src(), .{}, .{});
             defer vbox.deinit();
             dvui.label(@src(), "Shrink", .{}, .{});
+            var group = dvui.radioGroup(@src(), .{}, .{ .label = .{ .label_widget = .prev } });
             inline for (std.meta.tags(dvui.Options.Expand)) |opt| {
                 if (dvui.radio(@src(), Static.shrinkE == opt, @tagName(opt), .{ .id_extra = @intFromEnum(opt) })) {
                     Static.shrinkE = opt;
                 }
             }
+            group.deinit();
         }
     }
 

--- a/src/Examples/menus.zig
+++ b/src/Examples/menus.zig
@@ -152,8 +152,7 @@ pub fn menus() void {
         defer tbox.deinit();
 
         {
-            var tabs = dvui.TabsWidget.init(@src(), .{ .dir = layout_dir.* }, .{ .expand = if (layout_dir.* == .horizontal) .horizontal else .vertical });
-            tabs.install();
+            var tabs = dvui.tabs(@src(), .{ .dir = layout_dir.* }, .{ .expand = if (layout_dir.* == .horizontal) .horizontal else .vertical });
             defer tabs.deinit();
 
             inline for (0..8) |i| {

--- a/src/Examples/menus.zig
+++ b/src/Examples/menus.zig
@@ -140,6 +140,8 @@ pub fn menus() void {
         const active_tab = dvui.dataGetPtrDefault(null, hbox.data().id, "active_tab", usize, 0);
         {
             defer hbox.deinit();
+            var group = dvui.radioGroup(@src(), .{}, .{ .label = .{ .text = "Layout" } });
+            defer group.deinit();
             const entries = [_][]const u8{ "Horizontal", "Vertical" };
             for (0..2) |i| {
                 if (dvui.radio(@src(), @intFromEnum(layout_dir.*) == i, entries[i], .{ .id_extra = i })) {
@@ -334,6 +336,8 @@ pub fn focus() void {
         }
         hbox.drawBackground();
 
+        var group = dvui.radioGroup(@src(), .{}, .{ .label = .{ .text = "Radio buttons" } });
+        defer group.deinit();
         inline for (@typeInfo(RadioChoice).@"enum".fields, 0..) |field, i| {
             if (dvui.radio(@src(), radio_choice == @as(RadioChoice, @enumFromInt(field.value)), "Radio " ++ field.name, .{ .id_extra = i })) {
                 radio_choice = @enumFromInt(field.value);

--- a/src/Examples/plots.zig
+++ b/src/Examples/plots.zig
@@ -26,10 +26,10 @@ pub fn plots() void {
     {
         var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
         defer hbox.deinit();
-        if (dvui.button(@src(), "Save png", .{}, .{ .gravity_x = 1.0 })) {
+        if (dvui.button(@src(), "Save png", .{}, .{})) {
             save = .png;
         }
-        if (dvui.button(@src(), "Save jpg", .{}, .{ .gravity_x = 1.0 })) {
+        if (dvui.button(@src(), "Save jpg", .{}, .{})) {
             save = .jpg;
         }
     }

--- a/src/Examples/reorder_tree.zig
+++ b/src/Examples/reorder_tree.zig
@@ -65,6 +65,9 @@ pub fn reorderLists() void {
             var hbox2 = dvui.box(@src(), .{ .dir = .horizontal }, .{});
             defer hbox2.deinit();
 
+            var group = dvui.radioGroup(@src(), .{}, .{ .label = .{ .text = "Layout" } });
+            defer group.deinit();
+
             const entries = [_][]const u8{ "Vertical", "Horizontal", "Flex" };
             for (0..3) |i| {
                 if (dvui.radio(@src(), @intFromEnum(layo.*) == i, entries[i], .{ .id_extra = i })) {

--- a/src/Examples/theming.zig
+++ b/src/Examples/theming.zig
@@ -252,9 +252,8 @@ fn styles(theme: *Theme) bool {
     const hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });
     defer hbox.deinit();
     {
-        var tabs = dvui.TabsWidget.init(@src(), .{ .dir = .vertical }, .{ .expand = .vertical });
-        tabs.install();
-        defer tabs.deinit();
+        const vbox = dvui.box(@src(), .{}, .{});
+        defer vbox.deinit();
 
         {
             const theme_styles = comptime std.meta.tags(Theme.Style.Name);
@@ -277,6 +276,10 @@ fn styles(theme: *Theme) bool {
                 }
             }
         }
+
+        var tabs = dvui.TabsWidget.init(@src(), .{ .dir = .vertical }, .{ .expand = .both });
+        tabs.install();
+        defer tabs.deinit();
 
         style = switch (active_style.*) {
             .content => blk: {

--- a/src/Subwindows.zig
+++ b/src/Subwindows.zig
@@ -24,6 +24,7 @@ pub const Subwindow = struct {
     modal: bool = false,
     stay_above_parent_window: ?Id = null,
     mouse_events: bool = true,
+    focus_group: ?*dvui.FocusGroupWidget = null,
 };
 
 pub fn add(self: *Subwindows, gpa: std.mem.Allocator, id: Id, rect: Rect, rect_pixels: Rect.Physical, modal: bool, stay_above_parent_window: ?Id, mouse_events: bool) !void {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2829,27 +2829,29 @@ pub fn tooltip(src: std.builtin.SourceLocation, init_opts: FloatingTooltipWidget
     tt.deinit();
 }
 
-/// Turns off normal tab navigation.  Use for things like a radio button group,
-/// where tab should go to the group as a whole, but within the group focus
-/// moves via key up/down.
+/// Turns off normal tab navigation.  Use for things where tab should go to the
+/// group as a whole, but within the group focus moves via key up/down.
+///
+/// See `radioGroup`.
 ///
 /// Widgets inside the group are ordered by their Options.tab_index.
 ///
 /// FocusGroupWidget does no layout.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn focusGroup(src: std.builtin.SourceLocation, opts: Options) *FocusGroupWidget {
+pub fn focusGroup(src: std.builtin.SourceLocation, init_opts: FocusGroupWidget.InitOptions, opts: Options) *FocusGroupWidget {
+    const defaults: Options = .{ .role = .group };
     var ret = widgetAlloc(FocusGroupWidget);
-    ret.* = FocusGroupWidget.init(src, opts);
+    ret.* = FocusGroupWidget.init(src, init_opts, defaults.override(opts));
     ret.data().was_allocated_on_widget_stack = true;
     ret.install();
     return ret;
 }
 
 /// `focusGroup` where the default role is "radio_group".
-pub fn radioGroup(src: std.builtin.SourceLocation, opts: Options) *FocusGroupWidget {
+pub fn radioGroup(src: std.builtin.SourceLocation, init_opts: FocusGroupWidget.InitOptions, opts: Options) *FocusGroupWidget {
     const defaults: Options = .{ .role = .radio_group };
-    return focusGroup(src, defaults.override(opts));
+    return focusGroup(src, init_opts, defaults.override(opts));
 }
 
 /// Shim to make widget ids unique.

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2846,6 +2846,12 @@ pub fn focusGroup(src: std.builtin.SourceLocation, opts: Options) *FocusGroupWid
     return ret;
 }
 
+/// `focusGroup` where the default role is "radio_group".
+pub fn radioGroup(src: std.builtin.SourceLocation, opts: Options) *FocusGroupWidget {
+    const defaults: Options = .{ .role = .radio_group };
+    return focusGroup(src, defaults.override(opts));
+}
+
 /// Shim to make widget ids unique.
 ///
 /// Useful when you wrap some widgets into a function, but that function does

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1927,12 +1927,12 @@ pub fn tabIndexNext(event_num: ?u16) void {
     tabIndexNextEx(event_num, currentWindow().tab_index_prev.items);
 }
 
-pub fn tabIndexNextEx(event_num: ?u16, tabs: []dvui.TabIndex) void {
+pub fn tabIndexNextEx(event_num: ?u16, tabidxs: []dvui.TabIndex) void {
     const cw = currentWindow();
     const widgetId = focusedWidgetId();
     var oldtab: ?u16 = null;
     if (widgetId != null) {
-        for (tabs) |ti| {
+        for (tabidxs) |ti| {
             if (ti.windowId == cw.subwindows.focused_id and ti.widgetId == widgetId.?) {
                 oldtab = ti.tabIndex;
                 break;
@@ -1946,7 +1946,7 @@ pub fn tabIndexNextEx(event_num: ?u16, tabs: []dvui.TabIndex) void {
     var newId: ?Id = null;
     var foundFocus = false;
 
-    for (tabs) |ti| {
+    for (tabidxs) |ti| {
         if (ti.windowId == cw.subwindows.focused_id) {
             if (ti.widgetId == widgetId) {
                 foundFocus = true;
@@ -1961,7 +1961,7 @@ pub fn tabIndexNextEx(event_num: ?u16, tabs: []dvui.TabIndex) void {
                 newId = ti.widgetId;
                 break;
             } else if (oldtab == null or ti.tabIndex > oldtab.?) {
-                // tabs is ordered by insertion, not tab index, so have to
+                // tabidxs is ordered by insertion, not tab index, so have to
                 // search all of them to find the lowest that is above oldtab
                 if (newId == null or ti.tabIndex < newtab) {
                     newtab = ti.tabIndex;
@@ -1984,13 +1984,13 @@ pub fn tabIndexPrev(event_num: ?u16) void {
     tabIndexPrevEx(event_num, currentWindow().tab_index_prev.items);
 }
 
-pub fn tabIndexPrevEx(event_num: ?u16, tabs: []dvui.TabIndex) void {
+pub fn tabIndexPrevEx(event_num: ?u16, tabidxs: []dvui.TabIndex) void {
     const cw = currentWindow();
     const widgetId = focusedWidgetId();
     var oldtab: ?u16 = null;
     var oldshadow: bool = false;
     if (widgetId != null) {
-        for (tabs) |ti| {
+        for (tabidxs) |ti| {
             if (ti.windowId == cw.subwindows.focused_id and ti.widgetId == widgetId.?) {
                 oldtab = ti.tabIndex;
                 oldshadow = ti.shadow;
@@ -2005,7 +2005,7 @@ pub fn tabIndexPrevEx(event_num: ?u16, tabs: []dvui.TabIndex) void {
     var newId: ?Id = null;
     var foundFocus = false;
 
-    for (tabs) |ti| {
+    for (tabidxs) |ti| {
         if (ti.windowId == cw.subwindows.focused_id) {
             if (ti.widgetId == widgetId) {
                 foundFocus = true;
@@ -2016,7 +2016,7 @@ pub fn tabIndexPrevEx(event_num: ?u16, tabs: []dvui.TabIndex) void {
                     break;
                 }
             } else if (!ti.shadow) {
-                // tabs is ordered by insertion, not tab index, so have to
+                // tabidxs is ordered by insertion, not tab index, so have to
                 // search all of them to find the highest that is below oldtab
                 if (oldtab == null or ti.tabIndex < oldtab.? or (!foundFocus and ti.tabIndex == oldtab.?)) {
                     if (ti.tabIndex >= newtab) {
@@ -2034,7 +2034,7 @@ pub fn tabIndexPrevEx(event_num: ?u16, tabs: []dvui.TabIndex) void {
         // If we shift-tabbed from inside a focusGroup, we will always focus
         // the focusGroup itself, so do this again to focus the widget before
         // the focusGroup.
-        tabIndexPrevEx(event_num, tabs);
+        tabIndexPrevEx(event_num, tabidxs);
     }
 }
 
@@ -3241,6 +3241,14 @@ pub fn scale(src: std.builtin.SourceLocation, init_opts: ScaleWidget.InitOptions
     ret.data().was_allocated_on_widget_stack = true;
     ret.install();
     ret.processEvents();
+    return ret;
+}
+
+pub fn tabs(src: std.builtin.SourceLocation, init_opts: TabsWidget.InitOptions, opts: Options) *TabsWidget {
+    var ret = widgetAlloc(TabsWidget);
+    ret.* = TabsWidget.init(src, init_opts, opts);
+    ret.init_options.was_allocated_on_widget_stack = true;
+    ret.install();
     return ret;
 }
 

--- a/src/import_widgets.zig
+++ b/src/import_widgets.zig
@@ -18,6 +18,7 @@ pub const FloatingMenuWidget = @import("widgets/FloatingMenuWidget.zig");
 pub const FloatingTooltipWidget = @import("widgets/FloatingTooltipWidget.zig");
 pub const FloatingWidget = @import("widgets/FloatingWidget.zig");
 pub const FloatingWindowWidget = @import("widgets/FloatingWindowWidget.zig");
+pub const FocusGroupWidget = @import("widgets/FocusGroupWidget.zig");
 pub const IconWidget = @import("widgets/IconWidget.zig");
 pub const LabelWidget = @import("widgets/LabelWidget.zig");
 pub const MenuItemWidget = @import("widgets/MenuItemWidget.zig");

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -268,12 +268,6 @@ pub fn deinit(self: *FloatingMenuWidget) void {
         }
     }
 
-    // if no widget in this popup has focus, make the menu have focus to handle keyboard events
-    // - this only happens if no menu items are there, the first grabs focus if nothing has focus
-    if (dvui.focusedWidgetIdInCurrentSubwindow() == null) {
-        dvui.focusWidget(self.menu.data().id, null, null);
-    }
-
     if (!self.have_popup_child and !self.chainFocused(true)) {
         // if a popup chain is open and the user focuses a different window
         // (not the parent of the popups), then we want to close the popups

--- a/src/widgets/FocusGroupWidget.zig
+++ b/src/widgets/FocusGroupWidget.zig
@@ -1,0 +1,138 @@
+/// This is a widget that forwards all parent calls to its parent.  Useful
+/// where you want to wrap widgets but only to adjust their IDs.
+const std = @import("std");
+const dvui = @import("../dvui.zig");
+
+const Event = dvui.Event;
+const Options = dvui.Options;
+const Rect = dvui.Rect;
+const RectScale = dvui.RectScale;
+const Size = dvui.Size;
+const Widget = dvui.Widget;
+const WidgetData = dvui.WidgetData;
+
+const FocusGroupWidget = @This();
+
+wd: WidgetData,
+child_rect_union: ?Rect = null,
+
+last_focus: dvui.Id,
+tab_index_prev: []dvui.TabIndex,
+tab_index: std.ArrayListUnmanaged(dvui.TabIndex) = .empty,
+
+pub fn init(src: std.builtin.SourceLocation, opts: Options) FocusGroupWidget {
+    const id = dvui.parentGet().extendId(src, opts.idExtra());
+    const rect = dvui.dataGet(null, id, "_rect", Rect);
+    const defaults = Options{ .name = "Focus Group", .rect = rect orelse .{} };
+    return FocusGroupWidget{
+        .wd = WidgetData.init(src, .{}, defaults.override(opts)),
+        .last_focus = dvui.lastFocusedIdInFrame(),
+        .tab_index_prev = dvui.dataGetSlice(null, id, "_tab_prev", []dvui.TabIndex) orelse &.{},
+    };
+}
+
+pub fn install(self: *FocusGroupWidget) void {
+    dvui.parentSet(self.widget());
+    self.data().register();
+
+    // put ourselves in the tab index so the whole focus group can be focused by tab
+    dvui.tabIndexSet(self.data().id, self.data().options.tab_index);
+
+    if (self.data().id == dvui.focusedWidgetId()) {
+        // if we got focused, focus our first internal widget
+        // TODO: remember which internal widget was focused
+        dvui.tabIndexNextEx(null, self.tab_index_prev);
+    }
+
+    // only register ourselves if there is no focus group already registered
+    const cw = dvui.currentWindow();
+    if (cw.subwindows.get(dvui.subwindowCurrentId())) |sw| {
+        if (sw.focus_group == null) {
+            sw.focus_group = self;
+            //std.debug.print("subwindow {x} focus group {x}\n", .{ sw.id.asU64(), self.data().id.asU64() });
+        }
+    }
+}
+
+pub fn widget(self: *FocusGroupWidget) Widget {
+    return Widget.init(self, data, rectFor, screenRectScale, minSizeForChild);
+}
+
+pub fn data(self: *FocusGroupWidget) *WidgetData {
+    return self.wd.validate();
+}
+
+pub fn rectFor(self: *FocusGroupWidget, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+    const ret = self.data().parent.rectFor(id, min_size, e, g);
+    if (self.child_rect_union) |u| {
+        self.child_rect_union = u.unionWith(ret);
+    } else {
+        self.child_rect_union = ret;
+    }
+    return ret;
+}
+
+pub fn screenRectScale(self: *FocusGroupWidget, rect: Rect) RectScale {
+    return self.data().parent.screenRectScale(rect);
+}
+
+pub fn minSizeForChild(self: *FocusGroupWidget, s: Size) void {
+    self.data().parent.minSizeForChild(s);
+}
+
+pub fn deinit(self: *FocusGroupWidget) void {
+    const should_free = self.data().was_allocated_on_widget_stack;
+    defer if (should_free) dvui.widgetFree(self);
+    defer self.* = undefined;
+
+    const cw = dvui.currentWindow();
+
+    // only deregister ourselves if we were the one registered
+    // also do unhandled arrow events
+    if (cw.subwindows.get(dvui.subwindowCurrentId())) |sw| {
+        if (sw.focus_group == self) {
+            sw.focus_group = null;
+            //std.debug.print("subwindow {x} focus group null\n", .{sw.id.asU64()});
+
+            const focus_id = dvui.lastFocusedIdInFrameSince(self.last_focus);
+            const evts = dvui.events();
+            for (evts) |*e| {
+                if (!dvui.eventMatch(e, .{ .id = self.data().id, .focus_id = focus_id, .r = self.data().borderRectScale().r }))
+                    continue;
+
+                switch (e.evt) {
+                    .key => |ke| {
+                        if (ke.action == .down and (ke.code == .up or ke.code == .left)) {
+                            e.handle(@src(), self.data());
+                            dvui.tabIndexPrevEx(e.num, self.tab_index_prev);
+                            if (dvui.focusedWidgetId() == null) {
+                                // wrap around
+                                dvui.tabIndexPrevEx(e.num, self.tab_index_prev);
+                            }
+                        } else if (ke.action == .down and (ke.code == .down or ke.code == .right)) {
+                            e.handle(@src(), self.data());
+                            dvui.tabIndexNextEx(e.num, self.tab_index_prev);
+                            if (dvui.focusedWidgetId() == null) {
+                                // wrap around
+                                dvui.tabIndexNextEx(e.num, self.tab_index_prev);
+                            }
+                        }
+                    },
+                    else => {},
+                }
+            }
+        }
+    }
+
+    dvui.dataSetSlice(null, self.data().id, "_tab_prev", self.tab_index.items);
+    self.tab_index.deinit(cw.arena());
+
+    if (self.child_rect_union) |u| {
+        dvui.dataSet(null, self.data().id, "_rect", u);
+    }
+    dvui.parentReset(self.data().id, self.data().parent);
+}
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/FocusGroupWidget.zig
+++ b/src/widgets/FocusGroupWidget.zig
@@ -26,7 +26,7 @@ tab_index: std.ArrayListUnmanaged(dvui.TabIndex) = .empty,
 pub const InitOptions = struct {
     /// If true wrap focus around the first/last.  If false, focus stops at
     /// first/last.
-    wrap: bool = true,
+    wrap: bool = false,
 };
 
 pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) FocusGroupWidget {

--- a/src/widgets/FocusGroupWidget.zig
+++ b/src/widgets/FocusGroupWidget.zig
@@ -35,19 +35,20 @@ pub fn install(self: *FocusGroupWidget) void {
     dvui.parentSet(self.widget());
     self.data().register();
 
-    // put ourselves in the tab index so the whole focus group can be focused by tab
-    dvui.tabIndexSet(self.data().id, self.data().options.tab_index);
-
-    if (self.data().id == dvui.focusedWidgetId()) {
-        // if we got focused, focus our first internal widget
-        // TODO: remember which internal widget was focused
-        dvui.tabIndexNextEx(null, self.tab_index_prev);
-    }
-
     // only register ourselves if there is no focus group already registered
     const cw = dvui.currentWindow();
     if (cw.subwindows.get(dvui.subwindowCurrentId())) |sw| {
         if (sw.focus_group == null) {
+
+            // put ourselves in the tab index so the whole focus group can be focused by tab
+            dvui.tabIndexSet(self.data().id, self.data().options.tab_index);
+
+            if (self.data().id == dvui.focusedWidgetId()) {
+                // if we got focused, focus our first internal widget
+                // TODO: remember which internal widget was focused
+                dvui.tabIndexNextEx(null, self.tab_index_prev);
+            }
+
             sw.focus_group = self;
             //std.debug.print("subwindow {x} focus group {x}\n", .{ sw.id.asU64(), self.data().id.asU64() });
         }

--- a/src/widgets/FocusGroupWidget.zig
+++ b/src/widgets/FocusGroupWidget.zig
@@ -103,14 +103,14 @@ pub fn deinit(self: *FocusGroupWidget) void {
 
                 switch (e.evt) {
                     .key => |ke| {
-                        if (ke.action == .down and (ke.code == .up or ke.code == .left)) {
+                        if ((ke.action == .down or ke.action == .repeat) and (ke.code == .up or ke.code == .left)) {
                             e.handle(@src(), self.data());
                             dvui.tabIndexPrevEx(e.num, self.tab_index_prev);
                             if (dvui.focusedWidgetId() == null) {
                                 // wrap around
                                 dvui.tabIndexPrevEx(e.num, self.tab_index_prev);
                             }
-                        } else if (ke.action == .down and (ke.code == .down or ke.code == .right)) {
+                        } else if ((ke.action == .down or ke.action == .repeat) and (ke.code == .down or ke.code == .right)) {
                             e.handle(@src(), self.data());
                             dvui.tabIndexNextEx(e.num, self.tab_index_prev);
                             if (dvui.focusedWidgetId() == null) {

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -670,7 +670,7 @@ fn bodyScrollContainerCreate(self: *GridWidget) void {
         self.bscroll.?.processEvents();
         self.bscroll.?.processVelocity();
 
-        self.group = dvui.FocusGroupWidget.init(@src(), .{ .wrap = false }, .{});
+        self.group = dvui.FocusGroupWidget.init(@src(), .{}, .{});
         self.group.install();
     }
 }

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -173,6 +173,7 @@ pub const default_col_width: f32 = 100;
 //Widgets
 vbox: BoxWidget,
 /// SAFETY: Set in `install`
+group: dvui.FocusGroupWidget = undefined,
 scroll: ScrollAreaWidget = undefined, // main scroll area
 hscroll: ?ScrollAreaWidget = null, // header scroll area
 bscroll: ?ScrollContainerWidget = null, // body scroll container
@@ -358,6 +359,7 @@ pub fn deinit(self: *GridWidget) void {
     _ = dvui.spacer(@src(), .{ .min_size_content = this_size, .background = false });
 
     if (self.bscroll) |*bscroll| {
+        self.group.deinit();
         bscroll.deinit();
     }
     self.scroll.deinit();
@@ -667,6 +669,9 @@ fn bodyScrollContainerCreate(self: *GridWidget) void {
         self.bscroll.?.install();
         self.bscroll.?.processEvents();
         self.bscroll.?.processVelocity();
+
+        self.group = dvui.FocusGroupWidget.init(@src(), .{});
+        self.group.install();
     }
 }
 

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -670,7 +670,7 @@ fn bodyScrollContainerCreate(self: *GridWidget) void {
         self.bscroll.?.processEvents();
         self.bscroll.?.processVelocity();
 
-        self.group = dvui.FocusGroupWidget.init(@src(), .{});
+        self.group = dvui.FocusGroupWidget.init(@src(), .{ .wrap = false }, .{});
         self.group.install();
     }
 }

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -51,10 +51,6 @@ pub fn install(self: *MenuItemWidget) void {
 
     dvui.tabIndexSet(self.data().id, self.data().options.tab_index);
 
-    if (!menu().?.mouse_mode and menu().?.parentMenu != null and dvui.focusedWidgetIdInCurrentSubwindow() == null) {
-        dvui.focusWidget(self.data().id, null, null);
-    }
-
     self.data().borderAndBackground(.{});
 
     dvui.parentSet(self.widget());

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -138,7 +138,7 @@ pub fn install(self: *MenuWidget) void {
         self.processEvent(e);
     }
 
-    self.group = dvui.FocusGroupWidget.init(@src(), .{});
+    self.group = dvui.FocusGroupWidget.init(@src(), .{}, .{});
     self.group.install();
 
     // a floating menu could have been opened by mouse, but then a key is

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -73,6 +73,8 @@ parentMenu: ?*MenuWidget = null,
 last_focus: dvui.Id,
 last_focus_in_subwindow: dvui.Id,
 /// SAFETY: Set in `install`
+group: dvui.FocusGroupWidget = undefined,
+/// SAFETY: Set in `install`
 box: BoxWidget = undefined,
 
 // whether submenus should be open
@@ -135,6 +137,9 @@ pub fn install(self: *MenuWidget) void {
 
         self.processEvent(e);
     }
+
+    self.group = dvui.FocusGroupWidget.init(@src(), .{});
+    self.group.install();
 
     self.box = BoxWidget.init(@src(), .{ .dir = self.init_opts.dir }, self.data().options.strip().override(.{ .expand = .both }));
     self.box.install();
@@ -240,53 +245,30 @@ pub fn processEventsAfter(self: *MenuWidget) void {
                             e.handle(@src(), self.data());
                             self.close();
                         },
-                        .up => {
-                            if (self.init_opts.dir == .vertical) {
+                        .up, .down => {
+                            if (self.init_opts.dir == .horizontal) {
                                 e.handle(@src(), self.data());
-                                dvui.tabIndexPrev(e.num);
-                                if (dvui.focusedWidgetId() == null) {
-                                    // We stepped past the last item, cycle around
-                                    dvui.tabIndexPrev(e.num);
-                                }
                             }
-                        },
-                        .down => {
-                            if (self.init_opts.dir == .vertical) {
-                                e.handle(@src(), self.data());
-                                dvui.tabIndexNext(e.num);
-                                if (dvui.focusedWidgetId() == null) {
-                                    // We stepped past the last item, cycle around
-                                    dvui.tabIndexNext(e.num);
-                                }
-                            }
+                            // otherwise let focus group handle it
                         },
                         .left => {
                             if (self.init_opts.dir == .vertical) {
                                 e.handle(@src(), self.data());
                                 if (self.parentMenu) |pm| {
+                                    e.handle(@src(), self.data());
                                     pm.submenus_activated = false;
                                     if (self.init_opts.parentSubwindowId) |sid| {
                                         dvui.focusSubwindow(sid, null);
                                     }
                                 }
-                            } else {
-                                e.handle(@src(), self.data());
-                                dvui.tabIndexPrev(e.num);
-                                if (dvui.focusedWidgetId() == null) {
-                                    // We stepped past the last item, cycle around
-                                    dvui.tabIndexPrev(e.num);
-                                }
                             }
+                            // otherwise let focus group handle it
                         },
                         .right => {
-                            if (self.init_opts.dir == .horizontal) {
+                            if (self.init_opts.dir == .vertical) {
                                 e.handle(@src(), self.data());
-                                dvui.tabIndexNext(e.num);
-                                if (dvui.focusedWidgetId() == null) {
-                                    // We stepped past the last item, cycle around
-                                    dvui.tabIndexNext(e.num);
-                                }
                             }
+                            // otherwise let focus group handle it
                         },
                         else => {},
                     }
@@ -304,6 +286,7 @@ pub fn deinit(self: *MenuWidget) void {
     defer if (should_free) dvui.widgetFree(self);
     defer self.* = undefined;
     self.box.deinit();
+    self.group.deinit();
     dvui.dataSet(null, self.data().id, "_mouse_mode", self.mouse_mode);
     dvui.dataSet(null, self.data().id, "_sub_act", self.submenus_activated);
     dvui.dataSet(null, self.data().id, "_has_focused_child", self.last_focus_in_subwindow != dvui.lastFocusedIdInSubwindow());

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -141,6 +141,12 @@ pub fn install(self: *MenuWidget) void {
     self.group = dvui.FocusGroupWidget.init(@src(), .{});
     self.group.install();
 
+    // a floating menu could have been opened by mouse, but then a key is
+    // pressed, so focus the group which will focus the first thing in the menu
+    if (!self.mouse_mode and self.floating() and dvui.focusedWidgetIdInCurrentSubwindow() == null) {
+        dvui.focusWidget(self.group.data().id, null, null);
+    }
+
     self.box = BoxWidget.init(@src(), .{ .dir = self.init_opts.dir }, self.data().options.strip().override(.{ .expand = .both }));
     self.box.install();
     self.box.drawBackground();

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -35,7 +35,7 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 pub fn install(self: *TabsWidget) void {
     self.scroll.install();
 
-    self.group = dvui.FocusGroupWidget.init(@src(), .{});
+    self.group = dvui.FocusGroupWidget.init(@src(), .{}, .{});
     self.group.install();
 
     const margin: Rect = switch (self.init_options.dir) {

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -3,6 +3,8 @@ pub const TabsWidget = @This();
 init_options: InitOptions,
 scroll: ScrollAreaWidget,
 /// SAFETY: Set in `install`
+group: dvui.FocusGroupWidget = undefined,
+/// SAFETY: Set in `install`
 box: BoxWidget = undefined,
 tab_index: usize = 0,
 /// SAFETY: Set in `addTab`
@@ -33,11 +35,14 @@ pub fn init(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Optio
 pub fn install(self: *TabsWidget) void {
     self.scroll.install();
 
+    self.group = dvui.FocusGroupWidget.init(@src(), .{});
+    self.group.install();
+
     const margin: Rect = switch (self.init_options.dir) {
         .horizontal => .{ .y = 2 },
         .vertical => .{ .x = 2 },
     };
-    self.box = BoxWidget.init(@src(), .{ .dir = self.init_options.dir }, .{ .margin = margin });
+    self.box = BoxWidget.init(@src(), .{ .dir = self.init_options.dir }, .{ .margin = margin, .expand = .both });
     self.box.install();
 
     var r = self.scroll.data().contentRectScale().r;
@@ -161,6 +166,7 @@ pub fn deinit(self: *TabsWidget) void {
     defer if (should_free) dvui.widgetFree(self);
     defer self.* = undefined;
     self.box.deinit();
+    self.group.deinit();
     self.scroll.deinit();
 }
 

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -51,7 +51,7 @@ pub fn install(self: *TreeWidget) void {
 
     dvui.parentSet(self.widget());
 
-    self.group = dvui.FocusGroupWidget.init(@src(), .{ .wrap = false }, .{});
+    self.group = dvui.FocusGroupWidget.init(@src(), .{}, .{});
     self.group.install();
 
     if (self.group.data().accesskit_node()) |ak_node| {

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -51,7 +51,7 @@ pub fn install(self: *TreeWidget) void {
 
     dvui.parentSet(self.widget());
 
-    self.group = dvui.FocusGroupWidget.init(@src(), .{});
+    self.group = dvui.FocusGroupWidget.init(@src(), .{ .wrap = false }, .{});
     self.group.install();
 
     if (self.group.data().accesskit_node()) |ak_node| {

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -18,6 +18,8 @@ drag_point: ?dvui.Point.Physical = null,
 drag_ending: bool = false,
 branch_size: Size = .{},
 init_options: InitOptions = undefined,
+/// SAFETY: Set in `install`
+group: dvui.FocusGroupWidget = undefined,
 
 pub const InitOptions = struct {
     enable_reordering: bool = true,
@@ -49,7 +51,10 @@ pub fn install(self: *TreeWidget) void {
 
     dvui.parentSet(self.widget());
 
-    if (self.data().accesskit_node()) |ak_node| {
+    self.group = dvui.FocusGroupWidget.init(@src(), .{});
+    self.group.install();
+
+    if (self.group.data().accesskit_node()) |ak_node| {
         AccessKit.nodeAddAction(ak_node, AccessKit.Action.focus);
         AccessKit.nodeAddAction(ak_node, AccessKit.Action.click);
     }
@@ -139,6 +144,8 @@ pub fn deinit(self: *TreeWidget) void {
     const should_free = self.data().was_allocated_on_widget_stack;
     defer if (should_free) dvui.widgetFree(self);
     defer self.* = undefined;
+
+    self.group.deinit();
 
     if (self.drag_ending) {
         self.id_branch = null;

--- a/src/widgets/VirtualParentWidget.zig
+++ b/src/widgets/VirtualParentWidget.zig
@@ -19,7 +19,7 @@ child_rect_union: ?Rect = null,
 pub fn init(src: std.builtin.SourceLocation, opts: Options) VirtualParentWidget {
     const id = dvui.parentGet().extendId(src, opts.idExtra());
     const rect = dvui.dataGet(null, id, "_rect", Rect);
-    const defaults = Options{ .name = "Virtual Parent", .rect = rect orelse .{} };
+    const defaults = Options{ .name = "Virtual Parent", .rect = rect orelse .{}, .expand = .both };
     return VirtualParentWidget{ .wd = WidgetData.init(src, .{}, defaults.override(opts)) };
 }
 


### PR DESCRIPTION
Fixes #618 

So far I've only gotten to a point where I can make a radio group successfully.

Still needs:
- [x] work to ensure we are doing the right thing via AccessKit
- [x] testing (make sure nesting focusGroups works)
- [x] separate utility functions like `radioGroup` that call `focusGroup` with the correct role
- [x] add this to tabs somehow (also we don't have a high-level function for TabsWidget?)
- [x] can we use this for menus?  tree?  grid?
- [x] I think focusGroup should remember which internal widget had focus if you tab away and back?  Need to confirm that this is how other UI/apps work.
- [x] look through demo for places this should be