### PR TITLE
Quitting Events

### DIFF
--- a/examples/app.zig
+++ b/examples/app.zig
@@ -150,25 +150,27 @@ pub fn frame() !dvui.App.Result {
         }
     }
 
-    _ = dvui.checkbox(@src(), &warn_on_quit, "Warn on Quit", .{});
+    if (dvui.backend.kind != .web) {
+        _ = dvui.checkbox(@src(), &warn_on_quit, "Warn on Quit", .{});
 
-    if (warn_on_quit) {
-        if (warn_on_quit_closing) return .close;
+        if (warn_on_quit) {
+            if (warn_on_quit_closing) return .close;
 
-        const wd = dvui.currentWindow().data();
-        for (dvui.events()) |*e| {
-            if (!dvui.eventMatchSimple(e, wd)) continue;
+            const wd = dvui.currentWindow().data();
+            for (dvui.events()) |*e| {
+                if (!dvui.eventMatchSimple(e, wd)) continue;
 
-            if ((e.evt == .window and e.evt.window.action == .close) or (e.evt == .app and e.evt.app.action == .quit)) {
-                e.handle(@src(), wd);
+                if ((e.evt == .window and e.evt.window.action == .close) or (e.evt == .app and e.evt.app.action == .quit)) {
+                    e.handle(@src(), wd);
 
-                const warnAfter: dvui.DialogCallAfterFn = struct {
-                    fn warnAfter(_: dvui.Id, response: dvui.enums.DialogResponse) !void {
-                        if (response == .ok) warn_on_quit_closing = true;
-                    }
-                }.warnAfter;
+                    const warnAfter: dvui.DialogCallAfterFn = struct {
+                        fn warnAfter(_: dvui.Id, response: dvui.enums.DialogResponse) !void {
+                            if (response == .ok) warn_on_quit_closing = true;
+                        }
+                    }.warnAfter;
 
-                dvui.dialog(@src(), .{}, .{ .message = "Really Quit?", .cancel_label = "Cancel", .callafterFn = warnAfter });
+                    dvui.dialog(@src(), .{}, .{ .message = "Really Quit?", .cancel_label = "Cancel", .callafterFn = warnAfter });
+                }
             }
         }
     }

--- a/examples/raylib-ontop.zig
+++ b/examples/raylib-ontop.zig
@@ -48,7 +48,7 @@ pub fn main() !void {
         try win.begin(std.time.nanoTimestamp());
 
         // send all Raylib events to dvui for processing
-        _ = try backend.addAllEvents(&win);
+        try backend.addAllEvents(&win);
 
         if (backend.shouldBlockRaylibInput()) {
             // NOTE: I am using raygui here because it has a simple lock-unlock system

--- a/examples/raylib-standalone.zig
+++ b/examples/raylib-standalone.zig
@@ -65,8 +65,7 @@ pub fn main() !void {
         try win.begin(nstime);
 
         // send all events to dvui for processing
-        const quit = try backend.addAllEvents(&win);
-        if (quit) break :main_loop;
+        try backend.addAllEvents(&win);
 
         // if dvui widgets might not cover the whole window, then need to clear
         // the previous frame's render
@@ -211,6 +210,13 @@ fn dvui_frame() bool {
 
     // look at demo() for examples of dvui widgets, shows in a floating window
     dvui.Examples.demo();
+
+    // check for quitting
+    for (dvui.events()) |*e| {
+        // assume we only have a single window
+        if (e.evt == .window and e.evt.window.action == .close) return false;
+        if (e.evt == .app and e.evt.app.action == .quit) return false;
+    }
 
     return true;
 }

--- a/examples/sdl-standalone.zig
+++ b/examples/sdl-standalone.zig
@@ -70,8 +70,7 @@ pub fn main() !void {
         try win.begin(nstime);
 
         // send all SDL events to dvui for processing
-        const quit = try backend.addAllEvents(&win);
-        if (quit) break :main_loop;
+        try backend.addAllEvents(&win);
 
         // if dvui widgets might not cover the whole window, then need to clear
         // the previous frame's render
@@ -250,6 +249,13 @@ fn gui_frame() bool {
 
     // look at demo() for examples of dvui widgets, shows in a floating window
     dvui.Examples.demo();
+
+    // check for quitting
+    for (dvui.events()) |*e| {
+        // assume we only have a single window
+        if (e.evt == .window and e.evt.window.action == .close) return false;
+        if (e.evt == .app and e.evt.app.action == .quit) return false;
+    }
 
     return true;
 }

--- a/src/Event.zig
+++ b/src/Event.zig
@@ -9,6 +9,8 @@ pub const EventTypes = union(enum) {
     mouse: Mouse,
     key: Key,
     text: Text,
+    window: Window,
+    app: App,
 };
 
 /// Should not be set directly, use the `handle` method
@@ -30,6 +32,8 @@ pub fn format(self: *const Event, writer: *std.Io.Writer) !void {
         .mouse => |me| try writer.print("{s}}}", .{@tagName(me.action)}),
         .key => |ke| try writer.print("{s}}}", .{@tagName(ke.action)}),
         .text => try writer.print("}}", .{}),
+        .window => |w| try writer.print("{s}}}", .{@tagName(w.action)}),
+        .app => |a| try writer.print("{s}}}", .{@tagName(a.action)}),
     }
 }
 
@@ -128,6 +132,26 @@ pub const Mouse = struct {
 
     p: dvui.Point.Physical,
     floating_win: dvui.Id,
+};
+
+pub const Window = struct {
+    pub const Action = enum {
+        /// User clicked close (or did something) so the window manager is
+        /// telling this window to close.
+        close,
+    };
+
+    action: Action,
+};
+
+pub const App = struct {
+    pub const Action = enum {
+        /// App as a whole is requested to quit.  Usually this is just behind
+        /// the Window close event for the last remaining OS window.
+        quit,
+    };
+
+    action: Action,
 };
 
 test {

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -449,6 +449,7 @@ pub fn focusEvents(self: *Self, event_num: u16, windowId: ?Id, widgetId: ?Id) vo
                     e.target_widgetId = widgetId;
                 },
                 .mouse => {},
+                .window, .app => {},
             }
         }
     }
@@ -465,6 +466,7 @@ pub fn captureEvents(self: *Self, event_num: u16, widgetId: ?Id) void {
                         e.target_widgetId = widgetId;
                     }
                 },
+                .window, .app => {},
             }
         }
     }
@@ -776,6 +778,42 @@ pub fn addEventTouchMotion(self: *Self, finger: dvui.enums.Button, xnorm: f32, y
     const ret = (self.data().id != winId);
     try self.positionMouseEventAdd();
     return ret;
+}
+
+/// Add an event for a OS Window-level action (close, resize, etc.)
+///
+/// This can be called outside begin/end.  You should add all the events
+/// for a frame either before begin() or just after begin() and before
+/// calling normal dvui widgets.  end() clears the event list.
+pub fn addEventWindow(self: *Self, evt: Event.Window) std.mem.Allocator.Error!void {
+    self.positionMouseEventRemove();
+
+    self.event_num += 1;
+    try self.events.append(self.arena(), Event{
+        .num = self.event_num,
+        .target_windowId = self.data().id,
+        .evt = .{ .window = evt },
+    });
+
+    try self.positionMouseEventAdd();
+}
+
+/// Add an event for an Application-level action (quit, going to background, etc.)
+///
+/// This can be called outside begin/end.  You should add all the events
+/// for a frame either before begin() or just after begin() and before
+/// calling normal dvui widgets.  end() clears the event list.
+pub fn addEventApp(self: *Self, evt: Event.App) std.mem.Allocator.Error!void {
+    self.positionMouseEventRemove();
+
+    self.event_num += 1;
+    try self.events.append(self.arena(), Event{
+        .num = self.event_num,
+        .target_windowId = self.data().id,
+        .evt = .{ .app = evt },
+    });
+
+    try self.positionMouseEventAdd();
 }
 
 pub fn FPS(self: *const Self) f32 {

--- a/src/backends/raylib.zig
+++ b/src/backends/raylib.zig
@@ -502,8 +502,12 @@ pub fn cursorShow(_: *RaylibBackend, value: ?bool) bool {
 //TODO implement this function
 pub fn refresh(_: *RaylibBackend) void {}
 
-pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !bool {
+pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !void {
     var disable_raylib_input: bool = false;
+
+    if (!dvui.wasm and c.WindowShouldClose()) {
+        try win.addEventApp(.{ .action = .quit });
+    }
 
     const shift = c.IsKeyDown(c.KEY_LEFT_SHIFT) or c.IsKeyDown(c.KEY_RIGHT_SHIFT);
     const capslock = c.IsKeyDown(c.KEY_CAPS_LOCK);
@@ -658,8 +662,6 @@ pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !bool {
     //}
 
     self.dvui_consumed_events = disable_raylib_input;
-
-    return c.WindowShouldClose();
 }
 
 const RaylibMouseButtons = .{
@@ -997,14 +999,21 @@ pub fn main() !void {
         try win.begin(nstime);
 
         // send all events to dvui for processing
-        const quit = try b.addAllEvents(&win);
-        if (quit) break :main_loop;
+        try b.addAllEvents(&win);
 
         // if dvui widgets might not cover the whole window, then need to clear
         // the previous frame's render
         b.clear();
 
-        const res = try app.frameFn();
+        var res = try app.frameFn();
+
+        // check for unhandled quit/close
+        for (dvui.events()) |*e| {
+            if (e.handled) continue;
+            // assuming we only have a single window
+            if (e.evt == .window and e.evt.window.action == .close) res = .close;
+            if (e.evt == .app and e.evt.app.action == .quit) res = .close;
+        }
 
         // marks end of dvui frame, don't call dvui functions after this
         // - sends all dvui stuff to backend for rendering, must be called before renderPresent()

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1531,6 +1531,17 @@ pub fn eventMatch(e: *Event, opts: EventMatchOptions) bool {
     }
 
     switch (e.evt) {
+        .app => {}, // app events always match
+        .window => {
+            if (e.target_windowId) |wid| {
+                if (wid != opts.id) {
+                    if (builtin.mode == .Debug and opts.debug) {
+                        log.debug("eventMatch {f} not to this window", .{e});
+                    }
+                    return false;
+                }
+            }
+        },
         .key, .text => {
             if (e.target_windowId) |wid| {
                 // focusable event
@@ -3771,6 +3782,7 @@ pub fn slider(src: std.builtin.SourceLocation, init_opts: SliderInitOptions, opt
                 const value: f32 = std.fmt.parseFloat(f32, te.txt) catch break :blk;
                 init_opts.fraction.* = std.math.clamp(value, 0.0, 1.0);
             },
+            else => {},
         }
     }
 
@@ -4132,6 +4144,7 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
                     if (init_opts.max) |max| value = @min(max, value);
                     init_opts.value.* = value;
                 },
+                else => {},
             }
         }
 

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -290,6 +290,7 @@ pub fn hueSlider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hue
                     hue.* = new_hue;
                 }
             },
+            else => {},
         }
     }
 

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -913,6 +913,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event) void {
                 dvui.focusWidget(self.data().id, null, e.num);
             }
         },
+        else => {},
     }
 
     if (!e.handled) {


### PR DESCRIPTION
Fixes #599

This allows an application to intercept the normal close request.  Typical use is to show a dialog if the user has unsaved work.

* Introduces 2 new event types:
  * `Window` for events related to the OS window (only close for now, but in the future resize, focus, minimize, etc.)
    * These have `Event.target_windowId` set to the id of the dvui.Window they are for (only dx11 backend currently does multiple OS windows)
    * Will match via `eventMatch()` if the window Id is provided
  * `App` for events related to the application as a whole (only quit for now, but in the future maybe "going to background")
    * These always match via `eventMatch()`
 
For `dvui.App` users, the backend main loop will quit if it sees these unhandled events.  The example app has a "Warn on Quit" checkbox that shows a possible use.

The *-standalone examples have been updated to check for unhandled events.

Todo:
- [x] dx11 backend