### PR TITLE
Plot: fix plots with constant data and add manually specified tick locations

### DIFF
--- a/src/Examples/plots.zig
+++ b/src/Examples/plots.zig
@@ -146,9 +146,34 @@ pub fn plots() void {
     }
 
     {
+        const freqs = [_]f64{ 1, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8 };
+
         const S = struct {
             var resistance: f64 = 159;
             var capacitance: f64 = 1e-6;
+
+            var xaxis: dvui.PlotWidget.Axis = .{
+                .name = "Frequency",
+                .scale = .{ .log = .{} },
+                .ticks = .{
+                    .locations = .{
+                        .custom = &freqs,
+                    },
+                    .format = .{
+                        .custom = formatFrequency,
+                    },
+                },
+            };
+
+            var yaxis: dvui.PlotWidget.Axis = .{
+                .name = "Amplitude (dB)",
+                .max = 10,
+                .ticks = .{
+                    .locations = .{
+                        .auto = .{ .num_ticks = 6 },
+                    },
+                },
+            };
         };
 
         dvui.label(@src(), "Resistance (Ohm)", .{}, .{});
@@ -172,35 +197,10 @@ pub fn plots() void {
         var vbox = dvui.box(@src(), .{}, .{ .min_size_content = .{ .w = 300, .h = 100 }, .expand = .ratio });
         defer vbox.deinit();
 
-        const Static = struct {
-            var xaxis: dvui.PlotWidget.Axis = .{
-                .name = "Frequency",
-                .scale = .{ .log = .{} },
-                .ticks = .{
-                    .locations = .{
-                        .auto = .{ .num_ticks = 9 },
-                    },
-                    .format = .{
-                        .custom = formatFrequency,
-                    },
-                },
-            };
-
-            var yaxis: dvui.PlotWidget.Axis = .{
-                .name = "Amplitude (dB)",
-                .max = 10,
-                .ticks = .{
-                    .locations = .{
-                        .auto = .{ .num_ticks = 6 },
-                    },
-                },
-            };
-        };
-
         var plot = dvui.plot(@src(), .{
             .title = "RC low-pass filter",
-            .x_axis = &Static.xaxis,
-            .y_axis = &Static.yaxis,
+            .x_axis = &S.xaxis,
+            .y_axis = &S.yaxis,
             .border_thick = 2.0,
             .mouse_hover = true,
         }, .{ .expand = .both });

--- a/src/widgets/PlotWidget.zig
+++ b/src/widgets/PlotWidget.zig
@@ -51,11 +51,12 @@ pub const Axis = struct {
     } = .linear,
 
     ticks: struct {
-        locations: union(enum) {
+        locations: union(TickLocatorType) {
             none,
             auto: struct {
                 num_ticks: usize,
             },
+            custom: []const f64,
         } = .{ .auto = .{ .num_ticks = 3 } },
 
         lines: enum {
@@ -71,7 +72,27 @@ pub const Axis = struct {
     // only relevant if `ticks` != none
     draw_gridlines: bool = true,
 
-    const TickFormating = union(enum) {
+    pub const TickLocatorType = enum {
+        none,
+        auto,
+        custom,
+    };
+
+    pub const Ticks = struct {
+        locator_type: TickLocatorType,
+        values: []const f64,
+
+        fn deinit(self: *Ticks, gpa: std.mem.Allocator) void {
+            switch (self.locator_type) {
+                .auto => {
+                    gpa.free(self.values);
+                },
+                else => {},
+            }
+        }
+    };
+
+    pub const TickFormating = union(enum) {
         normal: struct {
             precision: usize = 2,
         },
@@ -181,14 +202,26 @@ pub const Axis = struct {
         return ticks;
     }
 
-    pub fn getTicks(self: *Axis, gpa: std.mem.Allocator) ![]f64 {
+    pub fn getTicks(self: *Axis, gpa: std.mem.Allocator) !Ticks {
         switch (self.ticks.locations) {
-            .none => return &.{},
+            .none => return Ticks{
+                .locator_type = .none,
+                .values = &.{},
+            },
             .auto => |auto_ticks| {
-                switch (self.scale) {
-                    .linear => return self.getTicksLinear(gpa, auto_ticks.num_ticks),
-                    .log => return self.getTicksLog(gpa, auto_ticks.num_ticks),
-                }
+                const values = try switch (self.scale) {
+                    .linear => self.getTicksLinear(gpa, auto_ticks.num_ticks),
+                    .log => self.getTicksLog(gpa, auto_ticks.num_ticks),
+                };
+
+                return Ticks{
+                    .locator_type = .auto,
+                    .values = values,
+                };
+            },
+            .custom => |ticks| return Ticks{
+                .locator_type = .custom,
+                .values = ticks,
             },
         }
     }
@@ -289,17 +322,23 @@ pub fn install(self: *PlotWidget) void {
 
     const tick_font = (dvui.Options{ .font_style = .caption }).fontGet();
 
-    const yticks = self.y_axis.getTicks(dvui.currentWindow().lifo()) catch &.{};
-    defer dvui.currentWindow().lifo().free(yticks);
+    var yticks = self.y_axis.getTicks(dvui.currentWindow().lifo()) catch Axis.Ticks{
+        .locator_type = .none,
+        .values = &.{},
+    };
+    defer yticks.deinit(dvui.currentWindow().lifo());
 
-    const xticks = self.x_axis.getTicks(dvui.currentWindow().lifo()) catch &.{};
-    defer dvui.currentWindow().lifo().free(xticks);
+    var xticks = self.x_axis.getTicks(dvui.currentWindow().lifo()) catch Axis.Ticks{
+        .locator_type = .none,
+        .values = &.{},
+    };
+    defer xticks.deinit(dvui.currentWindow().lifo());
 
     const y_axis_tick_width: f32 = blk: {
         if (self.y_axis.name == null) break :blk 0;
         var max_width: f32 = 0;
 
-        for (yticks) |ytick| {
+        for (yticks.values) |ytick| {
             const tick_str = self.y_axis.formatTick(dvui.currentWindow().lifo(), ytick) catch "";
             defer dvui.currentWindow().lifo().free(tick_str);
             max_width = @max(max_width, tick_font.textSize(tick_str).w);
@@ -309,10 +348,10 @@ pub fn install(self: *PlotWidget) void {
     };
 
     const x_axis_last_tick_width: f32 = blk: {
-        if (xticks.len == 0) break :blk 0;
+        if (xticks.values.len == 0) break :blk 0;
         const str = self.x_axis.formatTick(
             dvui.currentWindow().lifo(),
-            xticks[xticks.len - 1],
+            xticks.values[xticks.values.len - 1],
         ) catch "";
         defer dvui.currentWindow().lifo().free(str);
 
@@ -418,7 +457,7 @@ pub fn install(self: *PlotWidget) void {
 
     // y axis ticks
     if (self.y_axis.name) |_| {
-        for (yticks) |ytick| {
+        for (yticks.values) |ytick| {
             const tick: Data = .{ .x = self.x_axis.min orelse 0, .y = ytick };
             const tick_str = self.y_axis.formatTick(dvui.currentWindow().lifo(), ytick) catch "";
             defer dvui.currentWindow().lifo().free(tick_str);
@@ -496,7 +535,7 @@ pub fn install(self: *PlotWidget) void {
 
     // x axis ticks
     if (self.x_axis.name) |_| {
-        for (xticks) |xtick| {
+        for (xticks.values) |xtick| {
             const tick: Data = .{ .x = xtick, .y = self.y_axis.min orelse 0 };
             const tick_str = self.x_axis.formatTick(dvui.currentWindow().lifo(), xtick) catch "";
             defer dvui.currentWindow().lifo().free(tick_str);


### PR DESCRIPTION
I recently noticed that when we provide constant data the max and min values for an Axis are equal. Meaning that when we try to divide by (max - min) we divide by 0. I fixed this by increasing the max by 1 and decreasing the min by 1 when they are equal in `PlotWidget.deinit()`. I tested this and it works but I think it's worth considering adding a relative error field in `PlotWidget.Axis`. Because if the user wants to plot data that is the result of some float arithmetic then it's unlikely the floats are going to be exactly equal when they "should be equal". There will likely be some very small round-off error. For example if the max is 5.00000012 and the min is 4.9999999 then the user likely doesnt want the bounds of the plot to be these values but rather wants to see a straight line at ~5 while the bounds are 4 and 6.

Also another problem I found is that when using logarithmic scales and providing incorrect values(x <= 0) the plot silently fails and no values/ticks are displayed(since there are no min and max values). I think in this case printing warning messages would be helpful since this is unlikely to be what the user wants. A warning would help them realize something is wrong on their end. But I was hesitant to add this because it would flood the user's terminal.

Also I added the ability to manually specify the tick locations. Which is one of the features from the list discussed in #622.
On this note I think it would be worth it to create an issue with a TODO list of planned features and slowly tick them off as they are implemented. It would also make design discussions easier.