### PR TITLE
TreeWidget: Allow animating folder closing

### DIFF
--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -435,12 +435,8 @@ pub const Branch = struct {
             }
         }
 
-        if (self.anim) |a| {
-            if (a.end()) {
-                if (self.expanded) {
-                    self.expanded = false;
-                }
-            }
+        if (self.anim.?.end()) {
+            self.expanded = false;
         }
 
         if (self.expanded) {

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -400,8 +400,9 @@ pub const Branch = struct {
     };
 
     pub fn expander(self: *Branch, src: std.builtin.SourceLocation, init_opts: ExpanderOptions, opts: Options) bool {
+        var clicked: bool = false;
         if (self.button.clicked()) {
-            self.expanded = !self.expanded;
+            clicked = true;
         }
 
         self.hbox.deinit();
@@ -412,17 +413,37 @@ pub const Branch = struct {
             .margin = .{ .x = init_opts.indent },
         };
 
-        if (self.expanded) {
-            self.anim = dvui.animate(
-                @src(),
-                .{
-                    .duration = self.init_options.animation_duration,
-                    .easing = self.init_options.animation_easing,
-                    .kind = if (self.init_options.animation_duration > 0) .vertical else .none,
-                },
-                default_opts.override(opts),
-            );
+        self.anim = dvui.animate(
+            @src(),
+            .{
+                .duration = self.init_options.animation_duration,
+                .easing = self.init_options.animation_easing,
+                .kind = if (self.init_options.animation_duration > 0) .vertical else .none,
+            },
+            default_opts.override(opts),
+        );
 
+        if (clicked) {
+            if (self.expanded) {
+                self.anim.?.init_opts.easing = dvui.easing.outQuad;
+                self.anim.?.init_opts.duration = @divTrunc(self.init_options.animation_duration, 2);
+                self.anim.?.startEnd();
+            } else {
+                self.anim.?.val = 0.0;
+                self.anim.?.start();
+                self.expanded = true;
+            }
+        }
+
+        if (self.anim) |a| {
+            if (a.end()) {
+                if (self.expanded) {
+                    self.expanded = false;
+                }
+            }
+        }
+
+        if (self.expanded) {
             // Always expand the inner box to fill the animation
             const expander_opts = dvui.Options{ .expand = .both };
 
@@ -491,9 +512,9 @@ pub const Branch = struct {
         if (self.can_expand) {
             if (self.expanded) {
                 self.expander_vbox.deinit();
-                if (self.anim) |a| {
-                    a.deinit();
-                }
+            }
+            if (self.anim) |a| {
+                a.deinit();
             }
 
             dvui.dataSet(null, self.data().id, "_expanded", self.expanded);


### PR DESCRIPTION
Hi!

https://github.com/user-attachments/assets/a0cadc36-962e-47cc-8982-4404d7277a9e

Hopefully the video shows the intent, that we can also use the `startEnd` animation to reverse the animation on close. 

I tested this briefly in my own program and in the demo, both with and without an animation duration and things seem to work. One minor thing to note is that the close animation will not use the passed in easing fn, because any animations with overshoot, will delay the actual close until the animation is complete, which looks funny. I instead opted to just animate the close linearly instead, and allow the open animation to have a fancy easing fn. 

Please let me know if you'd like me to make any changes!

Thanks as always