### PR TITLE
web: mitigate ldexp incompatability for release builds

### DIFF
--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -192,8 +192,18 @@ export fn dvui_c_pow(x: f64, y: f64) f64 {
     return @exp(@log(x) * y);
 }
 
-export fn dvui_c_ldexp(x: f64, n: c_int) f64 {
+fn dvui_c_ldexp(x: f64, n: c_int) callconv(.c) f64 {
     return x * @exp2(@as(f64, @floatFromInt(n)));
+}
+
+// See https://github.com/ziglang/zig/issues/23358
+comptime {
+    switch (builtin.mode) {
+        .Debug => {
+            @export(&dvui_c_ldexp, .{ .name = "dvui_c_ldexp" });
+        },
+        else => {},
+    }
 }
 
 export fn dvui_c_floor(x: f64) f64 {


### PR DESCRIPTION
This is just a suggestion/discussion starter and a branch I can target in my projects so I can build in release mode.

A way to reproduce this is to build the web-app target with rdynamic enabled:

```
diff --git a/build.zig b/build.zig
index 0abe05d0..15581b5d 100644
--- a/build.zig
+++ b/build.zig
@@ -950,6 +950,7 @@ fn addWebExample(
     };
     const web_test = b.addExecutable(exeOptions);
     web_test.entry = .disabled;
+    web_test.rdynamic = true;
     web_test.root_module.addImport("dvui", example_opts.dvui_mod);
     web_test.root_module.addImport(example_opts.backend_name, example_opts.backend_mod);
```

---

When building with rdynamic, as is needed when building for wasm and needing to export symbols, we currently fail with

    ... undefined symbol: ldexp

when building dvui web in release mode. Only exporting the ldexp function when building for debug mitigates this.

See https://github.com/ziglang/zig/issues/23358 for details and progress.