### PR TITLE
Make AccesskitOptions public

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -10,7 +10,7 @@ pub const LinuxDisplayBackend = enum {
     Both,
 };
 
-const AccesskitOptions = enum {
+pub const AccesskitOptions = enum {
     static,
     shared,
     off,


### PR DESCRIPTION
This allows apps that build off of DVUI to expose the same option to the users with out having to juggle enum definitions.