### PR TITLE
syntax highlighting

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -850,6 +850,27 @@ pub fn addDvuiModule(
         }
     }
 
+    const tree_sitter_dep = b.lazyDependency("tree_sitter", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    if (tree_sitter_dep) |tsd| {
+        dvui_mod.linkLibrary(tsd.artifact("tree-sitter"));
+    }
+
+    const tree_sitter_c_dep = b.lazyDependency("tree_sitter_c", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    if (tree_sitter_c_dep) |tsc| {
+        dvui_mod.addIncludePath(tsc.path("src"));
+        dvui_mod.addCSourceFiles(.{
+            .root = tsc.path(""),
+            .files = &.{"src/parser.c"},
+            .flags = &.{"-std=c11"},
+        });
+    }
+
     return dvui_mod;
 }
 

--- a/build.zig
+++ b/build.zig
@@ -858,11 +858,11 @@ pub fn addDvuiModule(
         dvui_mod.linkLibrary(tsd.artifact("tree-sitter"));
     }
 
-    const tree_sitter_c_dep = b.lazyDependency("tree_sitter_c", .{
+    const tree_sitter_zig_dep = b.lazyDependency("tree_sitter_zig", .{
         .target = target,
         .optimize = optimize,
     });
-    if (tree_sitter_c_dep) |tsc| {
+    if (tree_sitter_zig_dep) |tsc| {
         dvui_mod.addIncludePath(tsc.path("src"));
         dvui_mod.addCSourceFiles(.{
             .root = tsc.path(""),

--- a/build.zig
+++ b/build.zig
@@ -71,6 +71,7 @@ pub fn build(b: *std.Build) !void {
     const freetype_option = b.option(bool, "freetype", "Freetype (or stb_truetype if false) for font rendering (default is backend specific)");
     const tiny_file_dialogs_option = b.option(bool, "tiny-file-dialogs", "OS-native file dialogs (default is backend specific)");
     const stb_image_option = b.option(bool, "stb-image", "Build stb_image (default is backend specific, some include stb_image)");
+    const tree_sitter_option = b.option(bool, "tree-sitter", "Build tree sitter (default is backend specific)");
 
     // This option is triggered only if it involved with raylib backend of any kind
     var linux_display_backend: ?LinuxDisplayBackend = null;
@@ -138,6 +139,7 @@ pub fn build(b: *std.Build) !void {
         .tiny_file_dialogs = tiny_file_dialogs_option,
         .linux_display_backend = linux_display_backend,
         .stb_image = stb_image_option,
+        .tree_sitter = tree_sitter_option,
     };
 
     if (back_to_build) |backend| {
@@ -217,7 +219,7 @@ pub fn buildBackend(backend: enums_backend.Backend, test_dvui_and_app: bool, dvu
     const optimize = dvui_opts.optimize;
     switch (backend) {
         .custom => {
-            dvui_opts.setDefaults(.{ .libc = false, .freetype = false, .tiny_file_dialogs = false, .stb_image = false });
+            dvui_opts.setDefaults(.{ .libc = false, .freetype = false, .tiny_file_dialogs = false, .stb_image = false, .tree_sitter = true });
 
             // For export to users who are bringing their own backend.  Use in your build.zig:
             // const dvui_mod = dvui_dep.module("dvui");
@@ -242,7 +244,7 @@ pub fn buildBackend(backend: enums_backend.Backend, test_dvui_and_app: bool, dvu
             }
         },
         .testing => {
-            dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true });
+            dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true, .tree_sitter = true });
             const testing_mod = b.addModule("testing", .{
                 .root_source_file = b.path("src/backends/testing.zig"),
                 .target = target,
@@ -266,7 +268,7 @@ pub fn buildBackend(backend: enums_backend.Backend, test_dvui_and_app: bool, dvu
             addExample("testing-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
         },
         .sdl2 => {
-            dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true });
+            dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true, .tree_sitter = true });
             const sdl_mod = b.addModule("sdl2", .{
                 .root_source_file = b.path("src/backends/sdl.zig"),
                 .target = target,
@@ -351,7 +353,7 @@ pub fn buildBackend(backend: enums_backend.Backend, test_dvui_and_app: bool, dvu
             addExample("sdl2-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
         },
         .sdl3gpu => {
-            dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true });
+            dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true, .tree_sitter = true });
             const sdl_mod = b.addModule("sdl3", .{
                 .root_source_file = b.path("src/backends/sdl3gpu.zig"),
                 .target = target,
@@ -385,7 +387,7 @@ pub fn buildBackend(backend: enums_backend.Backend, test_dvui_and_app: bool, dvu
             addExample("sdl3gpu-ontop", b.path("examples/sdl3gpu-ontop.zig"), true, example_opts, dvui_opts);
         },
         .sdl3 => {
-            dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true });
+            dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true, .tree_sitter = true });
             const sdl_mod = b.addModule("sdl3", .{
                 .root_source_file = b.path("src/backends/sdl.zig"),
                 .target = target,
@@ -422,7 +424,7 @@ pub fn buildBackend(backend: enums_backend.Backend, test_dvui_and_app: bool, dvu
             addExample("sdl3-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
         },
         .raylib => {
-            dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = false });
+            dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = false, .tree_sitter = true });
 
             const raylib_backend_mod = b.addModule("raylib", .{
                 .root_source_file = b.path("src/backends/raylib-c.zig"),
@@ -487,7 +489,7 @@ pub fn buildBackend(backend: enums_backend.Backend, test_dvui_and_app: bool, dvu
             addExample("raylib-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
         },
         .raylib_zig => {
-            dvui_opts.setDefaults(.{ .libc = dvui_opts_in.libc orelse true, .freetype = true, .tiny_file_dialogs = true, .stb_image = false });
+            dvui_opts.setDefaults(.{ .libc = dvui_opts_in.libc orelse true, .freetype = true, .tiny_file_dialogs = true, .stb_image = false, .tree_sitter = true });
 
             const raylib_backend_mod = b.addModule("raylib_zig", .{
                 .root_source_file = b.path("src/backends/raylib-zig.zig"),
@@ -541,7 +543,7 @@ pub fn buildBackend(backend: enums_backend.Backend, test_dvui_and_app: bool, dvu
             addExample("raylib-zig-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
         },
         .dx11 => {
-            dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true });
+            dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true, .tree_sitter = true });
             if (target.result.os.tag == .windows) {
                 const dx11_mod = b.addModule("dx11", .{
                     .root_source_file = b.path("src/backends/dx11.zig"),
@@ -574,7 +576,7 @@ pub fn buildBackend(backend: enums_backend.Backend, test_dvui_and_app: bool, dvu
             }
         },
         .web => {
-            dvui_opts.setDefaults(.{ .libc = false, .freetype = false, .tiny_file_dialogs = false, .stb_image = true });
+            dvui_opts.setDefaults(.{ .libc = false, .freetype = false, .tiny_file_dialogs = false, .stb_image = true, .tree_sitter = false });
             const export_symbol_names = &[_][]const u8{
                 "dvui_init",
                 "dvui_deinit",
@@ -620,10 +622,11 @@ pub fn buildBackend(backend: enums_backend.Backend, test_dvui_and_app: bool, dvu
                     .freetype = false,
                     .tiny_file_dialogs = false,
                     .stb_image = true,
+                    .tree_sitter = false,
                     // no tests or checks needed, they are check above in native build
                 };
 
-                wasm_dvui_opts.setDefaults(.{ .libc = false, .freetype = false, .tiny_file_dialogs = false, .stb_image = true });
+                wasm_dvui_opts.setDefaults(.{ .libc = false, .freetype = false, .tiny_file_dialogs = false, .stb_image = true, .tree_sitter = false });
 
                 const web_mod_wasm = b.createModule(.{
                     .root_source_file = b.path("src/backends/web.zig"),
@@ -664,12 +667,14 @@ const DvuiModuleOptions = struct {
     freetype: ?bool,
     linux_display_backend: ?LinuxDisplayBackend = null,
     stb_image: ?bool,
+    tree_sitter: ?bool,
 
     pub const DefaultOptions = struct {
         libc: bool,
         freetype: bool,
         tiny_file_dialogs: bool,
         stb_image: bool,
+        tree_sitter: bool,
     };
 
     fn setDefaults(self: *@This(), defaults: DefaultOptions) void {
@@ -677,6 +682,7 @@ const DvuiModuleOptions = struct {
         self.tiny_file_dialogs = self.tiny_file_dialogs orelse defaults.tiny_file_dialogs;
         self.freetype = self.freetype orelse defaults.freetype;
         self.stb_image = self.stb_image orelse defaults.stb_image;
+        self.tree_sitter = self.tree_sitter orelse defaults.tree_sitter;
     }
 
     fn makeDefaults(self: *const @This()) *std.Build.Step.Options {
@@ -695,6 +701,11 @@ const DvuiModuleOptions = struct {
             bool,
             "freetype",
             self.freetype orelse @panic("makeDefaults: freetype was null"),
+        );
+        ret.addOption(
+            bool,
+            "tree_sitter",
+            self.tree_sitter orelse @panic("makeDefaults: tree_sitter was null"),
         );
 
         return ret;
@@ -850,25 +861,28 @@ pub fn addDvuiModule(
         }
     }
 
-    const tree_sitter_dep = b.lazyDependency("tree_sitter", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    if (tree_sitter_dep) |tsd| {
-        dvui_mod.linkLibrary(tsd.artifact("tree-sitter"));
-    }
-
-    const tree_sitter_zig_dep = b.lazyDependency("tree_sitter_zig", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    if (tree_sitter_zig_dep) |tsc| {
-        dvui_mod.addIncludePath(tsc.path("src"));
-        dvui_mod.addCSourceFiles(.{
-            .root = tsc.path(""),
-            .files = &.{"src/parser.c"},
-            .flags = &.{"-std=c11"},
+    const tree_sitter = opts.tree_sitter orelse @panic("tree_sitter was null");
+    if (tree_sitter) {
+        const tree_sitter_dep = b.lazyDependency("tree_sitter", .{
+            .target = target,
+            .optimize = optimize,
         });
+        if (tree_sitter_dep) |tsd| {
+            dvui_mod.linkLibrary(tsd.artifact("tree-sitter"));
+        }
+
+        const tree_sitter_zig_dep = b.lazyDependency("tree_sitter_zig", .{
+            .target = target,
+            .optimize = optimize,
+        });
+        if (tree_sitter_zig_dep) |tsc| {
+            dvui_mod.addIncludePath(tsc.path("src"));
+            dvui_mod.addCSourceFiles(.{
+                .root = tsc.path(""),
+                .files = &.{"src/parser.c"},
+                .flags = &.{"-std=c11"},
+            });
+        }
     }
 
     return dvui_mod;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -58,5 +58,15 @@
             .hash = "zglfw-0.10.0-dev-zgVDNPKyIQCBi-wv_vxkvIQq1u0bP4D56Wszx_2mszc7",
             .lazy = true,
         },
+        .tree_sitter = .{
+            .url = "git+https://github.com/tree-sitter/tree-sitter#eacb95c85da15005f091729f3225609d0db67963",
+            .hash = "tree_sitter-0.27.0-Tw2sRwKWCwCqwcmq1ZXGlBVEa1887b3t2RwZdmIRrX3Z",
+            .lazy = true,
+        },
+        .tree_sitter_c = .{
+            .url = "git+https://github.com/tree-sitter/tree-sitter-c#586dd62ad4d3532895ea80a8382d21307b4733bd",
+            .hash = "tree_sitter_c-0.24.1-ns1YLwdjQACIi5BEwewiqu6a6Zcl91RWoSWbz0KmxUOj",
+            .lazy = true,
+        },
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -63,9 +63,9 @@
             .hash = "tree_sitter-0.27.0-Tw2sRwKWCwCqwcmq1ZXGlBVEa1887b3t2RwZdmIRrX3Z",
             .lazy = true,
         },
-        .tree_sitter_c = .{
-            .url = "git+https://github.com/tree-sitter/tree-sitter-c#586dd62ad4d3532895ea80a8382d21307b4733bd",
-            .hash = "tree_sitter_c-0.24.1-ns1YLwdjQACIi5BEwewiqu6a6Zcl91RWoSWbz0KmxUOj",
+        .tree_sitter_zig = .{
+            .url = "git+https://github.com/tree-sitter-grammars/tree-sitter-zig#6479aa13f32f701c383083d8b28360ebd682fb7d",
+            .hash = "tree_sitter_zig-1.1.2-AAAAAJ57XACsD_XBHC4i6G6rnCsZ1dZj7CLRTC09toEB",
             .lazy = true,
         },
     },

--- a/examples/app.zig
+++ b/examples/app.zig
@@ -118,7 +118,7 @@ const tsQueryCursorCaptureIterator = struct {
     }
 };
 
-var show_text_entry: bool = true;
+var show_text_entry: bool = false;
 
 pub fn frame() !dvui.App.Result {
     var scaler = dvui.scale(@src(), .{ .scale = &dvui.currentWindow().content_scale, .pinch_zoom = .global }, .{ .rect = .cast(dvui.windowRect()) });

--- a/examples/tree_sitter_zig_queries.scm
+++ b/examples/tree_sitter_zig_queries.scm
@@ -1,0 +1,283 @@
+; Variables
+(identifier) @variable
+
+; Parameters
+(parameter
+  name: (identifier) @variable.parameter)
+
+(payload
+  (identifier) @variable.parameter)
+
+; Types
+(parameter
+  type: (identifier) @type)
+
+((identifier) @type
+  (#lua-match? @type "^[A-Z_][a-zA-Z0-9_]*"))
+
+(variable_declaration
+  (identifier) @type
+  "="
+  [
+    (struct_declaration)
+    (enum_declaration)
+    (union_declaration)
+    (opaque_declaration)
+  ])
+
+[
+  (builtin_type)
+  "anyframe"
+] @type.builtin
+
+; Constants
+((identifier) @constant
+  (#lua-match? @constant "^[A-Z][A-Z_0-9]+$"))
+
+[
+  "null"
+  "unreachable"
+  "undefined"
+] @constant.builtin
+
+(field_expression
+  .
+  member: (identifier) @constant)
+
+(enum_declaration
+  (container_field
+    type: (identifier) @constant))
+
+; Labels
+(block_label
+  (identifier) @label)
+
+(break_label
+  (identifier) @label)
+
+; Fields
+(field_initializer
+  .
+  (identifier) @variable.member)
+
+(field_expression
+  (_)
+  member: (identifier) @variable.member)
+
+(container_field
+  name: (identifier) @variable.member)
+
+(initializer_list
+  (assignment_expression
+    left: (field_expression
+      .
+      member: (identifier) @variable.member)))
+
+; Functions
+(builtin_identifier) @function.builtin
+
+(call_expression
+  function: (identifier) @function.call)
+
+(call_expression
+  function: (field_expression
+    member: (identifier) @function.call))
+
+(function_declaration
+  name: (identifier) @function)
+
+; Modules
+(variable_declaration
+  (identifier) @module
+  (builtin_function
+    (builtin_identifier) @keyword.import
+    (#any-of? @keyword.import "@import" "@cImport")))
+
+; Builtins
+[
+  "c"
+  "..."
+] @variable.builtin
+
+((identifier) @variable.builtin
+  (#eq? @variable.builtin "_"))
+
+(calling_convention
+  (identifier) @variable.builtin)
+
+; Keywords
+[
+  "asm"
+  "defer"
+  "errdefer"
+  "test"
+  "error"
+  "const"
+  "var"
+] @keyword
+
+[
+  "struct"
+  "union"
+  "enum"
+  "opaque"
+] @keyword.type
+
+[
+  "async"
+  "await"
+  "suspend"
+  "nosuspend"
+  "resume"
+] @keyword.coroutine
+
+"fn" @keyword.function
+
+[
+  "and"
+  "or"
+  "orelse"
+] @keyword.operator
+
+"return" @keyword.return
+
+[
+  "if"
+  "else"
+  "switch"
+] @keyword.conditional
+
+[
+  "for"
+  "while"
+  "break"
+  "continue"
+] @keyword.repeat
+
+[
+  "usingnamespace"
+  "export"
+] @keyword.import
+
+[
+  "try"
+  "catch"
+] @keyword.exception
+
+[
+  "volatile"
+  "allowzero"
+  "noalias"
+  "addrspace"
+  "align"
+  "callconv"
+  "linksection"
+  "pub"
+  "inline"
+  "noinline"
+  "extern"
+  "comptime"
+  "packed"
+  "threadlocal"
+] @keyword.modifier
+
+; Operator
+[
+  "="
+  "*="
+  "*%="
+  "*|="
+  "/="
+  "%="
+  "+="
+  "+%="
+  "+|="
+  "-="
+  "-%="
+  "-|="
+  "<<="
+  "<<|="
+  ">>="
+  "&="
+  "^="
+  "|="
+  "!"
+  "~"
+  "-"
+  "-%"
+  "&"
+  "=="
+  "!="
+  ">"
+  ">="
+  "<="
+  "<"
+  "&"
+  "^"
+  "|"
+  "<<"
+  ">>"
+  "<<|"
+  "+"
+  "++"
+  "+%"
+  "-%"
+  "+|"
+  "-|"
+  "*"
+  "/"
+  "%"
+  "**"
+  "*%"
+  "*|"
+  "||"
+  ".*"
+  ".?"
+  "?"
+  ".."
+] @operator
+
+; Literals
+(character) @character
+
+([
+  (string)
+  (multiline_string)
+] @string
+  (#set! "priority" 95))
+
+(integer) @number
+
+(float) @number.float
+
+(boolean) @boolean
+
+(escape_sequence) @string.escape
+
+; Punctuation
+[
+  "["
+  "]"
+  "("
+  ")"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  ";"
+  "."
+  ","
+  ":"
+  "=>"
+  "->"
+] @punctuation.delimiter
+
+(payload
+  "|" @punctuation.bracket)
+
+; Comments
+(comment) @comment @spell
+
+((comment) @comment.documentation
+  (#lua-match? @comment.documentation "^//!"))

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -253,6 +253,7 @@ pub const dialogNativeFolderSelect = native_dialogs.Native.folderSelect;
 pub const useLibc = @import("default_options").libc;
 pub const useFreeType = @import("default_options").freetype;
 pub const useTinyFileDialogs = @import("default_options").tiny_file_dialogs;
+pub const useTreeSitter = @import("default_options").tree_sitter;
 
 /// The amount of physical pixels to scroll per "tick" of the scroll wheel
 pub var scroll_speed: f32 = 20;
@@ -301,7 +302,9 @@ pub const c = @cImport({
         @cInclude("tinyfiledialogs.h");
     }
 
-    @cInclude("tree_sitter/api.h");
+    if (useTreeSitter) {
+        @cInclude("tree_sitter/api.h");
+    }
 });
 
 pub var ft2lib: if (useFreeType) c.FT_Library else void = undefined;

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -300,6 +300,8 @@ pub const c = @cImport({
     if (useTinyFileDialogs) {
         @cInclude("tinyfiledialogs.h");
     }
+
+    @cInclude("tree_sitter/api.h");
 });
 
 pub var ft2lib: if (useFreeType) c.FT_Library else void = undefined;

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1154,7 +1154,7 @@ pub const hashIdKey = void;
 
 // Used for all the data functions
 fn currentOverrideOrPanic(win: ?*Window) *Window {
-    return win orelse current_window orelse @panic("dataSet current_window was null, pass a *Window as first parameter if calling from other thread or outside window.begin()/end()");
+    return win orelse current_window orelse @panic("current_window was null, pass a *Window as first parameter if calling from other thread or outside window.begin()/end()");
 }
 
 /// Set key/value pair for given id.
@@ -1175,6 +1175,21 @@ pub fn dataSet(win: ?*Window, id: Id, key: []const u8, data: anytype) void {
     (w.data_store.set(w.gpa, id.update(key), data)) catch |err| {
         dvui.logError(@src(), err, "id {x} key {s}", .{ id, key });
     };
+}
+
+/// Set a deinit function for data stored under id/key.
+///
+/// Can be called from any thread.
+///
+/// If called from non-GUI thread or outside `Window.begin`/`Window.end`, you must
+/// pass a pointer to the `Window` you want to add the data to.
+///
+/// When data for this id/key is about to be freed by dvui, it will first call
+/// the passed function.  This is useful for cases where data for a widget
+/// allocates memory outside of your control.
+pub fn dataSetDeinitFunction(win: ?*Window, id: Id, key: []const u8, func: Data.DeinitFunction) void {
+    const w = currentOverrideOrPanic(win);
+    w.data_store.setDeinitFunction(id.update(key), func);
 }
 
 /// Set key/value pair for given id, copying the slice contents. Can be passed

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -340,13 +340,6 @@ pub fn draw(self: *TextEntryWidget) void {
             self.textLayout.addText(pc, self.data().options.strip());
         }
     } else {
-        if (self.init_opts.cache_layout) {
-            self.textLayout.cache_layout_bytes = self.textLayout.bytesNeeded(
-                self.text_changed_start,
-                self.text_changed_end,
-                self.text_changed_added,
-            );
-        }
         self.textLayout.addText(self.text[0..self.len], self.data().options.strip());
     }
 
@@ -390,6 +383,14 @@ pub fn drawBeforeText(self: *TextEntryWidget) void {
 
     // set clip back to what textLayout had, so we don't draw over the scrollbars
     dvui.clipSet(self.textClip);
+
+    if (self.init_opts.cache_layout) {
+        self.textLayout.cache_layout_bytes = self.textLayout.bytesNeeded(
+            self.text_changed_start,
+            self.text_changed_end,
+            self.text_changed_added,
+        );
+    }
 }
 
 pub fn drawAfterText(self: *TextEntryWidget) void {

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -301,14 +301,7 @@ pub fn processEvents(self: *TextEntryWidget) void {
 }
 
 pub fn draw(self: *TextEntryWidget) void {
-    const focused = (self.data().id == dvui.focusedWidgetId());
-
-    if (focused) {
-        dvui.wantTextInput(self.data().borderRectScale().r.toNatural());
-    }
-
-    // set clip back to what textLayout had, so we don't draw over the scrollbars
-    dvui.clipSet(self.textClip);
+    self.drawBeforeText();
 
     if (self.init_opts.password_char) |pc| {
         // adjust selection for obfuscation
@@ -385,6 +378,22 @@ pub fn draw(self: *TextEntryWidget) void {
         sel.end = send.?;
     }
 
+    self.drawAfterText();
+}
+
+pub fn drawBeforeText(self: *TextEntryWidget) void {
+    const focused = (self.data().id == dvui.focusedWidgetId());
+
+    if (focused) {
+        dvui.wantTextInput(self.data().borderRectScale().r.toNatural());
+    }
+
+    // set clip back to what textLayout had, so we don't draw over the scrollbars
+    dvui.clipSet(self.textClip);
+}
+
+pub fn drawAfterText(self: *TextEntryWidget) void {
+    const focused = (self.data().id == dvui.focusedWidgetId());
     if (focused) {
         self.drawCursor();
     }

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -1645,7 +1645,7 @@ pub fn addTextDone(self: *TextLayoutWidget, opts: Options) void {
     const contentMinSize = self.data().min_size.padNeg(os.paddingGet()).padNeg(os.borderGet()).padNeg(os.marginGet());
     self.byte_heights_new.append(dvui.currentWindow().arena(), .{ .byte = self.bytes_seen, .height = contentMinSize.h }) catch {};
 
-    if (self.cache_layout) {
+    if (self.cache_layout and self.byte_heights.len > 0) {
         // sanity check
         const old = self.byte_heights[self.byte_heights.len - 1].height;
         const new = self.byte_heights_new.items[self.byte_heights_new.items.len - 1].height;

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -1580,6 +1580,10 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
 }
 
 pub fn addTextDone(self: *TextLayoutWidget, opts: Options) void {
+    if (self.add_text_done) {
+        dvui.log.debug("TextLayoutWidget addTextDone() called multiple times", .{});
+    }
+
     self.add_text_done = true;
 
     if (self.cache_layout and self.byte_heights.len > 0) {

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -1052,7 +1052,7 @@ pub fn bytesNeeded(self: *TextLayoutWidget, edit_start: usize, edit_end: usize, 
     // if we are moving the cursor, need to process the text around where we are moving it
     switch (self.sel_move) {
         .none => {},
-        .mouse => {}, // all in visible region
+        .mouse => {}, // all in visible region, excepted below
         .expand_pt => |*ep| {
             switch (ep.which) {
                 .word, .line => {}, // all in visible region
@@ -1073,7 +1073,7 @@ pub fn bytesNeeded(self: *TextLayoutWidget, edit_start: usize, edit_end: usize, 
         .word_left_right => include_cursor = true,
     }
 
-    if (include_cursor) {
+    if (include_cursor and self.sel_move != .mouse) {
         context.byte = @min(context.byte, self.selection.cursor);
         sel_end = @max(sel_end, self.selection.cursor);
     }


### PR DESCRIPTION
Towards implementing #539

It looks like tree-sitter is a good default direction for syntax highlighting.  So one goal is to make it easy to use a compiled tree-sitter grammar.

A second goal is to make it possible to use other syntax highlighting options by giving calling code control over the part of textEntry where it feeds the text to textLayout.

As of now this branch modifies the app example to show some editable c code with the identifiers colored in red.

Stuff to be done:
- [x] do full syntax highlighting using tree-sitters query stuff
- [x] figure out how to match tree-sitter node types (symbols) to dvui.Options
- [x] make it work incrementally
- [x] make it work with large documents (only reparse and rematch the displayed text
- [x] figure out how to make tree-sitter integration nice but optional (how large is integrating the tree-sitter library? how large is each compiled grammar?)
- [x] decide who owns the tree-sitter memory (does dvui figure out a way to clean it up?  do we punt this to client code?) 