### PR TITLE
AccessKit: Add text_run support

### DIFF
--- a/examples/app.zig
+++ b/examples/app.zig
@@ -96,9 +96,8 @@ pub fn frame() !dvui.App.Result {
     defer scroll.deinit();
 
     var tl = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal, .font = .theme(.title) });
-    const lorem = "This is a dvui.App example that can compile on multiple backends.";
+    const lorem = "This is a dvui.App example that can compile on multiple backends.\n";
     tl.addText(lorem, .{});
-    tl.addText("\n", .{});
     tl.format("Current backend: {s}", .{@tagName(dvui.backend.kind)}, .{});
     if (dvui.backend.kind == .web) {
         tl.format(" : {s}", .{if (dvui.backend.wasm.wasm_about_webgl2() == 1) "webgl2" else "webgl (no mipmaps)"}, .{});
@@ -111,14 +110,12 @@ pub fn frame() !dvui.App.Result {
         \\- paints the entire window
         \\- can show floating windows and dialogs
         \\- rest of the window is a scroll area
+        \\
+        \\
     , .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Framerate is variable and adjusts as needed for input events and animations.", .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Framerate is capped by vsync.", .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Cursor is always being set by dvui.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("Framerate is variable and adjusts as needed for input events and animations.\n\n", .{});
+    tl2.addText("Framerate is capped by vsync.\n\n", .{});
+    tl2.addText("Cursor is always being set by dvui.\n\n", .{});
     if (dvui.useFreeType) {
         tl2.addText("Fonts are being rendered by FreeType 2.", .{});
     } else {

--- a/examples/dx11-ontop.zig
+++ b/examples/dx11-ontop.zig
@@ -239,12 +239,9 @@ fn dvui_floating_stuff() void {
     tl.deinit();
 
     var tl2 = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal });
-    tl2.addText("The dvui is painting only floating windows and dialogs.", .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Framerate is managed by the application (in this demo capped at vsync).", .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Cursor is only being set by dvui for floating windows.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("The dvui is painting only floating windows and dialogs.\n\n", .{});
+    tl2.addText("Framerate is managed by the application (in this demo capped at vsync).\n\n", .{});
+    tl2.addText("Cursor is only being set by dvui for floating windows.\n\n", .{});
     if (dvui.useFreeType) {
         tl2.addText("Fonts are being rendered by FreeType 2.", .{});
     } else {

--- a/examples/dx11-standalone.zig
+++ b/examples/dx11-standalone.zig
@@ -177,18 +177,17 @@ fn gui_frame() !void {
         \\- can show floating windows and dialogs
         \\- example menu at the top of the window
         \\- rest of the window is a scroll area
+        \\
+        \\
     , .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Framerate is variable and adjusts as needed for input events and animations.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("Framerate is variable and adjusts as needed for input events and animations.\n\n", .{});
     if (vsync) {
-        tl2.addText("Framerate is capped by vsync.", .{});
+        tl2.addText("Framerate is capped by vsync.\n", .{});
     } else {
-        tl2.addText("Framerate is uncapped.", .{});
+        tl2.addText("Framerate is uncapped.\n", .{});
     }
-    tl2.addText("\n\n", .{});
-    tl2.addText("Cursor is always being set by dvui.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("\n", .{});
+    tl2.addText("Cursor is always being set by dvui.\n\n", .{});
     if (dvui.useFreeType) {
         tl2.addText("Fonts are being rendered by FreeType 2.", .{});
     } else {

--- a/examples/raylib-ontop.zig
+++ b/examples/raylib-ontop.zig
@@ -150,12 +150,9 @@ fn dvuiStuff() void {
     tl.deinit();
 
     var tl2 = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal });
-    tl2.addText("The dvui is painting only floating windows and dialogs.", .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Framerate is managed by the application (in this demo capped at vsync).", .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Cursor is only being set by dvui for floating windows.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("The dvui is painting only floating windows and dialogs.\n\n", .{});
+    tl2.addText("Framerate is managed by the application (in this demo capped at vsync).\n\n", .{});
+    tl2.addText("Cursor is only being set by dvui for floating windows.\n\n", .{});
     if (dvui.useFreeType) {
         tl2.addText("Fonts are being rendered by FreeType 2.", .{});
     } else {

--- a/examples/raylib-standalone.zig
+++ b/examples/raylib-standalone.zig
@@ -139,18 +139,17 @@ fn dvui_frame() bool {
         \\- can show floating windows and dialogs
         \\- example menu at the top of the window
         \\- rest of the window is a scroll area
+        \\
+        \\
     , .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Framerate is set by Raylib (C api).", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("Framerate is set by Raylib (C api).\n\n", .{});
     if (vsync) {
-        tl2.addText("Framerate is capped by vsync.", .{});
+        tl2.addText("Framerate is capped by vsync.\n", .{});
     } else {
-        tl2.addText("Framerate is uncapped.", .{});
+        tl2.addText("Framerate is uncapped.\n", .{});
     }
-    tl2.addText("\n\n", .{});
-    tl2.addText("Cursor is always being set by dvui.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("\n", .{});
+    tl2.addText("Cursor is always being set by dvui.\n\n", .{});
     if (dvui.useFreeType) {
         tl2.addText("Fonts are being rendered by FreeType 2.", .{});
     } else {

--- a/examples/raylib-zig-ontop.zig
+++ b/examples/raylib-zig-ontop.zig
@@ -154,12 +154,9 @@ fn dvuiStuff() void {
     tl.deinit();
 
     var tl2 = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal });
-    tl2.addText("The dvui is painting only floating windows and dialogs.", .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Framerate is managed by the application (in this demo capped at vsync).", .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Cursor is only being set by dvui for floating windows.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("The dvui is painting only floating windows and dialogs.\n\n", .{});
+    tl2.addText("Framerate is managed by the application (in this demo capped at vsync)\n\n.", .{});
+    tl2.addText("Cursor is only being set by dvui for floating windows.\n\n", .{});
     if (dvui.useFreeType) {
         tl2.addText("Fonts are being rendered by FreeType 2.", .{});
     } else {

--- a/examples/raylib-zig-standalone.zig
+++ b/examples/raylib-zig-standalone.zig
@@ -138,18 +138,17 @@ fn dvui_frame() bool {
         \\- can show floating windows and dialogs
         \\- example menu at the top of the window
         \\- rest of the window is a scroll area
+        \\
+        \\
     , .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Framerate is set by Raylib (raylib-zig).", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("Framerate is set by Raylib (raylib-zig).\n\n", .{});
     if (vsync) {
-        tl2.addText("Framerate is capped by vsync.", .{});
+        tl2.addText("Framerate is capped by vsync.\n", .{});
     } else {
-        tl2.addText("Framerate is uncapped.", .{});
+        tl2.addText("Framerate is uncapped.\n", .{});
     }
-    tl2.addText("\n\n", .{});
-    tl2.addText("Cursor is always being set by dvui.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("\n", .{});
+    tl2.addText("Cursor is always being set by dvui.\n\n", .{});
     if (dvui.useFreeType) {
         tl2.addText("Fonts are being rendered by FreeType 2.", .{});
     } else {

--- a/examples/sdl-ontop.zig
+++ b/examples/sdl-ontop.zig
@@ -132,17 +132,15 @@ fn dvui_floating_stuff() void {
     tl.deinit();
 
     var tl2 = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal });
-    tl2.addText("The dvui is painting only floating windows and dialogs.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("The dvui is painting only floating windows and dialogs.\n\n", .{});
     tl2.addText("Framerate is managed by the application", .{});
     if (vsync) {
-        tl2.addText(" (capped at vsync)", .{});
+        tl2.addText(" (capped at vsync)\n", .{});
     } else {
-        tl2.addText(" (uncapped - no vsync)", .{});
+        tl2.addText(" (uncapped - no vsync)\n", .{});
     }
-    tl2.addText("\n\n", .{});
-    tl2.addText("Cursor is only being set by dvui for floating windows.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("\n", .{});
+    tl2.addText("Cursor is only being set by dvui for floating windows.\n\n", .{});
     if (dvui.useFreeType) {
         tl2.addText("Fonts are being rendered by FreeType 2.", .{});
     } else {

--- a/examples/sdl-standalone.zig
+++ b/examples/sdl-standalone.zig
@@ -152,18 +152,17 @@ fn gui_frame() bool {
         \\- can show floating windows and dialogs
         \\- example menu at the top of the window
         \\- rest of the window is a scroll area
+        \\
+        \\
     , .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Framerate is variable and adjusts as needed for input events and animations.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("Framerate is variable and adjusts as needed for input events and animations.\n\n", .{});
     if (vsync) {
-        tl2.addText("Framerate is capped by vsync.", .{});
+        tl2.addText("Framerate is capped by vsync.\n", .{});
     } else {
-        tl2.addText("Framerate is uncapped.", .{});
+        tl2.addText("Framerate is uncapped.\n", .{});
     }
-    tl2.addText("\n\n", .{});
-    tl2.addText("Cursor is always being set by dvui.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("\n", .{});
+    tl2.addText("Cursor is always being set by dvui.\n\n", .{});
     if (dvui.useFreeType) {
         tl2.addText("Fonts are being rendered by FreeType 2.", .{});
     } else {

--- a/examples/sdl3gpu-ontop.zig
+++ b/examples/sdl3gpu-ontop.zig
@@ -154,17 +154,15 @@ fn dvui_floating_stuff() void {
     tl.deinit();
 
     var tl2 = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal });
-    tl2.addText("The dvui is painting only floating windows and dialogs.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("The dvui is painting only floating windows and dialogs.\n\n", .{});
     tl2.addText("Framerate is managed by the application", .{});
     if (vsync) {
-        tl2.addText(" (capped at vsync)", .{});
+        tl2.addText(" (capped at vsync)\n", .{});
     } else {
-        tl2.addText(" (uncapped - no vsync)", .{});
+        tl2.addText(" (uncapped - no vsync)\n", .{});
     }
-    tl2.addText("\n\n", .{});
-    tl2.addText("Cursor is only being set by dvui for floating windows.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("\n", .{});
+    tl2.addText("Cursor is only being set by dvui for floating windows.\n\n", .{});
     if (dvui.useFreeType) {
         tl2.addText("Fonts are being rendered by FreeType 2.", .{});
     } else {

--- a/examples/sdl3gpu-standalone.zig
+++ b/examples/sdl3gpu-standalone.zig
@@ -152,18 +152,17 @@ fn gui_frame() bool {
         \\- Efficient texture uploads via transfer buffers
         \\- Render passes for structured GPU work
         \\- Supports multiple shader formats (SPIR-V, DXIL, MSL)
+        \\
+        \\
     , .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Framerate is variable and adjusts as needed for input events and animations.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("Framerate is variable and adjusts as needed for input events and animations.\n\n", .{});
     if (vsync) {
-        tl2.addText("Framerate is capped by vsync (PRESENTMODE_VSYNC).", .{});
+        tl2.addText("Framerate is capped by vsync (PRESENTMODE_VSYNC).\n", .{});
     } else {
-        tl2.addText("Framerate is uncapped (PRESENTMODE_IMMEDIATE).", .{});
+        tl2.addText("Framerate is uncapped (PRESENTMODE_IMMEDIATE).\n", .{});
     }
-    tl2.addText("\n\n", .{});
-    tl2.addText("Cursor is always being set by dvui.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("\n", .{});
+    tl2.addText("Cursor is always being set by dvui.\n\n", .{});
     if (dvui.useFreeType) {
         tl2.addText("Fonts are being rendered by FreeType 2.", .{});
     } else {

--- a/examples/web-test.zig
+++ b/examples/web-test.zig
@@ -140,18 +140,17 @@ fn dvui_frame() !void {
         \\- can show floating windows and dialogs
         \\- example menu at the top of the window
         \\- rest of the window is a scroll area
+        \\
+        \\
     , .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Framerate is variable and adjusts as needed for input events and animations.", .{});
-    tl2.addText("\n\n", .{});
-    tl2.addText("Cursor is always being set by dvui.", .{});
-    tl2.addText("\n\n", .{});
+    tl2.addText("Framerate is variable and adjusts as needed for input events and animations.\n\n", .{});
+    tl2.addText("Cursor is always being set by dvui.\n\n", .{});
     if (dvui.useFreeType) {
-        tl2.addText("Fonts are being rendered by FreeType 2.", .{});
+        tl2.addText("Fonts are being rendered by FreeType 2.\n", .{});
     } else {
-        tl2.addText("Fonts are being rendered by stb_truetype.", .{});
+        tl2.addText("Fonts are being rendered by stb_truetype.\n", .{});
     }
-    tl2.addText("\n\n", .{});
+    tl2.addText("\n", .{});
     tl2.format("Scale: {d:0.2} (try pinch-zoom)", .{dvui.windowNaturalScale()}, .{});
     tl2.deinit();
 

--- a/readme-accessibility.md
+++ b/readme-accessibility.md
@@ -196,6 +196,18 @@ DVUI offers the following labeling options:
 
 Alternatively, you can also use the `AccessKit.nodeSetLabel` and `AccessKit.nodeSetLabeledBy` functions.
 
+#### Text
+Text created through the TextLayoutWidget will make the text accessibile to the screen reader through a text_run role. This is true for any widget that uses TextLayoutWidget to create text, e.g. TextEntryWidget.
+
+Each call to add_text creates a new text_run for each line or partial line of text added. 
+
+To make your text compatible with text_runs, you should:
+1) If there are no font/style changes, use addText() to add one or more full lines, including any trailing newline.
+2) If there are fonts/styles changes, use a different addText() for each font/style change.
+3) Do not call addText() just to add a newline, unless it is for a blank line, only containing a newline.
+
+Ignoring these rules will not break anything, but will make it harder for accessiblilty users to correctly navigate such text in their screen reader.
+
 ## Current State of Accessibility in DVUI
 
 * A role of `null` means the widget will not be added to the accessibility tree, unless the user passes a `role` for that widget via Options.
@@ -226,8 +238,8 @@ Alternatively, you can also use the `AccessKit.nodeSetLabel` and `AccessKit.node
 | ScrollBarWidget | scroll_bar | Y *| N* | Y | Due to bug in AccessKit, is set to read-only and cannot interact. Actual values displayed may not be accurate | 
 | SuggestionsWidget | suggestion, list_item | Y | Y | N | 
 | TabsWidget | .tab_panel, .tab | Y | Y | N | Sets active tabs and allows tab selection |
-| TextEntryWidget | text_input, multiline_text_input | Y* | N* | Y | Text entry should work for "reasonable" amounts of text. SetValue will replace all text. Needs to implement the .text_run role to properly allow users to fully perform text entry and editing. |
-| TextLayoutWidget | label | Y* | N/A | Y | Currently displays only visible text (TBC). Works OK for "reasonable" amounts of text. Does not support sending of formatting information | 
+| TextEntryWidget | text_input, multiline_text_input | Y* | N* | Y | TextRun support implemented for text. Allows selection and navigation. Scrolling for off-screen text requires improvement. Cached layouts needs more investigation. |
+| TextLayoutWidget | label | Y* | N/A | Y | Most features supported. Needs to implement the text_replace action. | 
 | TreeWidget | tree, tree_item | Y* | Y | Y | Adds tree and nodes. Implement expand / collapse when supported by AccessKit | 
 | windowHeader | label, button | Y | Y | N | |
 | dialogs | window | Y | Y | Y | All dialogs are displayed as windows, rather than dialogs and modal state is not displayed in accessibility insights. AccessKit currently has limted support for dialogs, so leaving as window until the situation changes and can revisit. |
@@ -241,6 +253,6 @@ Alternatively, you can also use the `AccessKit.nodeSetLabel` and `AccessKit.node
 | slider | slider | Y | Y | N | Fully supported |
 | progress | progress_indicator | Y | N/A  | N | Fully supported |
 | checkbox | check_box | Y | Y | N | Fully supported |
-| radio | radio_button | Y* | Y | N | Best practice: Create a radio group with a surrounding box|
+| radio | radio_button | Y* | Y | N | Best practice: Create a radio group with a surrounding radio group widget|
 | textEntryNumber | number_input | Y | Y | N | Fully supported. Supports min, max and valid/invalid. |
 

--- a/src/AccessKit.zig
+++ b/src/AccessKit.zig
@@ -94,7 +94,7 @@ pub fn initialize(self: *AccessKit) void {
 
 fn windowsHWND(window: *dvui.Window) c.HWND {
     switch (dvui.backend.kind) {
-        .sdl3 => {
+        .sdl3, .sdl3gpu => {
             const SDLBackend = dvui.backend;
             const properties: SDLBackend.c.SDL_PropertiesID = SDLBackend.c.SDL_GetWindowProperties(window.backend.impl.window);
             const hwnd = SDLBackend.c.SDL_GetPointerProperty(

--- a/src/AccessKit.zig
+++ b/src/AccessKit.zig
@@ -306,13 +306,12 @@ pub const TextRunOptions = struct {
     node_parent_id: dvui.Id,
     /// starting character offset
     char_offset: usize,
-    /// Text, including any newline
-    text: []const u8,
 };
 
 /// Populate the text_run node with character position and word length details.
 pub fn textRunPopulate(
     self: *AccessKit,
+    text: []const u8,
     opts: TextRunOptions,
     text_info: *std.MultiArrayList(CharPositionInfo),
     r: dvui.Rect.Physical,
@@ -323,7 +322,7 @@ pub fn textRunPopulate(
     var word_lengths: std.ArrayList(u8) = .empty;
     var word_len: u8 = 0;
     var prev_char_wordbreak: bool = false;
-    for (opts.text) |ch| {
+    for (text) |ch| {
         if (std.mem.indexOfScalar(u8, dvui.TextLayoutWidget.word_breaks, ch) == null) {
             if (prev_char_wordbreak) {
                 word_lengths.append(window.arena(), word_len) catch {};
@@ -337,7 +336,7 @@ pub fn textRunPopulate(
     }
     word_lengths.append(window.arena(), word_len) catch {};
 
-    const str = window.arena().dupeZ(u8, opts.text) catch "";
+    const str = window.arena().dupeZ(u8, text) catch "";
     defer window.arena().free(str);
 
     const ak_node = self.nodes.get(opts.node_id) orelse {

--- a/src/AccessKit.zig
+++ b/src/AccessKit.zig
@@ -23,6 +23,8 @@ nodes: std.AutoArrayHashMapUnmanaged(dvui.Id, *Node) = .empty,
 // Note: Any access to `action_requests` must be protected by `mutex`.
 action_requests: std.ArrayList(ActionRequest) = .empty,
 
+text_runs: std.ArrayList(TextRunOptions) = .empty,
+
 // The last seen node with `role = .label`
 prev_label_id: dvui.Id = .zero,
 
@@ -156,8 +158,9 @@ inline fn nodeCreateFake(_: *AccessKit, _: *dvui.WidgetData, _: Role) ?*Node {
 /// Create a new Node for AccessKit
 /// Returns null if no accessibility information is required for this widget.
 pub fn nodeCreateReal(self: *AccessKit, wd: *dvui.WidgetData, role: Role) ?*Node {
-    if (!wd.visible() and wd.id != dvui.focusedWidgetId()) return null;
     if (wd.options.role == .none) return null;
+    // text runs are created even if not visible.
+    if (!wd.visible() and wd.id != dvui.focusedWidgetId() and role != .text_run) return null;
 
     self.mutex.lock();
     defer self.mutex.unlock();
@@ -175,7 +178,7 @@ pub fn nodeCreateReal(self: *AccessKit, wd: *dvui.WidgetData, role: Role) ?*Node
     }
 
     if (debug_node_tree)
-        std.debug.print("Creating Node for {x} with role {?t} at {s}:{d}\n", .{ wd.id, wd.options.role, wd.src.file, wd.src.line });
+        std.debug.print("Creating Node for {x}:{d} with role {?t} at {s}:{d}\n", .{ wd.id, wd.id, wd.options.role, wd.src.file, wd.src.line });
 
     const ak_node = nodeNew(role.asU8()) orelse return null;
     wd.ak_node = ak_node;
@@ -183,7 +186,12 @@ pub fn nodeCreateReal(self: *AccessKit, wd: *dvui.WidgetData, role: Role) ?*Node
     nodeSetBounds(ak_node, .{ .x0 = border_rect.x, .y0 = border_rect.y, .x1 = border_rect.bottomRight().x, .y1 = border_rect.bottomRight().y });
 
     if (!wd.isRoot()) {
-        const parent_node: *Node = nodeParent(wd);
+        if (wd.options.ak_node_parent) |np| {
+            if (debug_node_tree)
+                std.debug.print("Setting node parent from options {x}:{d}\n", .{ self.nodeIdFromNode(np).?.asU64(), self.nodeIdFromNode(np).?.asU64() });
+        }
+        const parent_node: *Node = wd.options.ak_node_parent orelse nodeParent(wd);
+
         nodePushChild(parent_node, wd.id.asU64());
         if (wd.id == dvui.focusedWidgetId() orelse dvui.focusedSubwindowId()) {
             self.focused_id = wd.id.asU64();
@@ -262,10 +270,95 @@ pub fn nodeParent(wd_in: *dvui.WidgetData) *Node {
     unreachable;
 }
 
+/// Convert a node pointer into a node id.
+///
+/// Note: Assumes mutex is held and performs a linear search of nodes.
+pub fn nodeIdFromNode(self: *AccessKit, node: *Node) ?dvui.Id {
+    var itr = self.nodes.iterator();
+    while (itr.next()) |entry| {
+        if (entry.value_ptr.* == node) return entry.key_ptr.*;
+    }
+    return null;
+}
+
+/// Character positions and lengths of rendered text.
+pub const CharPositionInfo = struct {
+    l: u8, // length (height)
+    w: f32, // width
+    x: f32, // x pos
+};
+
+pub const TextRunOptions = struct {
+    /// id of the text run's widget
+    node_id: dvui.Id,
+    /// id of the controlling widget (e.g. text entry or text layout)
+    node_parent_id: dvui.Id,
+    /// starting character offset
+    char_offset: usize,
+    /// Text, including any newline
+    text: []const u8,
+};
+
+/// Populate the text_run node with character position and word length details.
+pub fn textRunPopulate(
+    self: *AccessKit,
+    opts: TextRunOptions,
+    text_info: *std.MultiArrayList(CharPositionInfo),
+    r: dvui.Rect.Physical,
+) void {
+    const window: *dvui.Window = @alignCast(@fieldParentPtr("accesskit", self));
+
+    // Word lengths include all punctuation for the word. e.g. `abc"$.` has a length of 6.
+    var word_lengths: std.ArrayList(u8) = .empty;
+    var word_len: u8 = 0;
+    var prev_char_wordbreak: bool = false;
+    for (opts.text) |ch| {
+        if (std.mem.indexOfScalar(u8, dvui.TextLayoutWidget.word_breaks, ch) == null) {
+            if (prev_char_wordbreak) {
+                word_lengths.append(window.arena(), word_len) catch {};
+                word_len = 0;
+            }
+            prev_char_wordbreak = false;
+        } else {
+            prev_char_wordbreak = true;
+        }
+        word_len +|= 1;
+    }
+    word_lengths.append(window.arena(), word_len) catch {};
+
+    const str = window.arena().dupeZ(u8, opts.text) catch "";
+    defer window.arena().free(str);
+
+    const ak_node = self.nodes.get(opts.node_id) orelse {
+        log.debug("textRunPopulate called for non-existent node_id {x}:{d} with parent {x}:{d}\n", .{ opts.node_id, opts.node_id, opts.node_parent_id, opts.node_parent_id });
+        return;
+    };
+    AccessKit.nodeSetRole(ak_node, Role.text_run.asU8());
+    // Make sure text run is at least 1 pixel wide to cater for newlines.
+    AccessKit.nodeSetBounds(ak_node, .{ .x0 = r.x, .y0 = r.y, .x1 = r.x + @max(r.w, 1), .y1 = r.y + r.h });
+    AccessKit.nodeSetValue(ak_node, str);
+    AccessKit.nodeSetCharacterLengths(ak_node, text_info.len, text_info.items(.l).ptr);
+    AccessKit.nodeSetCharacterWidths(ak_node, text_info.len, text_info.items(.w).ptr);
+    AccessKit.nodeSetCharacterPositions(ak_node, text_info.len, text_info.items(.x).ptr);
+    AccessKit.nodeSetWordLengths(ak_node, word_lengths.items.len, word_lengths.items.ptr);
+    AccessKit.nodeSetTextDirection(ak_node, AccessKit.TextDirection.left_to_right);
+    self.text_runs.append(window.gpa, opts) catch {}; // If text run can't be added, selection actions will fail this frame.
+
+    if (debug_textruns) {
+        std.debug.print("TEXT_RUN [{x}:{x}]: bounds = {f}\n", .{ opts.node_id, opts.node_parent_id, r });
+        std.debug.print("TEXT_RUN [{x}:{x}]: lengths = {x}\n", .{ opts.node_id, opts.node_parent_id, text_info.items(.l) });
+        std.debug.print("TEXT_RUN [{x}:{x}]: widths = {any}\n", .{ opts.node_id, opts.node_parent_id, text_info.items(.w) });
+        std.debug.print("TEXT_RUN [{x}:{x}]: positions = {any}\n", .{ opts.node_id, opts.node_parent_id, text_info.items(.x) });
+        std.debug.print("TEXT_RUN [{x}:{x}]: word_lens = {any}\n", .{ opts.node_id, opts.node_parent_id, word_lengths.items });
+        std.debug.print("TEXT_RUN [{x}:{x}]: text = {s}\n", .{ opts.node_id, opts.node_parent_id, opts.text });
+    }
+}
+
 /// Convert any actions during the frame into events to be processed next frame
 /// Note: Assumes `mutex` is already held.
 fn processActions(self: *AccessKit) void {
     const window: *dvui.Window = @alignCast(@fieldParentPtr("accesskit", self));
+
     for (self.action_requests.items) |request| {
         switch (request.action) {
             Action.click => {
@@ -315,17 +408,65 @@ fn processActions(self: *AccessKit) void {
                             },
                         }
                     };
-
-                    _ = window.addEventText(.{ .text = text_value, .target_id = @enumFromInt(request.target), .replace = true }) catch |err| logEventAddError(@src(), err);
+                    _ = window.addEventTextSelect(.{ .start = 0, .end = std.math.maxInt(usize), .target_id = @enumFromInt(request.target) }) catch |err| logEventAddError(@src(), err);
+                    _ = window.addEventText(.{ .text = text_value, .target_id = @enumFromInt(request.target) }) catch |err| logEventAddError(@src(), err);
                 }
             },
-            else => {},
+            Action.set_text_selection => {
+                if (!request.data.has_value or request.data.value.tag != ActionData.set_text_selection) {
+                    log.debug("Action set_text_selection has invalid data. Expected has_value = true, tag = {}; Received {}, {}\n", .{
+                        ActionData.set_text_selection,
+                        request.data.has_value,
+                        request.data.value.tag,
+                    });
+                    return;
+                }
+                // Anchor is the 'start' or non-moving part of the selection. Focus is the 'end' or moving part.
+                const anchor: TextPosition = request.data.value.unnamed_0.unnamed_7.set_text_selection.anchor;
+                const focus: TextPosition = request.data.value.unnamed_0.unnamed_7.set_text_selection.focus;
+                var anchor_run: ?TextRunOptions = null;
+                var focus_run: ?TextRunOptions = null;
+                // AK TODO: Consider making this a AutoArrayHashMap or similar to make this more scalable.
+                for (self.text_runs.items) |run| {
+                    if (run.node_id.asU64() == anchor.node) {
+                        anchor_run = run;
+                    }
+                    if (run.node_id.asU64() == focus.node) {
+                        focus_run = run;
+                    }
+                    if (anchor_run != null and focus_run != null) break;
+                }
+
+                if (anchor_run) |a| if (focus_run) |f| {
+                    _ = window.addEventTextSelect(.{
+                        .start = a.char_offset + anchor.character_index,
+                        .end = f.char_offset + focus.character_index,
+                    }) catch |err| {
+                        switch (err) {
+                            error.OutOfMemory => {},
+                        }
+                    };
+                };
+                if (anchor_run == null or focus_run == null) {
+                    log.debug("Action set_text_selection received for unknown text_run id {x}.", .{anchor.node});
+                }
+            },
+            Action.replace_selected_text => {
+                // TODO:
+            },
+            Action.scroll_into_view => {
+                // TODO:
+            },
+            else => |action| {
+                log.debug("Recieved unknown action {d}\n", .{action});
+            },
         }
     }
     if (self.action_requests.items.len > 0) {
-        self.action_requests.clearAndFree(window.gpa);
+        self.action_requests.clearRetainingCapacity();
         dvui.refresh(window, @src(), null);
     }
+    self.text_runs.clearAndFree(window.gpa);
 }
 
 fn logEventAddError(src: std.builtin.SourceLocation, err: anyerror) void {
@@ -387,6 +528,8 @@ pub fn deinit(self: *AccessKit) void {
 
     self.action_requests.clearAndFree(window.gpa);
     self.nodes.clearAndFree(window.gpa);
+    self.text_runs.clearAndFree(window.gpa);
+
     if (builtin.os.tag == .windows)
         if (dvui.backend.kind == .dx11) {
             c.accesskit_windows_adapter_free(self.adapter.?);
@@ -1459,3 +1602,4 @@ pub const RoleNoAccessKit = enum {
 };
 
 const debug_node_tree = false;
+const debug_textruns: bool = false;

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -982,6 +982,7 @@ pub fn ZigCodeFormatter(comptime T: type) type {
                         try writer.writeAll(" }");
                     },
                 },
+                .void => {},
                 else => @compileError("Unhandled field type: " ++ @typeName(T)),
             }
         }

--- a/src/Event.zig
+++ b/src/Event.zig
@@ -50,9 +50,19 @@ pub fn handle(self: *Event, src: std.builtin.SourceLocation, wd: *const dvui.Wid
 }
 
 pub const Text = struct {
-    txt: []u8,
-    selected: bool = false,
-    replace: bool = false,
+    pub const Selection = struct {
+        start: usize,
+        end: usize,
+    };
+
+    pub const Action = union(enum) {
+        value: struct {
+            txt: []u8,
+            selected: bool,
+        },
+        selection: Selection,
+    };
+    action: Action,
 };
 
 pub const Key = struct {

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -105,10 +105,6 @@ background: ?bool = null,
 /// Render a box shadow in `WidgetData.borderAndBackground`.
 box_shadow: ?BoxShadow = null,
 
-/// Overrides the default accesskit parent node.
-/// Use when the accesskit node tree is different to the widget tree.
-ak_node_parent: ?*dvui.AccessKit.Node = null,
-
 pub const LabelOpts = union(enum) {
     /// Use the label from a different widget.  This is preferred if there is a
     /// visible widget that labels this one.

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -105,6 +105,10 @@ background: ?bool = null,
 /// Render a box shadow in `WidgetData.borderAndBackground`.
 box_shadow: ?BoxShadow = null,
 
+/// Overrides the default accesskit parent node.
+/// Use when the accesskit node tree is different to the widget tree.
+ak_node_parent: ?*dvui.AccessKit.Node = null,
+
 pub const LabelOpts = union(enum) {
     /// Use the label from a different widget.  This is preferred if there is a
     /// visible widget that labels this one.

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -543,7 +543,6 @@ pub fn addEventKey(self: *Self, event: Event.Key) std.mem.Allocator.Error!bool {
 pub const AddEventTextOptions = struct {
     text: []const u8,
     selected: bool = false,
-    replace: bool = false,
     target_id: ?dvui.Id = null,
 };
 
@@ -561,11 +560,42 @@ pub fn addEventText(self: *Self, opts: AddEventTextOptions) std.mem.Allocator.Er
     try self.events.append(self.arena(), Event{
         .num = self.event_num,
         .evt = .{
-            .text = .{
+            .text = .{ .action = .{ .value = .{
                 .txt = try self.arena().dupe(u8, opts.text),
                 .selected = opts.selected,
-                .replace = opts.replace,
-            },
+            } } },
+        },
+        .target_windowId = self.subwindows.focused_id,
+        .target_widgetId = opts.target_id orelse if (self.subwindows.focused()) |sw| sw.focused_widget_id else null,
+    });
+
+    const ret = (self.data().id != self.subwindows.focused_id);
+    try self.positionMouseEventAdd();
+    return ret;
+}
+
+pub const AddEventTextSelectOptions = struct {
+    start: usize,
+    end: usize,
+    target_id: ?dvui.Id = null,
+};
+
+/// Add an event that represents text being selected.
+///
+/// This can be called outside begin/end.  You should add all the events
+/// for a frame either before begin() or just after begin() and before
+/// calling normal dvui widgets.  end() clears the event list.
+pub fn addEventTextSelect(self: *Self, opts: AddEventTextSelectOptions) std.mem.Allocator.Error!bool {
+    self.positionMouseEventRemove();
+
+    self.event_num += 1;
+    try self.events.append(self.arena(), Event{
+        .num = self.event_num,
+        .evt = .{
+            .text = .{ .action = .{ .selection = .{
+                .start = opts.start,
+                .end = opts.end,
+            } } },
         },
         .target_windowId = self.subwindows.focused_id,
         .target_widgetId = opts.target_id orelse if (self.subwindows.focused()) |sw| sw.focused_widget_id else null,

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -3743,10 +3743,15 @@ pub fn slider(src: std.builtin.SourceLocation, init_opts: SliderInitOptions, opt
                     }
                 }
             },
-            .text => |te| blk: {
-                e.handle(@src(), b.data());
-                const value: f32 = std.fmt.parseFloat(f32, te.txt) catch break :blk;
-                init_opts.fraction.* = std.math.clamp(value, 0.0, 1.0);
+            .text => |te| {
+                switch (te.action) {
+                    .value => |set| blk: {
+                        e.handle(@src(), b.data());
+                        const value: f32 = std.fmt.parseFloat(f32, set.txt) catch break :blk;
+                        init_opts.fraction.* = std.math.clamp(value, 0.0, 1.0);
+                    },
+                    else => {},
+                }
             },
             else => {},
         }
@@ -4105,11 +4110,16 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
                     }
                 },
                 .text => |te| {
-                    e.handle(@src(), b.data());
-                    var value = std.fmt.parseFloat(f32, te.txt) catch init_opts.min orelse 0;
-                    if (init_opts.min) |min| value = @max(min, value);
-                    if (init_opts.max) |max| value = @min(max, value);
-                    init_opts.value.* = value;
+                    switch (te.action) {
+                        .value => |set| {
+                            e.handle(@src(), b.data());
+                            var value = std.fmt.parseFloat(f32, set.txt) catch init_opts.min orelse 0;
+                            if (init_opts.min) |min| value = @max(min, value);
+                            if (init_opts.max) |max| value = @min(max, value);
+                            init_opts.value.* = value;
+                        },
+                        else => {},
+                    }
                 },
                 else => {},
             }

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -284,9 +284,14 @@ pub fn hueSlider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hue
                 }
             },
             .text => |te| {
-                const new_hue = std.fmt.parseFloat(f32, te.txt) catch hue.*;
-                if (new_hue >= 0 and new_hue < 360) {
-                    hue.* = new_hue;
+                switch (te.action) {
+                    .value => |set| {
+                        const new_hue = std.fmt.parseFloat(f32, set.txt) catch hue.*;
+                        if (new_hue >= 0 and new_hue < 360) {
+                            hue.* = new_hue;
+                        }
+                    },
+                    else => {},
                 }
             },
             else => {},

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -12,6 +12,7 @@ const Widget = dvui.Widget;
 const WidgetData = dvui.WidgetData;
 const ScrollAreaWidget = dvui.ScrollAreaWidget;
 const TextLayoutWidget = dvui.TextLayoutWidget;
+const AccessKit = dvui.AccessKit;
 
 const TextEntryWidget = @This();
 
@@ -204,7 +205,12 @@ pub fn init(self: *TextEntryWidget, src: std.builtin.SourceLocation, init_opts: 
         .cache_layout = self.init_opts.cache_layout,
         .focused = self.data().id == dvui.focusedWidgetId(),
         .show_touch_draggables = (self.len > 0),
-    }, self.data().options.strip().override(.{ .role = .none, .expand = .both, .padding = self.padding }));
+        .ak_text_parent = if (self.data().accesskit_node()) |_| self.data().id else null,
+    }, self.data().options.strip().override(.{
+        .role = .none,
+        .expand = .both,
+        .padding = self.padding,
+    }));
 
     // if textLayout forced cache_layout to false, we need to honor that
     self.init_opts.cache_layout = self.textLayout.cache_layout;
@@ -269,14 +275,17 @@ pub fn init(self: *TextEntryWidget, src: std.builtin.SourceLocation, init_opts: 
     // textLayout clips to its content, but we need to get events out to our border
     dvui.clipSet(borderClip);
     if (self.data().accesskit_node()) |ak_node| {
-        dvui.AccessKit.nodeAddAction(ak_node, dvui.AccessKit.Action.focus);
-        dvui.AccessKit.nodeAddAction(ak_node, dvui.AccessKit.Action.set_value);
+        AccessKit.nodeAddAction(ak_node, AccessKit.Action.focus);
+        AccessKit.nodeAddAction(ak_node, AccessKit.Action.set_value);
+        AccessKit.nodeAddAction(ak_node, AccessKit.Action.set_text_selection);
+        AccessKit.nodeAddAction(ak_node, AccessKit.Action.replace_selected_text);
+        AccessKit.nodeAddAction(ak_node, AccessKit.Action.scroll_into_view); // AK TODO - not yet implemented
+        AccessKit.nodeSetClipsChildren(ak_node); // AK TODO: Check this is correct?
+
         if (self.data().options.role != .password_input) {
-            const str = dvui.currentWindow().arena().dupeZ(u8, self.text) catch "";
+            const str = dvui.currentWindow().arena().dupeZ(u8, self.text[0..self.len]) catch "";
             defer dvui.currentWindow().arena().free(str);
-            // TODO: We don't want to always push large amounts of text each frame. So we either need to look at pushing
-            // only chunks of text, ot only pushing when the text has actually changed since last frame.
-            dvui.AccessKit.nodeSetValue(ak_node, str);
+            AccessKit.nodeSetValue(ak_node, str);
         }
     }
 }
@@ -292,6 +301,7 @@ pub fn matchEvent(self: *TextEntryWidget, e: *Event) bool {
 
 pub fn processEvents(self: *TextEntryWidget) void {
     const evts = dvui.events();
+    //std.debug.print("EVTS = {any}\n", .{evts});
     for (evts) |*e| {
         if (!self.matchEvent(e))
             continue;
@@ -971,24 +981,26 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event) void {
             }
         },
         .text => |te| {
-            e.handle(@src(), self.data());
-            var new = std.mem.sliceTo(te.txt, 0);
-            if (te.replace) {
-                self.textLayout.selection.selectAll();
-            }
-            if (self.init_opts.multiline) {
-                self.textTyped(new, te.selected);
-            } else {
-                var i: usize = 0;
-                while (i < new.len) {
-                    if (std.mem.indexOfScalar(u8, new[i..], '\n')) |idx| {
-                        self.textTyped(new[i..][0..idx], te.selected);
-                        i += idx + 1;
+            switch (te.action) {
+                .value => |set| {
+                    e.handle(@src(), self.data());
+                    var new = std.mem.sliceTo(set.txt, 0);
+                    if (self.init_opts.multiline) {
+                        self.textTyped(new, set.selected);
                     } else {
-                        self.textTyped(new[i..], te.selected);
-                        break;
+                        var i: usize = 0;
+                        while (i < new.len) {
+                            if (std.mem.indexOfScalar(u8, new[i..], '\n')) |idx| {
+                                self.textTyped(new[i..][0..idx], set.selected);
+                                i += idx + 1;
+                            } else {
+                                self.textTyped(new[i..], set.selected);
+                                break;
+                            }
+                        }
                     }
-                }
+                },
+                else => {},
             }
         },
         .mouse => |me| {

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -1442,18 +1442,8 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
             const r: Rect = .{ .x = self.insert_pt.x, .y = self.insert_pt.y, .w = s.w, .h = @min(s.h, self.data().contentRect().h - self.insert_pt.y) };
             const rs = self.screenRectScale(r);
             //std.debug.print("renderText: {} {s}\n", .{ rs.r, txt[0..end] });
-            var rtxt = if (self.newline) txt[0 .. end - 1] else txt[0..end];
+            const rtxt = txt[0..end];
 
-            // If the newline is part of the selection, then render it as a
-            // selected space.  This matches Chrome's behavior, although this is
-            // not a universal - Firefox doesn't do this.
-            if (self.newline and
-                (self.selection.start -| self.bytes_seen -| rtxt.len) == 0 and
-                (self.selection.end -| self.bytes_seen -| rtxt.len) > 0)
-            {
-                rtxt = std.mem.concat(cw.lifo(), u8, &.{ rtxt, " " }) catch txt;
-            }
-            defer if (txt.ptr != rtxt.ptr) cw.lifo().free(rtxt);
             const textrun_info: ?AccessKit.TextRunOptions = info: {
                 if (dvui.accesskit_enabled and cw.accesskit.text_run_parent != null) {
                     if (cw.accesskit.nodes.get(cw.accesskit.text_run_parent.?)) |_| {
@@ -1480,7 +1470,6 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
                             .node_id = text_run_widget.data().id,
                             .node_parent_id = cw.accesskit.text_run_parent.?,
                             .char_offset = self.bytes_seen,
-                            .text = txt[0..end],
                         };
                     }
                 }
@@ -1796,11 +1785,11 @@ pub fn addTextDone(self: *TextLayoutWidget, opts: Options) void {
                     .w = 0,
                     .x = 0,
                 }) catch {};
-                dvui.currentWindow().accesskit.textRunPopulate(.{
+                dvui.currentWindow().accesskit.textRunPopulate("",
+                    .{
                     .node_id = vp.data().id,
                     .node_parent_id = cw.accesskit.text_run_parent.?,
                     .char_offset = 0,
-                    .text = "",
                 }, &text_info, self.data().contentRectScale().rectToPhysical(empty_space));
             }
 


### PR DESCRIPTION
Initial text run support for testing.

- TextEntryWidget creates the TextLayoutWidget with a role of .none, and passes as the accessibility parent via Options.ak_node_parent.
- Each line of text must be in its own text_run.
- TextLayoutWidget creates a VirtualParentWidget using `self.bytes_seen` as the `extra_id` to generate a node_id for the text_run for that line
- In renderText() records the position and dimensions of each character in the text_info multi array list.
- Must be careful as renderText can delay rendering so text_info might not be populated when rederText() returns.
- In cases where text won't be rendered by renderrText, a text_run should not be created.
- AccessKits textRunPopulate() fills in the text run details for the node based on text_info from renderText(),

Complete:
- text_run for single and multi-line input boxes
- text_run for read-only text layout widgets.
- text selection action

TODO:
- [ ] Better support for text that has scrolled off screen. 
    - From testing, believe I should use the last visible word as the bounds for all non-visible text.

@ethindp Would appreciate if you could try this for the various text inputs and see if it behaves as you expect. 
Does it make sense to implement this for read-only text as well? 
Or is it better to implement this for any selectable text, whether read-only or not?

@david-vanderson Any ideas on what I could use as id_extra for nodeCreate when processing each line of text in the TextLayoutWidget? Alternatives I thought about:
1) The rounded y position, which would be more reliable, but that doesn't seem 100% safe? In theory someone could display 2 different lines of text in y position 10.1 and 10.2 with a very zoomed-out view. Also as above, there are issues if you don't finish an addText with a newline as the next text_run will have the same y position and thus same id_extra.
2) A hash of the string. But that doesn't work if someone puts the same string on multiple lines (e.g. single newlines especially)
3) Make textAdd supply a @src()? Then use line numbers vs the passed in @src()? - Actually, I think you'd need to add an id_extra as well, in case textAdd is called in a loop with the same @src() without any newlines.

If a duplicate id is generated, the application will panic, so I'd like to have something we can 100% rely on if possible.

Edit: I think just keeping a count of how many lines the TextLayoutWidget has processed, combined with how many times textAdd has been called will work. I will try that and see if it fixes things.

Thanks.