### PR TITLE
ReorderWidget: Always need last slot if dragging any item

### DIFF
--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -51,7 +51,7 @@ fn dragging(self: *ReorderWidget) bool {
 }
 
 pub fn needFinalSlot(self: *ReorderWidget) bool {
-    if (self.dragging() and self.data().borderRectScale().r.contains(dvui.currentWindow().mouse_pt)) {
+    if (self.dragging()) {
         return !self.found_slot;
     }
 


### PR DESCRIPTION
This is a very small change, but I think its a good change for the specific scenario of having a reorderable widget within a scroll area. I believe after looking, it makes sense that anytime an item is dragged it is removed from the list, but a space remains available for it to take even when it is not hovering the reorderable widget, so scroll areas are not affected by the change in widget size when trying to drag onto the free slot at the bottom.

Current behavior:

https://github.com/user-attachments/assets/68d6fc4a-cf81-4aac-91ea-b6c1c78a5851

Always when dragging:

https://github.com/user-attachments/assets/1cddfe4d-4828-49fe-8590-c5bc5da5739a

