### PR TITLE
Examples: Add view_source button to show each example's source code

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1002,6 +1002,18 @@ pub fn addDvuiModule(
                 .flags = &.{"-std=c11"},
             });
         }
+        const tree_sitter_zig_dep = b.lazyDependency("tree_sitter_zig", .{
+            .target = target,
+            .optimize = optimize,
+        });
+        if (tree_sitter_zig_dep) |tsc| {
+            dvui_mod.addIncludePath(tsc.path("src"));
+            dvui_mod.addCSourceFiles(.{
+                .root = tsc.path(""),
+                .files = &.{"src/parser.c"},
+                .flags = &.{"-std=c11"},
+            });
+        }
     }
 
     return dvui_mod;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -69,6 +69,10 @@
             .hash = "N-V-__8AAHNaAgD6kjK3HX6lAf89chPqS5zIm0tLpvBQLOtX",
             .lazy = true,
         },
+        .tree_sitter_zig = .{
+            .url = "git+https://github.com/tree-sitter-grammars/tree-sitter-zig.git#6479aa13f32f701c383083d8b28360ebd682fb7d",
+            .hash = "tree_sitter_zig-1.1.2-AAAAAJ57XACsD_XBHC4i6G6rnCsZ1dZj7CLRTC09toEB",
+        },
         .zgl = .{
             .url = "git+https://github.com/ziglibs/zgl#6ee54c287f3c4f176bd05a92746828bb791a1ad0",
             .hash = "zgl-1.1.0-p_NpAJNECgCzUGx0aF5KFsmD5VOwfw8LaOsN0fcoU2bi",

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -6,6 +6,8 @@ pub const zig_svg = @embedFile("zig-mark.svg");
 pub var show_demo_window: bool = false;
 pub var show_widgetpedia_window: bool = false;
 pub var icon_browser_show: bool = false;
+var source_code_show: bool = false;
+var source_code_rect: dvui.Rect = undefined;
 var frame_counter: u64 = 0;
 pub var show_dialog: bool = false;
 var scale_val: f32 = 1.0;
@@ -19,7 +21,7 @@ pub const demoKind = enum {
     layout,
     text_layout,
     plots,
-    reorderable,
+    reorder_tree,
     menus,
     scrolling,
     scroll_canvas,
@@ -39,7 +41,7 @@ pub const demoKind = enum {
             .layout => "Layout",
             .text_layout => "Text Layout",
             .plots => "Plots",
-            .reorderable => "Reorder / Tree",
+            .reorder_tree => "Reorder / Tree",
             .menus => "Menus / Focus",
             .scrolling => "Scrolling",
             .scroll_canvas => "Scroll Canvas",
@@ -61,7 +63,7 @@ pub const demoKind = enum {
             .layout => .{ .scale = 0.45, .offset = .{ .x = -50 } },
             .text_layout => .{ .scale = 0.45, .offset = .{} },
             .plots => .{ .scale = 0.45, .offset = .{} },
-            .reorderable => .{ .scale = 0.45, .offset = .{} },
+            .reorder_tree => .{ .scale = 0.45, .offset = .{} },
             .menus => .{ .scale = 0.45, .offset = .{} },
             .scrolling => .{ .scale = 0.45, .offset = .{ .x = -150, .y = 0 } },
             .scroll_canvas => .{ .scale = 0.35, .offset = .{ .y = -120 } },
@@ -210,7 +212,7 @@ pub fn demo(comptime include: DemoInclude) void {
                     .layout => layout(),
                     .text_layout => layoutText(),
                     .plots => plots(),
-                    .reorderable => reorderLists(),
+                    .reorder_tree => reorderLists(),
                     .menus => menus(),
                     .scrolling => scrolling(),
                     .scroll_canvas => scrollCanvas(),
@@ -240,7 +242,7 @@ pub fn demo(comptime include: DemoInclude) void {
 
     if (paned.showSecond()) {
         {
-            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });
             defer hbox.deinit();
 
             if (paned.collapsed() and dvui.button(@src(), "Back to Demos", .{}, .{ .min_size_content = .{ .h = 30 }, .tag = "dvui_demo_window_back" })) {
@@ -248,6 +250,11 @@ pub fn demo(comptime include: DemoInclude) void {
             }
 
             dvui.label(@src(), "{s}", .{demo_active.name()}, .{ .font = dvui.Font.theme(.title), .gravity_y = 0.5 });
+            if (dvui.labelClick(@src(), "View source code", .{}, .{}, .{ .gravity_x = 1.0, .gravity_y = 0.5, .color_text = dvui.themeGet().focus })) {
+                const window_rect = dvui.currentWindow().data().contentRect();
+                source_code_rect = .{ .x = window_rect.x + window_rect.w / 2, .y = window_rect.y, .h = window_rect.h, .w = window_rect.w / 2 };
+                source_code_show = true;
+            }
         }
 
         var scroll: ?*dvui.ScrollAreaWidget = null;
@@ -268,7 +275,7 @@ pub fn demo(comptime include: DemoInclude) void {
             .layout => layout(),
             .text_layout => layoutText(),
             .plots => plots(),
-            .reorderable => reorderLists(),
+            .reorder_tree => reorderLists(),
             .menus => menus(),
             .scrolling => scrolling(),
             .scroll_canvas => scrollCanvas(),
@@ -292,6 +299,15 @@ pub fn demo(comptime include: DemoInclude) void {
 
     if (StrokeTest.show) {
         show_stroke_test_window();
+    }
+
+    if (source_code_show) {
+        switch (demo_active) {
+            inline else => |demo_name| {
+                const source_code = if (dvui.useTreeSitter) @embedFile("Examples/" ++ @tagName(demo_name) ++ ".zig") else "";
+                displayZigSourceCode(@tagName(demo_name) ++ ".zig", source_code, &source_code_show, &source_code_rect);
+            },
+        }
     }
 }
 
@@ -464,6 +480,72 @@ pub fn grids() void {
         .row_heights => gridVariableRowHeights(),
         .selection => gridSelection(),
         .navigation => gridNavigation(),
+    }
+}
+
+fn displayZigSourceCode(filename: []const u8, source: []const u8, showing: *bool, rect: *Rect) void {
+    if (dvui.useTreeSitter) {
+        const fwin = dvui.floatingWindow(@src(), .{ .rect = rect, .open_flag = showing }, .{});
+        defer fwin.deinit();
+        fwin.dragAreaSet(dvui.windowHeader("View Zig Source", filename, showing));
+
+        const global = struct {
+            extern fn tree_sitter_zig() callconv(.c) *dvui.c.TSLanguage;
+            var source_code: []const u8 = "";
+        };
+
+        var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+        defer hbox.deinit();
+
+        const queries = @embedFile("Examples/tree_sitter_zig_queries.scm");
+
+        const highlights: []const dvui.TextEntryWidget.SyntaxHighlight = &.{
+            .{ .name = "comment", .opts = .{ .color_text = .fromHex("6A9955") } },
+            .{ .name = "keyword", .opts = .{ .color_text = .fromHex("569CD6") } },
+            .{ .name = "identifier", .opts = .{ .color_text = .fromHex("D4D4D4") } },
+            .{ .name = "function", .opts = .{ .color_text = .fromHex("DCDCAA") } },
+            .{ .name = "type", .opts = .{ .color_text = .fromHex("4EC9B0") } },
+            .{ .name = "builtin", .opts = .{ .color_text = .fromHex("4EC9B0") } },
+            .{ .name = "field", .opts = .{ .color_text = .fromHex("9CDCFE") } },
+            .{ .name = "variable", .opts = .{ .color_text = .fromHex("9CDCFE") } },
+            .{ .name = "constant", .opts = .{ .color_text = .fromHex("C586C0") } },
+            .{ .name = "string", .opts = .{ .color_text = .fromHex("CE9178") } },
+            .{ .name = "number", .opts = .{ .color_text = .fromHex("B5CEA8") } },
+            .{ .name = "operator", .opts = .{ .color_text = .fromHex("D4D4D4") } },
+            .{ .name = "error", .opts = .{ .color_text = .fromHex("F44747") } },
+        };
+
+        var te: dvui.TextEntryWidget = undefined;
+        te.init(@src(), .{
+            .multiline = true,
+            .cache_layout = true,
+            .text = .{ .internal = .{ .limit = 1_000_000 } },
+            .tree_sitter = .{
+                .language = global.tree_sitter_zig(),
+                .queries = queries,
+                .highlights = highlights,
+                .log_captures = false,
+            },
+        }, .{
+            .expand = .both,
+        });
+        defer te.deinit();
+
+        if (dvui.firstFrame(te.data().id) or source.ptr != global.source_code.ptr) {
+            te.textSet(source, false);
+            te.textLayout.selection.moveCursor(0, false); // keep from scrolling to the bottom
+            global.source_code = source;
+        }
+
+        // Don't process events. Read-only view.
+        te.draw();
+    } else {
+        if (showing.*) {
+            var url: std.io.Writer.Allocating = .init(dvui.currentWindow().arena());
+            url.writer.print("https://github.com/david-vanderson/dvui/blob/main/src/Examples/{s}", .{filename}) catch return;
+            _ = dvui.openURL(.{ .url = url.toOwnedSlice() catch return, .new_window = false });
+            showing.* = false;
+        }
     }
 }
 

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -250,10 +250,12 @@ pub fn demo(comptime include: DemoInclude) void {
             }
 
             dvui.label(@src(), "{s}", .{demo_active.name()}, .{ .font = dvui.Font.theme(.title), .gravity_y = 0.5 });
-            if (dvui.labelClick(@src(), "View source code", .{}, .{}, .{ .gravity_x = 1.0, .gravity_y = 0.5, .color_text = dvui.themeGet().focus })) {
-                const window_rect = dvui.currentWindow().data().contentRect();
-                source_code_rect = .{ .x = window_rect.x + window_rect.w / 2, .y = window_rect.y, .h = window_rect.h, .w = window_rect.w / 2 };
-                source_code_show = true;
+            if (include == .full) {
+                if (dvui.labelClick(@src(), "View source code", .{}, .{}, .{ .gravity_x = 1.0, .gravity_y = 0.5, .color_text = dvui.themeGet().focus })) {
+                    const window_rect = dvui.currentWindow().data().contentRect();
+                    source_code_rect = .{ .x = window_rect.x + window_rect.w / 2, .y = window_rect.y, .h = window_rect.h, .w = window_rect.w / 2 };
+                    source_code_show = true;
+                }
             }
         }
 
@@ -301,7 +303,7 @@ pub fn demo(comptime include: DemoInclude) void {
         show_stroke_test_window();
     }
 
-    if (source_code_show) {
+    if (include == .full and source_code_show) {
         switch (demo_active) {
             inline else => |demo_name| {
                 const source_code = if (dvui.useTreeSitter) @embedFile("Examples/" ++ @tagName(demo_name) ++ ".zig") else "";

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -537,7 +537,7 @@ fn displayZigSourceCode(filename: []const u8, source: []const u8, showing: *bool
             global.source_code = source;
         }
 
-        // Don't process events. Read-only view.
+        te.textLayout.processEvents();
         te.draw();
     } else {
         if (showing.*) {

--- a/src/Examples/tree_sitter_zig_queries.scm
+++ b/src/Examples/tree_sitter_zig_queries.scm
@@ -1,0 +1,283 @@
+; Variables
+(identifier) @variable
+
+; Parameters
+(parameter
+  name: (identifier) @variable.parameter)
+
+(payload
+  (identifier) @variable.parameter)
+
+; Types
+(parameter
+  type: (identifier) @type)
+
+((identifier) @type
+  (#lua-match? @type "^[A-Z_][a-zA-Z0-9_]*"))
+
+(variable_declaration
+  (identifier) @type
+  "="
+  [
+    (struct_declaration)
+    (enum_declaration)
+    (union_declaration)
+    (opaque_declaration)
+  ])
+
+[
+  (builtin_type)
+  "anyframe"
+] @type.builtin
+
+; Constants
+((identifier) @constant
+  (#lua-match? @constant "^[A-Z][A-Z_0-9]+$"))
+
+[
+  "null"
+  "unreachable"
+  "undefined"
+] @constant.builtin
+
+(field_expression
+  .
+  member: (identifier) @constant)
+
+(enum_declaration
+  (container_field
+    type: (identifier) @constant))
+
+; Labels
+(block_label
+  (identifier) @label)
+
+(break_label
+  (identifier) @label)
+
+; Fields
+(field_initializer
+  .
+  (identifier) @variable.member)
+
+(field_expression
+  (_)
+  member: (identifier) @variable.member)
+
+(container_field
+  name: (identifier) @variable.member)
+
+(initializer_list
+  (assignment_expression
+    left: (field_expression
+      .
+      member: (identifier) @variable.member)))
+
+; Functions
+(builtin_identifier) @function.builtin
+
+(call_expression
+  function: (identifier) @function.call)
+
+(call_expression
+  function: (field_expression
+    member: (identifier) @function.call))
+
+(function_declaration
+  name: (identifier) @function)
+
+; Modules
+(variable_declaration
+  (identifier) @module
+  (builtin_function
+    (builtin_identifier) @keyword.import
+    (#any-of? @keyword.import "@import" "@cImport")))
+
+; Builtins
+[
+  "c"
+  "..."
+] @variable.builtin
+
+((identifier) @variable.builtin
+  (#eq? @variable.builtin "_"))
+
+(calling_convention
+  (identifier) @variable.builtin)
+
+; Keywords
+[
+  "asm"
+  "defer"
+  "errdefer"
+  "test"
+  "error"
+  "const"
+  "var"
+] @keyword
+
+[
+  "struct"
+  "union"
+  "enum"
+  "opaque"
+] @keyword.type
+
+[
+  "async"
+  "await"
+  "suspend"
+  "nosuspend"
+  "resume"
+] @keyword.coroutine
+
+"fn" @keyword.function
+
+[
+  "and"
+  "or"
+  "orelse"
+] @keyword.operator
+
+"return" @keyword.return
+
+[
+  "if"
+  "else"
+  "switch"
+] @keyword.conditional
+
+[
+  "for"
+  "while"
+  "break"
+  "continue"
+] @keyword.repeat
+
+[
+  "usingnamespace"
+  "export"
+] @keyword.import
+
+[
+  "try"
+  "catch"
+] @keyword.exception
+
+[
+  "volatile"
+  "allowzero"
+  "noalias"
+  "addrspace"
+  "align"
+  "callconv"
+  "linksection"
+  "pub"
+  "inline"
+  "noinline"
+  "extern"
+  "comptime"
+  "packed"
+  "threadlocal"
+] @keyword.modifier
+
+; Operator
+[
+  "="
+  "*="
+  "*%="
+  "*|="
+  "/="
+  "%="
+  "+="
+  "+%="
+  "+|="
+  "-="
+  "-%="
+  "-|="
+  "<<="
+  "<<|="
+  ">>="
+  "&="
+  "^="
+  "|="
+  "!"
+  "~"
+  "-"
+  "-%"
+  "&"
+  "=="
+  "!="
+  ">"
+  ">="
+  "<="
+  "<"
+  "&"
+  "^"
+  "|"
+  "<<"
+  ">>"
+  "<<|"
+  "+"
+  "++"
+  "+%"
+  "-%"
+  "+|"
+  "-|"
+  "*"
+  "/"
+  "%"
+  "**"
+  "*%"
+  "*|"
+  "||"
+  ".*"
+  ".?"
+  "?"
+  ".."
+] @operator
+
+; Literals
+(character) @character
+
+([
+  (string)
+  (multiline_string)
+] @string
+  (#set! "priority" 95))
+
+(integer) @number
+
+(float) @number.float
+
+(boolean) @boolean
+
+(escape_sequence) @string.escape
+
+; Punctuation
+[
+  "["
+  "]"
+  "("
+  ")"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  ";"
+  "."
+  ","
+  ":"
+  "=>"
+  "->"
+] @punctuation.delimiter
+
+(payload
+  "|" @punctuation.bracket)
+
+; Comments
+(comment) @comment @spell
+
+((comment) @comment.documentation
+  (#lua-match? @comment.documentation "^//!"))


### PR DESCRIPTION
I got distracted from fixing accessibility issues and the tree sitter API is far too easy to use not to try this.

The `tree_sitter_zig_queries.scm` should come from the dependency, but I couldn't see any nice way to do that. There was an existing sample of this file in `examples`, so I just moved it to `src\Examples` instead.

- Display source code with treesitter if supported
- Otherwise open in browser

I'm pretty bad at colours, so if someone with better taste wants to improve the highlighting colours, please feel free.
It would be nice to have a read-only mode on the text entry widget that handles selection, copy/paste etc, but not modification. Even if it was a different processEvents that just did a sub-set of the events? But it's probably not generally useful as without the tree sitter requirement, I'd just use a text layout widget instead.
