### PR TITLE
Zig16 progress

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,8 +21,8 @@
             .lazy = true,
         },
         .raylib = .{
-            .url = "git+https://github.com/raysan5/raylib?ref=master#720dd22491cdc4a29ec0ea87b572d9380872198c",
-            .hash = "raylib-5.6.0-dev-whq8uMVQCgVTgRxG3REWgBBSi2BR-nf4bq6eqANxImt7",
+            .url = "git+https://github.com/kristoff-it/raylib?ref=zig-0.16#68eff3f612091d9e713d2229b4f840582dbfc28f",
+            .hash = "raylib-5.6.0-dev-whq8uLAJDQXCUoWbI50KR2RX8f1NhyzmklCim1bT2EH2",
             .lazy = true,
         },
         //used in the raylib-ontop example
@@ -49,13 +49,13 @@
 
         // Experimental zig bindings, any zig based backend will be located here
         .raylib_zig = .{
-            .url = "git+https://github.com/raylib-zig/raylib-zig?ref=devel#3cd4d3179d967fc8b931514603fdbc4a43a1d771",
-            .hash = "raylib_zig-5.6.0-dev-KE8REE1LBQCL7lia-DwUkusWI1G4kJmhtatLh2kNsuiE",
+            .url = "git+https://github.com/kristoff-it/raylib-zig?ref=zig-0.16#726be415fcff4b96e6a9684c48f17bbe494d64a7",
+            .hash = "raylib_zig-5.6.0-dev-KE8REIFNBQDiMLazOzPK8E2cdRvcgI7m9mRvLAi3y4y9",
             .lazy = true,
         },
         .zglfw = .{
-            .url = "git+https://github.com/zig-gamedev/zglfw.git#6034a5623312c58bf5e64c1a2b686691c28575f4",
-            .hash = "zglfw-0.10.0-dev-zgVDNPKyIQCBi-wv_vxkvIQq1u0bP4D56Wszx_2mszc7",
+            .url = "git+https://github.com/zig-gamedev/zglfw.git#d9c06187e8b23e91b2ba6865d265e4213e5e7d09",
+            .hash = "zglfw-0.10.0-dev-zgVDNC64IQCeL-_eVOA27Wa50WVitrJswOZVvgcXmIsy",
             .lazy = true,
         },
         .tree_sitter = .{

--- a/examples/sdl-ontop.zig
+++ b/examples/sdl-ontop.zig
@@ -30,7 +30,7 @@ pub fn main() !void {
     // app_init is a stand-in for what your application is already doing to set things up
     try app_init();
 
-    var io: std.Io.Threaded = .init(gpa);
+    var io: std.Io.Threaded = .init(gpa, .{});
     defer io.deinit();
 
     // create SDL backend using existing window and renderer, app still owns the window/renderer

--- a/examples/web-test.zig
+++ b/examples/web-test.zig
@@ -10,7 +10,7 @@ pub var js_console = WebBackend.Console.init(&wasm_log_console_buffer);
 
 pub fn logFn(
     comptime message_level: std.log.Level,
-    comptime scope: @Type(.enum_literal),
+    comptime scope: @EnumLiteral(),
     comptime format: []const u8,
     args: anytype,
 ) void {

--- a/src/Examples/reorder_tree.zig
+++ b/src/Examples/reorder_tree.zig
@@ -764,7 +764,7 @@ pub fn fileTree(src: std.builtin.SourceLocation, root_directory: []const u8, tre
 fn recurseFiles(root_directory: []const u8, outer_tree: *dvui.TreeWidget, uniqueId: dvui.Id, branch_options: dvui.Options, expander_options: dvui.Options) !void {
     const recursor = struct {
         fn search(directory: []const u8, tree: *dvui.TreeWidget, uid: dvui.Id, color_id: *usize, branch_opts: dvui.Options, expander_opts: dvui.Options) !void {
-            var dir = std.fs.cwd().openDir(directory, .{ .access_sub_paths = true, .iterate = true }) catch return;
+            var dir = std.Io.Dir.cwd().openDir(directory, .{ .access_sub_paths = true, .iterate = true }) catch return;
             defer dir.close();
 
             const padding = dvui.Rect.all(2);

--- a/src/backends/sdl3gpu.zig
+++ b/src/backends/sdl3gpu.zig
@@ -1796,7 +1796,7 @@ fn sdlLogCallback(userdata: ?*anyopaque, category: c_int, priority: c_uint, mess
     }
 }
 
-fn sdlLog(comptime category: @Type(.enum_literal), priority: c_uint, message: [*c]const u8) void {
+fn sdlLog(comptime category: @EnumLiteral(), priority: c_uint, message: [*c]const u8) void {
     const logger = std.log.scoped(category);
     switch (priority) {
         c.SDL_LOG_PRIORITY_VERBOSE => logger.debug("VERBOSE: {s}", .{message}),
@@ -1828,7 +1828,7 @@ pub fn enableSDLLogging() void {
 
     c.SDL_SetLogPriorities(default_log_level);
 
-    const categories = [_]struct { c_uint, @Type(.enum_literal) }{
+    const categories = [_]struct { c_uint, @EnumLiteral() }{
         .{ c.SDL_LOG_CATEGORY_APPLICATION, .SDL_APPLICATION },
         .{ c.SDL_LOG_CATEGORY_ERROR, .SDL_ERROR },
         .{ c.SDL_LOG_CATEGORY_ASSERT, .SDL_ASSERT },

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -868,7 +868,7 @@ pub var js_console = Console.init(&wasm_log_console_buffer);
 
 pub fn logFn(
     comptime message_level: std.log.Level,
-    comptime scope: @Type(.enum_literal),
+    comptime scope: @EnumLiteral(),
     comptime format: []const u8,
     args: anytype,
 ) void {

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -1,3 +1,4 @@
+io: std.Io,
 allocator: std.mem.Allocator,
 backend: *Backend,
 window: *Window,
@@ -106,7 +107,7 @@ pub fn init(options: InitOptions) !Self {
     if (should_write_snapshots()) {
         // ensure snapshot directory exists
         // NOTE: do fs operation through cwd to handle relative and absolute paths
-        std.fs.cwd().makeDir(options.snapshot_dir) catch |err| switch (err) {
+        std.Io.Dir.cwd().makeDir(options.snapshot_dir) catch |err| switch (err) {
             error.PathAlreadyExists => {},
             else => return err,
         };
@@ -236,7 +237,7 @@ pub fn snapshot(self: *Self, src: std.builtin.SourceLocation, frame: dvui.App.fr
     const filename = try std.fmt.allocPrint(self.allocator, "{s}-{s}-{d}", .{ src.file, src.fn_name, self.snapshot_index });
     defer self.allocator.free(filename);
     // NOTE: do fs operation through cwd to handle relative and absolute paths
-    var dir = std.fs.cwd().openDir(self.snapshot_dir, .{}) catch |err| switch (err) {
+    var dir = std.Io.Dir.cwd().openDir(self.snapshot_dir, .{}) catch |err| switch (err) {
         error.FileNotFound => {
             std.debug.print("{s}:{d}:{d}: Snapshot directory did not exist! Run the test with DVUI_SNAPSHOT_WRITE to create all snapshot files\n", .{ src.file, src.line, src.column });
             return error.MissingSnapshotFile;
@@ -332,7 +333,7 @@ pub fn saveImage(self: *Self, frame: dvui.App.frameFunction, rect: ?dvui.Rect.Ph
         return;
     }
 
-    var dir = try std.fs.cwd().makeOpenPath(self.image_dir.?, .{});
+    var dir = try std.Io.Dir.cwd().makeOpenPath(self.image_dir.?, .{});
     defer dir.close();
     const file = try dir.createFile(filename, .{});
     defer file.close();


### PR DESCRIPTION
Made some progress, most notably I've made forks of:

- raylib
- raylib-zig

I would imagine raylib (and maybe also raylib-zig) has no interest in keeping up with 0.16-dev so I would recommend at some point making your own fork.

This commit still doesn't compile but does reduce the list of compile errors to:

- some places where there's a missing `io` argument. I haven't fixed those because it wasn't immediately obvious what would be the right way to pass the argument around (see the fix to `cacheBuster.zig` for an example of how to use the new style of main function, which is required to access environment variables, among other things)
- a bajillion cImport errors, which seem to point at header files in zig's library. @Vexu, would you be able to diagnose what the problem could be?

