### PR TITLE
Fix tab ordering on grid demos and improve accessibility

### DIFF
--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -3430,8 +3430,8 @@ pub fn gridHeadingSortable(
     const sort_changed = switch (g.colSortOrder(col_num)) {
         // Use same src for each button so they get the same id and can retain focus accross frames.
         .unsorted => button(src, heading, .{}, heading_opts),
-        .ascending => buttonLabelAndIcon(src, .{ .label = heading, .tvg_bytes = icon_ascending, .button_opts = .{} }, heading_opts),
-        .descending => buttonLabelAndIcon(src, .{ .label = heading, .tvg_bytes = icon_descending, .button_opts = .{} }, heading_opts),
+        .ascending => buttonLabelAndIcon(src, .{ .label = heading, .icon_label = "sorted ascending", .tvg_bytes = icon_ascending, .button_opts = .{} }, heading_opts),
+        .descending => buttonLabelAndIcon(src, .{ .label = heading, .icon_label = "sorted descending", .tvg_bytes = icon_descending, .button_opts = .{} }, heading_opts),
     };
 
     if (sort_changed) {
@@ -4002,6 +4002,8 @@ pub const ButtonLabelAndIconOptions = struct {
     label: []const u8,
     tvg_bytes: []const u8,
     icon_first: bool = false,
+    // Best practice is to supply an icon label for accessibility.
+    icon_label: ?[]const u8 = null,
 };
 
 pub fn buttonLabelAndIcon(src: std.builtin.SourceLocation, combined_opts: ButtonLabelAndIconOptions, opts: Options) bool {
@@ -4018,7 +4020,7 @@ pub fn buttonLabelAndIcon(src: std.builtin.SourceLocation, combined_opts: Button
     {
         var outer_hbox = box(src, .{ .dir = .horizontal }, .{ .expand = .horizontal });
         defer outer_hbox.deinit();
-        icon(@src(), combined_opts.label, combined_opts.tvg_bytes, .{}, options.strip().override(.{ .gravity_x = if (combined_opts.icon_first) 0.0 else 1.0, .color_text = opts.color_text }));
+        icon(@src(), combined_opts.icon_label orelse combined_opts.label, combined_opts.tvg_bytes, .{}, options.strip().override(.{ .gravity_x = if (combined_opts.icon_first) 0.0 else 1.0, .color_text = opts.color_text }));
         labelEx(@src(), "{s}", .{combined_opts.label}, .{ .align_x = 0.5 }, options.strip().override(.{ .expand = .both }));
     }
 

--- a/src/selection.zig
+++ b/src/selection.zig
@@ -1,7 +1,7 @@
 //! Helpers for Multi and Single selection
 //! Implements an event queue for selections.
 //! Selectable objects can optionally raise selection events which
-//! are the processed by these helpers
+//! are processed by these helpers
 
 const std = @import("std");
 const dvui = @import("dvui.zig");

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -170,8 +170,10 @@ pub const default_col_width: f32 = 100;
 
 //Widgets
 vbox: BoxWidget,
-/// SAFETY: Set by `bodyScrollContainerCreate`, is valid when `bscroll` is non-null
-group: dvui.FocusGroupWidget,
+/// SAFETY: Set by `headerScrollAreaCreate`, is valid when `hscroll` is non-null
+header_group: dvui.FocusGroupWidget,
+/// SAFETY: Set by `bodyScrollAreaCreate`, is valid when `bscroll` is non-null
+body_group: dvui.FocusGroupWidget,
 scroll: ScrollAreaWidget, // main scroll area
 hscroll: ?ScrollAreaWidget = null, // header scroll area
 bscroll: ?ScrollContainerWidget = null, // body scroll container
@@ -225,7 +227,8 @@ pub fn init(self: *GridWidget, src: std.builtin.SourceLocation, cols: WidthsOrNu
 
         // SAFETY: Widgets set bellow
         .vbox = undefined,
-        .group = undefined,
+        .header_group = undefined,
+        .body_group = undefined,
         .scroll = undefined,
     };
 
@@ -355,6 +358,7 @@ pub fn deinit(self: *GridWidget) void {
         !std.math.approxEqAbs(f32, self.header_height, self.last_header_height, 0.01);
 
     if (self.hscroll) |*hscroll| {
+        self.header_group.deinit();
         hscroll.deinit();
     }
 
@@ -365,7 +369,7 @@ pub fn deinit(self: *GridWidget) void {
     _ = dvui.spacer(@src(), .{ .min_size_content = this_size, .background = false });
 
     if (self.bscroll) |*bscroll| {
-        self.group.deinit();
+        self.body_group.deinit();
         bscroll.deinit();
     }
     self.scroll.deinit();
@@ -663,12 +667,14 @@ fn headerScrollAreaCreate(self: *GridWidget) void {
         if (!std.math.approxEqAbs(f32, self.header_height, self.last_header_height, 0.01)) {
             self.resizing = true;
         }
+        self.header_group.init(@src(), .{ .nav_key_dir = .horizontal }, .{ .tab_index = self.data().options.tab_index });
     }
 }
 
 fn bodyScrollContainerCreate(self: *GridWidget) void {
     // Finished with headers.
     if (self.hscroll) |*hscroll| {
+        self.header_group.deinit();
         hscroll.deinit();
         self.hscroll = null;
     }
@@ -687,7 +693,7 @@ fn bodyScrollContainerCreate(self: *GridWidget) void {
         self.bscroll.?.processEvents();
         self.bscroll.?.processVelocity();
 
-        self.group.init(@src(), .{ .nav_key_dir = .vertical }, .{});
+        self.body_group.init(@src(), .{ .nav_key_dir = .vertical }, .{ .tab_index = self.data().options.tab_index });
     }
 }
 

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -44,7 +44,7 @@ pub fn init(self: *TabsWidget, src: std.builtin.SourceLocation, init_opts: InitO
 
     self.scroll.init(src, scroll_opts, defaults.override(opts));
 
-    self.group.init(@src(), .{ .nav_key_dir = self.init_options.dir }, .{});
+    self.group.init(@src(), .{ .nav_key_dir = self.init_options.dir }, .{ .tab_index = opts.tab_index });
 
     const margin: Rect = switch (self.init_options.dir) {
         .horizontal => .{ .y = 2 },


### PR DESCRIPTION
- Pass tab order to internal widget tab groups
- Tab groups no longer include themselves in the tab index if they don't contain any tab-able widgets
- Grid headers are now in a focus group
- Sortable grid headers now display focus rings
- Sortable grid headers now retain focus when sort changes.
- Improve tab order on grid styling demo.
- Grid cells are read correctly.

Known Issues:
- When reading the grid, the reader needs to be moved a second time to the right on the first cell in any row to read the cell label. Moving again to the right reads the label from the next column. It is only when moving to a new row that I see the issue.
- AccessKit appears to make grid cells selectable, even if they are not. The reade rreads "not selected" for each cell in addition to the text.

Fixes #690

I still need to fix the tab order for the remaining grid demos. And back out some speculative changes to them.