### PR TITLE
fix: prefer current line height for text height

### DIFF
--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -1615,7 +1615,6 @@ pub fn addTextDone(self: *TextLayoutWidget, opts: Options) void {
     self.add_text_done = true;
 
     if (self.cache_layout and self.byte_heights.len > 0) {
-
         var edit_height: f32 = undefined;
         if (self.byte_height_after_idx) |i| {
             // this is not the final one
@@ -1697,7 +1696,7 @@ pub fn addTextDone(self: *TextLayoutWidget, opts: Options) void {
     self.selection.end = @min(self.selection.end, self.bytes_seen);
 
     const options = self.data().options.override(opts);
-    const text_height = options.fontGet().textHeight();
+    const text_height = if (self.current_line_height > 0) self.current_line_height else options.fontGet().textHeight();
 
     if (!self.cursor_seen) {
         self.cursor_rect = Rect{ .x = self.insert_pt.x, .y = self.insert_pt.y, .w = 1, .h = text_height };
@@ -1792,8 +1791,7 @@ pub fn addTextDone(self: *TextLayoutWidget, opts: Options) void {
                     .w = 0,
                     .x = 0,
                 }) catch {};
-                dvui.currentWindow().accesskit.textRunPopulate("",
-                    .{
+                dvui.currentWindow().accesskit.textRunPopulate("", .{
                     .node_id = vp.data().id,
                     .node_parent_id = cw.accesskit.text_run_parent.?,
                     .char_offset = 0,


### PR DESCRIPTION
This PR changes the `line_height` s.t. the line height (and thus cursor) matches the current line height.

before:

<img width="133" height="88" alt="image" src="https://github.com/user-attachments/assets/c3ad2640-9d19-4f6b-b173-cabd9114622f" />
  
after:

<img width="260" height="148" alt="image" src="https://github.com/user-attachments/assets/40d9aa40-4b02-403b-80c6-725cca9231ef" />
