### PR TITLE
feat(sdl3gpu): support 32-bit index buffers

### DIFF
--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -8,9 +8,6 @@ const Backend = @This();
 
 pub const Common = @import("backends/common.zig");
 
-/// Index type used by the current backend implementation (u16 or u32)
-pub const IndexType = if (@hasDecl(Implementation, "IndexType")) Implementation.IndexType else u16;
-
 pub const GenericError = std.mem.Allocator.Error || error{BackendError};
 pub const TextureError = GenericError || error{ TextureCreate, TextureRead, TextureUpdate, NotImplemented };
 
@@ -68,7 +65,7 @@ pub fn contentScale(self: Backend) f32 {
 /// clipped to to `clipr` (if given).  Vertex positions and `clipr` are in
 /// physical pixels.  If `texture` is given, the vertexes uv coords are
 /// normalized (0-1). `clipr` (if given) has whole pixel values.
-pub fn drawClippedTriangles(self: Backend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const IndexType, clipr: ?dvui.Rect.Physical) GenericError!void {
+pub fn drawClippedTriangles(self: Backend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, clipr: ?dvui.Rect.Physical) GenericError!void {
     return self.impl.drawClippedTriangles(texture, vtx, idx, clipr);
 }
 

--- a/src/Triangles.zig
+++ b/src/Triangles.zig
@@ -1,5 +1,5 @@
 vertexes: []Vertex,
-indices: []dvui.backend.IndexType,
+indices: []Vertex.Index,
 bounds: Rect.Physical,
 
 pub const Triangles = @This();
@@ -14,7 +14,7 @@ pub const empty = Triangles{
 /// vertexes and indices is known
 pub const Builder = struct {
     vertexes: std.ArrayListUnmanaged(Vertex),
-    indices: std.ArrayListUnmanaged(dvui.backend.IndexType),
+    indices: std.ArrayListUnmanaged(Vertex.Index),
     /// w and h is max_x and max_y
     bounds: Rect.Physical = .{
         .x = math.floatMax(f32),
@@ -53,7 +53,7 @@ pub const Builder = struct {
     /// Triangles must be counter-clockwise (y going down) to avoid backface culling
     ///
     /// Asserts that points is a multiple of 3
-    pub fn appendTriangles(self: *Builder, points: []const dvui.backend.IndexType) void {
+    pub fn appendTriangles(self: *Builder, points: []const Vertex.Index) void {
         std.debug.assert(points.len % 3 == 0);
         self.indices.appendSliceAssumeCapacity(points);
     }
@@ -90,7 +90,7 @@ pub fn dupe(self: *const Triangles, allocator: std.mem.Allocator) std.mem.Alloca
     errdefer allocator.free(vtx);
     return .{
         .vertexes = vtx,
-        .indices = try allocator.dupe(dvui.backend.IndexType, self.indices),
+        .indices = try allocator.dupe(Vertex.Index, self.indices),
         .bounds = self.bounds,
     };
 }

--- a/src/Vertex.zig
+++ b/src/Vertex.zig
@@ -1,5 +1,10 @@
 const dvui = @import("dvui.zig");
 
+pub const Index = switch (@import("build_options").vertex_index) {
+    .u16 => u16,
+    .u32 => u32,
+};
+
 pos: dvui.Point.Physical,
 col: dvui.Color.PMA = .{},
 uv: @Vector(2, f32) = @splat(0),

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -685,7 +685,7 @@ pub fn contentScale(self: *SDLBackend) f32 {
     return self.initial_scale;
 }
 
-pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const u16, maybe_clipr: ?dvui.Rect.Physical) !void {
+pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, maybe_clipr: ?dvui.Rect.Physical) !void {
     //std.debug.print("drawClippedTriangles:\n", .{});
     //for (vtx) |v, i| {
     //  std.debug.print("  {d} vertex {}\n", .{i, v});
@@ -754,7 +754,7 @@ pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []co
             @as(c_int, @intCast(vtx.len)),
             idx.ptr,
             @as(c_int, @intCast(idx.len)),
-            @sizeOf(u16),
+            @sizeOf(dvui.Vertex.Index),
         ), "SDL_RenderGeometryRaw, in drawClippedTriangles");
     } else {
         try toErr(c.SDL_RenderGeometryRaw(
@@ -769,7 +769,7 @@ pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []co
             @as(c_int, @intCast(vtx.len)),
             idx.ptr,
             @as(c_int, @intCast(idx.len)),
-            @sizeOf(u16),
+            @sizeOf(dvui.Vertex.Index),
         ), "SDL_RenderGeometryRaw in drawClippedTriangles");
     }
 

--- a/src/backends/testing.zig
+++ b/src/backends/testing.zig
@@ -81,7 +81,7 @@ pub fn contentScale(_: *TestingBackend) f32 {
 /// clipped to to clipr (if given).  Vertex positions and clipr are in
 /// physical pixels.  If texture is given, the vertexes uv coords are
 /// normalized (0-1).
-pub fn drawClippedTriangles(_: *TestingBackend, _: ?dvui.Texture, _: []const dvui.Vertex, _: []const u16, _: ?dvui.Rect.Physical) !void {}
+pub fn drawClippedTriangles(_: *TestingBackend, _: ?dvui.Texture, _: []const dvui.Vertex, _: []const dvui.Vertex.Index, _: ?dvui.Rect.Physical) !void {}
 
 /// Create a texture from the given pixels in RGBA.  The returned
 /// pointer is what will later be passed to drawClippedTriangles.

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -572,7 +572,7 @@ pub fn contentScale(_: *WebBackend) f32 {
     return 1.0;
 }
 
-pub fn drawClippedTriangles(_: *WebBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const u16, maybe_clipr: ?dvui.Rect.Physical) !void {
+pub fn drawClippedTriangles(_: *WebBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, maybe_clipr: ?dvui.Rect.Physical) !void {
     var x: i32 = std.math.maxInt(i32);
     var w: i32 = std.math.maxInt(i32);
     var y: i32 = std.math.maxInt(i32);

--- a/src/render.zig
+++ b/src/render.zig
@@ -296,7 +296,7 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
 
         // don't output triangles for a zero-width glyph (space seems to be the only one)
         if (gi.w > 0) {
-            const vtx_offset: dvui.backend.IndexType = @intCast(builder.vertexes.items.len);
+            const vtx_offset: dvui.Vertex.Index = @intCast(builder.vertexes.items.len);
             var v: Vertex = undefined;
 
             v.pos.x = leftx;


### PR DESCRIPTION
## Summary
- add a build option for SDL3GPU index buffer bit size (16 or 32, default 16)
- route index buffer types through a backend `IndexType` alias
- bind the appropriate SDL GPU index element size when drawing

## Context
Fixes https://github.com/david-vanderson/dvui/issues/702 by allowing large render batches to use 32-bit indices while keeping 16-bit as the default.