### PR TITLE
Add Widget Stack to keep track of dynamic widget allocations

### DIFF
--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -24,7 +24,6 @@ min_size: Size,
 options: Options,
 src: std.builtin.SourceLocation,
 rect_scale: ?RectScale = null,
-was_allocated_on_widget_stack: bool = false,
 ak_node: if (dvui.accesskit_enabled) ?*dvui.AccessKit.Node else void = if (dvui.accesskit_enabled) null else {},
 
 pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Options) WidgetData {

--- a/src/WidgetStack.zig
+++ b/src/WidgetStack.zig
@@ -1,0 +1,72 @@
+//! A wrapper around an arena allocator that enforces that
+//! memory is freed like a stack. i.e. in LIFO order
+//!
+//! The widget stack can be queried to determine if any
+//! pointer is an element of the stack.
+
+const std = @import("std");
+const dvui = @import("dvui.zig");
+
+arena: std.heap.ArenaAllocator = undefined,
+allocations: std.ArrayList(*anyopaque) = .empty,
+
+const WidgetStack = @This();
+
+pub fn init(gpa: std.mem.Allocator) WidgetStack {
+    return .{
+        .arena = .init(gpa),
+    };
+}
+
+pub fn deinit(self: *WidgetStack) void {
+    const window: *const dvui.Window = @alignCast(@fieldParentPtr("_widget_stack", self));
+    self.allocations.deinit(window.gpa);
+    _ = self.arena.reset(.free_all);
+}
+
+/// Forget all widget allocations.
+/// Reset the widget stack arena according to `mode`
+pub fn reset(self: *WidgetStack, mode: std.heap.ArenaAllocator.ResetMode) void {
+    self.allocations.clearRetainingCapacity();
+    _ = self.arena.reset(mode);
+}
+
+/// Create a widget and remember it.
+pub fn create(self: *WidgetStack, T: type) *T {
+    const window: *const dvui.Window = @alignCast(@fieldParentPtr("_widget_stack", self));
+    const result = self.arena.allocator().create(T) catch @panic("OOM");
+    self.allocations.append(window.gpa, result) catch @panic("OOM");
+    return result;
+}
+
+/// Destroy a widget
+///
+/// Check that widget was created by this widget stack and
+/// that it is at the top of the stack.
+pub fn destroy(self: *WidgetStack, ptr: anytype) void {
+    if (self.allocations.items.len == 0) {
+        dvui.log.err("Attempt to free widget {*} from an empty widget stack", .{ptr});
+        return;
+    }
+    if (!self.created(ptr)) {
+        dvui.log.err("Attempt to free widget {*} but it was not allocated by the widget stack", .{ptr});
+        return;
+    } else if (self.allocations.items[self.allocations.items.len - 1] != @as(*anyopaque, @ptrCast(ptr))) {
+        dvui.log.err("Attempt to free widget {*}, but it is not at the top of the widget stack", .{ptr});
+        return;
+    }
+
+    _ = self.allocations.orderedRemove(self.allocations.items.len - 1);
+    self.arena.allocator().destroy(ptr);
+}
+
+/// Returns whether this pointer belongs to a widget created by
+/// the widget stack.
+pub fn created(self: *const WidgetStack, ptr: *anyopaque) bool {
+    if (self.allocations.items.len == 0) return false;
+    var idx: usize = self.allocations.items.len;
+    while (idx > 0) : (idx -= 1) {
+        if (self.allocations.items[idx - 1] == ptr) return true;
+    }
+    return false;
+}

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -112,7 +112,7 @@ gpa: std.mem.Allocator,
 _arena: std.heap.ArenaAllocator,
 _lifo_arena: std.heap.ArenaAllocator,
 /// Used to allocate widgets with a fixed location
-_widget_stack: std.heap.ArenaAllocator,
+_widget_stack: WidgetStack,
 render_target: dvui.RenderTarget = .{ .texture = null, .offset = .{} },
 end_rendering_done: bool = false,
 
@@ -1480,7 +1480,7 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
     }
 
     {
-        const cap = self._widget_stack.queryCapacity();
+        const cap = self._widget_stack.arena.queryCapacity();
         //std.log.debug("_widget_stack capacity {d}", .{cap});
         _ = self._widget_stack.reset(.{ .retain_with_limit = cap - @divTrunc(cap, 10) });
     }
@@ -1557,6 +1557,8 @@ pub fn minSizeForChild(self: *Self, s: Size) void {
     _ = self;
     _ = s;
 }
+
+const WidgetStack = @import("WidgetStack.zig");
 
 const Options = dvui.Options;
 const Rect = dvui.Rect;

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -464,17 +464,7 @@ pub fn logError(src: std.builtin.SourceLocation, err: anyerror, comptime fmt: []
         .{ "\nStack trace: {f}", stack_trace }
     else
         .{ "{s}", "" }; // Needed to keep the arg count the sames
-
-    // There is no nice way to combine a comptime tuple and a runtime tuple
-    const combined_args = switch (std.meta.fields(@TypeOf(args)).len) {
-        0 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), err_trace_arg, trace_arg },
-        1 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), args[0], err_trace_arg, trace_arg },
-        2 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), args[0], args[1], err_trace_arg, trace_arg },
-        3 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), args[0], args[1], args[2], err_trace_arg, trace_arg },
-        4 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), args[0], args[1], args[2], args[3], err_trace_arg, trace_arg },
-        5 => .{ src.file, src.line, src.column, src.fn_name, @errorName(err), args[0], args[1], args[2], args[3], args[4], err_trace_arg, trace_arg },
-        else => @compileError("Too many arguments"),
-    };
+    const combined_args = .{ src.file, src.line, src.column, src.fn_name, @errorName(err) } ++ args ++ .{ err_trace_arg, trace_arg };
     log.err("{s}:{d}:{d}: {s} got {s}: " ++ fmt ++ error_trace_fmt ++ stack_trace_fmt, combined_args);
 }
 

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -427,10 +427,7 @@ pub fn currentWindow() *Window {
 ///
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn widgetAlloc(comptime T: type) *T {
-    const cw = currentWindow();
-    const alloc = cw._widget_stack.allocator();
-    const ptr = alloc.create(T) catch @panic("OOM");
-    return ptr;
+    return dvui.currentWindow()._widget_stack.create(T);
 }
 
 /// Pops a widget off the alloc stack, if it was allocated there.
@@ -440,8 +437,14 @@ pub fn widgetAlloc(comptime T: type) *T {
 ///
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn widgetFree(ptr: anytype) void {
-    const ws = &currentWindow()._widget_stack;
-    ws.allocator().destroy(ptr);
+    dvui.currentWindow()._widget_stack.destroy(ptr);
+}
+
+/// Returns whether the widget was created with widgetAlloc.
+///
+/// Only valid between `Window.begin`and `Window.end`.
+pub fn widgetIsAllocated(ptr: anytype) bool {
+    return dvui.currentWindow()._widget_stack.created(ptr);
 }
 
 pub fn logError(src: std.builtin.SourceLocation, err: anyerror, comptime fmt: []const u8, args: anytype) void {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -422,8 +422,7 @@ pub fn currentWindow() *Window {
 /// if the stack overflows.
 ///
 /// The caller is responsible for ensuring that the widget calls
-/// `dvui.widgetFree` in it's `deinit`. Usually this is done by
-/// setting `dvui.WidgetData.was_allocated_on_widget_stack` to true
+/// `dvui.widgetFree` in it's `deinit`.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn widgetAlloc(comptime T: type) *T {
@@ -2120,7 +2119,6 @@ pub fn wantTextInput(r: Rect.Natural) void {
 pub fn floatingMenu(src: std.builtin.SourceLocation, init_opts: FloatingMenuWidget.InitOptions, opts: Options) *FloatingMenuWidget {
     var ret = widgetAlloc(FloatingMenuWidget);
     ret.init(src, init_opts, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     return ret;
 }
 
@@ -2133,7 +2131,6 @@ pub fn floatingMenu(src: std.builtin.SourceLocation, init_opts: FloatingMenuWidg
 pub fn floatingWindow(src: std.builtin.SourceLocation, floating_opts: FloatingWindowWidget.InitOptions, opts: Options) *FloatingWindowWidget {
     var ret = widgetAlloc(FloatingWindowWidget);
     ret.init(src, floating_opts, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     ret.processEventsBefore();
     ret.drawBackground();
     return ret;
@@ -2524,7 +2521,6 @@ pub fn toastsShow(id: ?Id, rect: Rect.Natural) void {
 pub fn animate(src: std.builtin.SourceLocation, init_opts: AnimateWidget.InitOptions, opts: Options) *AnimateWidget {
     var ret = widgetAlloc(AnimateWidget);
     ret.init(src, init_opts, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     return ret;
 }
 
@@ -2615,7 +2611,6 @@ pub fn suggestion(te: *TextEntryWidget, init_opts: SuggestionInitOptions) *Sugge
 
     var sug = widgetAlloc(SuggestionWidget);
     sug.init(@src(), .{
-        .was_allocated_on_widget_stack = true,
         .rs = te.data().borderRectScale(),
         .text_entry_id = te.data().id,
     }, .{ .label = .{ .text = te.getText() }, .min_size_content = .{ .w = min_width }, .padding = .{}, .border = te.data().options.borderGet() });
@@ -2698,7 +2693,6 @@ pub fn suggestion(te: *TextEntryWidget, init_opts: SuggestionInitOptions) *Sugge
 pub const ComboBox = struct {
     te: *TextEntryWidget = undefined,
     sug: *SuggestionWidget = undefined,
-    was_allocated_on_widget_stack: bool = false,
 
     /// Returns index of entry if one was selected
     pub fn entries(self: *ComboBox, items: []const []const u8) ?usize {
@@ -2714,8 +2708,7 @@ pub const ComboBox = struct {
     }
 
     pub fn deinit(self: *ComboBox) void {
-        const should_free = self.was_allocated_on_widget_stack;
-        defer if (should_free) dvui.widgetFree(self);
+        defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
         defer self.* = undefined;
         self.sug.deinit();
         self.te.deinit();
@@ -2729,10 +2722,8 @@ pub const ComboBox = struct {
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn comboBox(src: std.builtin.SourceLocation, init_opts: TextEntryWidget.InitOptions, opts: Options) *ComboBox {
     const combo = widgetAlloc(ComboBox);
-    combo.was_allocated_on_widget_stack = true;
     combo.te = widgetAlloc(TextEntryWidget);
     combo.te.init(src, init_opts, opts);
-    combo.te.data().was_allocated_on_widget_stack = true;
 
     if (combo.te.data().accesskit_node()) |ak_node| {
         AccessKit.nodeSetRole(ak_node, AccessKit.Role.editable_combo_box.asU8());
@@ -2817,7 +2808,6 @@ pub fn expander(src: std.builtin.SourceLocation, label_str: []const u8, init_opt
 pub fn paned(src: std.builtin.SourceLocation, init_opts: PanedWidget.InitOptions, opts: Options) *PanedWidget {
     var ret = widgetAlloc(PanedWidget);
     ret.init(src, init_opts, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     ret.processEvents();
     return ret;
 }
@@ -2831,7 +2821,6 @@ pub fn paned(src: std.builtin.SourceLocation, init_opts: PanedWidget.InitOptions
 pub fn textLayout(src: std.builtin.SourceLocation, init_opts: TextLayoutWidget.InitOptions, opts: Options) *TextLayoutWidget {
     var ret = widgetAlloc(TextLayoutWidget);
     ret.init(src, init_opts, opts);
-    ret.data().was_allocated_on_widget_stack = true;
 
     // can install corner widgets here
     //_ = dvui.button(@src(), "upright", .{}, .{ .gravity_x = 1.0 });
@@ -2859,7 +2848,6 @@ pub fn textLayout(src: std.builtin.SourceLocation, init_opts: TextLayoutWidget.I
 pub fn context(src: std.builtin.SourceLocation, init_opts: ContextWidget.InitOptions, opts: Options) *ContextWidget {
     var ret = widgetAlloc(ContextWidget);
     ret.init(src, init_opts, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     ret.processEvents();
     return ret;
 }
@@ -2900,7 +2888,6 @@ pub fn focusGroup(src: std.builtin.SourceLocation, init_opts: FocusGroupWidget.I
     const defaults: Options = .{ .role = .group };
     var ret = widgetAlloc(FocusGroupWidget);
     ret.init(src, init_opts, defaults.override(opts));
-    ret.data().was_allocated_on_widget_stack = true;
     return ret;
 }
 
@@ -2919,7 +2906,6 @@ pub fn radioGroup(src: std.builtin.SourceLocation, init_opts: FocusGroupWidget.I
 pub fn virtualParent(src: std.builtin.SourceLocation, opts: Options) *VirtualParentWidget {
     var ret = widgetAlloc(VirtualParentWidget);
     ret.init(src, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     return ret;
 }
 
@@ -2932,7 +2918,6 @@ pub fn virtualParent(src: std.builtin.SourceLocation, opts: Options) *VirtualPar
 pub fn overlay(src: std.builtin.SourceLocation, opts: Options) *OverlayWidget {
     var ret = widgetAlloc(OverlayWidget);
     ret.init(src, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     ret.drawBackground();
     return ret;
 }
@@ -2957,7 +2942,6 @@ pub fn overlay(src: std.builtin.SourceLocation, opts: Options) *OverlayWidget {
 pub fn box(src: std.builtin.SourceLocation, init_opts: BoxWidget.InitOptions, opts: Options) *BoxWidget {
     var ret = widgetAlloc(BoxWidget);
     ret.init(src, init_opts, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     ret.drawBackground();
     return ret;
 }
@@ -2970,7 +2954,6 @@ pub fn box(src: std.builtin.SourceLocation, init_opts: BoxWidget.InitOptions, op
 pub fn flexbox(src: std.builtin.SourceLocation, init_opts: FlexBoxWidget.InitOptions, opts: Options) *FlexBoxWidget {
     var ret = widgetAlloc(FlexBoxWidget);
     ret.init(src, init_opts, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     ret.drawBackground();
     return ret;
 }
@@ -2978,14 +2961,12 @@ pub fn flexbox(src: std.builtin.SourceLocation, init_opts: FlexBoxWidget.InitOpt
 pub fn cache(src: std.builtin.SourceLocation, init_opts: CacheWidget.InitOptions, opts: Options) *CacheWidget {
     var ret = widgetAlloc(CacheWidget);
     ret.init(src, init_opts, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     return ret;
 }
 
 pub fn reorder(src: std.builtin.SourceLocation, init_opts: ReorderWidget.InitOptions, opts: Options) *ReorderWidget {
     var ret = widgetAlloc(ReorderWidget);
     ret.init(src, init_opts, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     ret.processEvents();
     return ret;
 }
@@ -2993,14 +2974,12 @@ pub fn reorder(src: std.builtin.SourceLocation, init_opts: ReorderWidget.InitOpt
 pub fn scrollArea(src: std.builtin.SourceLocation, init_opts: ScrollAreaWidget.InitOpts, opts: Options) *ScrollAreaWidget {
     var ret = widgetAlloc(ScrollAreaWidget);
     ret.init(src, init_opts, opts);
-    ret.init_opts.was_allocated_on_widget_stack = true;
     return ret;
 }
 
 pub fn grid(src: std.builtin.SourceLocation, cols: GridWidget.WidthsOrNum, init_opts: GridWidget.InitOpts, opts: Options) *GridWidget {
     const ret = widgetAlloc(GridWidget);
     ret.init(src, cols, init_opts, opts);
-    ret.init_opts.was_allocated_on_widget_stack = true;
     return ret;
 }
 
@@ -3288,7 +3267,6 @@ pub fn spinner(src: std.builtin.SourceLocation, opts: Options) void {
 pub fn scale(src: std.builtin.SourceLocation, init_opts: ScaleWidget.InitOptions, opts: Options) *ScaleWidget {
     var ret = widgetAlloc(ScaleWidget);
     ret.init(src, init_opts, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     ret.processEvents();
     return ret;
 }
@@ -3296,14 +3274,12 @@ pub fn scale(src: std.builtin.SourceLocation, init_opts: ScaleWidget.InitOptions
 pub fn tabs(src: std.builtin.SourceLocation, init_opts: TabsWidget.InitOptions, opts: Options) *TabsWidget {
     var ret = widgetAlloc(TabsWidget);
     ret.init(src, init_opts, opts);
-    ret.init_options.was_allocated_on_widget_stack = true;
     return ret;
 }
 
 pub fn menu(src: std.builtin.SourceLocation, dir: enums.Direction, opts: Options) *MenuWidget {
     var ret = widgetAlloc(MenuWidget);
     ret.init(src, .{ .dir = dir }, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     return ret;
 }
 
@@ -3354,7 +3330,6 @@ pub fn menuItemIcon(src: std.builtin.SourceLocation, name: []const u8, tvg_bytes
 pub fn menuItem(src: std.builtin.SourceLocation, init_opts: MenuItemWidget.InitOptions, opts: Options) *MenuItemWidget {
     var ret = widgetAlloc(MenuItemWidget);
     ret.init(src, init_opts, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     ret.processEvents();
     ret.drawBackground();
     return ret;
@@ -4602,7 +4577,6 @@ pub fn findUtf8Start(text: []const u8, pos: usize) usize {
 pub fn textEntry(src: std.builtin.SourceLocation, init_opts: TextEntryWidget.InitOptions, opts: Options) *TextEntryWidget {
     var ret = widgetAlloc(TextEntryWidget);
     ret.init(src, init_opts, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     // can install corner widgets here
     //_ = dvui.button(@src(), "upright", .{}, .{ .gravity_x = 1.0 });
     ret.processEvents();
@@ -5042,7 +5016,6 @@ pub const Picture = struct {
 pub fn plot(src: std.builtin.SourceLocation, plot_opts: PlotWidget.InitOptions, opts: Options) *PlotWidget {
     var ret = widgetAlloc(PlotWidget);
     ret.init(src, plot_opts, opts);
-    ret.init_options.was_allocated_on_widget_stack = true;
     return ret;
 }
 

--- a/src/widgets/AnimateWidget.zig
+++ b/src/widgets/AnimateWidget.zig
@@ -131,8 +131,7 @@ pub fn minSizeForChild(self: *AnimateWidget, s: Size) void {
 }
 
 pub fn deinit(self: *AnimateWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     if (self.val) |v| {
         switch (self.init_opts.kind) {

--- a/src/widgets/BoxWidget.zig
+++ b/src/widgets/BoxWidget.zig
@@ -249,8 +249,7 @@ pub fn minSizeForChild(self: *BoxWidget, s: Size) void {
 }
 
 pub fn deinit(self: *BoxWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     const extra_space = (if (self.init_opts.dir == .horizontal) self.child_rect.w else self.child_rect.h) > 0.001;
     const ms: Size = if (self.init_opts.dir == .horizontal) .{

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -129,8 +129,7 @@ pub fn minSizeForChild(self: *ButtonWidget, s: Size) void {
 }
 
 pub fn deinit(self: *ButtonWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     self.data().minSizeSetAndRefresh();
     self.data().minSizeReportToParent();

--- a/src/widgets/CacheWidget.zig
+++ b/src/widgets/CacheWidget.zig
@@ -155,8 +155,7 @@ pub fn minSizeForChild(self: *CacheWidget, s: Size) void {
 /// This deinit function returns an error because of the additional
 /// texture handling it requires.
 pub fn deinit(self: *CacheWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     const cw = dvui.currentWindow();
     if (self.state == .ok and self.uncached()) {

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -16,7 +16,6 @@ box: dvui.BoxWidget = undefined,
 pub const InitOptions = struct {
     hsv: *Color.HSV,
     dir: dvui.enums.Direction = .horizontal,
-    was_allocated_on_widget_stack: bool = false,
 };
 
 pub var defaults = Options{
@@ -46,8 +45,7 @@ pub fn init(self: *ColorPickerWidget, src: std.builtin.SourceLocation, init_opts
 }
 
 pub fn deinit(self: *ColorPickerWidget) void {
-    const should_free = self.init_opts.was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     self.box.deinit();
 }

--- a/src/widgets/ContextWidget.zig
+++ b/src/widgets/ContextWidget.zig
@@ -130,8 +130,7 @@ pub fn processEvent(self: *ContextWidget, e: *Event) void {
 }
 
 pub fn deinit(self: *ContextWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     if (self.focused) {
         dvui.dataSet(null, self.data().id, "_activePt", self.activePt);

--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -25,7 +25,6 @@ pub var defaults: Options = .{
 pub const InitOptions = struct {
     label: ?[]const u8 = null,
     selected_index: ?usize = null,
-    was_allocated_on_widget_stack: bool = false,
 };
 
 pub fn wrapOuter(opts: Options) Options {
@@ -235,8 +234,7 @@ pub fn addChoice(self: *DropdownWidget) *MenuItemWidget {
 }
 
 pub fn deinit(self: *DropdownWidget) void {
-    const should_free = self.init_options.was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     if (self.drop != null) {
         self.drop.?.deinit();

--- a/src/widgets/FlexBoxWidget.zig
+++ b/src/widgets/FlexBoxWidget.zig
@@ -122,8 +122,7 @@ pub fn minSizeForChild(self: *FlexBoxWidget, s: Size) void {
 }
 
 pub fn deinit(self: *FlexBoxWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     dvui.dataSet(null, self.data().id, "_mrw", self.max_row_width);
     dvui.clipSet(self.prevClip);

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -221,8 +221,7 @@ pub fn chainFocused(self: *FloatingMenuWidget, self_call: bool) bool {
 }
 
 pub fn deinit(self: *FloatingMenuWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
 
     const evts = dvui.events();

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -219,8 +219,7 @@ pub fn minSizeForChild(self: *FloatingTooltipWidget, s: Size) void {
 }
 
 pub fn deinit(self: *FloatingTooltipWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     if (!self.installed) {
         return;

--- a/src/widgets/FloatingWidget.zig
+++ b/src/widgets/FloatingWidget.zig
@@ -123,8 +123,7 @@ pub fn minSizeForChild(self: *FloatingWidget, s: Size) void {
 }
 
 pub fn deinit(self: *FloatingWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     self.scaler.deinit();
     self.data().minSizeSetAndRefresh();

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -564,8 +564,7 @@ pub fn minSizeForChild(self: *FloatingWindowWidget, s: Size) void {
 }
 
 pub fn deinit(self: *FloatingWindowWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     self.layout.deinit();
 

--- a/src/widgets/FocusGroupWidget.zig
+++ b/src/widgets/FocusGroupWidget.zig
@@ -96,8 +96,7 @@ pub fn minSizeForChild(self: *FocusGroupWidget, s: Size) void {
 }
 
 pub fn deinit(self: *FocusGroupWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
 
     const cw = dvui.currentWindow();

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -151,8 +151,6 @@ pub const InitOpts = struct {
     // If var row heights is set to false, size.h is ignored.
     // When using var row heights row_nr must be populated sequentially for each column when creating bodyCells.
     row_height_variable: bool = false,
-
-    was_allocated_on_widget_stack: bool = false,
 };
 
 pub const WidthsOrNum = union(enum) {
@@ -338,8 +336,7 @@ pub fn init(self: *GridWidget, src: std.builtin.SourceLocation, cols: WidthsOrNu
 }
 
 pub fn deinit(self: *GridWidget) void {
-    const should_free = self.init_opts.was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
 
     if (self.data().accesskit_node()) |ak_node| {

--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -76,8 +76,7 @@ pub fn draw(self: *IconWidget) void {
 }
 
 pub fn deinit(self: *IconWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     self.data().minSizeSetAndRefresh();
     self.data().minSizeReportToParent();

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -228,8 +228,7 @@ pub fn matchEvent(self: *LabelWidget, e: *Event) bool {
 }
 
 pub fn deinit(self: *LabelWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     if (self.allocator) |alloc| alloc.free(self.label_str);
     self.data().minSizeSetAndRefresh();

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -280,8 +280,7 @@ pub fn processEvent(self: *MenuItemWidget, e: *Event) void {
 }
 
 pub fn deinit(self: *MenuItemWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     self.data().minSizeSetAndRefresh();
     self.data().minSizeReportToParent();

--- a/src/widgets/MenuWidget.zig
+++ b/src/widgets/MenuWidget.zig
@@ -294,8 +294,7 @@ pub fn deinit(self: *MenuWidget) void {
         self.submenus_activated = false;
     }
 
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     self.box.deinit();
     self.group.deinit();

--- a/src/widgets/OverlayWidget.zig
+++ b/src/widgets/OverlayWidget.zig
@@ -48,8 +48,7 @@ pub fn minSizeForChild(self: *OverlayWidget, s: Size) void {
 }
 
 pub fn deinit(self: *OverlayWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     self.data().minSizeSetAndRefresh();
     self.data().minSizeReportToParent();

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -465,8 +465,7 @@ pub fn processEvent(self: *PanedWidget, e: *Event) void {
 }
 
 pub fn deinit(self: *PanedWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     if (self.init_opts.draw_in_deinit) self.draw();
     dvui.clipSet(self.prevClip);

--- a/src/widgets/PlotWidget.zig
+++ b/src/widgets/PlotWidget.zig
@@ -32,7 +32,6 @@ pub const InitOptions = struct {
     border_thick: ?f32 = null,
     spine_color: ?dvui.Color = null,
     mouse_hover: bool = false,
-    was_allocated_on_widget_stack: bool = false,
 };
 
 pub const Axis = struct {
@@ -806,8 +805,7 @@ pub fn bar(self: *PlotWidget, opts: BarOptions) void {
 }
 
 pub fn deinit(self: *PlotWidget) void {
-    const should_free = self.init_options.was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     dvui.clipSet(self.old_clip);
 

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -135,8 +135,7 @@ pub fn processEvent(self: *ReorderWidget, e: *dvui.Event) void {
 }
 
 pub fn deinit(self: *ReorderWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     if (self.drag_ending) {
         self.id_reorderable = null;
@@ -221,7 +220,6 @@ pub fn draggable(src: std.builtin.SourceLocation, init_opts: draggableInitOption
 pub fn reorderable(self: *ReorderWidget, src: std.builtin.SourceLocation, init_opts: Reorderable.InitOptions, opts: Options) *Reorderable {
     const ret = dvui.widgetAlloc(Reorderable);
     ret.init(src, self, init_opts, opts);
-    ret.init_options.was_allocated_on_widget_stack = true;
     ret.install();
     return ret;
 }
@@ -242,8 +240,6 @@ pub const Reorderable = struct {
 
         // if false, caller responsible for calling reinstall() when targetRectScale() returns true
         reinstall: bool = true,
-
-        was_allocated_on_widget_stack: bool = false,
     };
 
     wd: WidgetData,
@@ -388,8 +384,7 @@ pub const Reorderable = struct {
     }
 
     pub fn deinit(self: *Reorderable) void {
-        const should_free = self.init_options.was_allocated_on_widget_stack;
-        defer if (should_free) dvui.widgetFree(self);
+        defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
         defer self.* = undefined;
         if (self.floating_widget) |*fw| {
             self.data().minSizeMax(fw.data().min_size);

--- a/src/widgets/ScaleWidget.zig
+++ b/src/widgets/ScaleWidget.zig
@@ -157,8 +157,7 @@ pub fn minSizeForChild(self: *ScaleWidget, s: Size) void {
 }
 
 pub fn deinit(self: *ScaleWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     dvui.dataSet(null, self.data().id, "_scale", self.scale.*);
     self.data().minSizeSetAndRefresh();

--- a/src/widgets/ScrollAreaWidget.zig
+++ b/src/widgets/ScrollAreaWidget.zig
@@ -38,8 +38,6 @@ pub const InitOpts = struct {
     lock_visible: bool = false,
     process_events_after: bool = true,
     container: bool = true,
-
-    was_allocated_on_widget_stack: bool = false,
 };
 
 hbox: BoxWidget,
@@ -183,8 +181,7 @@ pub fn setContainerRect(self: *ScrollAreaWidget, rect: dvui.Rect) void {
 }
 
 pub fn deinit(self: *ScrollAreaWidget) void {
-    const should_free = self.init_opts.was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
 
     if (self.scroll) |*s| {

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -222,8 +222,7 @@ pub fn grab(self: *ScrollBarWidget) Grab {
 }
 
 pub fn deinit(self: *ScrollBarWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     self.data().minSizeSetAndRefresh();
     self.data().minSizeReportToParent();

--- a/src/widgets/ScrollContainerWidget.zig
+++ b/src/widgets/ScrollContainerWidget.zig
@@ -630,8 +630,7 @@ pub fn processEventsAfter(self: *ScrollContainerWidget) void {
 }
 
 pub fn deinit(self: *ScrollContainerWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
 
     // need to reset clip before processEventsAfter, event_rect could be

--- a/src/widgets/SuggestionWidget.zig
+++ b/src/widgets/SuggestionWidget.zig
@@ -19,7 +19,6 @@ pub var defaults: Options = .{
 pub const InitOptions = struct {
     rs: RectScale,
     text_entry_id: dvui.Id,
-    was_allocated_on_widget_stack: bool = false,
 };
 
 /// It's expected to call this when `self` is `undefined`
@@ -116,8 +115,7 @@ pub fn addChoice(self: *SuggestionWidget) *MenuItemWidget {
 }
 
 pub fn deinit(self: *SuggestionWidget) void {
-    const should_free = self.init_options.was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     if (self.selected_index > (self.drop_mi_index -| 1)) {
         self.selected_index = self.drop_mi_index -| 1;

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -24,7 +24,6 @@ pub var defaults: Options = .{
 pub const InitOptions = struct {
     dir: dvui.enums.Direction = .horizontal,
     draw_focus: bool = true,
-    was_allocated_on_widget_stack: bool = false,
 };
 
 /// It's expected to call this when `self` is `undefined`
@@ -170,8 +169,7 @@ pub fn addTab(self: *TabsWidget, selected: bool, opts: Options) *ButtonWidget {
 }
 
 pub fn deinit(self: *TabsWidget) void {
-    const should_free = self.init_options.was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     self.box.deinit();
     self.group.deinit();

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -1318,8 +1318,7 @@ pub fn copy(self: *TextEntryWidget) void {
 }
 
 pub fn deinit(self: *TextEntryWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
 
     self.textLayout.deinit();

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -2202,8 +2202,7 @@ pub fn copy(self: *TextLayoutWidget) void {
 }
 
 pub fn deinit(self: *TextLayoutWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     if (!self.add_text_done) {
         self.addTextDone(.{});

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -58,7 +58,6 @@ pub fn init(self: *TreeWidget, src: std.builtin.SourceLocation, init_opts: InitO
 pub fn tree(src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) *TreeWidget {
     var ret = dvui.widgetAlloc(TreeWidget);
     ret.init(src, init_opts, opts);
-    ret.data().was_allocated_on_widget_stack = true;
     ret.processEvents();
     return ret;
 }
@@ -135,8 +134,7 @@ pub fn processEvent(self: *TreeWidget, e: *dvui.Event) void {
 }
 
 pub fn deinit(self: *TreeWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
 
     self.group.deinit();
@@ -181,7 +179,6 @@ pub fn branch(self: *TreeWidget, src: std.builtin.SourceLocation, init_opts: Bra
     const ret = dvui.widgetAlloc(Branch);
     ret.init(src, self, init_opts, opts);
     ret.install();
-    ret.data().was_allocated_on_widget_stack = true;
     if (ret.data().accesskit_node()) |ak_node| {
         AccessKit.nodeAddAction(ak_node, AccessKit.Action.focus);
         AccessKit.nodeAddAction(ak_node, AccessKit.Action.click);
@@ -500,8 +497,7 @@ pub const Branch = struct {
     }
 
     pub fn deinit(self: *Branch) void {
-        const should_free = self.data().was_allocated_on_widget_stack;
-        defer if (should_free) dvui.widgetFree(self);
+        defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
         defer self.* = undefined;
 
         if (self.can_expand) {

--- a/src/widgets/VirtualParentWidget.zig
+++ b/src/widgets/VirtualParentWidget.zig
@@ -53,8 +53,7 @@ pub fn minSizeForChild(self: *VirtualParentWidget, s: Size) void {
 }
 
 pub fn deinit(self: *VirtualParentWidget) void {
-    const should_free = self.data().was_allocated_on_widget_stack;
-    defer if (should_free) dvui.widgetFree(self);
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
     if (self.child_rect_union) |u| {
         dvui.dataSet(null, self.data().id, "_rect", u);


### PR DESCRIPTION
Creates WidgetStack struct which wraps the existing ArenaAllocator to:
  * Remember which widgets were dynamically allocated.
  * Enforce that widgets are deallocated in LIFO order.
  * Provide a way for widgets to tell if they were created on the widget stack
  * Log errors for any violation of LIFO deallocation rule.

By externalizing the knowledge of whether a widget was dynamically allocated on the widget stack,
`is_allocated_on_widget_stack` can be replaced by a single call to `dvui.widgetWasAllocated()` in each widget's deinit().