### PR TITLE
Add Group Box widget

### DIFF
--- a/src/Examples/basic_widgets.zig
+++ b/src/Examples/basic_widgets.zig
@@ -130,63 +130,66 @@ pub fn basicWidgets() void {
 
         dropdownAdvanced();
     }
-
     {
-        var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .min_size_content = .{ .h = 40 } });
-        defer hbox.deinit();
+        var gbox = dvui.groupBox(@src(), "Slider examples in a group box", .{ .expand = .horizontal });
+        defer gbox.deinit();
 
-        dvui.label(@src(), "Sliders", .{}, .{ .gravity_y = 0.5 });
-        _ = dvui.slider(@src(), .{ .fraction = &slider_val }, .{
-            .expand = .horizontal,
-            .gravity_y = 0.5,
-            .corner_radius = dvui.Rect.all(100),
-            .label = .{ .text = "Sliders1" },
-        });
-        _ = dvui.slider(@src(), .{ .dir = .vertical, .fraction = &slider_val }, .{
-            .expand = .vertical,
-            .min_size_content = .{ .w = 10 },
-            .corner_radius = dvui.Rect.all(100),
-            .label = .{ .text = "Sliders2" },
-        });
-        dvui.label(@src(), "Value: {d:2.2}", .{slider_val}, .{ .gravity_y = 0.5 });
-    }
+        {
+            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .min_size_content = .{ .h = 40 } });
+            defer hbox.deinit();
 
-    {
-        var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
-        defer hbox.deinit();
+            dvui.label(@src(), "Sliders", .{}, .{ .gravity_y = 0.5 });
+            _ = dvui.slider(@src(), .{ .fraction = &slider_val }, .{
+                .expand = .horizontal,
+                .gravity_y = 0.5,
+                .corner_radius = dvui.Rect.all(100),
+                .label = .{ .text = "Sliders1" },
+            });
+            _ = dvui.slider(@src(), .{ .dir = .vertical, .fraction = &slider_val }, .{
+                .expand = .vertical,
+                .min_size_content = .{ .w = 10 },
+                .corner_radius = dvui.Rect.all(100),
+                .label = .{ .text = "Sliders2" },
+            });
+            dvui.label(@src(), "Value: {d:2.2}", .{slider_val}, .{ .gravity_y = 0.5 });
+        }
 
-        dvui.label(@src(), "Slider Entry", .{}, .{ .gravity_y = 0.5 });
-        if (!slider_entry_vector) {
-            var custom_label: ?[]u8 = null;
-            if (slider_entry_label) {
-                const whole = @round(slider_entry_val);
-                const part = @round((slider_entry_val - whole) * 100);
-                custom_label = std.fmt.allocPrint(dvui.currentWindow().lifo(), "{d} and {d}p", .{ whole, part }) catch null;
+        {
+            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+            defer hbox.deinit();
+
+            dvui.label(@src(), "Slider Entry", .{}, .{ .gravity_y = 0.5 });
+            if (!slider_entry_vector) {
+                var custom_label: ?[]u8 = null;
+                if (slider_entry_label) {
+                    const whole = @round(slider_entry_val);
+                    const part = @round((slider_entry_val - whole) * 100);
+                    custom_label = std.fmt.allocPrint(dvui.currentWindow().lifo(), "{d} and {d}p", .{ whole, part }) catch null;
+                }
+                defer if (custom_label) |cl| dvui.currentWindow().lifo().free(cl);
+                _ = dvui.sliderEntry(
+                    @src(),
+                    "val: {d:0.3}",
+                    .{ .value = &slider_entry_val, .min = (if (slider_entry_min) 0 else null), .max = (if (slider_entry_max) 1 else null), .interval = (if (slider_entry_interval) 0.1 else null), .label = custom_label },
+                    .{ .gravity_y = 0.5 },
+                );
+                dvui.label(@src(), "(enter, ctrl-click or touch-tap)", .{}, .{ .gravity_y = 0.5 });
+            } else {
+                _ = dvui.sliderVector(@src(), "{d:0.2}", 3, &slider_vector_array, .{ .min = (if (slider_entry_min) 0 else null), .max = (if (slider_entry_max) 1 else null), .interval = (if (slider_entry_interval) 0.1 else null) }, .{});
             }
-            defer if (custom_label) |cl| dvui.currentWindow().lifo().free(cl);
-            _ = dvui.sliderEntry(
-                @src(),
-                "val: {d:0.3}",
-                .{ .value = &slider_entry_val, .min = (if (slider_entry_min) 0 else null), .max = (if (slider_entry_max) 1 else null), .interval = (if (slider_entry_interval) 0.1 else null), .label = custom_label },
-                .{ .gravity_y = 0.5 },
-            );
-            dvui.label(@src(), "(enter, ctrl-click or touch-tap)", .{}, .{ .gravity_y = 0.5 });
-        } else {
-            _ = dvui.sliderVector(@src(), "{d:0.2}", 3, &slider_vector_array, .{ .min = (if (slider_entry_min) 0 else null), .max = (if (slider_entry_max) 1 else null), .interval = (if (slider_entry_interval) 0.1 else null) }, .{});
+        }
+
+        {
+            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .padding = .{ .x = 10 } });
+            defer hbox.deinit();
+
+            _ = dvui.checkbox(@src(), &slider_entry_min, "Min", .{});
+            _ = dvui.checkbox(@src(), &slider_entry_max, "Max", .{});
+            _ = dvui.checkbox(@src(), &slider_entry_interval, "Interval", .{});
+            _ = dvui.checkbox(@src(), &slider_entry_vector, "Vector", .{});
+            _ = dvui.checkbox(@src(), &slider_entry_label, "Custom Label", .{});
         }
     }
-
-    {
-        var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .padding = .{ .x = 10 } });
-        defer hbox.deinit();
-
-        _ = dvui.checkbox(@src(), &slider_entry_min, "Min", .{});
-        _ = dvui.checkbox(@src(), &slider_entry_max, "Max", .{});
-        _ = dvui.checkbox(@src(), &slider_entry_interval, "Interval", .{});
-        _ = dvui.checkbox(@src(), &slider_entry_vector, "Vector", .{});
-        _ = dvui.checkbox(@src(), &slider_entry_label, "Custom Label", .{});
-    }
-
     _ = dvui.spacer(@src(), .{ .min_size_content = .height(4) });
 
     {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2830,17 +2830,21 @@ pub fn groupBox(src: std.builtin.SourceLocation, label_str: []const u8, opts: Op
         b.drawBackground();
     }
     const label_padding: Rect = .{ .x = LabelWidget.defaults.paddingGet().x, .w = LabelWidget.defaults.paddingGet().w, .y = 0, .h = 0 };
-    labelNoFmt(@src(), label_str, .{ .align_x = 0.5, .align_y = 0.5 }, options.strip().override(.{
-        .rect = .{
-            .x = 0, // Starts at padding.
-            .y = -options.paddingGet().y - options.borderGet().y / 2 - text_size.h / 2,
-            .w = @min(text_size.w + label_padding.x + label_padding.w, b.data().contentRect().w),
-            .h = text_size.h,
-        },
-        .background = options.background,
-        .corner_radius = options.corner_radius,
-        .padding = label_padding,
-    }));
+    const label_rect: Rect = .{
+        .x = 0, // Starts at padding.
+        .y = -options.paddingGet().y - options.borderGet().y / 2 - text_size.h / 2,
+        .w = @min(text_size.w + label_padding.x + label_padding.w, b.data().contentRect().w),
+        .h = text_size.h,
+    };
+
+    if (!label_rect.empty()) {
+        labelNoFmt(@src(), label_str, .{ .align_x = 0.5, .align_y = 0.5 }, options.strip().override(.{
+            .rect = label_rect,
+            .background = options.background,
+            .corner_radius = options.corner_radius,
+            .padding = label_padding,
+        }));
+    }
 
     // draw the border
     if (b.data().visible() and options.borderGet().nonZero()) {


### PR DESCRIPTION
dvui.groupBox() creates a bordered group with a title. Used for containing related widgets.
Also known as a fieldset in HTML.
Creates an accessibility role of group, labeled with the text of the title.
Adds example usage to basic_widgets.zig.

Fixes #685

<img width="295" height="284" alt="image" src="https://github.com/user-attachments/assets/aa349c3d-c15d-4cc2-8346-cf0d0305734c" />

<img width="288" height="292" alt="image" src="https://github.com/user-attachments/assets/9b048845-5973-43f8-902d-518136371e0b" />

<img width="276" height="356" alt="image" src="https://github.com/user-attachments/assets/ffa0a000-7a81-43c8-8edc-51ff4dfa9b84" />

<img width="368" height="367" alt="image" src="https://github.com/user-attachments/assets/f5cf35b1-35ca-47da-9b54-b659021a4aea" />

<img width="346" height="372" alt="image" src="https://github.com/user-attachments/assets/0ecdda4f-bf1e-4bb3-89da-de28575885ff" />

<img width="387" height="364" alt="image" src="https://github.com/user-attachments/assets/ef1b00cc-57f3-4a70-93c2-97672d745196" />

<img width="730" height="182" alt="image" src="https://github.com/user-attachments/assets/334f0459-2413-4ea8-a629-e6cb049bdcad" />
