### PR TITLE
Support display of optional values in drop downs

### DIFF
--- a/src/Examples/animations.zig
+++ b/src/Examples/animations.zig
@@ -97,7 +97,7 @@ pub fn animations() void {
 
             dvui.labelNoFmt(@src(), "Animate", .{}, .{ .gravity_y = 0.5 });
 
-            _ = dvui.dropdown(@src(), &.{ "alpha", "horizontal", "vertical", "none" }, &global.animation_choice, .{});
+            _ = dvui.dropdown(@src(), &.{ "alpha", "horizontal", "vertical", "none" }, .{ .choice = &global.animation_choice }, .{}, .{});
 
             dvui.labelNoFmt(@src(), "easing", .{}, .{ .gravity_y = 0.5 });
 
@@ -106,7 +106,7 @@ pub fn animations() void {
                 recalc = true;
             }
 
-            if (dvui.dropdown(@src(), &easing_names, &global.easing_choice, .{})) {
+            if (dvui.dropdown(@src(), &easing_names, .{ .choice = &global.easing_choice }, .{}, .{})) {
                 global.easing = easing_fns[global.easing_choice];
                 recalc = true;
             }

--- a/src/Examples/basic_widgets.zig
+++ b/src/Examples/basic_widgets.zig
@@ -18,7 +18,7 @@ const RadioChoice = enum(u8) {
     _,
 };
 var radio_choice: RadioChoice = @enumFromInt(0);
-var dropdown_val: usize = 1;
+var dropdown_val: ?usize = null;
 
 /// ![image](Examples-basic_widgets.png)
 pub fn basicWidgets() void {
@@ -126,7 +126,7 @@ pub fn basicWidgets() void {
 
         const entries = [_][]const u8{ "First", "Second", "Third is a really long one that doesn't fit" };
 
-        _ = dvui.dropdown(@src(), &entries, &dropdown_val, .{ .min_size_content = .{ .w = 100 }, .gravity_y = 0.5, .max_size_content = .width(200) });
+        _ = dvui.dropdown(@src(), &entries, .{ .choice_nullable = &dropdown_val }, .{ .placeholder = "Choose..." }, .{ .min_size_content = .{ .w = 100 }, .gravity_y = 0.5, .max_size_content = .width(200) });
 
         dropdownAdvanced();
     }

--- a/src/Examples/layout.zig
+++ b/src/Examples/layout.zig
@@ -37,7 +37,7 @@ pub fn layout() void {
 
                 dvui.label(@src(), "(debug) change the dialog button order:", .{}, .{ .gravity_y = 0.5 });
 
-                _ = dvui.dropdownEnum(@src(), dvui.enums.DialogButtonOrder, &dvui.currentWindow().button_order, .{}, .{});
+                _ = dvui.dropdownEnum(@src(), dvui.enums.DialogButtonOrder, .{ .choice = &dvui.currentWindow().button_order }, .{}, .{});
             }
 
             {

--- a/src/Examples/layout.zig
+++ b/src/Examples/layout.zig
@@ -37,7 +37,7 @@ pub fn layout() void {
 
                 dvui.label(@src(), "(debug) change the dialog button order:", .{}, .{ .gravity_y = 0.5 });
 
-                _ = dvui.dropdownEnum(@src(), dvui.enums.DialogButtonOrder, &dvui.currentWindow().button_order, .{});
+                _ = dvui.dropdownEnum(@src(), dvui.enums.DialogButtonOrder, &dvui.currentWindow().button_order, .{}, .{});
             }
 
             {

--- a/src/Examples/styling.zig
+++ b/src/Examples/styling.zig
@@ -144,7 +144,7 @@ pub fn styling() void {
                 var gbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
                 defer gbox.deinit();
                 dvui.label(@src(), "Gradient", .{}, .{ .gravity_y = 0.5 });
-                _ = dvui.dropdown(@src(), &.{ "flat", "horizontal", "vertical", "radial" }, gradient, .{});
+                _ = dvui.dropdown(@src(), &.{ "flat", "horizontal", "vertical", "radial" }, .{ .choice = gradient }, .{}, .{});
             }
 
             var drawBox = dvui.box(@src(), .{}, .{ .min_size_content = .{ .w = 200, .h = 100 } });

--- a/src/Examples/text_entry.zig
+++ b/src/Examples/text_entry.zig
@@ -580,7 +580,7 @@ pub fn textEntryWidgets(demo_win_id: dvui.Id) void {
 
         dvui.label(@src(), "Parse", .{}, .{ .gravity_y = 0.5 });
 
-        _ = dvui.dropdown(@src(), &parse_typenames, &S.type_dropdown_val, .{ .min_size_content = .{ .w = 20 }, .gravity_y = 0.5 });
+        _ = dvui.dropdown(@src(), &parse_typenames, .{ .choice = &S.type_dropdown_val }, .{}, .{ .min_size_content = .{ .w = 20 }, .gravity_y = 0.5 });
 
         left_alignment.spacer(@src(), 0);
 

--- a/src/Examples/text_layout.zig
+++ b/src/Examples/text_layout.zig
@@ -54,7 +54,7 @@ pub fn layoutText() void {
                     cache_ok = false;
                 }
 
-                if (dvui.dropdown(@src(), &.{ "Kern null", "Kern true", "Kern false" }, kerning, .{ .gravity_y = 0.5, .min_size_content = .width(120) })) {
+                if (dvui.dropdown(@src(), &.{ "Kern null", "Kern true", "Kern false" }, .{ .choice = kerning }, .{}, .{ .gravity_y = 0.5, .min_size_content = .width(120) })) {
                     cache_ok = false;
                 }
 

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2518,7 +2518,7 @@ pub const DropdownInitOptions = struct {
     // Text to be shown when there is no selection (for nullable choices only)
     placeholder: ?[]const u8 = null,
     // Can the user select a null value? (for nullable choices only)
-    disable_null_selection: bool = false,
+    null_selectable: bool = true,
 };
 
 pub fn DropdownChoice(T: type) type {
@@ -2528,6 +2528,7 @@ pub fn DropdownChoice(T: type) type {
         choice_nullable: *?T,
     };
 }
+const dropdown_placeholder_default = "Select ...";
 
 /// Show chosen entry, and click to display all entries in a floating menu.
 ///
@@ -2543,7 +2544,7 @@ pub fn dropdown(src: std.builtin.SourceLocation, entries: []const []const u8, ch
         switch (choice) {
             .choice => |ch| .{ .selected_index = ch.*, .label = entries[ch.*] },
             .choice_nullable => |ch| if (ch.* == null)
-                .{ .placeholder = init_opts.placeholder orelse "Select ..." }
+                .{ .placeholder = init_opts.placeholder orelse dropdown_placeholder_default }
             else
                 .{ .selected_index = ch.*, .label = entries[ch.*.?] },
         },
@@ -2552,8 +2553,15 @@ pub fn dropdown(src: std.builtin.SourceLocation, entries: []const []const u8, ch
 
     var ret = false;
     if (dd.dropped()) {
-        if (choice == .choice_nullable and !init_opts.disable_null_selection) {
-            if (dd.addChoiceLabel("")) {
+        if (choice == .choice_nullable and init_opts.null_selectable) {
+            var mi = dd.addChoice();
+            defer mi.deinit();
+            dvui.labelNoFmt(@src(), init_opts.placeholder orelse dropdown_placeholder_default, .{}, opts.strip().override(.{
+                .gravity_y = 0.5,
+                .color_text = opts.color(.text).opacity(0.65),
+            }));
+            if (mi.activeRect()) |_| {
+                dd.close();
                 choice.choice_nullable.* = null;
                 ret = true;
             }
@@ -2588,7 +2596,7 @@ pub fn dropdownEnum(src: std.builtin.SourceLocation, T: type, choice: DropdownCh
         switch (choice) {
             .choice => |ch| .{ .selected_index = @intFromEnum(ch.*), .label = @tagName(ch.*) },
             .choice_nullable => |ch| if (ch.* == null)
-                .{ .placeholder = init_opts.placeholder orelse "Select ..." }
+                .{ .placeholder = init_opts.placeholder orelse dropdown_placeholder_default }
             else
                 .{ .selected_index = @intFromEnum(ch.*.?), .label = @tagName(ch.*.?) },
         },
@@ -2598,8 +2606,15 @@ pub fn dropdownEnum(src: std.builtin.SourceLocation, T: type, choice: DropdownCh
 
     var ret = false;
     if (dd.dropped()) {
-        if (choice == .choice_nullable and !init_opts.disable_null_selection) {
-            if (dd.addChoiceLabel("")) {
+        if (choice == .choice_nullable and init_opts.null_selectable) {
+            var mi = dd.addChoice();
+            defer mi.deinit();
+            dvui.labelNoFmt(@src(), init_opts.placeholder orelse dropdown_placeholder_default, .{}, opts.strip().override(.{
+                .gravity_y = 0.5,
+                .color_text = opts.color(.text).opacity(0.65),
+            }));
+            if (mi.activeRect()) |_| {
+                dd.close();
                 choice.choice_nullable.* = null;
                 ret = true;
             }

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -350,7 +350,7 @@ pub fn enumFieldWidget(
         const choices = std.meta.FieldEnum(T);
         const entries = std.meta.fieldNames(choices);
         var choice: usize = @intFromEnum(std.meta.stringToEnum(std.meta.FieldEnum(T), @tagName(field_value_ptr.*)).?);
-        _ = dvui.dropdown(@src(), entries, &choice, .{});
+        _ = dvui.dropdown(@src(), entries, .{ .choice = &choice }, .{}, .{});
 
         field_value_ptr.* = std.meta.stringToEnum(T, @tagName(@as(std.meta.FieldEnum(T), @enumFromInt(choice)))).?;
     }
@@ -381,7 +381,7 @@ pub fn boolFieldWidget(
     } else {
         const entries = .{ "false", "true" };
         var choice: usize = if (field_value_ptr.* == false) 0 else 1;
-        _ = dvui.dropdown(@src(), &entries, &choice, .{});
+        _ = dvui.dropdown(@src(), &entries, .{ .choice = &choice }, .{}, .{});
         field_value_ptr.* = if (choice == 0) false else true;
     }
 }
@@ -539,7 +539,7 @@ pub fn unionFieldWidget(
         if (read_only) {
             dvui.labelNoFmt(@src(), @tagName(active_tag), .{}, .{});
         } else {
-            if (dvui.dropdown(@src(), choice_names, &active_choice_num, .{})) {
+            if (dvui.dropdown(@src(), choice_names, .{ .choice = &active_choice_num }, .{}, .{})) {
                 active_tag = std.meta.stringToEnum(@TypeOf(active_tag), choice_names[active_choice_num]).?; // This should never fail.
             }
         }
@@ -569,7 +569,7 @@ pub fn optionalFieldWidget(
         alignment.record(hbox.data().id, hbox_aligned.data());
 
         if (!read_only) {
-            _ = dvui.dropdown(@src(), &.{ "Null", "Not Null" }, &choice, .{});
+            _ = dvui.dropdown(@src(), &.{ "Null", "Not Null" }, .{ .choice = &choice }, .{}, .{});
         } else {
             dvui.labelNoFmt(@src(), if (choice == 0) "Null" else "Not Null", .{}, .{});
         }


### PR DESCRIPTION
Support display of optional values in dropdowns.:
- Add placeholder init_options to DropDownWidget
- Add init options to dropdown() and dropdownEnum() to control null display
- Add DropdownChoice(T) to accept optional and non-optional choice parameters.
- Optionally allow display and selection of the blank "null" value.

Fixes #710 