### PR TITLE
dropdown: Highlight correct selected index when dropped

### DIFF
--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -246,6 +246,7 @@ pub fn addChoice(self: *DropdownWidget) *MenuItemWidget {
             }
         } else if (self.drop_mi_index == 0) {
             dvui.focusWidget(self.drop_mi.data().id, null, null);
+            dvui.dataSet(null, self.data().id, "_drop_adjust", self.drop_height);
         }
     }
     self.drop_mi_index += 1;


### PR DESCRIPTION
- The incorrect selected item was highlighted when placeholder text is shown in the dropdown list

There is still an inconsistency when first dropped down with the placeholder vs after a selection has taken place. The placeholder is highlighted on the first dropdown, but in subsequent drops, it is not. But is a minor visual bug compared to this main issue.

Fixes: #729