### PR TITLE
Window.native(): return OS-level pointers

### DIFF
--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -1,6 +1,7 @@
 //! Provides a consistent API for interacting with the backend
 
 const std = @import("std");
+const builtin = @import("builtin");
 const dvui = @import("dvui.zig");
 
 const Implementation = @import("backend");
@@ -151,6 +152,18 @@ pub fn accessKitInitInBegin(self: Backend, accessKit: *dvui.AccessKit) GenericEr
     if (self.impl.accessKitShouldInitialize()) {
         accessKit.initialize();
         try self.impl.accessKitInitInBegin();
+    }
+}
+
+pub fn native(self: Backend, window: *dvui.Window) dvui.Window.Native {
+    if (comptime !@hasDecl(Implementation, "native")) {
+        return switch (builtin.os.tag) {
+            .windows => .{ .hwnd = null },
+            .macos => .{ .cocoa_window = null },
+            else => {},
+        };
+    } else {
+        return self.impl.native(window);
     }
 }
 

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -311,6 +311,16 @@ pub fn init(
     return self;
 }
 
+pub const Native = switch (builtin.os.tag) {
+    .windows => struct { hwnd: ?*anyopaque },
+    .macos => struct { cocoa_window: ?*anyopaque },
+    else => void,
+};
+
+pub fn native(self: *Self) Native {
+    return self.backend.native(self);
+}
+
 pub fn addFont(self: *Self, name: []const u8, ttf_bytes: []const u8, ttf_bytes_allocator: ?std.mem.Allocator) (std.mem.Allocator.Error || dvui.Font.Error)!void {
     try self.fonts.database.ensureUnusedCapacity(self.gpa, 1);
     // TODO: try to get this info from the ttf file, and also add override options

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -431,6 +431,23 @@ pub fn cursorShow(_: *SDLBackend, value: ?bool) !bool {
     }
 }
 
+pub fn native(self: *SDLBackend, _: *dvui.Window) dvui.Window.Native {
+    if (sdl3) {
+        const props = c.SDL_GetWindowProperties(self.window);
+        switch (builtin.os.tag) {
+            .windows => return .{ .hwnd = c.SDL_GetPointerProperty(props, c.SDL_PROP_WINDOW_WIN32_HWND_POINTER, null) },
+            .macos => return .{ .cocoa_window = c.SDL_GetPointerProperty(props, c.SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, null) },
+            else => return {},
+        }
+    } else {
+        switch (builtin.os.tag) {
+            .windows => return .{ .hwnd = null },
+            .macos => return .{ .cocoa_window = null },
+            else => return {},
+        }
+    }
+}
+
 pub fn refresh(_: *SDLBackend) void {
     var ue = std.mem.zeroes(c.SDL_Event);
     ue.type = if (sdl3) c.SDL_EVENT_USER else c.SDL_USEREVENT;

--- a/src/backends/sdl3gpu.zig
+++ b/src/backends/sdl3gpu.zig
@@ -880,6 +880,15 @@ pub fn cursorShow(_: *SDLBackend, value: ?bool) !bool {
     return prev;
 }
 
+pub fn native(self: *SDLBackend, _: *dvui.Window) dvui.Window.Native {
+    const props: c.SDL_PropertiesID = c.SDL_GetWindowProperties(self.window);
+    switch (builtin.os.tag) {
+        .windows => return .{ .hwnd = c.SDL_GetPointerProperty(props, c.SDL_PROP_WINDOW_WIN32_HWND_POINTER, null) },
+        .macos => return .{ .cocoa_window = c.SDL_GetPointerProperty(props, c.SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, null) },
+        else => return {},
+    }
+}
+
 pub fn refresh(_: *SDLBackend) void {
     var ue = std.mem.zeroes(c.SDL_Event);
     ue.type = c.SDL_EVENT_USER;


### PR DESCRIPTION
fixes #739 

Provide a way to get OS-level window pointers from `dvui.Window`.