### PR TITLE
build: switch SDL3 dependency

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,8 +11,8 @@
             .lazy = true,
         },
         .sdl3 = .{
-            .url = "git+https://github.com/castholm/SDL#887fa805e40d5c7bb3955ae69b89ed566c6a0471",
-            .hash = "sdl-0.4.0+3.4.0-SDL--rq2owEZsySGuHCuVJ9naEvH3i3e_pyUIjziBtJ-",
+            .url = "git+https://codeberg.org/brodo/SDL.git?ref=v3.4.2#50804093f262be4a8572917e9f167d1db88ee619",
+            .hash = "sdl-0.4.0+3.4.2-SDL--kUpAgD4KSzqQJ5MPxKjEdcAZXbMGvdyPqvhaXaV",
             .lazy = true,
         },
         .freetype = .{


### PR DESCRIPTION
This PR switches the SDL3 package to [this one](https://codeberg.org/brodo/SDL). We need this for [the Awebo CI process](https://codeberg.org/awebo-chat/awebo/issues/69). I've opened a [PR](https://github.com/castholm/SDL/pull/37) in the original repo, so we might be able to switch back in the future.