### PR TITLE
fixed copy paste typo in JPGEncoder.zig logging

### DIFF
--- a/src/JPGEncoder.zig
+++ b/src/JPGEncoder.zig
@@ -94,7 +94,7 @@ fn stbi_write_jpg_callback(ctx: ?*anyopaque, data_ptr: ?*anyopaque, len: c_int) 
     const self: *JPGEncoder = @ptrCast(@alignCast(ctx.?));
     const data: []const u8 = @as([*]const u8, @ptrCast(@alignCast(data_ptr.?)))[0..@intCast(len)];
     // TODO: Maybe propagate writer error by storing it as a field?
-    self.callback(data) catch |err| dvui.logError(@src(), err, "Failed to write png data to output", .{});
+    self.callback(data) catch |err| dvui.logError(@src(), err, "Failed to write jpg data to output", .{});
 }
 
 const std = @import("std");


### PR DESCRIPTION
Found a small error in the logging message of the JPGEncoder module. Looks like a leftover from a copy past of the PNGEncode.