### PR TITLE
add dvui build utility `svgPathToTvgPath` with inline documentation for using custom SVGs more easily in build scripts

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1111,3 +1111,50 @@ fn addWebExample(
 
     b.getInstallStep().dependOn(compile_step);
 }
+
+/// Given a lazy path to an svg file, e.g. `b.path('./src/image.svg')`
+/// return a LazyPath containing the generated tvg bytes. You can use this
+/// to make icons for DVUI apps from SVGs at build time
+/// (with svg2tvg supported SVG features only).
+///
+/// Example build.zig:
+///
+/// ```zig
+/// const dvui = @import("dvui");
+/// ...
+/// const tvg_bytes_path = dvui.svgPathToTvgPath(b.path())
+/// my_exe.root_module.addAnonymousImport("image", .{ .root_source_file = tvg_bytes_path });
+/// ````
+///
+/// Example usage in dvui application code:
+///
+/// ```zig
+/// const tvg_bytes = @embedFile("image");
+/// _ = dvui.buttonIcon(@src(), "my image", tvg_bytes, .{}, .{}, .{});
+/// ```
+pub fn svgPathToTvgPath(b: *std.Build, svg_path: std.Build.LazyPath) std.Build.LazyPath {
+    // use fast and native options since this is just for building
+    const optimize: std.builtin.OptimizeMode = .ReleaseFast;
+    const target: std.Build.ResolvedTarget = b.graph.host;
+    const svg2tvg_dep = b.dependency("svg2tvg", .{ .optimize = optimize, .target = target });
+    const svg2tvg_exe = b.addExecutable(.{
+        .name = "svg2tvg",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .root_source_file = b.path("./tools/svg2tvg.zig"),
+            .imports = &.{
+                .{
+                    .name = "svg2tvg",
+                    .module = svg2tvg_dep.module("svg2tvg"),
+                },
+            },
+        }),
+    });
+
+    const run_svg2tvg_step = b.addRunArtifact(svg2tvg_exe);
+    run_svg2tvg_step.addFileArg(svg_path);
+    run_svg2tvg_step.addArg("-o");
+    const tvg_bytes = run_svg2tvg_step.addOutputFileArg("out.tvg");
+    return tvg_bytes;
+}

--- a/tools/svg2tvg.zig
+++ b/tools/svg2tvg.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+const svg2tvg = @import("svg2tvg");
+
+pub fn main() !void {
+    return impl();
+}
+
+fn impl() !void {
+    const gpa = std.heap.smp_allocator;
+    var args = try std.process.argsWithAllocator(gpa);
+    defer args.deinit();
+
+    _ = args.next();
+    const input_path = args.next() orelse return error.NoInputArg;
+    // this should be '-o' but we just ignore it
+    _ = args.next() orelse return error.NoOutputFlag;
+    const output_path = args.next() orelse return error.NoOutputArg;
+
+    errdefer {
+        var path_buf: [1024]u8 = undefined;
+        std.debug.print("error: input_path='{s}' output_path='{s}'", .{ input_path, output_path });
+        const cwd = std.fs.cwd().realpath(".", &path_buf) catch "CWD TOO LONG";
+        std.debug.print(" cwd='{s}'\n", .{cwd});
+    }
+
+    const input_file = try std.fs.cwd().openFile(input_path, .{});
+    defer input_file.close();
+
+    const output_file = try std.fs.cwd().createFile(output_path, .{});
+    defer output_file.close();
+
+    var buf: [8192]u8 = undefined;
+    //var reader = input_file.reader(read_buf);
+
+    const svg_bytes = try input_file.readToEndAlloc(gpa, 1<<16);
+    const tvg_bytes = try svg2tvg.tvg_from_svg(gpa, svg_bytes, .{});
+
+    var writer = output_file.writer(&buf);
+    try writer.interface.writeAll(tvg_bytes);
+    try writer.interface.flush();
+    // REPORTME: would be nice to have a 
+}


### PR DESCRIPTION
Putting this first pass up for discussion.

If this looks good, I intend to add a test in the DVUI code base, possibly usage in an example, to confirm it works.
I have confirmed it works in my own DVUI application, and replaces the local utility I was using.