### PR TITLE
widgetpedia: add menu builder

### DIFF
--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -110,8 +110,7 @@ pub fn widgetpedia() void {
                         defer branch_child.deinit();
                         dvui.labelNoFmt(@src(), child.name, .{}, .{ .expand = .horizontal });
                         if (branch_child.button.clicked()) {
-                            current_widget = child;
-                            reset_widget = true;
+                            setCurrentWidget(child);
                         }
                     }
                 }
@@ -126,6 +125,11 @@ pub fn widgetpedia() void {
     }
 }
 
+fn setCurrentWidget(widget: WidgetHierarchy) void {
+    current_widget = widget;
+    reset_widget = true;
+}
+
 // Only supports 2 levels, parent and children.
 const WidgetHierarchy = struct {
     name: []const u8,
@@ -133,7 +137,9 @@ const WidgetHierarchy = struct {
     displayFn: *const fn (reset_widget: bool) void,
 };
 
-var current_widget: WidgetHierarchy = widget_hierarchy[0];
+var current_widget: WidgetHierarchy = .{ .name = "menu", .displayFn = DisplayMenu.displayFn, .children = null };
+
+//widget_hierarchy[0];
 
 fn displayEmpty(_: bool) void {
     var label_str = std.Io.Writer.Allocating.initCapacity(dvui.currentWindow().arena(), current_widget.name.len + 2) catch return;
@@ -1286,6 +1292,122 @@ const DisplayLink = struct {
     }
 };
 
+const DisplayMenu = struct {
+    var name: []const u8 = "menu()";
+    var allocator_buffer: [10 * 1024]u8 = undefined;
+
+    var wd: dvui.WidgetData = undefined;
+    var options: dvui.Options = undefined;
+    var test_options: struct {
+        direction: dvui.enums.Direction,
+    } = undefined;
+    var allocator: std.heap.FixedBufferAllocator = undefined;
+    //var allocator: std.heap.DebugAllocator(.{}) = .init;
+    var arena: std.heap.ArenaAllocator = undefined;
+
+    const MenuItem = struct {
+        label: []const u8,
+        sub_items: std.ArrayList(MenuItem) = .empty,
+    };
+
+    var menu_items: std.ArrayList(MenuItem) = .empty;
+
+    pub fn displayFn(reset: bool) void {
+        if (reset) resetWidget();
+        displayWidgetTemplate(@This());
+    }
+
+    pub fn resetWidget() void {
+        allocator = .init(&allocator_buffer);
+        arena = .init(allocator.allocator());
+        menu_items = .empty;
+
+        options = .{};
+        test_options = .{ .direction = .horizontal };
+        menu_items.append(arena.allocator(), .{
+            .label = "File",
+        }) catch @panic("OOM");
+    }
+
+    pub fn layoutWidget() void {
+        var menu = dvui.menu(@src(), test_options.direction, options.override(.{ .data_out = &wd }));
+        defer menu.deinit();
+        displayMenuItems(menu, menu_items);
+    }
+
+    fn displayMenuItems(menu: *dvui.MenuWidget, items: std.ArrayList(MenuItem)) void {
+        for (items.items, 0..) |menu_item, i| {
+            if (dvui.menuItemLabel(@src(), menu_item.label, .{ .submenu = menu_item.sub_items.items.len > 0 }, .{ .id_extra = i, .expand = .horizontal })) |r| {
+                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{ .id_extra = i });
+                defer fw.deinit();
+                // If there are no sub menus to display close on click.
+                if (menu_item.sub_items.items.len == 0) {
+                    menu.close();
+                } else {
+                    displayMenuItems(menu, menu_item.sub_items);
+                }
+            }
+        }
+    }
+
+    pub fn layoutWidgetControls() void {
+        dvui.structUI(@src(), test_options_label, &test_options, 1, .{}, .{});
+        var al: dvui.Alignment = .init(@src(), 0);
+        defer al.deinit();
+        if (struct_ui.displayContainer(@src(), "Menu builder")) |container| {
+            defer container.deinit();
+            displayMenuControls(&menu_items);
+            al.spacer(@src(), 0);
+            if (dvui.buttonIcon(@src(), "add", dvui.entypo.circle_with_plus, .{}, .{}, .{})) {
+                menu_items.append(arena.allocator(), .{ .label = "Main" }) catch {};
+                dvui.refresh(null, @src(), null);
+            }
+        }
+    }
+
+    fn displayMenuControls(items: *std.ArrayList(MenuItem)) void {
+        var to_remove: std.ArrayList(usize) = .empty;
+
+        var indent = dvui.box(@src(), .{ .dir = .vertical }, .{
+            .expand = .horizontal,
+            .border = .{ .x = 1 },
+            .background = true,
+            .margin = .{ .x = 12 },
+        });
+        defer indent.deinit();
+
+        for (items.items, 0..) |*menu_item, i| {
+            var vbox = dvui.box(@src(), .{}, .{ .id_extra = i });
+            defer vbox.deinit();
+            {
+                var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+                defer hbox.deinit();
+                {
+                    const size = dvui.themeGet().font_body.sizeM(10, 1);
+                    var te = dvui.textEntry(@src(), .{}, .{ .min_size_content = size, .max_size_content = .cast(size) });
+                    defer te.deinit();
+                    if (dvui.firstFrame(te.data().id)) {
+                        te.textSet(menu_item.label, false);
+                    }
+                    menu_item.label = te.textGet();
+                }
+                if (dvui.buttonIcon(@src(), "delete", dvui.entypo.circle_with_minus, .{}, .{}, .{ .expand = .both })) {
+                    to_remove.append(arena.allocator(), i) catch {};
+                    continue;
+                }
+                if (dvui.buttonIcon(@src(), "add", dvui.entypo.circle_with_plus, .{}, .{}, .{ .expand = .both })) {
+                    menu_item.sub_items.append(arena.allocator(), .{ .label = "Sub..." }) catch {};
+                }
+            }
+            displayMenuControls(&menu_item.sub_items);
+        }
+        while (to_remove.pop()) |index| {
+            // TODO: Menu leak here when deleting branch nodes.
+            _ = items.orderedRemove(index);
+        }
+    }
+};
+
 const DisplayProgress = struct {
     var name: []const u8 = "progress()";
 
@@ -1988,7 +2110,7 @@ const DisplayToast = struct {
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
     var init_opts: dvui.ToastOptions = undefined;
-    var selection: ?enum { @"floating window" } = null;
+    var selection: ?enum { @"widgetpedia window" } = null;
     var box_id: dvui.Id = undefined;
 
     var test_options: struct {
@@ -2006,7 +2128,7 @@ const DisplayToast = struct {
     }
 
     pub fn layoutWidget() void {
-        init_opts.subwindow_id = if (selection == .@"floating window") dvui.subwindowCurrentId() else null;
+        init_opts.subwindow_id = if (selection == .@"widgetpedia window") dvui.subwindowCurrentId() else null;
         if (dvui.button(@src(), "Display toast", .{}, .{})) {
             dvui.toast(@src(), init_opts);
         }
@@ -2201,7 +2323,7 @@ const widget_hierarchy = [_]WidgetHierarchy{
     .{ .name = "link", .displayFn = DisplayLink.displayFn, .children = null },
 
     .{ .name = "menus", .displayFn = displayEmpty, .children = &.{
-        .{ .name = "menu", .displayFn = displayEmpty, .children = null },
+        .{ .name = "menu", .displayFn = DisplayMenu.displayFn, .children = null },
         .{ .name = "menuItem", .displayFn = displayEmpty, .children = null },
         .{ .name = "menuItemIcon", .displayFn = displayEmpty, .children = null },
         .{ .name = "menuItemLabel", .displayFn = displayEmpty, .children = null },

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -137,9 +137,7 @@ const WidgetHierarchy = struct {
     displayFn: *const fn (reset_widget: bool) void,
 };
 
-var current_widget: WidgetHierarchy = .{ .name = "menu", .displayFn = DisplayMenu.displayFn, .children = null };
-
-//widget_hierarchy[0];
+var current_widget: WidgetHierarchy = widget_hierarchy[0];
 
 fn displayEmpty(_: bool) void {
     var label_str = std.Io.Writer.Allocating.initCapacity(dvui.currentWindow().arena(), current_widget.name.len + 2) catch return;
@@ -757,17 +755,17 @@ const DisplayContext = struct {
         defer ctext.deinit();
 
         if (ctext.activePoint()) |cp| {
-            var fw2 = dvui.floatingMenu(@src(), .{ .from = Rect.Natural.fromPoint(cp) }, .{});
-            defer fw2.deinit();
+            var fw = dvui.floatingMenu(@src(), .{ .from = Rect.Natural.fromPoint(cp) }, .{});
+            defer fw.deinit();
 
             if (dvui.menuItemLabel(@src(), "Menu Item 1", .{}, .{ .expand = .horizontal })) |_| {
-                fw2.close();
+                fw.close();
             }
             if (dvui.menuItemLabel(@src(), "Menu Item 2", .{}, .{ .expand = .horizontal })) |_| {
-                fw2.close();
+                fw.close();
             }
             if ((dvui.menuItemLabel(@src(), "Menu Item 3", .{}, .{ .expand = .horizontal }))) |_| {
-                fw2.close();
+                fw.close();
             }
         }
     }
@@ -1302,59 +1300,67 @@ const DisplayMenu = struct {
         direction: dvui.enums.Direction,
     } = undefined;
 
-    var fba: std.heap.FixedBufferAllocator = undefined;
-    const allocator = fba.allocator();
-
-    var menu_id: usize = 0;
-
-    const MenuItem = struct {
-        label: []const u8,
-        id: usize,
-        sub_items: std.ArrayList(MenuItem) = .empty,
-    };
-
-    var menu_items: std.ArrayList(MenuItem) = .empty;
-
     pub fn displayFn(reset: bool) void {
         if (reset) resetWidget();
         displayWidgetTemplate(@This());
     }
 
-    // Give each menu item a unique id as their index in the arraylist can change with deletions.
-    fn menuId() usize {
-        defer menu_id += 1;
-        return menu_id;
-    }
-
     pub fn resetWidget() void {
-        fba = .init(&allocator_buffer);
-        menu_items = .empty;
-
         options = .{};
         test_options = .{ .direction = .horizontal };
-        menu_items.append(allocator, .{
-            .label = allocator.dupe(u8, "File") catch "",
-            .id = menuId(),
-        }) catch {};
     }
 
     pub fn layoutWidget() void {
         var menu = dvui.menu(@src(), test_options.direction, options.override(.{ .data_out = &wd }));
         defer menu.deinit();
-        displayMenuItems(menu, menu_items);
+        {
+            if (dvui.menuItemLabel(@src(), "Item", .{ .submenu = true }, .{})) |r| {
+                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+                defer fw.deinit();
+                var mi = dvui.menuItem(@src(), .{}, .{ .expand = .horizontal });
+                defer mi.deinit();
+                {
+                    var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });
+                    defer hbox.deinit();
+                    dvui.icon(@src(), "bell", dvui.entypo.bell, .{}, .{ .expand = .ratio });
+                    dvui.labelNoFmt(@src(), "MenuItemWidget with icon and text", .{}, .{});
+                }
+                if (mi.activeRect()) |_| {
+                    menu.close();
+                }
+            }
+            if (dvui.menuItemLabel(@src(), "ItemIcon", .{ .submenu = true }, .{})) |r| {
+                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+                defer fw.deinit();
+                if (dvui.menuItemIcon(@src(), "brush", dvui.entypo.brush, .{}, .{ .expand = .ratio })) |_| {
+                    menu.close();
+                }
+            }
+            if (dvui.menuItemLabel(@src(), "ItemLabel", .{ .submenu = true }, .{})) |r| {
+                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+                defer fw.deinit();
+                if (dvui.menuItemLabel(@src(), "Menu label", .{}, .{ .expand = .horizontal })) |_| {
+                    menu.close();
+                }
+            }
+            if (dvui.menuItemLabel(@src(), "SubMenus", .{ .submenu = true }, .{})) |r| {
+                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+                defer fw.deinit();
+                submenu();
+                if (dvui.menuItemLabel(@src(), "Close", .{ .submenu = false }, .{ .expand = .horizontal })) |_| {
+                    menu.close();
+                }
+            }
+        }
     }
 
-    fn displayMenuItems(menu: *dvui.MenuWidget, items: std.ArrayList(MenuItem)) void {
-        for (items.items, 0..) |menu_item, i| {
-            if (dvui.menuItemLabel(@src(), menu_item.label, .{ .submenu = menu_item.sub_items.items.len > 0 }, .{ .id_extra = i, .expand = .horizontal })) |r| {
-                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{ .id_extra = i });
-                defer fw.deinit();
-                // If there are no sub menus to display close on click.
-                if (menu_item.sub_items.items.len == 0) {
-                    menu.close();
-                } else {
-                    displayMenuItems(menu, menu_item.sub_items);
-                }
+    pub fn submenu() void {
+        if (dvui.menuItemLabel(@src(), "Sub...", .{ .submenu = true }, .{ .expand = .horizontal })) |r| {
+            var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+            defer fw.deinit();
+            submenu();
+            if (dvui.menuItemLabel(@src(), "Close", .{ .submenu = false }, .{ .expand = .horizontal })) |_| {
+                fw.close();
             }
         }
     }
@@ -1363,70 +1369,6 @@ const DisplayMenu = struct {
         dvui.structUI(@src(), test_options_label, &test_options, 1, .{}, .{});
         var al: dvui.Alignment = .init(@src(), 0);
         defer al.deinit();
-        if (struct_ui.displayContainer(@src(), "Menu builder")) |container| {
-            defer container.deinit();
-            displayMenuControls(&menu_items);
-            al.spacer(@src(), 0);
-            if (dvui.buttonIcon(@src(), "add", dvui.entypo.circle_with_plus, .{}, .{}, .{})) {
-                const label = std.fmt.allocPrint(allocator, "Main {}", .{menu_items.items.len + 1}) catch "";
-                menu_items.append(allocator, .{ .label = label, .id = menuId() }) catch {};
-                dvui.refresh(null, @src(), null);
-            }
-        }
-    }
-
-    fn displayMenuControls(items: *std.ArrayList(MenuItem)) void {
-        var indent = dvui.box(@src(), .{ .dir = .vertical }, .{
-            .expand = .horizontal,
-            .border = .{ .x = 1 },
-            .background = true,
-            .margin = .{ .x = 12 },
-        });
-        defer indent.deinit();
-
-        var to_remove: ?usize = null;
-        for (items.items, 0..) |*menu_item, i| {
-            var vbox = dvui.box(@src(), .{}, .{ .id_extra = menu_item.id });
-            defer vbox.deinit();
-            {
-                var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
-                defer hbox.deinit();
-                {
-                    const size = dvui.themeGet().font_body.sizeM(10, 1);
-                    var te = dvui.textEntry(@src(), .{}, .{ .min_size_content = size, .max_size_content = .cast(size) });
-                    defer te.deinit();
-                    if (dvui.firstFrame(te.data().id)) {
-                        te.textSet(menu_item.label, false);
-                    }
-                    // FBA allocated strings are only used to initialize the text entry's value.
-                    // Once that is done, free them and set the menu item's label to the text entry's internal buffer.
-                    if (@intFromPtr(menu_item.label.ptr) >= @intFromPtr(&allocator_buffer) and @intFromPtr(menu_item.label.ptr) <= @intFromPtr(&allocator_buffer) + allocator_buffer.len) {
-                        allocator.free(menu_item.label);
-                    }
-                    menu_item.label = te.textGet();
-                }
-                if (dvui.buttonIcon(@src(), "delete", dvui.entypo.circle_with_minus, .{}, .{}, .{ .expand = .both })) {
-                    to_remove = i;
-                    continue;
-                }
-                if (dvui.buttonIcon(@src(), "add", dvui.entypo.circle_with_plus, .{}, .{}, .{ .expand = .both })) {
-                    const label = std.fmt.allocPrint(allocator, "Sub {d}...", .{menu_item.sub_items.items.len + 1}) catch "";
-                    menu_item.sub_items.append(allocator, .{ .label = label, .id = menuId() }) catch {};
-                }
-            }
-            displayMenuControls(&menu_item.sub_items);
-        }
-        if (to_remove) |index| {
-            deinitMenuItem(items, index);
-            to_remove = null;
-        }
-    }
-    pub fn deinitMenuItem(items: *std.ArrayList(MenuItem), index: usize) void {
-        while (items.items[index].sub_items.items.len > 0) {
-            // deinit from end to start
-            deinitMenuItem(&items.items[index].sub_items, items.items[index].sub_items.items.len - 1);
-        }
-        _ = items.orderedRemove(index);
     }
 };
 
@@ -1542,6 +1484,8 @@ const DisplayMenuItemLabel = struct {
     var options: dvui.Options = undefined;
     var init_opts: dvui.MenuItemWidget.InitOptions = undefined;
 
+    // Since FixedBufferAllocator only frees the last allocation, there is little point in performing
+    // deallocations. If the FBA returns OOM, call resetWidget(.oom).
     var allocator_buffer: [10 * 1024]u8 = undefined;
     var fba: std.heap.FixedBufferAllocator = undefined;
     const allocator = fba.allocator();
@@ -1556,7 +1500,7 @@ const DisplayMenuItemLabel = struct {
     var menu_items: std.ArrayList(MenuItem) = .empty;
 
     pub fn displayFn(reset: bool) void {
-        if (reset) resetWidget();
+        if (reset) resetWidget(.reset);
         displayWidgetTemplate(@This());
     }
 
@@ -1565,7 +1509,7 @@ const DisplayMenuItemLabel = struct {
         return menu_id;
     }
 
-    pub fn resetWidget() void {
+    pub fn resetWidget(reason: enum { reset, oom }) void {
         fba = .init(&allocator_buffer);
         menu_items = .empty;
 
@@ -1574,9 +1518,39 @@ const DisplayMenuItemLabel = struct {
             .submenu = true,
         };
         menu_items.append(allocator, .{
-            .label = allocator.dupe(u8, "File") catch "",
+            .label = "File",
             .id = menuId(),
-        }) catch {};
+            .sub_items = populateSubItems(&.{
+                .{
+                    .id = menuId(),
+                    .label = "Export...",
+                    .sub_items = populateSubItems(&.{
+                        .{ .id = menuId(), .label = "png" },
+                        .{ .id = menuId(), .label = "jpg" },
+                    }),
+                },
+                .{ .id = menuId(), .label = "Close" },
+            }),
+        }) catch unreachable;
+        menu_items.append(allocator, .{
+            .label = "Help",
+            .id = menuId(),
+            .sub_items = populateSubItems(&.{
+                .{ .id = menuId(), .label = "About" },
+            }),
+        }) catch unreachable;
+
+        if (reason == .oom) {
+            dvui.toast(@src(), .{ .subwindow_id = dvui.currentWindow().subwindows.current_id, .message = "Menu builder exceeded memory limit and has been reset " });
+        }
+    }
+
+    fn populateSubItems(sub_items: []const MenuItem) std.ArrayList(MenuItem) {
+        var result: std.ArrayList(MenuItem) = .empty;
+        for (sub_items) |menu_item| {
+            result.append(allocator, menu_item) catch resetWidget(.oom);
+        }
+        return result;
     }
 
     pub fn layoutWidget() void {
@@ -1611,8 +1585,8 @@ const DisplayMenuItemLabel = struct {
             displayMenuControls(&menu_items);
             al.spacer(@src(), 0);
             if (dvui.buttonIcon(@src(), "add", dvui.entypo.circle_with_plus, .{}, .{}, .{})) {
-                const label = std.fmt.allocPrint(allocator, "Main {}", .{menu_items.items.len + 1}) catch "";
-                menu_items.append(allocator, .{ .label = label, .id = menuId() }) catch {};
+                const label = std.fmt.allocPrint(allocator, "Main {}", .{menu_items.items.len + 1}) catch return resetWidget(.oom);
+                menu_items.append(allocator, .{ .label = label, .id = menuId() }) catch return resetWidget(.oom);
                 dvui.refresh(null, @src(), null);
             }
         }
@@ -1641,11 +1615,6 @@ const DisplayMenuItemLabel = struct {
                     if (dvui.firstFrame(te.data().id)) {
                         te.textSet(menu_item.label, false);
                     }
-                    // FBA allocated strings are only used to initialize the text entry's value.
-                    // Once that is done, free them and set the menu item's label to the text entry's internal buffer.
-                    if (@intFromPtr(menu_item.label.ptr) >= @intFromPtr(&allocator_buffer) and @intFromPtr(menu_item.label.ptr) <= @intFromPtr(&allocator_buffer) + allocator_buffer.len) {
-                        allocator.free(menu_item.label);
-                    }
                     menu_item.label = te.textGet();
                 }
                 if (dvui.buttonIcon(@src(), "delete", dvui.entypo.circle_with_minus, .{}, .{}, .{ .expand = .both })) {
@@ -1653,23 +1622,16 @@ const DisplayMenuItemLabel = struct {
                     continue;
                 }
                 if (dvui.buttonIcon(@src(), "add", dvui.entypo.circle_with_plus, .{}, .{}, .{ .expand = .both })) {
-                    const label = std.fmt.allocPrint(allocator, "Sub {d}...", .{menu_item.sub_items.items.len + 1}) catch "";
-                    menu_item.sub_items.append(allocator, .{ .label = label, .id = menuId() }) catch {};
+                    const label = std.fmt.allocPrint(allocator, "Sub {d}...", .{menu_item.sub_items.items.len + 1}) catch return resetWidget(.oom);
+                    menu_item.sub_items.append(allocator, .{ .label = label, .id = menuId() }) catch return resetWidget(.oom);
                 }
             }
             displayMenuControls(&menu_item.sub_items);
         }
         if (to_remove) |index| {
-            deinitMenuItem(items, index);
+            _ = items.orderedRemove(index);
             to_remove = null;
         }
-    }
-    pub fn deinitMenuItem(items: *std.ArrayList(MenuItem), index: usize) void {
-        while (items.items[index].sub_items.items.len > 0) {
-            // deinit from end to start
-            deinitMenuItem(&items.items[index].sub_items, items.items[index].sub_items.items.len - 1);
-        }
-        _ = items.orderedRemove(index);
     }
 };
 

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -1430,7 +1430,7 @@ const DisplayMenuItem = struct {
 };
 
 const DisplayMenuItemIcon = struct {
-    var name: []const u8 = "tooltip()";
+    var name: []const u8 = "menuItemIcon()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -1301,12 +1301,15 @@ const DisplayMenu = struct {
     var test_options: struct {
         direction: dvui.enums.Direction,
     } = undefined;
-    var allocator: std.heap.FixedBufferAllocator = undefined;
-    //var allocator: std.heap.DebugAllocator(.{}) = .init;
-    var arena: std.heap.ArenaAllocator = undefined;
+
+    var fba: std.heap.FixedBufferAllocator = undefined;
+    const allocator = fba.allocator();
+
+    var menu_id: usize = 0;
 
     const MenuItem = struct {
         label: []const u8,
+        id: usize,
         sub_items: std.ArrayList(MenuItem) = .empty,
     };
 
@@ -1317,16 +1320,22 @@ const DisplayMenu = struct {
         displayWidgetTemplate(@This());
     }
 
+    // Give each menu item a unique id as their index in the arraylist can change with deletions.
+    fn menuId() usize {
+        defer menu_id += 1;
+        return menu_id;
+    }
+
     pub fn resetWidget() void {
-        allocator = .init(&allocator_buffer);
-        arena = .init(allocator.allocator());
+        fba = .init(&allocator_buffer);
         menu_items = .empty;
 
         options = .{};
         test_options = .{ .direction = .horizontal };
-        menu_items.append(arena.allocator(), .{
-            .label = "File",
-        }) catch @panic("OOM");
+        menu_items.append(allocator, .{
+            .label = allocator.dupe(u8, "File") catch "",
+            .id = menuId(),
+        }) catch {};
     }
 
     pub fn layoutWidget() void {
@@ -1359,15 +1368,14 @@ const DisplayMenu = struct {
             displayMenuControls(&menu_items);
             al.spacer(@src(), 0);
             if (dvui.buttonIcon(@src(), "add", dvui.entypo.circle_with_plus, .{}, .{}, .{})) {
-                menu_items.append(arena.allocator(), .{ .label = "Main" }) catch {};
+                const label = std.fmt.allocPrint(allocator, "Main {}", .{menu_items.items.len + 1}) catch "";
+                menu_items.append(allocator, .{ .label = label, .id = menuId() }) catch {};
                 dvui.refresh(null, @src(), null);
             }
         }
     }
 
     fn displayMenuControls(items: *std.ArrayList(MenuItem)) void {
-        var to_remove: std.ArrayList(usize) = .empty;
-
         var indent = dvui.box(@src(), .{ .dir = .vertical }, .{
             .expand = .horizontal,
             .border = .{ .x = 1 },
@@ -1376,8 +1384,9 @@ const DisplayMenu = struct {
         });
         defer indent.deinit();
 
+        var to_remove: ?usize = null;
         for (items.items, 0..) |*menu_item, i| {
-            var vbox = dvui.box(@src(), .{}, .{ .id_extra = i });
+            var vbox = dvui.box(@src(), .{}, .{ .id_extra = menu_item.id });
             defer vbox.deinit();
             {
                 var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
@@ -1389,22 +1398,278 @@ const DisplayMenu = struct {
                     if (dvui.firstFrame(te.data().id)) {
                         te.textSet(menu_item.label, false);
                     }
+                    // FBA allocated strings are only used to initialize the text entry's value.
+                    // Once that is done, free them and set the menu item's label to the text entry's internal buffer.
+                    if (@intFromPtr(menu_item.label.ptr) >= @intFromPtr(&allocator_buffer) and @intFromPtr(menu_item.label.ptr) <= @intFromPtr(&allocator_buffer) + allocator_buffer.len) {
+                        allocator.free(menu_item.label);
+                    }
                     menu_item.label = te.textGet();
                 }
                 if (dvui.buttonIcon(@src(), "delete", dvui.entypo.circle_with_minus, .{}, .{}, .{ .expand = .both })) {
-                    to_remove.append(arena.allocator(), i) catch {};
+                    to_remove = i;
                     continue;
                 }
                 if (dvui.buttonIcon(@src(), "add", dvui.entypo.circle_with_plus, .{}, .{}, .{ .expand = .both })) {
-                    menu_item.sub_items.append(arena.allocator(), .{ .label = "Sub..." }) catch {};
+                    const label = std.fmt.allocPrint(allocator, "Sub {d}...", .{menu_item.sub_items.items.len + 1}) catch "";
+                    menu_item.sub_items.append(allocator, .{ .label = label, .id = menuId() }) catch {};
                 }
             }
             displayMenuControls(&menu_item.sub_items);
         }
-        while (to_remove.pop()) |index| {
-            // TODO: Menu leak here when deleting branch nodes.
-            _ = items.orderedRemove(index);
+        if (to_remove) |index| {
+            deinitMenuItem(items, index);
+            to_remove = null;
         }
+    }
+    pub fn deinitMenuItem(items: *std.ArrayList(MenuItem), index: usize) void {
+        while (items.items[index].sub_items.items.len > 0) {
+            // deinit from end to start
+            deinitMenuItem(&items.items[index].sub_items, items.items[index].sub_items.items.len - 1);
+        }
+        _ = items.orderedRemove(index);
+    }
+};
+
+const DisplayMenuItem = struct {
+    var name: []const u8 = "menuItem()";
+
+    var wd: dvui.WidgetData = undefined;
+    var options: dvui.Options = undefined;
+    var init_opts: dvui.MenuItemWidget.InitOptions = undefined;
+    var checked: bool = false;
+    var test_options: struct {
+        scenario: enum { @"text only", @"with icon" },
+        text: []const u8,
+    } = undefined;
+
+    pub fn displayFn(reset: bool) void {
+        if (reset) resetWidget();
+        displayWidgetTemplate(@This());
+    }
+
+    pub fn resetWidget() void {
+        options = .{ .min_size_content = .all(30) };
+        init_opts = .{};
+        checked = false;
+    }
+
+    pub fn layoutWidget() void {
+        {
+            var menu = dvui.menu(@src(), .horizontal, .{});
+            defer menu.deinit();
+            if (dvui.menuItemLabel(@src(), "File", .{ .submenu = true }, .{})) |r| {
+                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+                defer fw.deinit();
+                {
+                    var mi = dvui.menuItem(@src(), init_opts, options.override(.{ .data_out = &wd }));
+                    defer mi.deinit();
+                    var vbox = dvui.box(@src(), .{}, .{});
+                    defer vbox.deinit();
+                    dvui.labelNoFmt(@src(), "Menu items can contain other widgets", .{}, .{});
+                    dvui.spinner(@src(), .{ .color_text = .green });
+                    if (mi.activeRect()) |_| {
+                        menu.close();
+                    }
+                }
+                _ = dvui.checkbox(@src(), &checked, "Checkbox outside menu item", .{});
+                if (dvui.menuItemLabel(@src(), "Standard item", .{}, .{ .expand = .horizontal })) |_| {
+                    menu.close();
+                }
+            }
+        }
+    }
+
+    pub fn layoutWidgetControls() void {
+        const display_opts = StructOptions(dvui.MenuItemWidget.InitOptions).initWithDefaults(.{
+            .submenu = .defaultReadOnly,
+        }, null);
+        dvui.structUI(@src(), "init_opts", &init_opts, 1, .{display_opts}, .{});
+    }
+};
+
+const DisplayMenuItemIcon = struct {
+    var name: []const u8 = "tooltip()";
+
+    var wd: dvui.WidgetData = undefined;
+    var options: dvui.Options = undefined;
+    var init_opts: dvui.MenuItemWidget.InitOptions = undefined;
+
+    var test_options: struct {
+        scenario: enum { @"text only", @"with icon" },
+        text: []const u8,
+    } = undefined;
+
+    pub fn displayFn(reset: bool) void {
+        if (reset) resetWidget();
+        displayWidgetTemplate(@This());
+    }
+
+    pub fn resetWidget() void {
+        options = .{ .min_size_content = .all(30) };
+        init_opts = .{};
+    }
+
+    pub fn layoutWidget() void {
+        {
+            var menu = dvui.menu(@src(), .horizontal, .{});
+            defer menu.deinit();
+            if (dvui.menuItemIcon(@src(), "chevron_thin_down", dvui.entypo.chevron_thin_down, init_opts, options.override(.{ .data_out = &wd }))) |r| {
+                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+                defer fw.deinit();
+                _ = dvui.menuItemIcon(@src(), "aircraft", dvui.entypo.aircraft, init_opts, options.override(.{ .data_out = &wd }));
+                _ = dvui.menuItemIcon(@src(), "aircraft_landing", dvui.entypo.aircraft_landing, init_opts, options.override(.{ .data_out = &wd }));
+                _ = dvui.menuItemIcon(@src(), "aircraft_take_off", dvui.entypo.aircraft_take_off, init_opts, options.override(.{ .data_out = &wd }));
+            }
+            _ = dvui.menuItemIcon(@src(), "aircraft", dvui.entypo.aircraft, init_opts, options.override(.{ .data_out = &wd }));
+            _ = dvui.menuItemIcon(@src(), "aircraft_landing", dvui.entypo.aircraft_landing, init_opts, options.override(.{ .data_out = &wd }));
+            _ = dvui.menuItemIcon(@src(), "aircraft_take_off", dvui.entypo.aircraft_take_off, init_opts, options.override(.{ .data_out = &wd }));
+        }
+        var tl = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal, .gravity_y = 1.0, .gravity_x = 0.5 });
+        defer tl.deinit();
+        tl.addText("The first icon will show a submenu when submenus are enabled", .{ .expand = .horizontal, .gravity_x = 0.5 });
+    }
+
+    pub fn layoutWidgetControls() void {
+        const display_opts = StructOptions(dvui.MenuItemWidget.InitOptions).initWithDefaults(.{}, null);
+        dvui.structUI(@src(), "init_opts", &init_opts, 1, .{display_opts}, .{});
+    }
+};
+
+const DisplayMenuItemLabel = struct {
+    var name: []const u8 = "menuItemLabel()";
+
+    var wd: dvui.WidgetData = undefined;
+    var options: dvui.Options = undefined;
+    var init_opts: dvui.MenuItemWidget.InitOptions = undefined;
+
+    var allocator_buffer: [10 * 1024]u8 = undefined;
+    var fba: std.heap.FixedBufferAllocator = undefined;
+    const allocator = fba.allocator();
+    var menu_id: usize = 0;
+
+    const MenuItem = struct {
+        label: []const u8,
+        id: usize,
+        sub_items: std.ArrayList(MenuItem) = .empty,
+    };
+
+    var menu_items: std.ArrayList(MenuItem) = .empty;
+
+    pub fn displayFn(reset: bool) void {
+        if (reset) resetWidget();
+        displayWidgetTemplate(@This());
+    }
+
+    fn menuId() usize {
+        defer menu_id += 1;
+        return menu_id;
+    }
+
+    pub fn resetWidget() void {
+        fba = .init(&allocator_buffer);
+        menu_items = .empty;
+
+        options = .{};
+        init_opts = .{
+            .submenu = true,
+        };
+        menu_items.append(allocator, .{
+            .label = allocator.dupe(u8, "File") catch "",
+            .id = menuId(),
+        }) catch {};
+    }
+
+    pub fn layoutWidget() void {
+        var menu = dvui.menu(@src(), .horizontal, .{});
+        defer menu.deinit();
+        displayMenuItems(menu, menu_items);
+    }
+
+    fn displayMenuItems(menu: *dvui.MenuWidget, items: std.ArrayList(MenuItem)) void {
+        for (items.items, 0..) |menu_item, i| {
+            var init_opts_submenu = init_opts;
+            init_opts_submenu.submenu = init_opts.submenu and menu_item.sub_items.items.len > 0;
+            if (dvui.menuItemLabel(@src(), menu_item.label, init_opts_submenu, .{ .id_extra = i, .expand = .horizontal, .data_out = &wd })) |r| {
+                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{ .id_extra = i });
+                defer fw.deinit();
+                // If there are no sub menus to display close on click.
+                if (menu_item.sub_items.items.len == 0) {
+                    menu.close();
+                } else {
+                    displayMenuItems(menu, menu_item.sub_items);
+                }
+            }
+        }
+    }
+
+    pub fn layoutWidgetControls() void {
+        dvui.structUI(@src(), "init_opts", &init_opts, 1, .{}, .{});
+        var al: dvui.Alignment = .init(@src(), 0);
+        defer al.deinit();
+        if (struct_ui.displayContainer(@src(), "Menu builder")) |container| {
+            defer container.deinit();
+            displayMenuControls(&menu_items);
+            al.spacer(@src(), 0);
+            if (dvui.buttonIcon(@src(), "add", dvui.entypo.circle_with_plus, .{}, .{}, .{})) {
+                const label = std.fmt.allocPrint(allocator, "Main {}", .{menu_items.items.len + 1}) catch "";
+                menu_items.append(allocator, .{ .label = label, .id = menuId() }) catch {};
+                dvui.refresh(null, @src(), null);
+            }
+        }
+    }
+
+    fn displayMenuControls(items: *std.ArrayList(MenuItem)) void {
+        var indent = dvui.box(@src(), .{ .dir = .vertical }, .{
+            .expand = .horizontal,
+            .border = .{ .x = 1 },
+            .background = true,
+            .margin = .{ .x = 12 },
+        });
+        defer indent.deinit();
+
+        var to_remove: ?usize = null;
+        for (items.items, 0..) |*menu_item, i| {
+            var vbox = dvui.box(@src(), .{}, .{ .id_extra = menu_item.id });
+            defer vbox.deinit();
+            {
+                var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+                defer hbox.deinit();
+                {
+                    const size = dvui.themeGet().font_body.sizeM(10, 1);
+                    var te = dvui.textEntry(@src(), .{}, .{ .min_size_content = size, .max_size_content = .cast(size) });
+                    defer te.deinit();
+                    if (dvui.firstFrame(te.data().id)) {
+                        te.textSet(menu_item.label, false);
+                    }
+                    // FBA allocated strings are only used to initialize the text entry's value.
+                    // Once that is done, free them and set the menu item's label to the text entry's internal buffer.
+                    if (@intFromPtr(menu_item.label.ptr) >= @intFromPtr(&allocator_buffer) and @intFromPtr(menu_item.label.ptr) <= @intFromPtr(&allocator_buffer) + allocator_buffer.len) {
+                        allocator.free(menu_item.label);
+                    }
+                    menu_item.label = te.textGet();
+                }
+                if (dvui.buttonIcon(@src(), "delete", dvui.entypo.circle_with_minus, .{}, .{}, .{ .expand = .both })) {
+                    to_remove = i;
+                    continue;
+                }
+                if (dvui.buttonIcon(@src(), "add", dvui.entypo.circle_with_plus, .{}, .{}, .{ .expand = .both })) {
+                    const label = std.fmt.allocPrint(allocator, "Sub {d}...", .{menu_item.sub_items.items.len + 1}) catch "";
+                    menu_item.sub_items.append(allocator, .{ .label = label, .id = menuId() }) catch {};
+                }
+            }
+            displayMenuControls(&menu_item.sub_items);
+        }
+        if (to_remove) |index| {
+            deinitMenuItem(items, index);
+            to_remove = null;
+        }
+    }
+    pub fn deinitMenuItem(items: *std.ArrayList(MenuItem), index: usize) void {
+        while (items.items[index].sub_items.items.len > 0) {
+            // deinit from end to start
+            deinitMenuItem(&items.items[index].sub_items, items.items[index].sub_items.items.len - 1);
+        }
+        _ = items.orderedRemove(index);
     }
 };
 
@@ -2324,9 +2589,9 @@ const widget_hierarchy = [_]WidgetHierarchy{
 
     .{ .name = "menus", .displayFn = displayEmpty, .children = &.{
         .{ .name = "menu", .displayFn = DisplayMenu.displayFn, .children = null },
-        .{ .name = "menuItem", .displayFn = displayEmpty, .children = null },
-        .{ .name = "menuItemIcon", .displayFn = displayEmpty, .children = null },
-        .{ .name = "menuItemLabel", .displayFn = displayEmpty, .children = null },
+        .{ .name = "menuItem", .displayFn = DisplayMenuItem.displayFn, .children = null },
+        .{ .name = "menuItemIcon", .displayFn = DisplayMenuItemIcon.displayFn, .children = null },
+        .{ .name = "menuItemLabel", .displayFn = DisplayMenuItemLabel.displayFn, .children = null },
     } },
 
     .{ .name = "paned", .displayFn = displayEmpty, .children = null },

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -1589,7 +1589,7 @@ const DisplayMenuItemLabel = struct {
         for (items.items, 0..) |menu_item, i| {
             var init_opts_submenu = init_opts;
             init_opts_submenu.submenu = init_opts.submenu and menu_item.sub_items.items.len > 0;
-            if (dvui.menuItemLabel(@src(), menu_item.label, init_opts_submenu, .{ .id_extra = i, .expand = .horizontal, .data_out = &wd })) |r| {
+            if (dvui.menuItemLabel(@src(), menu_item.label, init_opts_submenu, options.override(.{ .id_extra = i, .data_out = &wd }))) |r| {
                 var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{ .id_extra = i });
                 defer fw.deinit();
                 // If there are no sub menus to display close on click.

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -1393,11 +1393,12 @@ pub fn displayContainer(comptime src: std.builtin.SourceLocation, field_name: ?[
         .{ .default_expanded = defaults.display_expanded },
         .{ .expand = .horizontal },
     )) {
+        // Use src again in case exoander is not created.
         vbox = dvui.box(src, .{ .dir = .vertical }, .{
             .expand = .horizontal,
             .border = if (field_name != null) .{ .x = 1 } else null,
             .background = true,
-            .margin = if (field_name != null) .{ .w = 12, .x = 12 } else null,
+            .margin = if (field_name != null) .{ .x = 12 } else null,
             .id_extra = 1,
         });
     }


### PR DESCRIPTION
If you have some time would appreciate your thoughts on the menu builder in the `menu()` entry.

Is it obvious what each of the + and - do?
Is it weird that - deletes a top-level menu, but the + on the same level adds a sub-menu item?

Something just doesn't feel quite right to me about it.

I'm still trying to refine how this will work, but I'll prob move this to menuItemLabel() and have a similar one for the icons etc. And then options would be applied to all the menu items created. 

