### PR TITLE
coalesce draw calls with same texture/clip

### DIFF
--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -158,9 +158,15 @@ pub fn show(self: *Debug) void {
 
         var wd: dvui.WidgetData = undefined;
         _ = dvui.checkbox(@src(), &dvui.currentWindow().debug.touch_simulate_events, "Use Mouse as Touch", .{ .data_out = &wd });
-        _ = dvui.checkbox(@src(), &dvui.currentWindow().debug.log_stats, "Log Stats", .{});
 
         dvui.tooltip(@src(), .{ .active_rect = wd.borderRectScale().r }, "mouse drag will scroll\ntext layout/entry have draggables and menu", .{}, .{});
+    }
+
+    {
+        var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+        defer hbox.deinit();
+        _ = dvui.checkbox(@src(), &dvui.currentWindow().debug.log_stats, "Log Stats", .{});
+        _ = dvui.checkbox(@src(), &dvui.currentWindow().batch_draws, "Batch Draws", .{});
     }
 
     _ = dvui.spacer(@src(), .{ .min_size_content = .all(4) });

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -29,6 +29,8 @@ widget_panic: bool = false,
 touch_simulate_events: bool = false,
 touch_simulate_down: bool = false,
 
+log_stats: bool = false,
+
 const Debug = @This();
 
 pub const DebugTarget = enum {
@@ -155,7 +157,8 @@ pub fn show(self: *Debug) void {
         }
 
         var wd: dvui.WidgetData = undefined;
-        _ = dvui.checkbox(@src(), &dvui.currentWindow().debug.touch_simulate_events, "Simulate Touch With Mouse", .{ .data_out = &wd });
+        _ = dvui.checkbox(@src(), &dvui.currentWindow().debug.touch_simulate_events, "Use Mouse as Touch", .{ .data_out = &wd });
+        _ = dvui.checkbox(@src(), &dvui.currentWindow().debug.log_stats, "Log Stats", .{});
 
         dvui.tooltip(@src(), .{ .active_rect = wd.borderRectScale().r }, "mouse drag will scroll\ntext layout/entry have draggables and menu", .{}, .{});
     }
@@ -397,7 +400,7 @@ fn showFrameTimes(self: *Debug) void {
         var tl = dvui.textLayout(@src(), .{}, .{ .expand = .both });
         defer tl.deinit();
 
-        tl.addText("Shows time (ms) between Window.begin/end for last 400 frames.", .{});
+        tl.addText("Time between Window.begin/end for last 400 frames.", .{});
     }
 
     const uniqueId = dvui.parentGet().extendId(@src(), 0);

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -115,10 +115,22 @@ _lifo_arena: std.heap.ArenaAllocator,
 _widget_stack: WidgetStack,
 render_target: dvui.RenderTarget = .{ .texture = null, .offset = .{} },
 end_rendering_done: bool = false,
+triQueue: struct {
+    texture: ?dvui.Texture,
+    clipr: ?dvui.Rect.Physical,
+    vtx: std.ArrayList(dvui.Vertex), // backed by gpa
+    idx: std.ArrayList(dvui.Vertex.Index), // backed by gpa
+},
+stats: Stats,
+stats_last_frame: Stats,
 
 debug: @import("Debug.zig") = .{},
 
 accesskit: dvui.AccessKit,
+
+pub const Stats = struct {
+    draw_calls: usize = 0,
+};
 
 pub const InitOptions = struct {
     id_extra: usize = 0,
@@ -150,6 +162,14 @@ pub fn init(
         ._arena = if (init_opts.arena) |a| a else .init(gpa),
         ._lifo_arena = .init(gpa),
         ._widget_stack = .init(gpa),
+        .triQueue = .{
+            .texture = null,
+            .clipr = null,
+            .vtx = .empty,
+            .idx = .empty,
+        },
+        .stats = .{},
+        .stats_last_frame = .{},
         .wd = WidgetData{
             .src = src,
             .id = hashval,
@@ -373,6 +393,9 @@ pub fn deinit(self: *Self) void {
     self.fonts.deinit(self.gpa, self.backend);
 
     self.debug.deinit(self.gpa);
+    const tq = &self.triQueue;
+    tq.vtx.deinit(self.gpa);
+    tq.idx.deinit(self.gpa);
 
     self.subwindows.deinit(self.gpa);
     self.min_sizes.deinit(self.gpa);
@@ -1108,6 +1131,8 @@ pub fn begin(
     self.last_focused_id_in_subwindow = .zero;
 
     self.debug.reset(self.gpa);
+    self.stats_last_frame = self.stats;
+    self.stats = .{};
 
     self.data_store.reset(self.gpa);
     self.texture_cache.reset(self.backend);
@@ -1364,6 +1389,40 @@ pub fn toastsShow(self: *Self, subwindow_id: ?Id, rect: Rect.Natural) void {
     }
 }
 
+pub fn trianglesQueue(self: *Self, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, clipr: ?dvui.Rect.Physical) !void {
+    const tq = &self.triQueue;
+    //if (!std.mem.eql(u8, std.mem.asBytes(&tq.texture), std.mem.asBytes(&texture)) or
+    //    !std.mem.eql(u8, std.mem.asBytes(&tq.clipr), std.mem.asBytes(&clipr)))
+    if (true) {
+        // can't coalesce
+        try self.trianglesFlush();
+
+        tq.texture = texture;
+        tq.clipr = clipr;
+    }
+
+    const offset: dvui.Vertex.Index = @intCast(tq.vtx.items.len);
+    try tq.vtx.appendSlice(self.gpa, vtx);
+    const i = tq.idx.items.len;
+    try tq.idx.appendSlice(self.gpa, idx);
+    for (tq.idx.items[i..]) |*index| {
+        index.* += offset;
+    }
+}
+
+pub fn trianglesFlush(self: *Self) !void {
+    const tq = &self.triQueue;
+    if (tq.vtx.items.len == 0) return;
+
+    self.stats.draw_calls += 1;
+    try self.backend.drawClippedTriangles(tq.texture, tq.vtx.items, tq.idx.items, tq.clipr);
+
+    tq.vtx.clearRetainingCapacity();
+    tq.idx.clearRetainingCapacity();
+    tq.texture = null;
+    tq.clipr = null;
+}
+
 pub const endOptions = struct {
     show_toasts: bool = true,
 };
@@ -1397,6 +1456,10 @@ pub fn endRendering(self: *Self, opts: endOptions) void {
         sw.render_cmds_after = .empty;
     }
 
+    self.trianglesFlush() catch |err| {
+        dvui.logError(@src(), err, "Failed to flush queued triangles", .{});
+    };
+
     self.end_rendering_done = true;
 }
 
@@ -1411,6 +1474,10 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
 
     if (!self.end_rendering_done) {
         self.endRendering(opts);
+    }
+
+    if (self.debug.log_stats) {
+        log.debug("stats draw_calls {d}", .{self.stats.draw_calls});
     }
 
     // Call this before freeing data so backend can use data allocated during frame.

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -115,6 +115,7 @@ _lifo_arena: std.heap.ArenaAllocator,
 _widget_stack: WidgetStack,
 render_target: dvui.RenderTarget = .{ .texture = null, .offset = .{} },
 end_rendering_done: bool = false,
+batch_draws: bool = false,
 triQueue: struct {
     texture: ?dvui.Texture,
     clipr: ?dvui.Rect.Physical,
@@ -1391,9 +1392,10 @@ pub fn toastsShow(self: *Self, subwindow_id: ?Id, rect: Rect.Natural) void {
 
 pub fn trianglesQueue(self: *Self, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, clipr: ?dvui.Rect.Physical) !void {
     const tq = &self.triQueue;
-    //if (!std.mem.eql(u8, std.mem.asBytes(&tq.texture), std.mem.asBytes(&texture)) or
-    //    !std.mem.eql(u8, std.mem.asBytes(&tq.clipr), std.mem.asBytes(&clipr)))
-    if (true) {
+    if (!self.batch_draws or
+        !std.mem.eql(u8, std.mem.asBytes(&tq.texture), std.mem.asBytes(&texture)) or
+        !std.mem.eql(u8, std.mem.asBytes(&tq.clipr), std.mem.asBytes(&clipr)))
+    {
         // can't coalesce
         try self.trianglesFlush();
 

--- a/src/render.zig
+++ b/src/render.zig
@@ -15,6 +15,9 @@ pub const Target = struct {
     /// Only valid between `Window.begin`and `Window.end`.
     pub fn setAsCurrent(target: Target) Target {
         var cw = dvui.currentWindow();
+        cw.trianglesFlush() catch |err| {
+            dvui.logError(@src(), err, "Failed to flush triangles", .{});
+        };
         const ret = cw.render_target;
         cw.backend.renderTarget(target.texture) catch |err| {
             // TODO: This might be unrecoverable? Or brake rendering too badly?

--- a/src/render.zig
+++ b/src/render.zig
@@ -58,8 +58,9 @@ pub const RenderCommand = struct {
     };
 };
 
-/// Rendered `Triangles` taking in to account the current clip rect
-/// and deferred rendering through render targets.
+/// Render `Triangles` taking in to account the current clip rect and deferred
+/// rendering through render targets.  Multiple calls here with the same clip
+/// rect and texture will be coalesced before sending to the backend.
 ///
 /// Expect that `dvui.Window.alpha` has already been applied.
 ///
@@ -97,7 +98,7 @@ pub fn renderTriangles(triangles: Triangles, tex: ?Texture) Backend.GenericError
         }
     }
 
-    try cw.backend.drawClippedTriangles(tex, triangles.vertexes, triangles.indices, clipr);
+    try cw.trianglesQueue(tex, triangles.vertexes, triangles.indices, clipr);
 }
 
 pub const TextOptions = struct {


### PR DESCRIPTION
Fixes #637 

While running the demo, this generally halves the number of backend.drawClippedTriangles calls.

Need some feedback about whether this actually addresses the performance issues.