### PR TITLE
Widgetpedia4

### DIFF
--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -834,10 +834,13 @@ fn stylePage(self: *Options, id: dvui.Id) bool {
             var vbox = dvui.box(@src(), .{}, .{});
             defer vbox.deinit();
 
-            const field: *?dvui.Color = switch (active_color.*) {
-                inline else => |c| &@field(self, "color_" ++ @tagName(c)),
+            const field: *?dvui.Color, const default: dvui.Color = switch (active_color.*) {
+                inline else => |c| .{
+                    &@field(self, "color_" ++ @tagName(c)),
+                    dvui.themeGet().color(.control, std.meta.stringToEnum(dvui.Options.ColorAsk, @tagName(c)) orelse unreachable),
+                },
             };
-            var hsv = dvui.Color.HSV.fromColor(field.* orelse .white);
+            var hsv = dvui.Color.HSV.fromColor(field.* orelse default);
             if (dvui.colorPicker(@src(), .{ .hsv = &hsv, .dir = .horizontal }, .{})) {
                 changed = true;
                 field.* = hsv.toColor();

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -493,11 +493,11 @@ fn copyOptionsToClipboard(id: dvui.Id, options: Options) void {
     dvui.clipboardTextSet(aw.written());
 }
 
-fn sliderRectOptional(src: std.builtin.SourceLocation, comptime label: []const u8, rect: *?Rect, comptime field: std.meta.FieldEnum(dvui.Rect), link_all: bool, default: dvui.Rect) bool {
-    return sliderRectOptionalWithInitOpts(src, label, rect, field, link_all, default, null);
+fn sliderRectOptional(src: std.builtin.SourceLocation, comptime label: []const u8, comptime fmt: []const u8, rect: *?Rect, comptime field: std.meta.FieldEnum(dvui.Rect), link_all: bool, default: dvui.Rect) bool {
+    return sliderRectOptionalWithInitOpts(src, label, fmt, rect, field, link_all, default, null);
 }
 
-fn sliderRectOptionalWithInitOpts(src: std.builtin.SourceLocation, comptime label: []const u8, rect: *?Rect, comptime field: std.meta.FieldEnum(dvui.Rect), link_all: bool, default: dvui.Rect, init_opts: ?dvui.SliderEntryInitOptions) bool {
+fn sliderRectOptionalWithInitOpts(src: std.builtin.SourceLocation, comptime label: []const u8, comptime fmt: []const u8, rect: *?Rect, comptime field: std.meta.FieldEnum(dvui.Rect), link_all: bool, default: dvui.Rect, init_opts: ?dvui.SliderEntryInitOptions) bool {
     var changed: bool = false;
     var hbox = dvui.box(src, .{ .dir = .horizontal }, .{ .min_size_content = .{ .w = 160 }, .max_size_content = .width(160) });
     defer hbox.deinit();
@@ -525,7 +525,7 @@ fn sliderRectOptionalWithInitOpts(src: std.builtin.SourceLocation, comptime labe
 
         if (dvui.sliderEntry(
             @src(),
-            label ++ ": {d:0.1}",
+            label ++ ": " ++ fmt,
             slider_init_opts,
             .{ .margin = .{ .x = 0, .y = 4, .w = 4, .h = 4 }, .gravity_y = 0.5 },
         )) {
@@ -571,6 +571,7 @@ fn layoutPage(self: *Options, id: dvui.Id, wd: *const dvui.WidgetData) bool {
         changed = sliderRectOptionalWithInitOpts(
             @src(),
             "rotation",
+            "{d:0.2}",
             &rot_rect,
             .x,
             false,
@@ -595,7 +596,7 @@ fn layoutPage(self: *Options, id: dvui.Id, wd: *const dvui.WidgetData) bool {
         defer row.deinit();
 
         var has_min_size = self.min_size_content != null;
-        if (dvui.checkbox(@src(), &has_min_size, "min size", .{ .gravity_y = 0.5, .min_size_content = .{ .w = 90 } })) {
+        if (dvui.checkbox(@src(), &has_min_size, "min_size_content", .{ .gravity_y = 0.5, .min_size_content = .{ .w = 90 } })) {
             if (self.min_size_content) |_| {
                 self.min_size_content = null;
             } else {
@@ -619,7 +620,7 @@ fn layoutPage(self: *Options, id: dvui.Id, wd: *const dvui.WidgetData) bool {
         defer row.deinit();
 
         var has_max_size = self.max_size_content != null;
-        if (dvui.checkbox(@src(), &has_max_size, "max size", .{ .gravity_y = 0.5, .min_size_content = .{ .w = 90 } })) {
+        if (dvui.checkbox(@src(), &has_max_size, "max_size_content", .{ .gravity_y = 0.5, .min_size_content = .{ .w = 90 } })) {
             if (self.max_size_content) |_| {
                 self.max_size_content = null;
             } else {
@@ -644,20 +645,20 @@ fn layoutPage(self: *Options, id: dvui.Id, wd: *const dvui.WidgetData) bool {
         { // Top Left
             var col = dvui.box(@src(), .{}, .{ .border = .all(1), .expand = .vertical });
             defer col.deinit();
-            changed = sliderRectOptional(@src(), "radius", &self.corner_radius, .x, link_radius.*, wd.options.corner_radiusGet()) or changed;
+            changed = sliderRectOptional(@src(), "corner_radius", "{d}", &self.corner_radius, .x, link_radius.*, wd.options.corner_radiusGet()) or changed;
         }
         { // Top Center
             var col = dvui.box(@src(), .{}, .{ .border = .all(1) });
             defer col.deinit();
-            changed = sliderRectOptional(@src(), "margin", &self.margin, .y, link_margin.*, wd.options.marginGet()) or changed;
-            changed = sliderRectOptional(@src(), "border", &self.border, .y, link_border.*, wd.options.borderGet()) or changed;
-            changed = sliderRectOptional(@src(), "padding", &self.padding, .y, link_padding.*, wd.options.paddingGet()) or changed;
+            changed = sliderRectOptional(@src(), "margin", "{d:0.0}", &self.margin, .y, link_margin.*, wd.options.marginGet()) or changed;
+            changed = sliderRectOptional(@src(), "border", "{d:0.0}", &self.border, .y, link_border.*, wd.options.borderGet()) or changed;
+            changed = sliderRectOptional(@src(), "padding", "{d:0.0}", &self.padding, .y, link_padding.*, wd.options.paddingGet()) or changed;
         }
         { // Top Right
             var col = dvui.box(@src(), .{}, .{ .border = .all(1), .expand = .vertical });
             defer col.deinit();
 
-            changed = sliderRectOptional(@src(), "radius", &self.corner_radius, .y, link_radius.*, wd.options.corner_radiusGet()) or changed;
+            changed = sliderRectOptional(@src(), "corner_radius", "{d:0.2}", &self.corner_radius, .y, link_radius.*, wd.options.corner_radiusGet()) or changed;
         }
     }
 
@@ -667,9 +668,9 @@ fn layoutPage(self: *Options, id: dvui.Id, wd: *const dvui.WidgetData) bool {
         { // Middle Left
             var col = dvui.box(@src(), .{}, .{ .border = .all(1) });
             defer col.deinit();
-            changed = sliderRectOptional(@src(), "margin", &self.margin, .x, link_margin.*, wd.options.marginGet()) or changed;
-            changed = sliderRectOptional(@src(), "border", &self.border, .x, link_border.*, wd.options.borderGet()) or changed;
-            changed = sliderRectOptional(@src(), "padding", &self.padding, .x, link_padding.*, wd.options.paddingGet()) or changed;
+            changed = sliderRectOptional(@src(), "margin", "{d:0.0}", &self.margin, .x, link_margin.*, wd.options.marginGet()) or changed;
+            changed = sliderRectOptional(@src(), "border", "{d:0.0}", &self.border, .x, link_border.*, wd.options.borderGet()) or changed;
+            changed = sliderRectOptional(@src(), "padding", "{d:0.0}", &self.padding, .x, link_padding.*, wd.options.paddingGet()) or changed;
         }
         { // Middle Center
             var col = dvui.box(@src(), .{ .dir = .horizontal }, .{ .border = .all(1), .expand = .both });
@@ -704,9 +705,9 @@ fn layoutPage(self: *Options, id: dvui.Id, wd: *const dvui.WidgetData) bool {
         { // Middle Right
             var col = dvui.box(@src(), .{}, .{ .border = .all(1) });
             defer col.deinit();
-            changed = sliderRectOptional(@src(), "margin", &self.margin, .w, link_margin.*, wd.options.marginGet()) or changed;
-            changed = sliderRectOptional(@src(), "border", &self.border, .w, link_border.*, wd.options.borderGet()) or changed;
-            changed = sliderRectOptional(@src(), "padding", &self.padding, .w, link_padding.*, wd.options.paddingGet()) or changed;
+            changed = sliderRectOptional(@src(), "margin", "{d:0.0}", &self.margin, .w, link_margin.*, wd.options.marginGet()) or changed;
+            changed = sliderRectOptional(@src(), "border", "{d:0.0}", &self.border, .w, link_border.*, wd.options.borderGet()) or changed;
+            changed = sliderRectOptional(@src(), "padding", "{d:0.0}", &self.padding, .w, link_padding.*, wd.options.paddingGet()) or changed;
         }
     }
 
@@ -717,20 +718,20 @@ fn layoutPage(self: *Options, id: dvui.Id, wd: *const dvui.WidgetData) bool {
             var col = dvui.box(@src(), .{}, .{ .border = .all(1), .expand = .vertical });
             defer col.deinit();
 
-            changed = sliderRectOptional(@src(), "radius", &self.corner_radius, .h, link_radius.*, wd.options.corner_radiusGet()) or changed;
+            changed = sliderRectOptional(@src(), "corner_radius", "{d:0.2}", &self.corner_radius, .h, link_radius.*, wd.options.corner_radiusGet()) or changed;
         }
         { // Bottom Center
             var col = dvui.box(@src(), .{}, .{ .border = .all(1) });
             defer col.deinit();
-            changed = sliderRectOptional(@src(), "margin", &self.margin, .h, link_margin.*, wd.options.marginGet()) or changed;
-            changed = sliderRectOptional(@src(), "border", &self.border, .h, link_border.*, wd.options.borderGet()) or changed;
-            changed = sliderRectOptional(@src(), "padding", &self.padding, .h, link_padding.*, wd.options.paddingGet()) or changed;
+            changed = sliderRectOptional(@src(), "margin", "{d:0.0}", &self.margin, .h, link_margin.*, wd.options.marginGet()) or changed;
+            changed = sliderRectOptional(@src(), "border", "{d:0.0}", &self.border, .h, link_border.*, wd.options.borderGet()) or changed;
+            changed = sliderRectOptional(@src(), "padding", "{d:0.0}", &self.padding, .h, link_padding.*, wd.options.paddingGet()) or changed;
         }
         { // Bottom Right
             var col = dvui.box(@src(), .{}, .{ .border = .all(1), .expand = .vertical });
             defer col.deinit();
 
-            changed = sliderRectOptional(@src(), "radius", &self.corner_radius, .w, link_radius.*, wd.options.corner_radiusGet()) or changed;
+            changed = sliderRectOptional(@src(), "corner_radius", "{d:0.2}", &self.corner_radius, .w, link_radius.*, wd.options.corner_radiusGet()) or changed;
         }
     }
 
@@ -758,7 +759,7 @@ fn layoutPage(self: *Options, id: dvui.Id, wd: *const dvui.WidgetData) bool {
                 changed = true;
             }
         }
-        if (dvui.checkbox(@src(), link_radius, "radius", .{})) {
+        if (dvui.checkbox(@src(), link_radius, "corner_radius", .{})) {
             if (self.corner_radius) |*radius| {
                 radius.* = .all(radius.x);
                 changed = true;

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -837,7 +837,7 @@ fn stylePage(self: *Options, id: dvui.Id) bool {
             const field: *?dvui.Color, const default: dvui.Color = switch (active_color.*) {
                 inline else => |c| .{
                     &@field(self, "color_" ++ @tagName(c)),
-                    dvui.themeGet().color(.control, std.meta.stringToEnum(dvui.Options.ColorAsk, @tagName(c)) orelse unreachable),
+                    self.color(std.meta.stringToEnum(dvui.Options.ColorAsk, @tagName(c)) orelse unreachable),
                 },
             };
             var hsv = dvui.Color.HSV.fromColor(field.* orelse default);

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -475,6 +475,7 @@ pub fn optionsEditor(self: *Options, wd: *const dvui.WidgetData) bool {
             if (stylePage(self, vbox.data().id)) changed = true;
         },
         .info => {
+            // Note uses wd.options here instead of self, so it can pick up defaults from the widget, like .role etc.
             infoPage(wd.options);
         },
     }

--- a/src/Examples/struct_ui.zig
+++ b/src/Examples/struct_ui.zig
@@ -71,7 +71,7 @@ pub fn structUI() void {
 
         var alignment: dvui.Alignment = .init(@src(), 0);
         defer alignment.deinit();
-        if (struct_ui.displayStruct(@src(), "test_struct", &test_instance, 1, .{ .standard = .{} }, .{TestStruct.structui_options}, &alignment)) |box| {
+        if (struct_ui.displayStruct(@src(), "test_struct", &test_instance, 1, .default, .{TestStruct.structui_options}, &alignment)) |box| {
             defer box.deinit();
 
             // Treat the u8 array as a fixed buffer, passing itself as the backing buffer for the string.
@@ -86,7 +86,7 @@ pub fn structUI() void {
             struct_ui.displayOptional(@src(), TestStruct, "opt_int_ptr", &test_instance.opt_int_ptr, 1, .{ .number = .{} }, .{}, &alignment, &TestStruct.ts_int);
 
             // Union fields can also be handled manually if custom initialization is required for different cases.
-            if (struct_ui.displayContainer(@src(), "union_manual")) |union_box| {
+            if (struct_ui.displayContainer(@src(), "union_manual", true)) |union_box| {
                 defer union_box.deinit();
                 const selected_tag = struct_ui.unionFieldWidget(@src(), "union_manual", &test_instance.union_manual, .default);
                 switch (selected_tag) {

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -2138,7 +2138,7 @@ const DisplayScrollArea = struct {
     var check_bottom_right = false;
     var user_scroll: dvui.Point = undefined;
 
-    var focus_id: ?dvui.Id = undefined;
+    var focus_id: enum { null, top_left, bottom_right } = undefined;
 
     var nr_boxes: struct {
         w: usize,
@@ -2155,7 +2155,7 @@ const DisplayScrollArea = struct {
         init_opts = .{};
         scroll_info = .{};
         nr_boxes = .{ .w = 20, .h = 20 };
-        focus_id = null;
+        focus_id = .null;
         check_bottom_right = false;
         check_top_left = false;
         user_scroll = .{ .x = 0, .y = 0 };
@@ -2163,8 +2163,15 @@ const DisplayScrollArea = struct {
 
     pub fn layoutWidget() void {
         const box_size = 26;
-        options.min_size_content = if (init_opts.scroll_info == null) null else .{ .w = @floatFromInt(nr_boxes.w * (box_size + 2)), .h = @floatFromInt(nr_boxes.h * (box_size + 2)) };
         const color_fill = options.color(.border).opacity(0.25);
+
+        options.min_size_content = if (init_opts.scroll_info == null) null else .{ .w = @floatFromInt(nr_boxes.w * (box_size + 2)), .h = @floatFromInt(nr_boxes.h * (box_size + 2)) };
+        init_opts.focus_id = switch (focus_id) {
+            .null => null,
+            .top_left => top_left_wd.id,
+            .bottom_right => bottom_right_wd.id,
+        };
+
         var scroll = dvui.scrollArea(@src(), init_opts, options.override(.{ .data_out = &wd }));
         defer scroll.deinit();
         var vbox = dvui.box(@src(), .{}, .{ .expand = .both });
@@ -2271,12 +2278,7 @@ const DisplayScrollArea = struct {
         defer hbox_aligned.deinit();
         alignment.record(box.data().id, hbox_aligned.data());
 
-        const selected_index: usize = if (init_opts.focus_id == null)
-            0
-        else if (init_opts.focus_id == top_left_wd.id)
-            1
-        else
-            2;
+        const selected_index: usize = @intFromEnum(focus_id);
 
         var dd: dvui.DropdownWidget = undefined;
         dd.init(@src(), .{ .selected_index = selected_index, .label = if (selected_index == 0) "null" else if (selected_index == 1) "top left" else "bottom right" }, .{});
@@ -2298,7 +2300,7 @@ const DisplayScrollArea = struct {
                 dvui.label(@src(), "top left\n{f}", .{top_left_wd.id}, .{});
                 if (mi.activeRect()) |_| {
                     dd.close();
-                    init_opts.focus_id = top_left_wd.id;
+                    focus_id = .top_left;
                 }
             }
             {
@@ -2307,7 +2309,7 @@ const DisplayScrollArea = struct {
                 dvui.label(@src(), "bottom right\n{f}", .{bottom_right_wd.id}, .{});
                 if (mi.activeRect()) |_| {
                     dd.close();
-                    init_opts.focus_id = bottom_right_wd.id;
+                    focus_id = .bottom_right;
                 }
             }
         }

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -571,8 +571,8 @@ const DisplayButtonLabelAndIcon = struct {
             &combined_opts,
             1,
             .{ StructOptions(dvui.ButtonLabelAndIconOptions).initWithDefaults(.{
-                .label = .{ .text = .{ .display = .read_write } },
-                .tvg_bytes = .{ .standard = .{ .display = .none } },
+                .label = .defaultTextRW,
+                .tvg_bytes = .defaultHidden,
             }, null), struct_options.color },
             .{},
         );
@@ -621,7 +621,7 @@ const DisplayCheckbox = struct {
             &test_options,
             1,
             .{StructOptions(@TypeOf(test_options)).initWithDefaults(.{
-                .label_str = .{ .text = .{ .display = .read_write } },
+                .label_str = .defaultTextRW,
             }, null)},
             .{},
         );
@@ -1010,7 +1010,10 @@ const DisplayFloatingWindow = struct {
                 id_extra += 1;
             }
         }
-        const display_opts: StructOptions(dvui.FloatingWindowWidget.InitOptions) = .initWithDefaults(.{}, .{ .rect = &rect, .open_flag = &open_flag });
+        const display_opts: StructOptions(dvui.FloatingWindowWidget.InitOptions) = .initWithDefaults(
+            .{},
+            .{ .rect = &rect, .open_flag = &open_flag },
+        );
         dvui.structUI(@src(), "floating_opts", &floating_opts, 2, .{display_opts}, .{});
     }
 };
@@ -1170,52 +1173,6 @@ const DisplayGroupBox = struct {
 
     pub fn layoutWidgetControls() void {
         dvui.structUI(@src(), test_options_label, &test_options, 1, .{}, .{});
-    }
-};
-
-const DisplayTextEntryNumber = struct {
-    const NumberType = i32;
-    const name = "textEntryNumber()";
-
-    var wd: dvui.WidgetData = undefined;
-    var init_opts: dvui.TextEntryNumberInitOptions(NumberType) = undefined;
-    var options: dvui.Options = undefined;
-    var value: NumberType = undefined;
-    var result: dvui.TextEntryNumberResult(NumberType) = undefined;
-    const init_opts_defaults: dvui.TextEntryNumberInitOptions(NumberType) = .{ .value = &value, .placeholder = "Enter a number", .text = "", .min = -100, .max = 100 };
-
-    pub fn displayFn(reset: bool) void {
-        if (reset) resetWidget();
-        displayWidgetTemplate(@This());
-    }
-
-    pub fn resetWidget() void {
-        init_opts = .{};
-        options = .{ .gravity_y = 0.5 };
-        value = -789;
-    }
-
-    pub fn layoutWidget() void {
-        result = dvui.textEntryNumber(@src(), NumberType, init_opts, options.override(.{ .data_out = &wd }));
-    }
-
-    pub fn layoutResults() void {
-        const r = result;
-        dvui.structUI(@src(), null, &r, 99, .{
-            StructOptions(dvui.TextEntryNumberResult(NumberType)).initWithDefaults(.{
-                .changed = .{ .boolean = .{ .widget_type = .{ .trigger_on = true } } },
-                .enter_pressed = .{ .boolean = .{ .widget_type = .{ .trigger_on = true } } },
-            }, null),
-        }, .{ .gravity_x = 1.0 });
-    }
-
-    pub fn layoutWidgetControls() void {
-        dvui.structUI(@src(), "init_opts", &init_opts, 1, .{
-            StructOptions(dvui.TextEntryNumberInitOptions(NumberType)).initWithDefaults(.{
-                .text = .{ .text = .{ .display = .read_write } },
-                .placeholder = .{ .text = .{ .display = .read_write } },
-            }, init_opts_defaults),
-        }, .{});
     }
 };
 
@@ -1811,6 +1768,50 @@ const DisplayPaned = struct {
     }
 };
 
+const DisplayPlot = struct {
+    const name: []const u8 = "plot()";
+
+    var wd: dvui.WidgetData = undefined;
+    var options: dvui.Options = undefined;
+    var init_opts: dvui.PlotWidget.InitOptions = undefined;
+    var x_axis: dvui.PlotWidget.Axis = undefined;
+    var y_axis: dvui.PlotWidget.Axis = undefined;
+
+    pub fn displayFn(reset: bool) void {
+        if (reset) resetWidget();
+        displayWidgetTemplate(@This());
+    }
+
+    pub fn resetWidget() void {
+        options = .{ .expand = .both };
+        init_opts = .{};
+        x_axis = .{
+            .name = "X",
+        };
+        y_axis = .{
+            .name = "Y",
+        };
+    }
+
+    pub fn layoutWidget() void {
+        var plot = dvui.plot(@src(), init_opts, options.override(.{ .data_out = &wd }));
+        defer plot.deinit();
+        plot.bar(.{ .x = 0, .y = 0, .w = 10, .h = 100 });
+        plot.bar(.{ .x = 10, .y = 0, .w = 10, .h = 100, .color = .red });
+    }
+
+    pub fn layoutWidgetControls() void {
+        const axis_opts: StructOptions(dvui.PlotWidget.Axis) = .initWithDefaults(.{
+            .name = .defaultTextRW,
+        }, null);
+        const display_opts: StructOptions(dvui.PlotWidget.InitOptions) = .initWithDefaults(.{}, .{
+            .x_axis = &x_axis,
+            .y_axis = &y_axis,
+        });
+        dvui.structUI(@src(), "init_opts", &init_opts, 3, .{ display_opts, axis_opts, struct_options.color }, .{});
+    }
+};
+
 const DisplayProgress = struct {
     const name: []const u8 = "progress()";
 
@@ -1968,7 +1969,9 @@ const DisplayScale = struct {
     }
 
     pub fn layoutWidgetControls() void {
-        const display_opts = StructOptions(dvui.ScaleWidget.InitOptions).initWithDefaults(.{ .scale = .{ .number = .{ .widget_type = .slider_entry, .min = 0, .max = 10 } } }, .{ .scale = &scale });
+        const display_opts = StructOptions(dvui.ScaleWidget.InitOptions).initWithDefaults(.{
+            .scale = .{ .number = .{ .widget_type = .slider_entry, .min = 0, .max = 10 } },
+        }, .{ .scale = &scale });
         dvui.structUI(@src(), "init_opts", &init_opts, 1, .{display_opts}, .{});
     }
 };
@@ -2056,15 +2059,17 @@ const DisplayScrollArea = struct {
             .viewport = .{ .number = .{ .customDisplayFn = displayViewport } },
             .virtual_size = .defaultConst,
         }, null);
-        // Only override the Point type display only for fields named "velocity"
+        // Only override the Point type display widget type for fields named "velocity"
         const velocity_opts = StructOptions(dvui.Point).init(.{
-            .x = .{ .number = .{ .widget_type = .number_placeholder } },
-            .y = .{ .number = .{ .widget_type = .number_placeholder } },
+            .x = .{ .number = .{ .widget_type = .entry_on_enter } },
+            .y = .{ .number = .{ .widget_type = .entry_on_enter } },
         }, null).forFieldName("velocity");
 
         dvui.structUI(@src(), "init_opts", &init_opts, 2, .{ display_opts, velocity_opts, si_opts }, .{});
     }
 
+    /// Show sliders for the viewport x if init_opts.scroll_info.horizontal.horizontal == .given
+    /// Show sliders for the viewport y if init_opts.scroll_info.horizontal.vertical == .given
     fn displayViewport(field_name: []const u8, ptr: *anyopaque, _: bool, _: *dvui.Alignment) void {
         const field_value_ptr: *Rect = @ptrCast(@alignCast(ptr));
 
@@ -2677,6 +2682,94 @@ const DisplayTextEntry = struct {
     }
 };
 
+const DisplayTextEntryColor = struct {
+    const name = "textEntryColor()";
+
+    var wd: dvui.WidgetData = undefined;
+    var init_opts: dvui.TextEntryColorInitOptions = undefined;
+    var options: dvui.Options = undefined;
+    var value: dvui.Color = undefined;
+    var result: dvui.TextEntryColorResult = undefined;
+
+    pub fn displayFn(reset: bool) void {
+        if (reset) resetWidget();
+        displayWidgetTemplate(@This());
+    }
+
+    pub fn resetWidget() void {
+        init_opts = .{};
+        options = .{};
+        value = .white;
+    }
+
+    pub fn layoutWidget() void {
+        result = dvui.textEntryColor(@src(), init_opts, options.override(.{ .data_out = &wd }));
+    }
+
+    pub fn layoutResults() void {
+        const result_opts: StructOptions(dvui.TextEntryColorResult) = .initWithDefaults(.{
+            .changed = .{ .boolean = .{ .widget_type = .{ .trigger_on = true } } },
+            .enter_pressed = .{ .boolean = .{ .widget_type = .{ .trigger_on = true } } },
+        }, null);
+        const r = result;
+        dvui.structUI(@src(), null, &r, 2, .{ struct_options.color, result_opts }, .{});
+    }
+
+    pub fn layoutWidgetControls() void {
+        dvui.structUI(@src(), "init_opts", &init_opts, 1, .{
+            StructOptions(dvui.TextEntryColorInitOptions).initWithDefaults(.{
+                .placeholder = .defaultTextRW,
+            }, .{ .value = &value }),
+        }, .{});
+    }
+};
+
+const DisplayTextEntryNumber = struct {
+    const NumberType = i32;
+    const name = "textEntryNumber()";
+
+    var wd: dvui.WidgetData = undefined;
+    var init_opts: dvui.TextEntryNumberInitOptions(NumberType) = undefined;
+    var options: dvui.Options = undefined;
+    var value: NumberType = undefined;
+    var result: dvui.TextEntryNumberResult(NumberType) = undefined;
+    const init_opts_defaults: dvui.TextEntryNumberInitOptions(NumberType) = .{ .value = &value, .placeholder = "Enter a number", .text = "", .min = -100, .max = 100 };
+
+    pub fn displayFn(reset: bool) void {
+        if (reset) resetWidget();
+        displayWidgetTemplate(@This());
+    }
+
+    pub fn resetWidget() void {
+        init_opts = .{};
+        options = .{ .gravity_y = 0.5 };
+        value = -789;
+    }
+
+    pub fn layoutWidget() void {
+        result = dvui.textEntryNumber(@src(), NumberType, init_opts, options.override(.{ .data_out = &wd }));
+    }
+
+    pub fn layoutResults() void {
+        const r = result;
+        dvui.structUI(@src(), null, &r, 99, .{
+            StructOptions(dvui.TextEntryNumberResult(NumberType)).initWithDefaults(.{
+                .changed = .{ .boolean = .{ .widget_type = .{ .trigger_on = true } } },
+                .enter_pressed = .{ .boolean = .{ .widget_type = .{ .trigger_on = true } } },
+            }, null),
+        }, .{ .gravity_x = 1.0 });
+    }
+
+    pub fn layoutWidgetControls() void {
+        dvui.structUI(@src(), "init_opts", &init_opts, 1, .{
+            StructOptions(dvui.TextEntryNumberInitOptions(NumberType)).initWithDefaults(.{
+                .text = .defaultTextRW,
+                .placeholder = .defaultTextRW,
+            }, init_opts_defaults),
+        }, .{});
+    }
+};
+
 const DisplayToast = struct {
     const name: []const u8 = "toast()";
 
@@ -2897,7 +2990,7 @@ const widget_hierarchy = [_]WidgetHierarchy{
     .{ .name = "paned", .displayFn = DisplayPaned.displayFn, .children = null },
 
     .{ .name = "plots", .displayFn = displayEmpty, .children = &.{
-        .{ .name = "plot", .displayFn = displayEmpty, .children = null },
+        .{ .name = "plot", .displayFn = DisplayPlot.displayFn, .children = null },
         .{ .name = "plotXY", .displayFn = displayEmpty, .children = null },
     } },
 
@@ -2922,7 +3015,7 @@ const widget_hierarchy = [_]WidgetHierarchy{
 
     .{ .name = "textEntries", .displayFn = displayEmpty, .children = &.{
         .{ .name = "textEntry", .displayFn = DisplayTextEntry.displayFn, .children = null },
-        .{ .name = "textEntryColor", .displayFn = displayEmpty, .children = null },
+        .{ .name = "textEntryColor", .displayFn = DisplayTextEntryColor.displayFn, .children = null },
         .{ .name = "textEntryNumber", .displayFn = DisplayTextEntryNumber.displayFn, .children = null },
     } },
 

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -137,8 +137,7 @@ const WidgetHierarchy = struct {
     displayFn: *const fn (reset_widget: bool) void,
 };
 
-var current_widget: WidgetHierarchy = .{ .name = "floatingWindow", .displayFn = DisplayFloatingWindow.displayFn };
-//widget_hierarchy[0];
+var current_widget: WidgetHierarchy = widget_hierarchy[0];
 
 fn displayEmpty(_: bool) void {
     var label_str = std.Io.Writer.Allocating.initCapacity(dvui.currentWindow().arena(), current_widget.name.len + 2) catch return;
@@ -164,6 +163,7 @@ pub fn displayWidgetTemplate(widget_display: type) void {
     const state = struct {
         // Guess at initial split
         var split_ratio: f32 = 0.9;
+        var split_ratio_inner: f32 = 0.5;
         var split_ratio_open: f32 = 0.5;
         var split_ratio_closed: f32 = 0.9;
         var options_editor_open: bool = false;
@@ -183,9 +183,13 @@ pub fn displayWidgetTemplate(widget_display: type) void {
 
     if (paned.showFirst()) {
         {
-            var hbox = dvui.box(@src(), .{ .dir = .horizontal, .equal_space = true }, .{ .expand = .both });
-            defer hbox.deinit();
-            {
+            var inner_paned = dvui.paned(@src(), .{ .direction = .horizontal, .collapsed_size = 0, .split_ratio = &state.split_ratio_inner }, .{ .expand = .both });
+            defer inner_paned.deinit();
+            // Don't let the first pane completely close as it will stop the widget being displayed.
+            // Important for floating widgets.
+            if (state.split_ratio_inner < 0.01) state.split_ratio_inner = 0.01;
+
+            if (inner_paned.showFirst()) {
                 var vbox = dvui.box(@src(), .{}, .{ .expand = .both });
                 defer vbox.deinit();
                 {
@@ -200,17 +204,19 @@ pub fn displayWidgetTemplate(widget_display: type) void {
                 }
             }
             if (std.meta.hasFn(widget_display, "layoutWidgetControls")) {
-                var scroll = dvui.scrollArea(@src(), .{}, .{
-                    .corner_radius = Rect.all(3),
-                    .border = Rect.all(1),
-                    .padding = Rect.all(6),
-                    .expand = .both,
-                    .margin = .{ .x = 6, .y = 6 + dvui.themeGet().font_body.lineHeight() / 2 - 1, .w = 6, .h = 6 },
-                    .background = false,
-                    .min_size_content = .{ .w = 350 },
-                });
-                defer scroll.deinit();
-                widget_display.layoutWidgetControls();
+                if (inner_paned.showSecond()) {
+                    var scroll = dvui.scrollArea(@src(), .{}, .{
+                        .corner_radius = Rect.all(3),
+                        .border = Rect.all(1),
+                        .padding = Rect.all(6),
+                        .expand = .both,
+                        .margin = .{ .x = 6, .y = 6 + dvui.themeGet().font_body.lineHeight() / 2 - 1, .w = 6, .h = 6 },
+                        .background = false,
+                        .min_size_content = .{ .w = 350 },
+                    });
+                    defer scroll.deinit();
+                    widget_display.layoutWidgetControls();
+                }
             }
         }
     }
@@ -531,8 +537,6 @@ const DisplayButtonLabelAndIcon = struct {
     const name = "buttonLabelAndIcon()";
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
-    var init_opts: dvui.ButtonWidget.InitOptions = undefined;
-    var icon_opts: dvui.IconRenderOptions = undefined;
     var combined_opts: dvui.ButtonLabelAndIconOptions = undefined;
     var result: bool = undefined;
 
@@ -542,7 +546,7 @@ const DisplayButtonLabelAndIcon = struct {
     }
 
     pub fn resetWidget() void {
-        options = .{};
+        options = .{ .expand = .horizontal };
         combined_opts = .{
             .label = "Button",
             .tvg_bytes = dvui.entypo.aircraft,
@@ -572,7 +576,6 @@ const DisplayButtonLabelAndIcon = struct {
             }, null), struct_options.color },
             .{},
         );
-        dvui.structUI(@src(), "icon_opts", &icon_opts, 1, .{struct_options.color}, .{});
     }
 };
 
@@ -605,11 +608,7 @@ const DisplayCheckbox = struct {
     }
 
     pub fn layoutWidget() void {
-        var theme_override = dvui.themeGet();
-        theme_override.highlight.fill = .red;
-        theme_override.fill = .green;
-
-        result = dvui.checkbox(@src(), &test_options.checked, test_options.label_str, options.override(.{ .data_out = &wd, .theme = &theme_override }));
+        result = dvui.checkbox(@src(), &test_options.checked, test_options.label_str, options.override(.{ .data_out = &wd }));
     }
 
     pub fn layoutResults() void {

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -582,7 +582,6 @@ const DisplayButtonLabelAndIcon = struct {
 const DisplayCheckbox = struct {
     const name = "checkbox()";
     var wd: dvui.WidgetData = undefined;
-    var init_opts: dvui.ButtonWidget.InitOptions = undefined;
     var options: dvui.Options = undefined;
 
     var result: bool = undefined;
@@ -598,7 +597,6 @@ const DisplayCheckbox = struct {
     }
 
     pub fn resetWidget() void {
-        init_opts = .{};
         options = .{};
         test_options = .{
             .label_str = "checkbox label",
@@ -1312,7 +1310,7 @@ const DisplayLabelEx = struct {
 };
 
 const DisplayLabelClick = struct {
-    var name: []const u8 = "labelClick()";
+    const name: []const u8 = "labelClick()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -1365,7 +1363,7 @@ const DisplayLabelClick = struct {
 };
 
 const DisplayLink = struct {
-    var name: []const u8 = "link()";
+    const name: []const u8 = "link()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -1395,8 +1393,7 @@ const DisplayLink = struct {
 };
 
 const DisplayMenu = struct {
-    var name: []const u8 = "menu()";
-    var allocator_buffer: [10 * 1024]u8 = undefined;
+    const name: []const u8 = "menu()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -1475,7 +1472,7 @@ const DisplayMenu = struct {
 };
 
 const DisplayMenuItem = struct {
-    var name: []const u8 = "menuItem()";
+    const name: []const u8 = "menuItem()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -1528,16 +1525,11 @@ const DisplayMenuItem = struct {
 };
 
 const DisplayMenuItemIcon = struct {
-    var name: []const u8 = "menuItemIcon()";
+    const name: []const u8 = "menuItemIcon()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
     var init_opts: dvui.MenuItemWidget.InitOptions = undefined;
-
-    var test_options: struct {
-        scenario: enum { @"text only", @"with icon" },
-        text: []const u8,
-    } = undefined;
 
     pub fn displayFn(reset: bool) void {
         if (reset) resetWidget();
@@ -1576,7 +1568,7 @@ const DisplayMenuItemIcon = struct {
 };
 
 const DisplayMenuItemLabel = struct {
-    var name: []const u8 = "menuItemLabel()";
+    const name: []const u8 = "menuItemLabel()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -1734,7 +1726,7 @@ const DisplayMenuItemLabel = struct {
 };
 
 const DisplayPaned = struct {
-    var name: []const u8 = "paned()";
+    const name: []const u8 = "paned()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -1820,7 +1812,7 @@ const DisplayPaned = struct {
 };
 
 const DisplayProgress = struct {
-    var name: []const u8 = "progress()";
+    const name: []const u8 = "progress()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -1853,7 +1845,7 @@ const DisplayProgress = struct {
 };
 
 const DisplayRadio = struct {
-    var name: []const u8 = "radio()";
+    const name: []const u8 = "radio()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -1899,7 +1891,7 @@ const DisplayRadio = struct {
 };
 
 const DisplayRadioGroup = struct {
-    var name: []const u8 = "radioGroup()";
+    const name: []const u8 = "radioGroup()";
     const nr_radio_buttons = 3;
 
     var wd: dvui.WidgetData = undefined;
@@ -1951,7 +1943,7 @@ const DisplayRadioGroup = struct {
 };
 
 const DisplayScale = struct {
-    var name: []const u8 = "scale()";
+    const name: []const u8 = "scale()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -1982,7 +1974,7 @@ const DisplayScale = struct {
 };
 
 const DisplayScrollArea = struct {
-    var name: []const u8 = "scrollArea()";
+    const name: []const u8 = "scrollArea()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -2175,7 +2167,7 @@ const DisplayScrollArea = struct {
 };
 
 const DisplaySeparator = struct {
-    var name: []const u8 = "separator()";
+    const name: []const u8 = "separator()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -2213,7 +2205,7 @@ const DisplaySeparator = struct {
 };
 
 const DisplaySlider = struct {
-    var name: []const u8 = "slider()";
+    const name: []const u8 = "slider()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -2256,7 +2248,7 @@ const DisplaySlider = struct {
 };
 
 const DisplaySliderEntry = struct {
-    var name: []const u8 = "sliderEntry()";
+    const name: []const u8 = "sliderEntry()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -2326,7 +2318,7 @@ const DisplaySliderEntry = struct {
 };
 
 const DisplaySpacer = struct {
-    var name: []const u8 = "spacer()";
+    const name: []const u8 = "spacer()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -2380,7 +2372,7 @@ const DisplaySpacer = struct {
 };
 
 const DisplaySpinner = struct {
-    var name: []const u8 = "spinner()";
+    const name: []const u8 = "spinner()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -2409,7 +2401,7 @@ const DisplaySpinner = struct {
 };
 
 const DisplayTabs = struct {
-    var name: []const u8 = "tabs()";
+    const name: []const u8 = "tabs()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -2492,7 +2484,7 @@ const DisplayTabs = struct {
 };
 
 const DisplayTextEntry = struct {
-    var name: []const u8 = "textEntry()";
+    const name: []const u8 = "textEntry()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -2708,7 +2700,7 @@ const DisplayTextEntry = struct {
 };
 
 const DisplayToast = struct {
-    var name: []const u8 = "toast()";
+    const name: []const u8 = "toast()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -2761,7 +2753,7 @@ const DisplayToast = struct {
 };
 
 const DisplayToolTip = struct {
-    var name: []const u8 = "tooltip()";
+    const name: []const u8 = "tooltip()";
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -963,6 +963,50 @@ const DisplayExpander = struct {
     }
 };
 
+const DisplayFlexBox = struct {
+    const name = "flexBox()";
+    var wd: dvui.WidgetData = undefined;
+    var options: dvui.Options = undefined;
+    var init_opts: dvui.FlexBoxWidget.InitOptions = undefined;
+
+    var test_options: struct {
+        nr_boxes: usize,
+        expand: dvui.Options.Expand,
+    } = undefined;
+
+    pub fn displayFn(reset: bool) void {
+        if (reset) resetWidget();
+        displayWidgetTemplate(@This());
+    }
+
+    pub fn resetWidget() void {
+        test_options.nr_boxes = 25;
+        test_options.expand = .none;
+        init_opts = .{};
+        options = .{ .border = .all(1) };
+    }
+
+    pub fn layoutWidget() void {
+        var box = dvui.flexbox(@src(), init_opts, options.override(.{ .data_out = &wd }));
+        defer box.deinit();
+        for (0..test_options.nr_boxes) |i| {
+            var b = dvui.box(@src(), .{}, .{
+                .min_size_content = .{ .h = 30, .w = 30 },
+                .border = .all(1),
+                .id_extra = i,
+                .expand = test_options.expand,
+                .color_border = options.themeGet().focus,
+            });
+            b.deinit();
+        }
+    }
+
+    pub fn layoutWidgetControls() void {
+        dvui.structUI(@src(), test_options_label, &test_options, 1, .{}, .{});
+        dvui.structUI(@src(), "init_opts", &init_opts, 1, .{}, .{});
+    }
+};
+
 const DisplayFloatingWindow = struct {
     const name = "floatingWindow()";
     var wd: dvui.WidgetData = undefined;
@@ -2118,7 +2162,9 @@ const DisplayScrollArea = struct {
     }
 
     pub fn layoutWidget() void {
-        options.min_size_content = if (init_opts.scroll_info == null) null else .{ .w = @floatFromInt(nr_boxes.w * 27), .h = @floatFromInt(nr_boxes.h * 27) };
+        const box_size = 26;
+        options.min_size_content = if (init_opts.scroll_info == null) null else .{ .w = @floatFromInt(nr_boxes.w * (box_size + 2)), .h = @floatFromInt(nr_boxes.h * (box_size + 2)) };
+        const color_fill = options.color(.border).opacity(0.25);
         var scroll = dvui.scrollArea(@src(), init_opts, options.override(.{ .data_out = &wd }));
         defer scroll.deinit();
         var vbox = dvui.box(@src(), .{}, .{ .expand = .both });
@@ -2127,12 +2173,12 @@ const DisplayScrollArea = struct {
             var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .id_extra = i });
             defer hbox.deinit();
             for (0..nr_boxes.w) |j| {
-                var box = dvui.box(@src(), .{}, .{ .min_size_content = .all(25), .color_fill = if ((i + j) % 2 == 0) options.color(.border) else null, .id_extra = i * 1_000_000 + j, .border = .all(1), .background = true });
+                var box = dvui.box(@src(), .{}, .{ .min_size_content = .all(box_size), .color_border = color_fill, .color_fill = if ((i + j) % 2 == 0) color_fill else null, .id_extra = i * 1_000_000 + j, .border = .all(1), .background = true });
                 defer box.deinit();
                 if (i == 0 and j == 0) {
-                    _ = dvui.checkbox(@src(), &check_top_left, "", .{ .gravity_x = 0.5, .gravity_y = 0.5, .data_out = &top_left_wd, .padding = .all(0) });
+                    _ = dvui.buttonIcon(@src(), "top_left", dvui.entypo.box, .{}, .{}, .{ .data_out = &top_left_wd, .expand = .both, .padding = .all(0) });
                 } else if (i == nr_boxes.h - 1 and j == nr_boxes.w - 1) {
-                    _ = dvui.checkbox(@src(), &check_bottom_right, "", .{ .gravity_x = 0.5, .gravity_y = 0.5, .data_out = &bottom_right_wd, .padding = .all(0) });
+                    _ = dvui.buttonIcon(@src(), "bottom_right", dvui.entypo.box, .{}, .{}, .{ .data_out = &bottom_right_wd, .expand = .both, .padding = .all(0) });
                 }
             }
         }
@@ -2153,7 +2199,16 @@ const DisplayScrollArea = struct {
                 .w = .{ .number = .{ .min = 2, .max = 200 } },
                 .h = .{ .number = .{ .min = 2, .max = 200 } },
             }, null);
-            dvui.structUI(@src(), "Boxes", &nr_boxes, 1, .{display_opts}, .{});
+            var al: dvui.Alignment = .init(@src(), 0);
+            defer al.deinit();
+            if (struct_ui.displayStruct(@src(), "Boxes", &nr_boxes, 1, .default, .{display_opts}, &al)) |container_inner| {
+                defer container_inner.deinit();
+            }
+            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+            defer hbox.deinit();
+            dvui.icon(@src(), "box", dvui.entypo.box, .{}, .{ .max_size_content = .all(25), .gravity_y = 0.5, .padding = .{ .x = 6 } });
+            al.spacer(@src(), 0);
+            dvui.labelNoFmt(@src(), "Focus with focus_id\nthen click scrollbar", .{}, .{});
         }
         const display_opts: StructOptions(dvui.ScrollAreaWidget.InitOpts) = .initWithDefaults(.{
             .focus_id = .{ .standard = .{ .customDisplayFn = displayFocusId } },
@@ -3051,7 +3106,7 @@ const widget_hierarchy = [_]WidgetHierarchy{
         .{ .name = "dropdownEnum", .displayFn = DisplayDropDownEnum.displayFn, .children = null },
     } },
     .{ .name = "expander", .displayFn = DisplayExpander.displayFn, .children = null },
-    .{ .name = "flexbox", .displayFn = displayEmpty, .children = null },
+    .{ .name = "flexbox", .displayFn = DisplayFlexBox.displayFn, .children = null },
     // FloatingMenuWidget is typically combined with other widgets, and not used standalone.
     //    .{ .name = "floatingMenu", .displayFn = displayEmpty, .children = null },
 

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -2036,8 +2036,8 @@ const DisplayScrollArea = struct {
     }
 
     pub fn layoutWidget() void {
-        const min_size: ?dvui.Size = if (init_opts.scroll_info == null) null else .{ .w = @floatFromInt(nr_boxes.w * 27), .h = @floatFromInt(nr_boxes.h * 27) };
-        var scroll = dvui.scrollArea(@src(), init_opts, options.override(.{ .data_out = &wd, .min_size_content = min_size }));
+        options.min_size_content = if (init_opts.scroll_info == null) null else .{ .w = @floatFromInt(nr_boxes.w * 27), .h = @floatFromInt(nr_boxes.h * 27) };
+        var scroll = dvui.scrollArea(@src(), init_opts, options.override(.{ .data_out = &wd }));
         defer scroll.deinit();
         var vbox = dvui.box(@src(), .{}, .{ .expand = .both });
         defer vbox.deinit();
@@ -2056,10 +2056,10 @@ const DisplayScrollArea = struct {
         }
         if (init_opts.scroll_info) |si| {
             if (si.horizontal == .given) {
-                si.virtual_size.w = min_size.?.w;
+                si.virtual_size.w = options.min_size_content.?.w;
             }
             if (si.vertical == .given) {
-                si.virtual_size.h = min_size.?.h;
+                si.virtual_size.h = options.min_size_content.?.h;
             }
         }
     }
@@ -2068,8 +2068,8 @@ const DisplayScrollArea = struct {
         if (struct_ui.displayContainer(@src(), test_options_label)) |container| {
             defer container.deinit();
             const display_opts: StructOptions(@TypeOf(nr_boxes)) = .init(.{
-                .w = .{ .number = .{ .min = 0, .max = 500 } },
-                .h = .{ .number = .{ .min = 0, .max = 500 } },
+                .w = .{ .number = .{ .min = 2, .max = 200 } },
+                .h = .{ .number = .{ .min = 2, .max = 200 } },
             }, null);
             dvui.structUI(@src(), "Boxes", &nr_boxes, 1, .{display_opts}, .{});
         }
@@ -2078,13 +2078,13 @@ const DisplayScrollArea = struct {
         }, .{ .scroll_info = &scroll_info, .frame_viewport = .{ .x = 100, .y = 100 }, .user_scroll = &user_scroll });
         const si_opts: StructOptions(dvui.ScrollInfo) = .initWithDefaults(.{
             .viewport = .{ .number = .{ .customDisplayFn = displayViewport } },
+            .velocity = .{ .number = .{ .customDisplayFn = displayVelocity } },
         }, null);
-        // TODO: This is another example of need for struct_ui enhancement. Luckily velocity is the
-        // only Point is the struct so I can override the type. But I really just want to override the
-        // point display for the velocity field.
+        // TODO: This is another example of need for struct_ui enhancement. There are multiple points and we
+        // need to override one of them (velocity). Ideally we'd just like to override velocity with it's own options
         const point_opts: StructOptions(dvui.Point) = .init(.{
-            .x = .{ .number = .{ .widget_type = .number_placeholder } },
-            .y = .{ .number = .{ .widget_type = .number_placeholder } },
+            .x = .defaultReadOnly,
+            .y = .defaultReadOnly,
         }, null);
         // TODO: Same with size
         const size_opts: StructOptions(dvui.Size) = .init(.{
@@ -2177,6 +2177,17 @@ const DisplayScrollArea = struct {
                 }
             }
         }
+    }
+
+    fn displayVelocity(_: []const u8, _: *anyopaque, _: bool, _: *dvui.Alignment) void {
+        const display_opts: StructOptions(dvui.Point) = .init(.{
+            .x = .{ .number = .{ .widget_type = .number_placeholder } },
+            .y = .{ .number = .{ .widget_type = .number_placeholder } },
+        }, null);
+        // Ignore the old alignment as structs always start a new alignment.
+        var al: dvui.Alignment = .init(@src(), 0);
+        defer al.deinit();
+        if (struct_ui.displayStruct(@src(), "velocity", &scroll_info.velocity, 1, .default, .{display_opts}, &al)) |box| box.deinit();
     }
 };
 

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -137,7 +137,7 @@ const WidgetHierarchy = struct {
     displayFn: *const fn (reset_widget: bool) void,
 };
 
-var current_widget: WidgetHierarchy = widget_hierarchy[0];
+var current_widget: WidgetHierarchy = .{ .name = "plot", .displayFn = DisplayPlot.displayFn, .children = null };
 
 fn displayEmpty(_: bool) void {
     var label_str = std.Io.Writer.Allocating.initCapacity(dvui.currentWindow().arena(), current_widget.name.len + 2) catch return;
@@ -1777,6 +1777,12 @@ const DisplayPlot = struct {
     var x_axis: dvui.PlotWidget.Axis = undefined;
     var y_axis: dvui.PlotWidget.Axis = undefined;
 
+    var test_options: struct {
+        plot_type: enum { bar, line },
+        nr_points: u8,
+        seed: u8,
+    } = undefined;
+
     pub fn displayFn(reset: bool) void {
         if (reset) resetWidget();
         displayWidgetTemplate(@This());
@@ -1785,6 +1791,11 @@ const DisplayPlot = struct {
     pub fn resetWidget() void {
         options = .{ .expand = .both };
         init_opts = .{};
+        test_options = .{
+            .plot_type = .bar,
+            .nr_points = 5,
+            .seed = 1,
+        };
         x_axis = .{
             .name = "X",
         };
@@ -1794,21 +1805,45 @@ const DisplayPlot = struct {
     }
 
     pub fn layoutWidget() void {
+        var rng: std.Random.DefaultPrng = .init(test_options.seed);
         var plot = dvui.plot(@src(), init_opts, options.override(.{ .data_out = &wd }));
         defer plot.deinit();
-        plot.bar(.{ .x = 0, .y = 0, .w = 10, .h = 100 });
-        plot.bar(.{ .x = 10, .y = 0, .w = 10, .h = 100, .color = .red });
+        switch (test_options.plot_type) {
+            .bar => {
+                for (0..test_options.nr_points) |i| {
+                    const point_nr: f64 = @floatFromInt(i);
+                    plot.bar(.{ .x = point_nr * 15, .y = 0, .w = 10, .h = @floatFromInt(rng.next() % 100) });
+                }
+            },
+            .line => {
+                var line = plot.line();
+                defer line.deinit();
+                for (0..test_options.nr_points) |i| {
+                    const point_nr: f64 = @floatFromInt(i);
+
+                    line.point(10 * point_nr, @floatFromInt(rng.next() % 100));
+                }
+                line.stroke(2, .blue);
+            },
+        }
     }
 
     pub fn layoutWidgetControls() void {
+        dvui.structUI(@src(), test_options_label, &test_options, 1, .{}, .{});
         const axis_opts: StructOptions(dvui.PlotWidget.Axis) = .initWithDefaults(.{
             .name = .defaultTextRW,
         }, null);
-        const display_opts: StructOptions(dvui.PlotWidget.InitOptions) = .initWithDefaults(.{}, .{
+        const tick_opts: StructOptions(dvui.PlotWidget.Axis.TickFormating) = .initWithDefaults(.{
+            .custom = .defaultHidden,
+        }, .{ .normal = .{} });
+        //const location_opts: StructOptions(@TypeOf(init_opts.x_axis.?.ticks.locations)) = .initWithDefaults(.{}, .{.{}});
+        const display_opts: StructOptions(dvui.PlotWidget.InitOptions) = .initWithDefaults(.{
+            .title = .defaultTextRW,
+        }, .{
             .x_axis = &x_axis,
             .y_axis = &y_axis,
         });
-        dvui.structUI(@src(), "init_opts", &init_opts, 3, .{ display_opts, axis_opts, struct_options.color }, .{});
+        dvui.structUI(@src(), "init_opts", &init_opts, 3, .{ display_opts, axis_opts, struct_options.color, tick_opts }, .{});
     }
 };
 

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -2056,7 +2056,7 @@ const DisplayScrollArea = struct {
             .viewport = .{ .number = .{ .customDisplayFn = displayViewport } },
             .virtual_size = .defaultConst,
         }, null);
-        // Only override the Point type display for fields named "velocity"
+        // Only override the Point type display only for fields named "velocity"
         const velocity_opts = StructOptions(dvui.Point).init(.{
             .x = .{ .number = .{ .widget_type = .number_placeholder } },
             .y = .{ .number = .{ .widget_type = .number_placeholder } },
@@ -2147,17 +2147,6 @@ const DisplayScrollArea = struct {
                 }
             }
         }
-    }
-
-    fn displayVelocity(_: []const u8, _: *anyopaque, _: bool, _: *dvui.Alignment) void {
-        const display_opts: StructOptions(dvui.Point) = .init(.{
-            .x = .{ .number = .{ .widget_type = .number_placeholder } },
-            .y = .{ .number = .{ .widget_type = .number_placeholder } },
-        }, null);
-        // Ignore the old alignment as structs always start a new alignment.
-        var al: dvui.Alignment = .init(@src(), 0);
-        defer al.deinit();
-        if (struct_ui.displayStruct(@src(), "velocity", &scroll_info.velocity, 1, .default, .{display_opts}, &al)) |box| box.deinit();
     }
 };
 
@@ -2291,24 +2280,18 @@ const DisplaySliderEntry = struct {
     }
 
     pub fn layoutWidgetControls() void {
-        // TODO: StructUI needs a way to support read-write optionals to read-only text. at the moment it is tied to the field, so display
-        // sets both whether the optional can be changed and whether the value can be changed. Here we want user to set the optional to null or not
-        // but not set label_fmt
-        if (struct_ui.displayContainer(@src(), test_options_label)) |container| {
-            defer container.deinit();
-            var al: dvui.Alignment = .init(@src(), 0);
-            defer al.deinit();
-            if (struct_ui.optionalFieldWidget(@src(), "label_fmt", &test_options.label_fmt, .default, &al)) {
-                test_options.label_fmt = "{d:0.1}";
-                struct_ui.displayString(@src(), "label_fmt", &test_options.label_fmt.?, .{ .text = .{ .display = .read_only } }, &al);
-            } else {
-                test_options.label_fmt = null;
-            }
+        {
+            const display_options: StructOptions(@TypeOf(test_options)) = .initWithDefaults(.{
+                .label_fmt = .{ .optional = .{ .child = .{ .text = .{ .display = .read_only } } } },
+            }, .{ .label_fmt = "{d:0.1}", .value = 0 });
+            dvui.structUI(@src(), test_options_label, &test_options, 1, .{display_options}, .{});
         }
-        const display_options = StructOptions(dvui.SliderEntryInitOptions).initWithDefaults(.{
-            .label = .defaultTextRW,
-        }, .{ .label = "slider entry", .value = &test_options.value });
-        dvui.structUI(@src(), "init_opts", &init_opts, 1, .{display_options}, .{});
+        {
+            const display_options = StructOptions(dvui.SliderEntryInitOptions).initWithDefaults(.{
+                .label = .defaultTextRW,
+            }, .{ .label = "slider entry", .value = &test_options.value });
+            dvui.structUI(@src(), "init_opts", &init_opts, 1, .{display_options}, .{});
+        }
     }
 };
 

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -352,7 +352,7 @@ const DisplayAnimate = struct {
         {
             var box = dvui.box(@src(), .{}, .{ .expand = .horizontal });
             defer box.deinit();
-            if (struct_ui.displayContainer(@src(), test_options_label)) |container| {
+            if (struct_ui.displayContainer(@src(), test_options_label, true)) |container| {
                 defer container.deinit();
                 container.data().options.expand = .horizontal;
                 if (dvui.button(@src(), "Restart animation", .{}, .{})) {
@@ -521,7 +521,7 @@ const DisplayButtonIcon = struct {
     }
 
     pub fn layoutWidgetControls() void {
-        if (struct_ui.displayContainer(@src(), test_options_label)) |container| {
+        if (struct_ui.displayContainer(@src(), test_options_label, true)) |container| {
             defer container.deinit();
             if (dvui.dropdownEnum(@src(), EntypoIcons, .{ .choice = &icon }, .{}, .{ .expand = .horizontal })) {
                 switch (icon) {
@@ -1003,7 +1003,7 @@ const DisplayFloatingWindow = struct {
     }
 
     pub fn layoutWidgetControls() void {
-        if (struct_ui.displayContainer(@src(), test_options_label)) |container| {
+        if (struct_ui.displayContainer(@src(), test_options_label, true)) |container| {
             defer container.deinit();
             if (dvui.button(@src(), "Relaunch window", .{}, .{})) {
                 open_flag = true;
@@ -1205,7 +1205,7 @@ const DisplayIcon = struct {
     }
 
     pub fn layoutWidgetControls() void {
-        if (struct_ui.displayContainer(@src(), test_options_label)) |container| {
+        if (struct_ui.displayContainer(@src(), test_options_label, true)) |container| {
             defer container.deinit();
             var al: dvui.Alignment = .init(@src(), 0);
             defer al.deinit();
@@ -1627,7 +1627,7 @@ const DisplayMenuItemLabel = struct {
         dvui.structUI(@src(), "init_opts", &init_opts, 1, .{}, .{});
         var al: dvui.Alignment = .init(@src(), 0);
         defer al.deinit();
-        if (struct_ui.displayContainer(@src(), "Menu builder")) |container| {
+        if (struct_ui.displayContainer(@src(), "Menu builder", true)) |container| {
             defer container.deinit();
             displayMenuControls(&menu_items);
             al.spacer(@src(), 0);
@@ -1754,7 +1754,7 @@ const DisplayPaned = struct {
     }
 
     pub fn layoutWidgetControls() void {
-        if (struct_ui.displayContainer(@src(), test_options_label)) |container| {
+        if (struct_ui.displayContainer(@src(), test_options_label, true)) |container| {
             defer container.deinit();
             auto_fit = dvui.button(@src(), "Auto fit", .{}, .{});
             dvui.labelNoFmt(@src(), "*requires autofit_first to be set", .{}, .{});
@@ -1893,7 +1893,7 @@ const DisplayPlotXY = struct {
         dvui.plotXY(@src(), init_opts, options.override(.{ .data_out = &wd }));
     }
 
-    // TODO: make these const
+    // TODO: make these options shared if possible.
     pub fn layoutWidgetControls() void {
         dvui.structUI(@src(), test_options_label, &test_options, 1, .{}, .{});
         const axis_opts: StructOptions(dvui.PlotWidget.Axis) = .initWithDefaults(.{
@@ -1908,7 +1908,11 @@ const DisplayPlotXY = struct {
             .x_axis = &x_axis,
             .y_axis = &y_axis,
         });
-        dvui.structUI(@src(), "init_opts", &init_opts, 3, .{ plot_opts, axis_opts, struct_options.color, tick_opts }, .{});
+        const display_opts: StructOptions(dvui.PlotXYOptions) = .initWithDefaults(.{
+            .xs = .{ .standard = .{ .default_expanded = false } },
+            .ys = .{ .standard = .{ .default_expanded = false } },
+        }, null);
+        dvui.structUI(@src(), "init_opts", &init_opts, 3, .{ display_opts, plot_opts, axis_opts, struct_options.color, tick_opts }, .{});
     }
 };
 
@@ -2143,7 +2147,7 @@ const DisplayScrollArea = struct {
     }
 
     pub fn layoutWidgetControls() void {
-        if (struct_ui.displayContainer(@src(), test_options_label)) |container| {
+        if (struct_ui.displayContainer(@src(), test_options_label, true)) |container| {
             defer container.deinit();
             const display_opts: StructOptions(@TypeOf(nr_boxes)) = .init(.{
                 .w = .{ .number = .{ .min = 2, .max = 200 } },
@@ -2173,7 +2177,7 @@ const DisplayScrollArea = struct {
     fn displayViewport(field_name: []const u8, ptr: *anyopaque, _: bool, _: *dvui.Alignment) void {
         const field_value_ptr: *Rect = @ptrCast(@alignCast(ptr));
 
-        if (struct_ui.displayContainer(@src(), field_name)) |container| {
+        if (struct_ui.displayContainer(@src(), field_name, true)) |container| {
             defer container.deinit();
             var al: dvui.Alignment = .init(@src(), 0);
             defer al.deinit();
@@ -2283,7 +2287,7 @@ const DisplaySeparator = struct {
     }
 
     pub fn layoutWidgetControls() void {
-        if (struct_ui.displayContainer(@src(), test_options_label)) |container| {
+        if (struct_ui.displayContainer(@src(), test_options_label, true)) |container| {
             defer container.deinit();
             var al: dvui.Alignment = .init(@src(), 0);
             defer al.deinit();
@@ -2474,7 +2478,7 @@ const DisplaySpinner = struct {
     }
 
     pub fn layoutWidgetControls() void {
-        if (struct_ui.displayContainer(@src(), test_options_label)) |container| {
+        if (struct_ui.displayContainer(@src(), test_options_label, true)) |container| {
             defer container.deinit();
             var al: dvui.Alignment = .init(@src(), 0);
             defer al.deinit();
@@ -2757,7 +2761,7 @@ const DisplayTextEntry = struct {
     fn structDisplayMultiLineInitOpts(field_value_ptr: *dvui.TextEntryWidget.InitOptions) void {
         const T = dvui.TextEntryWidget.InitOptions;
 
-        if (struct_ui.displayContainer(@src(), "init_opts")) |container| {
+        if (struct_ui.displayContainer(@src(), "init_opts", true)) |container| {
             defer container.deinit();
             var al: dvui.Alignment = .init(@src(), 0);
             defer al.deinit();

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -2183,9 +2183,9 @@ const DisplayScrollArea = struct {
                 var box = dvui.box(@src(), .{}, .{ .min_size_content = .all(box_size), .color_border = color_fill, .color_fill = if ((i + j) % 2 == 0) color_fill else null, .id_extra = i * 1_000_000 + j, .border = .all(1), .background = true });
                 defer box.deinit();
                 if (i == 0 and j == 0) {
-                    _ = dvui.buttonIcon(@src(), "top_left", dvui.entypo.box, .{}, .{}, .{ .data_out = &top_left_wd, .expand = .both, .padding = .all(0) });
+                    _ = dvui.buttonIcon(@src(), "top_left", dvui.entypo.hair_cross, .{}, .{}, .{ .data_out = &top_left_wd, .expand = .both, .padding = .all(0) });
                 } else if (i == nr_boxes.h - 1 and j == nr_boxes.w - 1) {
-                    _ = dvui.buttonIcon(@src(), "bottom_right", dvui.entypo.box, .{}, .{}, .{ .data_out = &bottom_right_wd, .expand = .both, .padding = .all(0) });
+                    _ = dvui.buttonIcon(@src(), "bottom_right", dvui.entypo.hair_cross, .{}, .{}, .{ .data_out = &bottom_right_wd, .expand = .both, .padding = .all(0) });
                 }
             }
         }
@@ -2213,7 +2213,7 @@ const DisplayScrollArea = struct {
             }
             var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
             defer hbox.deinit();
-            dvui.icon(@src(), "box", dvui.entypo.box, .{}, .{ .max_size_content = .all(25), .gravity_y = 0.5, .padding = .{ .x = 6 } });
+            dvui.icon(@src(), "box", dvui.entypo.hair_cross, .{}, .{ .max_size_content = .all(25), .gravity_y = 0.5, .padding = .{ .x = 6 } });
             al.spacer(@src(), 0);
             dvui.labelNoFmt(@src(), "Focus with focus_id\nthen click scrollbar", .{}, .{});
         }
@@ -2458,6 +2458,42 @@ const DisplaySliderEntry = struct {
             }, .{ .label = "slider entry", .value = &test_options.value });
             dvui.structUI(@src(), "init_opts", &init_opts, 1, .{display_options}, .{});
         }
+    }
+};
+
+const DisplaySliderVector = struct {
+    const name: []const u8 = "sliderVector()";
+
+    var wd: dvui.WidgetData = undefined;
+    var options: dvui.Options = undefined;
+    var init_opts: dvui.SliderVectorInitOptions = undefined;
+    var result: bool = undefined;
+
+    const pi = std.math.pi;
+    var slider_values = [_]f32{ -2 * pi, -pi, 0, pi, 2 * pi };
+
+    pub fn displayFn(reset: bool) void {
+        if (reset) resetWidget();
+        displayWidgetTemplate(@This());
+    }
+
+    pub fn resetWidget() void {
+        options = .{};
+        init_opts = .{ .min = -2 * pi, .max = 2 * pi, .interval = 0.01 };
+    }
+
+    pub fn layoutWidget() void {
+        result = dvui.sliderVector(@src(), "{d:0.2}", 5, &slider_values, init_opts, options.override(.{ .data_out = &wd }));
+    }
+
+    pub fn layoutResults() void {
+        var al = dvui.Alignment.init(@src(), 0);
+        defer al.deinit();
+        struct_ui.displayBool(@src(), "result", &result, .{ .boolean = .{ .display = .read_only } }, &al);
+    }
+
+    pub fn layoutWidgetControls() void {
+        dvui.structUI(@src(), "init_opts", &init_opts, 1, .{struct_options.color}, .{});
     }
 };
 
@@ -3166,7 +3202,7 @@ const widget_hierarchy = [_]WidgetHierarchy{
     .{ .name = "sliders", .displayFn = displayEmpty, .children = &.{
         .{ .name = "slider", .displayFn = DisplaySlider.displayFn, .children = null },
         .{ .name = "sliderEntry", .displayFn = DisplaySliderEntry.displayFn, .children = null },
-        .{ .name = "sliderVector", .displayFn = displayEmpty, .children = null },
+        .{ .name = "sliderVector", .displayFn = DisplaySliderVector.displayFn, .children = null },
     } },
 
     .{ .name = "spacer", .displayFn = DisplaySpacer.displayFn, .children = null },

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -137,7 +137,8 @@ const WidgetHierarchy = struct {
     displayFn: *const fn (reset_widget: bool) void,
 };
 
-var current_widget: WidgetHierarchy = widget_hierarchy[0];
+var current_widget: WidgetHierarchy = .{ .name = "floatingWindow", .displayFn = DisplayFloatingWindow.displayFn };
+//widget_hierarchy[0];
 
 fn displayEmpty(_: bool) void {
     var label_str = std.Io.Writer.Allocating.initCapacity(dvui.currentWindow().arena(), current_widget.name.len + 2) catch return;
@@ -604,7 +605,11 @@ const DisplayCheckbox = struct {
     }
 
     pub fn layoutWidget() void {
-        result = dvui.checkbox(@src(), &test_options.checked, test_options.label_str, options.override(.{ .data_out = &wd }));
+        var theme_override = dvui.themeGet();
+        theme_override.highlight.fill = .red;
+        theme_override.fill = .green;
+
+        result = dvui.checkbox(@src(), &test_options.checked, test_options.label_str, options.override(.{ .data_out = &wd, .theme = &theme_override }));
     }
 
     pub fn layoutResults() void {
@@ -959,6 +964,115 @@ const DisplayExpander = struct {
             }, null),
         }, .{});
         dvui.structUI(@src(), "init_opts", &init_opts, 2, .{}, .{});
+    }
+};
+
+const DisplayFloatingWindow = struct {
+    const name = "floatingWindow()";
+    var wd: dvui.WidgetData = undefined;
+    var floating_opts: dvui.FloatingWindowWidget.InitOptions = .{};
+    var options: dvui.Options = undefined;
+    var open_flag = false;
+    var rect: Rect = undefined;
+    // Used to "relaunch" as a new window.
+    var id_extra: usize = undefined;
+
+    pub fn displayFn(reset: bool) void {
+        if (reset) resetWidget();
+        displayWidgetTemplate(@This());
+    }
+
+    pub fn resetWidget() void {
+        open_flag = true;
+        rect = .all(0);
+        id_extra = 0;
+        floating_opts = .{ .open_flag = &open_flag };
+        options = .{ .min_size_content = .all(350) };
+    }
+
+    pub fn layoutWidget() void {
+        if (!open_flag) return;
+
+        var fw = dvui.floatingWindow(@src(), floating_opts, options.override(.{ .data_out = &wd, .id_extra = id_extra }));
+        defer fw.deinit();
+        dvui.icon(@src(), "rocket", dvui.entypo.rocket, .{}, .{ .expand = .both });
+        if (floating_opts.modal) {
+            if (dvui.button(@src(), "End Modal", .{}, .{ .gravity_x = 0.5, .gravity_y = 0.5 })) {
+                floating_opts.modal = false;
+            }
+        }
+        if (floating_opts.rect == null) {
+            rect = fw.data().rect;
+        }
+    }
+
+    pub fn layoutWidgetControls() void {
+        if (struct_ui.displayContainer(@src(), test_options_label)) |container| {
+            defer container.deinit();
+            if (dvui.button(@src(), "Relaunch window", .{}, .{})) {
+                open_flag = true;
+                id_extra += 1;
+            }
+        }
+        const display_opts: StructOptions(dvui.FloatingWindowWidget.InitOptions) = .initWithDefaults(.{}, .{ .rect = &rect, .open_flag = &open_flag });
+        dvui.structUI(@src(), "floating_opts", &floating_opts, 2, .{display_opts}, .{});
+    }
+};
+
+const DisplayWindowHeader = struct {
+    const name = "windowHeader()";
+    var wd: dvui.WidgetData = undefined;
+    var options: dvui.Options = undefined;
+
+    var test_options: struct {
+        str: []const u8,
+        right_str: []const u8,
+        open_flag: bool,
+    } = undefined;
+
+    var result: Rect.Physical = undefined;
+
+    pub fn displayFn(reset: bool) void {
+        if (reset) resetWidget();
+        displayWidgetTemplate(@This());
+    }
+
+    pub fn resetWidget() void {
+        options = .{};
+        test_options = .{
+            .str = "Window heading",
+            .right_str = "right text",
+            .open_flag = true,
+        };
+    }
+
+    pub fn layoutWidget() void {
+        {
+            var tl = dvui.textLayout(@src(), .{}, .{ .gravity_y = 1.0, .gravity_x = 0.5 });
+            defer tl.deinit();
+            tl.addText("This widget has no configurable DVUI options.", .{});
+        }
+        if (!test_options.open_flag) return;
+
+        var fw = dvui.floatingWindow(@src(), .{ .open_flag = &test_options.open_flag }, .{ .min_size_content = .all(350) });
+        defer fw.deinit();
+        result = dvui.windowHeader(test_options.str, test_options.right_str, &test_options.open_flag);
+        fw.dragAreaSet(result);
+
+        dvui.icon(@src(), "rocket", dvui.entypo.rocket, .{}, .{ .expand = .both });
+    }
+
+    pub fn displayResults() void {
+        const result_c = result;
+        dvui.structUI(@src(), null, &result_c, 1, .{}, .{});
+    }
+
+    pub fn layoutWidgetControls() void {
+        const display_opts: StructOptions(@TypeOf(test_options)) = .initWithDefaults(.{
+            .str = .defaultTextRW,
+            .right_str = .defaultTextRW,
+        }, null);
+        dvui.structUI(@src(), test_options_label, &test_options, 1, .{display_opts}, .{});
     }
 };
 
@@ -2518,11 +2632,12 @@ const widget_hierarchy = [_]WidgetHierarchy{
     } },
     .{ .name = "expander", .displayFn = DisplayExpander.displayFn, .children = null },
     .{ .name = "flexbox", .displayFn = displayEmpty, .children = null },
-    .{ .name = "floatingMenu", .displayFn = displayEmpty, .children = null },
+    // FloatingMenuWidget is typically combined with other widgets, and not used standalone.
+    //    .{ .name = "floatingMenu", .displayFn = displayEmpty, .children = null },
 
     .{ .name = "floatingWindow", .displayFn = displayEmpty, .children = &.{
-        .{ .name = "floatingWindow", .displayFn = displayEmpty, .children = null },
-        .{ .name = "windowHeader", .displayFn = displayEmpty, .children = null },
+        .{ .name = "floatingWindow", .displayFn = DisplayFloatingWindow.displayFn, .children = null },
+        .{ .name = "windowHeader", .displayFn = DisplayWindowHeader.displayFn, .children = null },
     } },
 
     .{ .name = "focusGroup", .displayFn = DisplayFocusGroup.displayFn, .children = null },

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -1053,7 +1053,7 @@ const DisplayWindowHeader = struct {
         }
         if (!test_options.open_flag) return;
 
-        var fw = dvui.floatingWindow(@src(), .{ .open_flag = &test_options.open_flag }, .{ .min_size_content = .all(350) });
+        var fw = dvui.floatingWindow(@src(), .{ .open_flag = &test_options.open_flag }, .{ .min_size_content = .all(350), .data_out = &wd });
         defer fw.deinit();
         result = dvui.windowHeader(test_options.str, test_options.right_str, &test_options.open_flag);
         fw.dragAreaSet(result);
@@ -2005,6 +2005,15 @@ const DisplayScrollArea = struct {
     var options: dvui.Options = undefined;
     var init_opts: dvui.ScrollAreaWidget.InitOpts = undefined;
     var scroll_info: dvui.ScrollInfo = undefined;
+
+    var top_left_wd: dvui.WidgetData = undefined;
+    var bottom_right_wd: dvui.WidgetData = undefined;
+    var check_top_left: bool = false;
+    var check_bottom_right = false;
+    var user_scroll: dvui.Point = undefined;
+
+    var focus_id: ?dvui.Id = undefined;
+
     var nr_boxes: struct {
         w: usize,
         h: usize,
@@ -2018,7 +2027,12 @@ const DisplayScrollArea = struct {
     pub fn resetWidget() void {
         options = .{};
         init_opts = .{};
+        scroll_info = .{};
         nr_boxes = .{ .w = 20, .h = 20 };
+        focus_id = null;
+        check_bottom_right = false;
+        check_top_left = false;
+        user_scroll = .{ .x = 0, .y = 0 };
     }
 
     pub fn layoutWidget() void {
@@ -2033,6 +2047,11 @@ const DisplayScrollArea = struct {
             for (0..nr_boxes.w) |j| {
                 var box = dvui.box(@src(), .{}, .{ .min_size_content = .all(25), .color_fill = if ((i + j) % 2 == 0) options.color(.border) else null, .id_extra = i * 1_000_000 + j, .border = .all(1), .background = true });
                 defer box.deinit();
+                if (i == 0 and j == 0) {
+                    _ = dvui.checkbox(@src(), &check_top_left, "", .{ .gravity_x = 0.5, .gravity_y = 0.5, .data_out = &top_left_wd, .padding = .all(0) });
+                } else if (i == nr_boxes.h - 1 and j == nr_boxes.w - 1) {
+                    _ = dvui.checkbox(@src(), &check_bottom_right, "", .{ .gravity_x = 0.5, .gravity_y = 0.5, .data_out = &bottom_right_wd, .padding = .all(0) });
+                }
             }
         }
         if (init_opts.scroll_info) |si| {
@@ -2048,9 +2067,15 @@ const DisplayScrollArea = struct {
     pub fn layoutWidgetControls() void {
         if (struct_ui.displayContainer(@src(), test_options_label)) |container| {
             defer container.deinit();
-            dvui.structUI(@src(), "Boxes", &nr_boxes, 1, .{}, .{});
+            const display_opts: StructOptions(@TypeOf(nr_boxes)) = .init(.{
+                .w = .{ .number = .{ .min = 0, .max = 500 } },
+                .h = .{ .number = .{ .min = 0, .max = 500 } },
+            }, null);
+            dvui.structUI(@src(), "Boxes", &nr_boxes, 1, .{display_opts}, .{});
         }
-        const display_opts: StructOptions(dvui.ScrollAreaWidget.InitOpts) = .initWithDefaults(.{}, .{ .scroll_info = &scroll_info });
+        const display_opts: StructOptions(dvui.ScrollAreaWidget.InitOpts) = .initWithDefaults(.{
+            .focus_id = .{ .standard = .{ .customDisplayFn = displayFocusId } },
+        }, .{ .scroll_info = &scroll_info, .frame_viewport = .{ .x = 100, .y = 100 }, .user_scroll = &user_scroll });
         const si_opts: StructOptions(dvui.ScrollInfo) = .initWithDefaults(.{
             .viewport = .{ .number = .{ .customDisplayFn = displayViewport } },
         }, null);
@@ -2061,7 +2086,13 @@ const DisplayScrollArea = struct {
             .x = .{ .number = .{ .widget_type = .number_placeholder } },
             .y = .{ .number = .{ .widget_type = .number_placeholder } },
         }, null);
-        dvui.structUI(@src(), "init_opts", &init_opts, 2, .{ display_opts, si_opts, point_opts }, .{});
+        // TODO: Same with size
+        const size_opts: StructOptions(dvui.Size) = .init(.{
+            .w = .defaultReadOnly,
+            .h = .defaultReadOnly,
+        }, null);
+
+        dvui.structUI(@src(), "init_opts", &init_opts, 2, .{ display_opts, si_opts, point_opts, size_opts }, .{});
     }
 
     fn displayViewport(field_name: []const u8, ptr: *anyopaque, _: bool, _: *dvui.Alignment) void {
@@ -2094,6 +2125,57 @@ const DisplayScrollArea = struct {
             }
             struct_ui.displayNumber(@src(), "w", &field_value_ptr.w, .defaultReadOnly, &al);
             struct_ui.displayNumber(@src(), "h", &field_value_ptr.h, .defaultReadOnly, &al);
+        }
+    }
+
+    fn displayFocusId(field_name: []const u8, _: *anyopaque, _: bool, alignment: *dvui.Alignment) void {
+        var box = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+        defer box.deinit();
+
+        dvui.label(@src(), "{s}", .{field_name}, .{});
+        var hbox_aligned = dvui.box(@src(), .{ .dir = .horizontal }, .{ .margin = alignment.margin(box.data().id) });
+        defer hbox_aligned.deinit();
+        alignment.record(box.data().id, hbox_aligned.data());
+
+        const selected_index: usize = if (init_opts.focus_id == null)
+            0
+        else if (init_opts.focus_id == top_left_wd.id)
+            1
+        else
+            2;
+
+        var dd: dvui.DropdownWidget = undefined;
+        dd.init(@src(), .{ .selected_index = selected_index, .label = if (selected_index == 0) "null" else if (selected_index == 1) "top left" else "bottom right" }, .{});
+        defer dd.deinit();
+
+        if (dd.dropped()) {
+            {
+                var mi = dd.addChoice();
+                defer mi.deinit();
+                dvui.labelNoFmt(@src(), "null", .{}, .{});
+                if (mi.activeRect()) |_| {
+                    dd.close();
+                    init_opts.focus_id = null;
+                }
+            }
+            {
+                var mi = dd.addChoice();
+                defer mi.deinit();
+                dvui.label(@src(), "top left\n{f}", .{top_left_wd.id}, .{});
+                if (mi.activeRect()) |_| {
+                    dd.close();
+                    init_opts.focus_id = top_left_wd.id;
+                }
+            }
+            {
+                var mi = dd.addChoice();
+                defer mi.deinit();
+                dvui.label(@src(), "bottom right\n{f}", .{bottom_right_wd.id}, .{});
+                if (mi.activeRect()) |_| {
+                    dd.close();
+                    init_opts.focus_id = bottom_right_wd.id;
+                }
+            }
         }
     }
 };

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -137,7 +137,7 @@ const WidgetHierarchy = struct {
     displayFn: *const fn (reset_widget: bool) void,
 };
 
-var current_widget: WidgetHierarchy = .{ .name = "plot", .displayFn = DisplayPlot.displayFn, .children = null };
+var current_widget: WidgetHierarchy = widget_hierarchy[0];
 
 fn displayEmpty(_: bool) void {
     var label_str = std.Io.Writer.Allocating.initCapacity(dvui.currentWindow().arena(), current_widget.name.len + 2) catch return;
@@ -1305,7 +1305,7 @@ const DisplayLabelClick = struct {
             click_event_valid = click_event;
         }
         if (click_event_valid) |cev| {
-            struct_ui.displayUnion(@src(), "last click_event", &cev, 1, .defaultReadOnly, .{});
+            struct_ui.displayUnion(@src(), "last click_event", &cev, 1, .{ .standard = .{ .display = .read_only, .default_expanded = false } }, .{});
         }
     }
 

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -2005,7 +2005,10 @@ const DisplayScrollArea = struct {
     var options: dvui.Options = undefined;
     var init_opts: dvui.ScrollAreaWidget.InitOpts = undefined;
     var scroll_info: dvui.ScrollInfo = undefined;
-    var nr_widgets: usize = undefined;
+    var nr_boxes: struct {
+        w: usize,
+        h: usize,
+    } = undefined;
 
     pub fn displayFn(reset: bool) void {
         if (reset) resetWidget();
@@ -2015,20 +2018,83 @@ const DisplayScrollArea = struct {
     pub fn resetWidget() void {
         options = .{};
         init_opts = .{};
-        nr_widgets = 30;
+        nr_boxes = .{ .w = 20, .h = 20 };
     }
 
     pub fn layoutWidget() void {
-        var scroll = dvui.scrollArea(@src(), init_opts, options.override(.{ .data_out = &wd }));
+        const min_size: ?dvui.Size = if (init_opts.scroll_info == null) null else .{ .w = @floatFromInt(nr_boxes.w * 27), .h = @floatFromInt(nr_boxes.h * 27) };
+        var scroll = dvui.scrollArea(@src(), init_opts, options.override(.{ .data_out = &wd, .min_size_content = min_size }));
         defer scroll.deinit();
-        for (0..nr_widgets) |i| {
-            dvui.label(@src(), "Line {}", .{i}, .{ .id_extra = i });
+        var vbox = dvui.box(@src(), .{}, .{ .expand = .both });
+        defer vbox.deinit();
+        for (0..nr_boxes.h) |i| {
+            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .id_extra = i });
+            defer hbox.deinit();
+            for (0..nr_boxes.w) |j| {
+                var box = dvui.box(@src(), .{}, .{ .min_size_content = .all(25), .color_fill = if ((i + j) % 2 == 0) options.color(.border) else null, .id_extra = i * 1_000_000 + j, .border = .all(1), .background = true });
+                defer box.deinit();
+            }
+        }
+        if (init_opts.scroll_info) |si| {
+            if (si.horizontal == .given) {
+                si.virtual_size.w = min_size.?.w;
+            }
+            if (si.vertical == .given) {
+                si.virtual_size.h = min_size.?.h;
+            }
         }
     }
 
     pub fn layoutWidgetControls() void {
-        const display_opts = StructOptions(dvui.ScrollAreaWidget.InitOpts).initWithDefaults(.{}, .{ .scroll_info = &scroll_info });
-        dvui.structUI(@src(), "init_opts", &init_opts, 2, .{display_opts}, .{});
+        if (struct_ui.displayContainer(@src(), test_options_label)) |container| {
+            defer container.deinit();
+            dvui.structUI(@src(), "Boxes", &nr_boxes, 1, .{}, .{});
+        }
+        const display_opts: StructOptions(dvui.ScrollAreaWidget.InitOpts) = .initWithDefaults(.{}, .{ .scroll_info = &scroll_info });
+        const si_opts: StructOptions(dvui.ScrollInfo) = .initWithDefaults(.{
+            .viewport = .{ .number = .{ .customDisplayFn = displayViewport } },
+        }, null);
+        // TODO: This is another example of need for struct_ui enhancement. Luckily velocity is the
+        // only Point is the struct so I can override the type. But I really just want to override the
+        // point display for the velocity field.
+        const point_opts: StructOptions(dvui.Point) = .init(.{
+            .x = .{ .number = .{ .widget_type = .number_placeholder } },
+            .y = .{ .number = .{ .widget_type = .number_placeholder } },
+        }, null);
+        dvui.structUI(@src(), "init_opts", &init_opts, 2, .{ display_opts, si_opts, point_opts }, .{});
+    }
+
+    fn displayViewport(field_name: []const u8, ptr: *anyopaque, _: bool, _: *dvui.Alignment) void {
+        const field_value_ptr: *Rect = @ptrCast(@alignCast(ptr));
+
+        if (struct_ui.displayContainer(@src(), field_name)) |container| {
+            defer container.deinit();
+            var al: dvui.Alignment = .init(@src(), 0);
+            defer al.deinit();
+            if (init_opts.scroll_info) |si| {
+                struct_ui.displayNumber(@src(), "x", &field_value_ptr.x, .{
+                    .number = .{
+                        .widget_type = if (si.horizontal == .given) .slider_entry else .number_entry,
+                        .min = 0,
+                        .max = scroll_info.virtual_size.w - scroll_info.viewport.w,
+                        .display = if (si.horizontal == .given) .read_write else .read_only,
+                    },
+                }, &al);
+                struct_ui.displayNumber(@src(), "y", &field_value_ptr.y, .{
+                    .number = .{
+                        .widget_type = if (si.vertical == .given) .slider_entry else .number_entry,
+                        .min = 0,
+                        .max = scroll_info.virtual_size.h - scroll_info.viewport.h,
+                        .display = if (si.vertical == .given) .read_write else .read_only,
+                    },
+                }, &al);
+            } else {
+                struct_ui.displayNumber(@src(), "x", &field_value_ptr.x, .defaultReadOnly, &al);
+                struct_ui.displayNumber(@src(), "y`", &field_value_ptr.y, .defaultReadOnly, &al);
+            }
+            struct_ui.displayNumber(@src(), "w", &field_value_ptr.w, .defaultReadOnly, &al);
+            struct_ui.displayNumber(@src(), "h", &field_value_ptr.h, .defaultReadOnly, &al);
+        }
     }
 };
 

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -118,7 +118,7 @@ pub fn widgetpedia() void {
         }
     }
     {
-        var vbox = dvui.box(@src(), .{}, .{ .expand = .both, .background = true, .padding = Rect.all(6), .corner_radius = Rect.all(5), .border = Rect.all(1) });
+        var vbox = dvui.box(@src(), .{}, .{ .expand = .both, .background = true, .padding = .all(6), .corner_radius = .all(5), .border = .all(1) });
         defer vbox.deinit();
         current_widget.displayFn(reset_widget);
         reset_widget = false;
@@ -206,9 +206,9 @@ pub fn displayWidgetTemplate(widget_display: type) void {
             if (std.meta.hasFn(widget_display, "layoutWidgetControls")) {
                 if (inner_paned.showSecond()) {
                     var scroll = dvui.scrollArea(@src(), .{}, .{
-                        .corner_radius = Rect.all(3),
-                        .border = Rect.all(1),
-                        .padding = Rect.all(6),
+                        .corner_radius = .all(3),
+                        .border = .all(1),
+                        .padding = .all(6),
                         .expand = .both,
                         .margin = .{ .x = 6, .y = 6 + dvui.themeGet().font_body.lineHeight() / 2 - 1, .w = 6, .h = 6 },
                         .background = false,
@@ -225,16 +225,16 @@ pub fn displayWidgetTemplate(widget_display: type) void {
         var outer_vbox = dvui.box(@src(), .{}, .{
             .margin = .{ .x = 0, .y = 6, .h = 0, .w = 0 },
             .expand = .horizontal,
-            .border = Rect.all(1),
-            .corner_radius = Rect.all(3),
+            .border = .all(1),
+            .corner_radius = .all(3),
             .min_size_content = .{ .h = state.paned_content_height },
         });
         defer outer_vbox.deinit();
         var expander_wd: dvui.WidgetData = undefined;
         if (dvui.expander(@src(), "Options editor", .{ .default_expanded = false }, .{ .expand = .horizontal, .data_out = &expander_wd })) {
             var scroll = dvui.scrollArea(@src(), .{}, .{
-                .corner_radius = Rect.all(3),
-                .padding = Rect.all(6),
+                .corner_radius = .all(3),
+                .padding = .all(6),
                 .expand = .both,
                 .background = false,
                 .min_size_content = .{ .h = 40 },
@@ -411,7 +411,7 @@ const DisplayBox = struct {
         test_options.nr_boxes = 5;
         test_options.expand = .none;
         init_opts = .{};
-        options = .{ .expand = .both, .border = Rect.all(1) };
+        options = .{ .expand = .both, .border = .all(1) };
     }
 
     pub fn layoutWidget() void {
@@ -420,7 +420,7 @@ const DisplayBox = struct {
         for (0..test_options.nr_boxes) |i| {
             var b = dvui.box(@src(), .{}, .{
                 .min_size_content = .{ .h = 30, .w = 30 },
-                .border = Rect.all(1),
+                .border = .all(1),
                 .id_extra = i,
                 .expand = test_options.expand,
             });
@@ -759,7 +759,7 @@ const DisplayContext = struct {
         defer ctext.deinit();
 
         if (ctext.activePoint()) |cp| {
-            var fw = dvui.floatingMenu(@src(), .{ .from = Rect.Natural.fromPoint(cp) }, .{});
+            var fw = dvui.floatingMenu(@src(), .{ .from = .fromPoint(cp) }, .{});
             defer fw.deinit();
 
             if (dvui.menuItemLabel(@src(), "Menu Item 1", .{}, .{ .expand = .horizontal })) |_| {
@@ -1748,6 +1748,92 @@ const DisplayMenuItemLabel = struct {
     }
 };
 
+const DisplayPaned = struct {
+    var name: []const u8 = "paned()";
+
+    var wd: dvui.WidgetData = undefined;
+    var options: dvui.Options = undefined;
+    var init_opts: dvui.PanedWidget.InitOptions = undefined;
+    var split_ratio: f32 = undefined;
+    var auto_fit: bool = false;
+
+    pub fn displayFn(reset: bool) void {
+        if (reset) resetWidget();
+        displayWidgetTemplate(@This());
+    }
+
+    pub fn resetWidget() void {
+        options = .{ .expand = .both };
+        init_opts = .{ .direction = .horizontal, .collapsed_size = 0 };
+        split_ratio = 0.5;
+        auto_fit = false;
+    }
+
+    pub fn layoutWidget() void {
+        var paned = dvui.paned(@src(), init_opts, options.override(.{ .data_out = &wd }));
+        defer paned.deinit();
+        if (auto_fit) {
+            paned.autoFit();
+            auto_fit = false;
+        }
+
+        if (paned.showFirst()) {
+            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .both, .border = .all(1), .corner_radius = .all(5) });
+            defer hbox.deinit();
+            if (paned.collapsed() and !paned.collapsing) {
+                if (dvui.buttonIcon(
+                    @src(),
+                    "chevron",
+                    if (init_opts.direction == .horizontal) dvui.entypo.chevron_thin_left else dvui.entypo.chevron_thin_up,
+                    .{},
+                    .{},
+                    .{ .min_size_content = .all(25), .gravity_x = 1.0 },
+                )) {
+                    paned.animateSplit(0.0);
+                }
+            }
+
+            dvui.icon(@src(), "lock", if (paned.collapsed()) dvui.entypo.lock else dvui.entypo.lock_open, .{}, .{ .expand = .both });
+        }
+        if (paned.showSecond()) {
+            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .both, .border = .all(1), .corner_radius = .all(5) });
+            defer hbox.deinit();
+            if (paned.collapsed() and !paned.collapsing) {
+                if (dvui.buttonIcon(
+                    @src(),
+                    "chevron",
+                    if (init_opts.direction == .horizontal) dvui.entypo.chevron_thin_right else dvui.entypo.chevron_thin_down,
+
+                    .{},
+                    .{},
+                    .{
+                        .min_size_content = .all(25),
+                        .gravity_x = if (init_opts.direction == .vertical) 1.0 else null,
+                    },
+                )) {
+                    paned.animateSplit(1.0);
+                }
+            }
+
+            dvui.icon(@src(), "key", dvui.entypo.key, .{}, .{ .expand = .both });
+        }
+    }
+
+    pub fn layoutWidgetControls() void {
+        if (struct_ui.displayContainer(@src(), test_options_label)) |container| {
+            defer container.deinit();
+            auto_fit = dvui.button(@src(), "Auto fit", .{}, .{});
+            dvui.labelNoFmt(@src(), "*requires autofit_first to be set", .{}, .{});
+        }
+        const display_opts: StructOptions(dvui.PanedWidget.InitOptions) = .initWithDefaults(.{}, .{
+            .direction = .horizontal,
+            .split_ratio = &split_ratio,
+            .collapsed_size = 0,
+        });
+        dvui.structUI(@src(), "init_opts", &init_opts, 1, .{display_opts}, .{});
+    }
+};
+
 const DisplayProgress = struct {
     var name: []const u8 = "progress()";
 
@@ -1902,12 +1988,47 @@ const DisplayScale = struct {
     pub fn layoutWidget() void {
         var scalew = dvui.scale(@src(), init_opts, options.override(.{ .data_out = &wd, .expand = .both }));
         defer scalew.deinit();
-        dvui.labelNoFmt(@src(), "Scalable", .{}, .{ .border = Rect.all(1), .color_border = dvui.themeGet().focus, .gravity_x = 0.5, .gravity_y = 0.5 });
+        dvui.labelNoFmt(@src(), "Scalable", .{}, .{ .border = .all(1), .color_border = dvui.themeGet().focus, .gravity_x = 0.5, .gravity_y = 0.5 });
     }
 
     pub fn layoutWidgetControls() void {
         const display_opts = StructOptions(dvui.ScaleWidget.InitOptions).initWithDefaults(.{ .scale = .{ .number = .{ .widget_type = .slider_entry, .min = 0, .max = 10 } } }, .{ .scale = &scale });
         dvui.structUI(@src(), "init_opts", &init_opts, 1, .{display_opts}, .{});
+    }
+};
+
+const DisplayScrollArea = struct {
+    var name: []const u8 = "scrollArea()";
+    const nr_radio_buttons = 3;
+
+    var wd: dvui.WidgetData = undefined;
+    var options: dvui.Options = undefined;
+    var init_opts: dvui.ScrollAreaWidget.InitOpts = undefined;
+    var scroll_info: dvui.ScrollInfo = undefined;
+    var nr_widgets: usize = undefined;
+
+    pub fn displayFn(reset: bool) void {
+        if (reset) resetWidget();
+        displayWidgetTemplate(@This());
+    }
+
+    pub fn resetWidget() void {
+        options = .{};
+        init_opts = .{};
+        nr_widgets = 30;
+    }
+
+    pub fn layoutWidget() void {
+        var scroll = dvui.scrollArea(@src(), init_opts, options.override(.{ .data_out = &wd }));
+        defer scroll.deinit();
+        for (0..nr_widgets) |i| {
+            dvui.label(@src(), "Line {}", .{i}, .{ .id_extra = i });
+        }
+    }
+
+    pub fn layoutWidgetControls() void {
+        const display_opts = StructOptions(dvui.ScrollAreaWidget.InitOpts).initWithDefaults(.{}, .{ .scroll_info = &scroll_info });
+        dvui.structUI(@src(), "init_opts", &init_opts, 2, .{display_opts}, .{});
     }
 };
 
@@ -1944,7 +2065,7 @@ const DisplaySeparator = struct {
             var al: dvui.Alignment = .init(@src(), 0);
             defer al.deinit();
             struct_ui.displayOptional(@src(), dvui.Options, "expand", &options.expand, 1, .default, .{}, &al, .horizontal);
-            struct_ui.displayOptional(@src(), dvui.Options, "border", &options.border, 1, .default, .{}, &al, .{});
+            struct_ui.displayOptional(@src(), dvui.Options, "min_size_content", &options.min_size_content, 1, .default, .{}, &al, .all(1));
         }
     }
 };
@@ -2107,7 +2228,7 @@ const DisplaySpacer = struct {
             struct_ui.displayBool(@src(), "border", &border, .{ .boolean = .{ .widget_type = .checkbox } }, &al);
             if (prev_border != border) {
                 if (border) {
-                    options.border = Rect.all(1);
+                    options.border = .all(1);
                 } else {
                     options.border = null;
                 }
@@ -2208,7 +2329,7 @@ const DisplayTabs = struct {
         }
 
         {
-            var border = dvui.Rect.all(1);
+            var border: dvui.Rect = .all(1);
             switch (init_opts.dir) {
                 .horizontal => border.y = 0,
                 .vertical => border.x = 0,
@@ -2518,7 +2639,7 @@ const DisplayToolTip = struct {
 
     pub fn resetWidget() void {
         options = .{};
-        init_opts = .{ .active_rect = Rect.Physical.all(0) };
+        init_opts = .{ .active_rect = .all(0) };
         test_options = .{
             .text = "This is tooltip text",
             .scenario = .@"text only",
@@ -2527,7 +2648,7 @@ const DisplayToolTip = struct {
 
     pub fn layoutWidget() void {
         var label_wd: dvui.WidgetData = undefined;
-        dvui.labelNoFmt(@src(), "Mouse over me", .{}, .{ .border = Rect.all(1), .data_out = &label_wd, .gravity_x = 0.5, .gravity_y = 0.5 });
+        dvui.labelNoFmt(@src(), "Mouse over me", .{}, .{ .border = .all(1), .data_out = &label_wd, .gravity_x = 0.5, .gravity_y = 0.5 });
         init_opts.active_rect = label_wd.borderRectScale().r;
         switch (test_options.scenario) {
             .@"text only" => dvui.tooltip(@src(), init_opts, "{s}", .{test_options.text}, options.override(.{ .data_out = &wd })),
@@ -2538,7 +2659,7 @@ const DisplayToolTip = struct {
                 if (tt.shown()) {
                     var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .both });
                     defer hbox.deinit();
-                    dvui.icon(@src(), "warning", dvui.entypo.warning, .{}, .{ .min_size_content = .all(30), .margin = Rect.all(6) });
+                    dvui.icon(@src(), "warning", dvui.entypo.warning, .{}, .{ .min_size_content = .all(30), .margin = .all(6) });
                     var tl = dvui.textLayout(@src(), .{}, .{ .background = false, .gravity_y = 0.5 });
                     tl.addText(test_options.text, .{});
                     tl.deinit();
@@ -2564,7 +2685,7 @@ const DisplayToolTip = struct {
                 .h = .defaultReadOnly,
             }, null);
             const display_opts = StructOptions(dvui.FloatingTooltipWidget.InitOptions).initWithDefaults(.{
-                .delay = .{ .number = .{ .label = "delay (μs)" } },
+                .delay = .{ .number = .{ .label = "delay (µs)" } },
             }, null);
             dvui.structUI(@src(), "init_opts", &init_opts, 1, .{ display_opts, rect_opts }, .{});
         }
@@ -2600,7 +2721,7 @@ fn structColorPicker(field_name: []const u8, ptr: *anyopaque, read_only: bool, a
             .color_fill = field_value_ptr.*,
             .background = true,
             .gravity_y = 0.5,
-            .margin = Rect.all(6),
+            .margin = .all(6),
         });
         color_box.deinit();
     } else {
@@ -2670,7 +2791,7 @@ const widget_hierarchy = [_]WidgetHierarchy{
         .{ .name = "menuItemLabel", .displayFn = DisplayMenuItemLabel.displayFn, .children = null },
     } },
 
-    .{ .name = "paned", .displayFn = displayEmpty, .children = null },
+    .{ .name = "paned", .displayFn = DisplayPaned.displayFn, .children = null },
 
     .{ .name = "plots", .displayFn = displayEmpty, .children = &.{
         .{ .name = "plot", .displayFn = displayEmpty, .children = null },
@@ -2682,7 +2803,7 @@ const widget_hierarchy = [_]WidgetHierarchy{
     .{ .name = "radioGroup", .displayFn = DisplayRadioGroup.displayFn, .children = null },
     .{ .name = "reorder", .displayFn = displayEmpty, .children = null },
     .{ .name = "scale", .displayFn = DisplayScale.displayFn, .children = null },
-    .{ .name = "scrollArea", .displayFn = displayEmpty, .children = null },
+    .{ .name = "scrollArea", .displayFn = DisplayScrollArea.displayFn, .children = null },
     .{ .name = "separator", .displayFn = DisplaySeparator.displayFn, .children = null },
 
     .{ .name = "sliders", .displayFn = displayEmpty, .children = &.{

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -1847,6 +1847,71 @@ const DisplayPlot = struct {
     }
 };
 
+const DisplayPlotXY = struct {
+    const name: []const u8 = "plotXY()";
+
+    var wd: dvui.WidgetData = undefined;
+    var options: dvui.Options = undefined;
+    var init_opts: dvui.PlotXYOptions = undefined;
+    var x_axis: dvui.PlotWidget.Axis = undefined;
+    var y_axis: dvui.PlotWidget.Axis = undefined;
+    var xs: [20]f64 = undefined;
+    var ys: [20]f64 = undefined;
+
+    var test_options: struct {
+        plot_type: enum { bar, line },
+        seed: u8,
+    } = undefined;
+
+    pub fn displayFn(reset: bool) void {
+        if (reset) resetWidget();
+        displayWidgetTemplate(@This());
+    }
+
+    pub fn resetWidget() void {
+        options = .{ .expand = .both };
+        init_opts = .{ .xs = &xs, .ys = &ys };
+        test_options = .{
+            .plot_type = .bar,
+            .seed = 1,
+        };
+        x_axis = .{
+            .name = "X",
+        };
+        y_axis = .{
+            .name = "Y",
+        };
+    }
+
+    pub fn layoutWidget() void {
+        var rng: std.Random.DefaultPrng = .init(test_options.seed);
+        for (0..xs.len) |i| {
+            xs[i] = @floatFromInt(rng.next() % 50);
+            ys[i] = @floatFromInt(rng.next() % 50);
+        }
+
+        dvui.plotXY(@src(), init_opts, options.override(.{ .data_out = &wd }));
+    }
+
+    // TODO: make these const
+    pub fn layoutWidgetControls() void {
+        dvui.structUI(@src(), test_options_label, &test_options, 1, .{}, .{});
+        const axis_opts: StructOptions(dvui.PlotWidget.Axis) = .initWithDefaults(.{
+            .name = .defaultTextRW,
+        }, null);
+        const tick_opts: StructOptions(dvui.PlotWidget.Axis.TickFormating) = .initWithDefaults(.{
+            .custom = .defaultHidden,
+        }, .{ .normal = .{} });
+        const plot_opts: StructOptions(dvui.PlotWidget.InitOptions) = .initWithDefaults(.{
+            .title = .defaultTextRW,
+        }, .{
+            .x_axis = &x_axis,
+            .y_axis = &y_axis,
+        });
+        dvui.structUI(@src(), "init_opts", &init_opts, 3, .{ plot_opts, axis_opts, struct_options.color, tick_opts }, .{});
+    }
+};
+
 const DisplayProgress = struct {
     const name: []const u8 = "progress()";
 
@@ -3026,7 +3091,7 @@ const widget_hierarchy = [_]WidgetHierarchy{
 
     .{ .name = "plots", .displayFn = displayEmpty, .children = &.{
         .{ .name = "plot", .displayFn = DisplayPlot.displayFn, .children = null },
-        .{ .name = "plotXY", .displayFn = displayEmpty, .children = null },
+        .{ .name = "plotXY", .displayFn = DisplayPlotXY.displayFn, .children = null },
     } },
 
     .{ .name = "progress", .displayFn = DisplayProgress.displayFn, .children = null },

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -1879,7 +1879,7 @@ const DisplayRadioGroup = struct {
     }
 };
 
-const DiplayScale = struct {
+const DisplayScale = struct {
     var name: []const u8 = "scale()";
     const nr_radio_buttons = 3;
 
@@ -1911,7 +1911,7 @@ const DiplayScale = struct {
     }
 };
 
-const DiplaySeparator = struct {
+const DisplaySeparator = struct {
     var name: []const u8 = "separator()";
 
     var wd: dvui.WidgetData = undefined;
@@ -1949,7 +1949,7 @@ const DiplaySeparator = struct {
     }
 };
 
-const DiplaySlider = struct {
+const DisplaySlider = struct {
     var name: []const u8 = "slider()";
 
     var wd: dvui.WidgetData = undefined;
@@ -1992,7 +1992,7 @@ const DiplaySlider = struct {
     }
 };
 
-const DiplaySliderEntry = struct {
+const DisplaySliderEntry = struct {
     var name: []const u8 = "sliderEntry()";
 
     var wd: dvui.WidgetData = undefined;
@@ -2062,7 +2062,7 @@ const DiplaySliderEntry = struct {
     }
 };
 
-const DiplaySpacer = struct {
+const DisplaySpacer = struct {
     var name: []const u8 = "spacer()";
 
     var wd: dvui.WidgetData = undefined;
@@ -2116,7 +2116,7 @@ const DiplaySpacer = struct {
     }
 };
 
-const DiplaySpinner = struct {
+const DisplaySpinner = struct {
     var name: []const u8 = "spinner()";
 
     var wd: dvui.WidgetData = undefined;
@@ -2145,7 +2145,7 @@ const DiplaySpinner = struct {
     }
 };
 
-const DiplayTabs = struct {
+const DisplayTabs = struct {
     var name: []const u8 = "tabs()";
 
     var wd: dvui.WidgetData = undefined;
@@ -2499,7 +2499,7 @@ const DisplayToast = struct {
     }
 };
 
-const DiplayToolTip = struct {
+const DisplayToolTip = struct {
     var name: []const u8 = "tooltip()";
 
     var wd: dvui.WidgetData = undefined;
@@ -2681,20 +2681,20 @@ const widget_hierarchy = [_]WidgetHierarchy{
     .{ .name = "radio", .displayFn = DisplayRadio.displayFn, .children = null },
     .{ .name = "radioGroup", .displayFn = DisplayRadioGroup.displayFn, .children = null },
     .{ .name = "reorder", .displayFn = displayEmpty, .children = null },
-    .{ .name = "scale", .displayFn = DiplayScale.displayFn, .children = null },
+    .{ .name = "scale", .displayFn = DisplayScale.displayFn, .children = null },
     .{ .name = "scrollArea", .displayFn = displayEmpty, .children = null },
-    .{ .name = "separator", .displayFn = DiplaySeparator.displayFn, .children = null },
+    .{ .name = "separator", .displayFn = DisplaySeparator.displayFn, .children = null },
 
     .{ .name = "sliders", .displayFn = displayEmpty, .children = &.{
-        .{ .name = "slider", .displayFn = DiplaySlider.displayFn, .children = null },
-        .{ .name = "sliderEntry", .displayFn = DiplaySliderEntry.displayFn, .children = null },
+        .{ .name = "slider", .displayFn = DisplaySlider.displayFn, .children = null },
+        .{ .name = "sliderEntry", .displayFn = DisplaySliderEntry.displayFn, .children = null },
         .{ .name = "sliderVector", .displayFn = displayEmpty, .children = null },
     } },
 
-    .{ .name = "spacer", .displayFn = DiplaySpacer.displayFn, .children = null },
-    .{ .name = "spinner", .displayFn = DiplaySpinner.displayFn, .children = null },
+    .{ .name = "spacer", .displayFn = DisplaySpacer.displayFn, .children = null },
+    .{ .name = "spinner", .displayFn = DisplaySpinner.displayFn, .children = null },
     .{ .name = "suggestion", .displayFn = displayEmpty, .children = null },
-    .{ .name = "tabs", .displayFn = DiplayTabs.displayFn, .children = null },
+    .{ .name = "tabs", .displayFn = DisplayTabs.displayFn, .children = null },
 
     .{ .name = "textEntries", .displayFn = displayEmpty, .children = &.{
         .{ .name = "textEntry", .displayFn = DisplayTextEntry.displayFn, .children = null },
@@ -2704,7 +2704,7 @@ const widget_hierarchy = [_]WidgetHierarchy{
 
     .{ .name = "textLayout", .displayFn = displayEmpty, .children = null },
     .{ .name = "toast", .displayFn = DisplayToast.displayFn, .children = null },
-    .{ .name = "tooltip", .displayFn = DiplayToolTip.displayFn, .children = null },
+    .{ .name = "tooltip", .displayFn = DisplayToolTip.displayFn, .children = null },
 };
 
 const lorem: []const []const u8 = &.{

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -600,7 +600,6 @@ const DisplayCheckbox = struct {
     pub fn resetWidget() void {
         init_opts = .{};
         options = .{};
-        test_options.checked = false;
         test_options = .{
             .label_str = "checkbox label",
             .checked = false,
@@ -1061,7 +1060,7 @@ const DisplayWindowHeader = struct {
         dvui.icon(@src(), "rocket", dvui.entypo.rocket, .{}, .{ .expand = .both });
     }
 
-    pub fn displayResults() void {
+    pub fn layoutResults() void {
         const result_c = result;
         dvui.structUI(@src(), null, &result_c, 1, .{}, .{});
     }
@@ -1081,9 +1080,6 @@ const DisplayFocusGroup = struct {
     var init_opts: dvui.FocusGroupWidget.InitOptions = .{};
     var options: dvui.Options = undefined;
     var first_frame: bool = undefined;
-    var test_options: struct {
-        label: []const u8,
-    } = undefined;
 
     pub fn displayFn(reset: bool) void {
         if (reset) resetWidget();
@@ -1093,7 +1089,6 @@ const DisplayFocusGroup = struct {
     pub fn resetWidget() void {
         init_opts = .{};
         options = .{};
-        test_options = .{ .label = "Expander" };
         first_frame = true;
     }
 
@@ -1282,8 +1277,6 @@ const DisplayLabelEx = struct {
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
     var init_opts: dvui.LabelWidget.InitOptions = undefined;
-    var icon_opts: dvui.IconRenderOptions = undefined;
-    var icon_bytes: []const u8 = undefined;
     var test_opts: struct {
         label: []const u8,
     } = undefined;
@@ -1324,8 +1317,6 @@ const DisplayLabelClick = struct {
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
     var init_opts: dvui.LabelClickOptions = undefined;
-    var icon_opts: dvui.IconRenderOptions = undefined;
-    var icon_bytes: []const u8 = undefined;
     var test_opts: struct {
         label: []const u8,
     } = undefined;
@@ -1480,8 +1471,6 @@ const DisplayMenu = struct {
 
     pub fn layoutWidgetControls() void {
         dvui.structUI(@src(), test_options_label, &test_options, 1, .{}, .{});
-        var al: dvui.Alignment = .init(@src(), 0);
-        defer al.deinit();
     }
 };
 
@@ -1492,10 +1481,6 @@ const DisplayMenuItem = struct {
     var options: dvui.Options = undefined;
     var init_opts: dvui.MenuItemWidget.InitOptions = undefined;
     var checked: bool = false;
-    var test_options: struct {
-        scenario: enum { @"text only", @"with icon" },
-        text: []const u8,
-    } = undefined;
 
     pub fn displayFn(reset: bool) void {
         if (reset) resetWidget();
@@ -1967,7 +1952,6 @@ const DisplayRadioGroup = struct {
 
 const DisplayScale = struct {
     var name: []const u8 = "scale()";
-    const nr_radio_buttons = 3;
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -1999,7 +1983,6 @@ const DisplayScale = struct {
 
 const DisplayScrollArea = struct {
     var name: []const u8 = "scrollArea()";
-    const nr_radio_buttons = 3;
 
     var wd: dvui.WidgetData = undefined;
     var options: dvui.Options = undefined;
@@ -2121,7 +2104,7 @@ const DisplayScrollArea = struct {
                 }, &al);
             } else {
                 struct_ui.displayNumber(@src(), "x", &field_value_ptr.x, .defaultReadOnly, &al);
-                struct_ui.displayNumber(@src(), "y`", &field_value_ptr.y, .defaultReadOnly, &al);
+                struct_ui.displayNumber(@src(), "y", &field_value_ptr.y, .defaultReadOnly, &al);
             }
             struct_ui.displayNumber(@src(), "w", &field_value_ptr.w, .defaultReadOnly, &al);
             struct_ui.displayNumber(@src(), "h", &field_value_ptr.h, .defaultReadOnly, &al);
@@ -2731,7 +2714,6 @@ const DisplayToast = struct {
     var options: dvui.Options = undefined;
     var init_opts: dvui.ToastOptions = undefined;
     var selection: ?enum { @"widgetpedia window" } = null;
-    var box_id: dvui.Id = undefined;
 
     var test_options: struct {
         message: []const u8,
@@ -2768,7 +2750,6 @@ const DisplayToast = struct {
 
         var box = dvui.box(@src(), .{ .dir = .horizontal }, .{});
         defer box.deinit();
-        box_id = box.data().id;
 
         dvui.label(@src(), "{s}", .{field_name}, .{});
         var hbox_aligned = dvui.box(@src(), .{ .dir = .horizontal }, .{ .margin = alignment.margin(box.data().id) });

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -2053,21 +2053,27 @@ const DisplayScrollArea = struct {
         }, .{ .scroll_info = &scroll_info, .frame_viewport = .{ .x = 100, .y = 100 }, .user_scroll = &user_scroll });
         const si_opts: StructOptions(dvui.ScrollInfo) = .initWithDefaults(.{
             .viewport = .{ .number = .{ .customDisplayFn = displayViewport } },
-            .velocity = .{ .number = .{ .customDisplayFn = displayVelocity } },
         }, null);
-        // TODO: This is another example of need for struct_ui enhancement. There are multiple points and we
-        // need to override one of them (velocity). Ideally we'd just like to override velocity with it's own options
+        // Only override the Point type display for fields named "velocity"
+        const velocity_opts = StructOptions(dvui.Point).init(.{
+            .x = .{ .number = .{ .widget_type = .number_placeholder } },
+            .y = .{ .number = .{ .widget_type = .number_placeholder } },
+        }, null).forFieldName("velocity");
+
+        // TODO: Need struct_ui enhancement to mark struct fields as read-only
+        // and propogate that to the struct's fields.
+        // But ew also need a soft "const" that recursively propogates read-only to all children.
         const point_opts: StructOptions(dvui.Point) = .init(.{
             .x = .defaultReadOnly,
             .y = .defaultReadOnly,
         }, null);
-        // TODO: Same with size
+        // TODO: Same issue with size
         const size_opts: StructOptions(dvui.Size) = .init(.{
             .w = .defaultReadOnly,
             .h = .defaultReadOnly,
         }, null);
 
-        dvui.structUI(@src(), "init_opts", &init_opts, 2, .{ display_opts, si_opts, point_opts, size_opts }, .{});
+        dvui.structUI(@src(), "init_opts", &init_opts, 2, .{ display_opts, velocity_opts, si_opts, point_opts, size_opts }, .{});
     }
 
     fn displayViewport(field_name: []const u8, ptr: *anyopaque, _: bool, _: *dvui.Alignment) void {
@@ -2968,4 +2974,5 @@ const lorem: []const []const u8 = &.{
 
 const struct_ui = dvui.struct_ui;
 const StructOptions = struct_ui.StructOptions;
+const StructOptionsForField = struct_ui.StructOptionsForField;
 const Rect = dvui.Rect;

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -2050,9 +2050,11 @@ const DisplayScrollArea = struct {
         }
         const display_opts: StructOptions(dvui.ScrollAreaWidget.InitOpts) = .initWithDefaults(.{
             .focus_id = .{ .standard = .{ .customDisplayFn = displayFocusId } },
+            .user_scroll = .defaultConst,
         }, .{ .scroll_info = &scroll_info, .frame_viewport = .{ .x = 100, .y = 100 }, .user_scroll = &user_scroll });
         const si_opts: StructOptions(dvui.ScrollInfo) = .initWithDefaults(.{
             .viewport = .{ .number = .{ .customDisplayFn = displayViewport } },
+            .virtual_size = .defaultConst,
         }, null);
         // Only override the Point type display for fields named "velocity"
         const velocity_opts = StructOptions(dvui.Point).init(.{
@@ -2060,20 +2062,7 @@ const DisplayScrollArea = struct {
             .y = .{ .number = .{ .widget_type = .number_placeholder } },
         }, null).forFieldName("velocity");
 
-        // TODO: Need struct_ui enhancement to mark struct fields as read-only
-        // and propogate that to the struct's fields.
-        // But ew also need a soft "const" that recursively propogates read-only to all children.
-        const point_opts: StructOptions(dvui.Point) = .init(.{
-            .x = .defaultReadOnly,
-            .y = .defaultReadOnly,
-        }, null);
-        // TODO: Same issue with size
-        const size_opts: StructOptions(dvui.Size) = .init(.{
-            .w = .defaultReadOnly,
-            .h = .defaultReadOnly,
-        }, null);
-
-        dvui.structUI(@src(), "init_opts", &init_opts, 2, .{ display_opts, velocity_opts, si_opts, point_opts, size_opts }, .{});
+        dvui.structUI(@src(), "init_opts", &init_opts, 2, .{ display_opts, velocity_opts, si_opts }, .{});
     }
 
     fn displayViewport(field_name: []const u8, ptr: *anyopaque, _: bool, _: *dvui.Alignment) void {
@@ -2304,7 +2293,7 @@ const DisplaySliderEntry = struct {
     pub fn layoutWidgetControls() void {
         // TODO: StructUI needs a way to support read-write optionals to read-only text. at the moment it is tied to the field, so display
         // sets both whether the optional can be changed and whether the value can be changed. Here we want user to set the optional to null or not
-        // buty not set label_fmt
+        // but not set label_fmt
         if (struct_ui.displayContainer(@src(), test_options_label)) |container| {
             defer container.deinit();
             var al: dvui.Alignment = .init(@src(), 0);
@@ -2814,18 +2803,11 @@ const DisplayToolTip = struct {
             dvui.structUI(@src(), test_options_label, &test_options, 1, .{display_opts}, .{});
         }
         {
-            // TODO: Annoyingly we can't just set the field to read_only because it does not yet propagate to the children of the field.
-            // Needs an enhancement to struct_ui.
-            const rect_opts: StructOptions(dvui.Rect.Physical) = .initWithDefaults(.{
-                .x = .defaultReadOnly,
-                .y = .defaultReadOnly,
-                .w = .defaultReadOnly,
-                .h = .defaultReadOnly,
-            }, null);
             const display_opts = StructOptions(dvui.FloatingTooltipWidget.InitOptions).initWithDefaults(.{
                 .delay = .{ .number = .{ .label = "delay (µs)" } },
+                .active_rect = .defaultConst,
             }, null);
-            dvui.structUI(@src(), "init_opts", &init_opts, 1, .{ display_opts, rect_opts }, .{});
+            dvui.structUI(@src(), "init_opts", &init_opts, 1, .{display_opts}, .{});
         }
 
         if (init_opts.position == .absolute) {

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -8,9 +8,6 @@
 //! string_map holds any heap-allocated memory created when strings are modified.
 //! These are automatically cleaned up during Window.deinit().
 
-// TODO: Add OptionalFieldOptions that can have different display options for the optional
-// vs the value of the optional. i.e. can set a field to be null or a read-only string
-
 pub const defaults = struct {
     /// display structs and sub-structs expanded
     pub var display_expanded: bool = true;
@@ -159,7 +156,11 @@ pub const FieldOptions = union(enum) {
         switch (self) {
             inline else => |fo| {
                 if (@hasField(@TypeOf(fo), "child")) {
-                    return fo.child.asFieldOption() orelse self;
+                    return fo.child.asFieldOption() orelse .{ .standard = .{
+                        .display = fo.display,
+                        .label = fo.label,
+                        .customDisplayFn = fo.customDisplayFn,
+                    } };
                 }
                 return self;
             },

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -33,6 +33,7 @@ const log = std.log.scoped(.struct_ui);
 /// - display: DisplayMode
 /// - label: ?[]const u8
 /// - customDisplayFn: ?*const fn(field_name: []const u8, field_value_ptr: *anyopaque, read_only: bool, al: *dvui.Alignment)
+/// - default_expanded: ?bool
 pub const FieldOptions = union(enum) {
     /// Control if the field should be displayed and if it is editable.
     const DisplayMode = enum {
@@ -185,6 +186,13 @@ pub const FieldOptions = union(enum) {
         }
     }
 
+    /// For container fields, controls whether the field is displayed expanded or collapsed.
+    pub fn defaultExpanded(self: FieldOptions) bool {
+        return switch (self) {
+            inline else => |*fo| fo.default_expanded orelse defaults.display_expanded,
+        };
+    }
+
     pub fn hasCustomDisplayFn(self: FieldOptions) bool {
         switch (self) {
             inline else => |fo| return fo.customDisplayFn != null,
@@ -213,6 +221,9 @@ pub const StandardFieldOptions = struct {
     customDisplayFn: ?*const fn ([]const u8, *anyopaque, bool, *dvui.Alignment) void = null,
 
     label: ?[]const u8 = null,
+    // For container fields, controls if the container displayed expanded or collapsed.
+    // If not set uses defaults.display_expnaded.
+    default_expanded: ?bool = null,
 };
 
 /// Creates a default set of field options for a struct or union.
@@ -365,6 +376,7 @@ pub const NumberFieldOptions = struct {
     display: FieldOptions.DisplayMode = .read_write,
     label: ?[]const u8 = null,
     customDisplayFn: ?*const fn ([]const u8, *anyopaque, bool, *dvui.Alignment) void = null,
+    default_expanded: ?bool = null,
 
     /// For .read_write, display as either a text entry box or as a slider.
     widget_type: enum {
@@ -734,6 +746,7 @@ pub const BoolFieldOptions = struct {
     display: FieldOptions.DisplayMode = .read_write,
     label: ?[]const u8 = null,
     customDisplayFn: ?*const fn ([]const u8, *anyopaque, bool, *dvui.Alignment) void = null,
+    default_expanded: ?bool = null,
     widget_type: union(enum) {
         // true/false/null dropdown.
         dropdown: void,
@@ -864,6 +877,7 @@ pub const TextFieldOptions = struct {
     display: FieldOptions.DisplayMode = .read_write,
     label: ?[]const u8 = null,
     customDisplayFn: ?*const fn ([]const u8, *anyopaque, bool, *dvui.Alignment) void = null,
+    default_expanded: ?bool = false,
     multiline: bool = false,
 
     /// Set to true if the string is heap allocated and should be
@@ -1040,6 +1054,7 @@ pub const OptionalFieldOptions = struct {
     customDisplayFn: ?*const fn ([]const u8, *anyopaque, bool, *dvui.Alignment) void = null,
 
     label: ?[]const u8 = null,
+    default_expanded: ?bool = null,
     /// the optional and the option's value can have different display modes.
     child: FieldOptions.ChildFieldOptions = .none,
 
@@ -1224,7 +1239,7 @@ pub fn displayArray(
     validateFieldPtrType(field_name, &.{.array}, "displayArray", @TypeOf(field_value_ptr));
     if (field_option.displayMode() == .none) return;
 
-    if (displayContainer(src, field_option.displayLabel(field_name))) |vbox| {
+    if (displayContainer(src, field_option.displayLabel(field_name), field_option.defaultExpanded())) |vbox| {
         defer vbox.deinit();
         var alignment: dvui.Alignment = .init(@src(), depth);
         defer alignment.deinit();
@@ -1254,7 +1269,7 @@ pub fn displaySlice(
     validateFieldPtrTypeSlice(field_name, "displaySlice", @TypeOf(field_value_ptr));
     if (field_option.displayMode() == .none) return;
 
-    if (displayContainer(src, field_option.displayLabel(field_name))) |vbox| {
+    if (displayContainer(src, field_option.displayLabel(field_name), field_option.defaultExpanded())) |vbox| {
         defer vbox.deinit();
         var alignment: dvui.Alignment = .init(@src(), depth);
         defer alignment.deinit();
@@ -1297,7 +1312,7 @@ pub fn displayUnion(
     const current_choice = std.meta.activeTag(field_value_ptr.*);
     const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.displayMode() != .read_write;
 
-    if (displayContainer(src, field_option.displayLabel(field_name))) |vbox| {
+    if (displayContainer(src, field_option.displayLabel(field_name), field_option.defaultExpanded())) |vbox| {
         defer vbox.deinit();
 
         const UnionT = @TypeOf(field_value_ptr.*);
@@ -1507,7 +1522,7 @@ pub fn displayStruct(
     const StructT = @TypeOf(field_value_ptr.*);
     const struct_options: StructOptions(StructT) = findMatchingStructOption(StructT, field_name orelse "", options) orelse .initWithDefaults(.{}, null);
 
-    const vbox: ?*dvui.BoxWidget = displayContainer(src, if (field_name) |name| field_option.displayLabel(name) else null);
+    const vbox: ?*dvui.BoxWidget = displayContainer(src, if (field_name) |name| field_option.displayLabel(name) else null, field_option.defaultExpanded());
     if (vbox != null) {
         var struct_alignment: dvui.Alignment = .init(@src(), depth);
         defer struct_alignment.deinit();
@@ -1540,12 +1555,12 @@ pub fn displayStruct(
 
 /// Create and expander to display a container field and indent the container's fields.
 /// can be used for the custom display of structs and unions.
-pub fn displayContainer(src: std.builtin.SourceLocation, field_name: ?[]const u8) ?*dvui.BoxWidget {
+pub fn displayContainer(src: std.builtin.SourceLocation, field_name: ?[]const u8, default_expanded: bool) ?*dvui.BoxWidget {
     var vbox: ?*dvui.BoxWidget = null;
     if (field_name == null or dvui.expander(
         src,
         field_name.?,
-        .{ .default_expanded = defaults.display_expanded },
+        .{ .default_expanded = default_expanded },
         .{ .expand = .horizontal },
     )) {
         // Use src again in case exoander is not created.

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -8,6 +8,9 @@
 //! string_map holds any heap-allocated memory created when strings are modified.
 //! These are automatically cleaned up during Window.deinit().
 
+// TODO: Add OptionalFieldOptions that can have different display options for the optional
+// vs the value of the optional. i.e. can set a field to be null or a read-only string
+
 pub const defaults = struct {
     /// display structs and sub-structs expanded
     pub var display_expanded: bool = true;
@@ -50,6 +53,28 @@ pub const FieldOptions = union(enum) {
     number: NumberFieldOptions,
     text: TextFieldOptions,
     boolean: BoolFieldOptions,
+    optional: OptionalFieldOptions,
+
+    // Types without a FieldOptions field
+    // Prevent FieldOptions becoming a recursive type.
+    pub const ChildFieldOptions = union(enum) {
+        none: void,
+        standard: StandardFieldOptions,
+        number: NumberFieldOptions,
+        text: TextFieldOptions,
+        boolean: BoolFieldOptions,
+        // optional excluded as it contains child FieldOptions field.
+
+        pub fn asFieldOption(self: ChildFieldOptions) ?FieldOptions {
+            switch (self) {
+                .none => return null,
+                .standard => |fo| return @unionInit(FieldOptions, "standard", fo),
+                .number => |fo| return @unionInit(FieldOptions, "number", fo),
+                .text => |fo| return @unionInit(FieldOptions, "text", fo),
+                .boolean => |fo| return @unionInit(FieldOptions, "boolean", fo),
+            }
+        }
+    };
 
     /// All field can use `default` standard field option, however using the correct field
     /// option will ensure the field is displayed correctly.
@@ -115,6 +140,30 @@ pub const FieldOptions = union(enum) {
                 return .{};
             },
         };
+    }
+
+    pub fn optionOptional(self: FieldOptions, _: []const u8) OptionalFieldOptions {
+        return switch (self) {
+            .optional => |fo| fo,
+            inline else => |fo| .{
+                .label = fo.label,
+                .display = fo.display,
+                .customDisplayFn = fo.customDisplayFn,
+            },
+        };
+    }
+
+    /// If this FieldOption supports child options,
+    /// return the child options, otherwise return self.
+    pub fn childOption(self: FieldOptions) FieldOptions {
+        switch (self) {
+            inline else => |fo| {
+                if (@hasField(@TypeOf(fo), "child")) {
+                    return fo.child.asFieldOption() orelse self;
+                }
+                return self;
+            },
+        }
     }
 
     pub fn displayMode(self: FieldOptions) DisplayMode {
@@ -991,25 +1040,40 @@ pub fn unionFieldWidget(
     return active_tag;
 }
 
+/// Standard field options allow control of the display mode and
+/// option to provide an alternative label.
+/// All FieldOption types must support the display and label fields.
+pub const OptionalFieldOptions = struct {
+    display: FieldOptions.DisplayMode = .read_write,
+    /// Display the field using this function, instead of the default struct_ui function.
+    customDisplayFn: ?*const fn ([]const u8, *anyopaque, bool, *dvui.Alignment) void = null,
+
+    label: ?[]const u8 = null,
+    /// the optional and the option's value can have different display modes.
+    child: FieldOptions.ChildFieldOptions = .none,
+
+    pub const default: OptionalFieldOptions = .{};
+};
+
 /// Display an optional
 /// returns true if optional is not null
 pub fn optionalFieldWidget(
     src: std.builtin.SourceLocation,
     field_name: []const u8,
     field_value_ptr: anytype,
-    opts: FieldOptions,
+    opts: OptionalFieldOptions,
     alignment: *dvui.Alignment,
 ) bool {
     validateFieldPtrType(null, &.{.optional}, "optionalFieldWidget", @TypeOf(field_value_ptr));
 
     // Display mode is ignored. It controls whether the optional value is read_only, not the optional itself.
-    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or opts.isReadOnly();
+    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or isReadOnly(opts);
 
     var choice: usize = if (field_value_ptr.* == null) 0 else 1; // 0 = Null, 1 = Not Null
 
     var hbox = dvui.box(src, .{ .dir = .horizontal }, .{});
     defer hbox.deinit();
-    dvui.label(@src(), "{s}?", .{opts.displayLabel(field_name)}, .{ .margin = .{ .y = 4 } });
+    dvui.label(@src(), "{s}?", .{opts.label orelse field_name}, .{ .margin = .{ .y = 4 } });
     {
         var hbox_aligned = dvui.box(@src(), .{ .dir = .horizontal }, .{ .margin = alignment.margin(hbox.data().id) });
         defer hbox_aligned.deinit();
@@ -1315,19 +1379,19 @@ pub fn displayOptional(
     if (field_option.displayMode() == .none) return;
 
     const optional = @typeInfo(@TypeOf(field_value_ptr.*)).optional;
-
+    const child_field_option = field_option.childOption();
     // Shortcut some common optionals
     switch (@typeInfo(optional.child)) {
         .bool => {
-            boolFieldWidgetOptional(src, field_name, field_value_ptr, field_option.optionBool(field_name), al);
+            boolFieldWidgetOptional(src, field_name, field_value_ptr, child_field_option.optionBool(field_name), al);
             return;
         },
         .@"enum" => {
-            enumFieldWidgetOptional(src, field_name, field_value_ptr, field_option.optionStandard(field_name), al);
+            enumFieldWidgetOptional(src, field_name, field_value_ptr, child_field_option.optionStandard(field_name), al);
             return;
         },
         .int, .float => {
-            const fo = field_option.optionNumber(field_name);
+            const fo = child_field_option.optionNumber(field_name);
             if (fo.widget_type == .number_entry) {
                 numberFieldWidgetOptional(@src(), field_name, field_value_ptr, fo, al);
                 return;
@@ -1337,7 +1401,7 @@ pub fn displayOptional(
     }
 
     const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.isReadOnly();
-    if (optionalFieldWidget(src, field_name, field_value_ptr, field_option, al)) {
+    if (optionalFieldWidget(src, field_name, field_value_ptr, field_option.optionOptional(field_name), al)) {
         if (!read_only) {
             if (field_value_ptr.* == null) {
                 field_value_ptr.* = default_value orelse
@@ -1345,7 +1409,7 @@ pub fn displayOptional(
             }
         }
         if (field_value_ptr.*) |*val| {
-            displayField(@src(), ContainerT, field_name, val, depth, field_option, options, al);
+            displayField(@src(), ContainerT, field_name, val, depth, child_field_option, options, al);
         } else {
             log.debug("Optional field {s} cannot be selected as no default value is provided. Use struct_ui.StructOptions({s}) with a default or StructOptions({s}) with a default, setting a value for {s}.", .{
                 field_name,

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -1031,7 +1031,7 @@ pub fn unionFieldWidget(
     return active_tag;
 }
 
-/// Opiotnal field options can provide separate field options for both
+/// Optional field options can provide separate field options for both
 /// the optional and the optional's value.
 /// The value for the optional is set via the `child` field.
 pub const OptionalFieldOptions = struct {
@@ -1317,7 +1317,13 @@ pub fn displayUnion(
                         } else {
                             log.debug(
                                 "Union field {s}.{s} cannot be selected as no default value is provided. Use struct_ui.StructOptions({s}) to provide a default.",
-                                .{ field_name, @tagName(choice), @typeName(@FieldType(UnionT, @tagName(choice))) },
+                                .{
+                                    field_name, @tagName(choice),
+                                    switch (@typeInfo(@FieldType(UnionT, @tagName(choice)))) {
+                                        .@"union", .@"struct" => @typeName(@FieldType(UnionT, @tagName(choice))),
+                                        else => @typeName(UnionT),
+                                    },
+                                },
                             );
                             return;
                         }
@@ -1559,7 +1565,7 @@ pub fn defaultValue(T: type, ContainerT: type, comptime field_name: []const u8, 
     // If the containing struct has a default value, get the field's default value from
     // the corresponding field within the struct's default value.
     inline for (struct_options) |option| {
-        if (@TypeOf(option).StructT == ContainerT) {
+        if (@TypeOf(option).StructT == ContainerT and @typeInfo(ContainerT) == .@"struct") {
             if (option.default_value) |default_value| {
                 if (@typeInfo(@FieldType(ContainerT, field_name)) == .optional) {
                     if (@field(default_value, field_name) != null) {
@@ -1609,6 +1615,7 @@ pub fn defaultValue(T: type, ContainerT: type, comptime field_name: []const u8, 
         },
 
         inline .@"enum" => |e| return @enumFromInt(e.fields[0].value),
+        inline .void => return {},
         inline else => return null,
     }
 }

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -383,7 +383,7 @@ pub const NumberFieldOptions = struct {
         slider_entry,
         // Apply a number only when the user presses enter.
         // Display the value as a placeholder if no value is being entered.
-        number_placeholder,
+        entry_on_enter,
     } = .number_entry,
     /// Minimum value - required if widget_type is slider.
     min: ?f64 = null,
@@ -514,7 +514,7 @@ pub fn numberFieldWidget(
             if (!defaults.narrow or read_only)
                 dvui.label(@src(), "{d}", .{field_value_ptr.*}, .{ .margin = .{ .y = 4 } });
         },
-        .number_placeholder => {
+        .entry_on_enter => {
             var box = dvui.box(src, .{ .dir = .horizontal }, .{});
             defer box.deinit();
 
@@ -651,7 +651,7 @@ pub fn numberFieldWidgetOptional(
             if (!defaults.narrow or read_only)
                 dvui.label(@src(), "{?d}", .{field_value_optional_ptr.*}, .{ .margin = .{ .y = 4 } });
         },
-        .slider, .slider_entry, .number_placeholder => {
+        .slider, .slider_entry, .entry_on_enter => {
             unreachable;
         },
     }
@@ -1041,9 +1041,9 @@ pub fn unionFieldWidget(
     return active_tag;
 }
 
-/// Standard field options allow control of the display mode and
-/// option to provide an alternative label.
-/// All FieldOption types must support the display and label fields.
+/// Opiotnal field options can provide separate field options for both
+/// the optional and the optional's value.
+/// The value for the optional is set via the `child` field.
 pub const OptionalFieldOptions = struct {
     display: FieldOptions.DisplayMode = .read_write,
     /// Display the field using this function, instead of the default struct_ui function.
@@ -1317,7 +1317,7 @@ pub fn displayUnion(
                 inline else => |choice| {
                     const default_value = defaultValue(
                         @FieldType(UnionT, @tagName(choice)),
-                        @FieldType(UnionT, @tagName(choice)),
+                        UnionT,
                         field_name,
                         options,
                     );
@@ -1438,7 +1438,7 @@ pub fn displayPointer(
 
     const field_option = blk: {
         const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const;
-        if (read_only and field_option_.displayMode() == .read_write) {
+        if (field_option_.displayMode() == .constant or (read_only and field_option_.displayMode() != .none)) {
             // Everything pointed to by a pointer to const must be const.
             var field_option = field_option_;
             field_option.markConst();
@@ -1506,12 +1506,11 @@ pub fn displayStruct(
             @compileError("The struct_ui.displayStruct() options parameter must be passed as a tuple of StructOptions");
         }
     }
-    if (field_option.standard.display == .none) return null;
+    if (field_option.displayMode() == .none) return null;
 
     const StructT = @TypeOf(field_value_ptr.*);
     const struct_options: StructOptions(StructT) = findMatchingStructOption(StructT, field_name orelse "", options) orelse .initWithDefaults(.{}, null);
 
-    if (field_option.displayMode() == .none) return null;
     const vbox: ?*dvui.BoxWidget = displayContainer(src, if (field_name) |name| field_option.displayLabel(name) else null);
     if (vbox != null) {
         var struct_alignment: dvui.Alignment = .init(@src(), depth);

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -1077,13 +1077,13 @@ pub fn optionalFieldWidget(
         }
     }
     return choice == 1; // Not null
-}
+} //
 
 /// Display a field within a container.
 /// displayField can be used when iterating through a list of fields of varying types.
 /// it will call the correct display function based on the type of the field.
 /// NOTE: Inlining this slightly speeds up Debug compile times and also reduces binary
-/// size in optimization modes, except ReleaseSmall
+/// size in all optimization modes, except ReleaseSmall (~55k for demo at time of testing)
 /// (With inline)    - ReleaseSmall 7737856 sdl3-standalone.exe
 /// (without inline) - ReleaseSmall 7683072 sdl3-standalone.exe
 pub inline fn displayField(

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -168,16 +168,20 @@ pub fn StructOptions(Struct: type) type {
         else => @compileError(std.fmt.comptimePrint("StructOptions(T) requires Struct or Union, but received a {s}.", .{@typeName(Struct)})),
     }
     return struct {
-        pub const StructOptionsT = std.EnumMap(std.meta.FieldEnum(StructT), FieldOptions);
         const Self = @This();
+
+        pub const StructOptionsT = std.EnumMap(std.meta.FieldEnum(StructT), FieldOptions);
         // Type of struct or union these options belong to
         pub const StructT = Struct;
+
         // display options for each field to be displayed
         field_options: StructOptionsT,
         // A default value to be used whenever an instance of this type is created
         default_value: ?StructT = null,
         // Display the struct using this function, instead of the default struct_ui function.
         customDisplayFn: ?*const fn ([]const u8, *anyopaque, bool, *dvui.Alignment) void = null,
+        // If set, this struct_option will only apply to fields with this name
+        for_field_name: ?[]const u8 = null,
 
         /// Initialize and display only the fields provided.
         /// options: field options for all the fields to be displayed.
@@ -243,6 +247,7 @@ pub fn StructOptions(Struct: type) type {
             };
         }
 
+        /// Use a custom display function to display this struct.
         pub fn initWithDisplayFn(
             // Display the struct using this function, instead of the default struct_ui function.
             customDisplayFn: *const fn (field_name: []const u8, field_value_ptr: *anyopaque, read_only: bool, *dvui.Alignment) void,
@@ -253,6 +258,23 @@ pub fn StructOptions(Struct: type) type {
                 .customDisplayFn = customDisplayFn,
                 .default_value = default_value,
             };
+        }
+
+        /// Helper for setting `for_field_name` after construction.
+        /// If `for_field_name` is set, these options will only apply to fields
+        /// field with that field name.
+        ///
+        /// Useful for common struct such as dvui.Point where you want to display
+        /// different fields of the same type using different widgets.
+        ///
+        /// NOTE: Ordering is important. If there are multiple options for the same struct type
+        /// order the field_name variants before the generic struct options.
+        pub fn forFieldName(self: Self, field_name: []const u8) Self {
+            // This should be rarely used, so this is fine. But if we add more of these
+            // options, move to using an init_opts struct, rather than this builder pattern.
+            var result = self;
+            result.for_field_name = field_name;
+            return result;
         }
 
         /// Return a default value for a field if no default for that field has been supplied through
@@ -1014,7 +1036,7 @@ pub inline fn displayField(
 
     switch (@typeInfo(@typeInfo(PtrT).pointer.child)) {
         .@"struct", .@"union" => {
-            const struct_options = findMatchingStructOption(@TypeOf(field_value_ptr.*), options);
+            const struct_options = findMatchingStructOption(@TypeOf(field_value_ptr.*), field_name, options);
             if (struct_options) |so| {
                 if (so.customDisplayFn) |displayFn| {
                     const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.displayMode() == .read_only;
@@ -1233,7 +1255,7 @@ pub fn displayUnion(
             inline else => |*active, active_tag| {
                 var inner_vbox = dvui.box(@src(), .{ .dir = .vertical }, .{ .expand = .horizontal, .id_extra = @intFromEnum(active_tag) });
                 defer inner_vbox.deinit();
-                const struct_options: StructOptions(UnionT) = findMatchingStructOption(UnionT, options) orelse .initWithDefaults(.{}, null);
+                const struct_options: StructOptions(UnionT) = findMatchingStructOption(UnionT, field_name, options) orelse .initWithDefaults(.{}, null);
                 var alignment: dvui.Alignment = .init(@src(), depth);
                 defer alignment.deinit();
 
@@ -1401,7 +1423,7 @@ pub fn displayStruct(
     // Potentially introduce a "const" options that propgates read-only to all children.
 
     const StructT = @TypeOf(field_value_ptr.*);
-    const struct_options: StructOptions(StructT) = findMatchingStructOption(StructT, options) orelse .initWithDefaults(.{}, null);
+    const struct_options: StructOptions(StructT) = findMatchingStructOption(StructT, field_name orelse "", options) orelse .initWithDefaults(.{}, null);
 
     if (field_option.displayMode() == .none) return null;
     const vbox: ?*dvui.BoxWidget = displayContainer(src, if (field_name) |name| field_option.displayLabel(name) else null);
@@ -1610,10 +1632,17 @@ pub fn validateFieldPtrTypeString(field_name: ?[]const u8, comptime caller: []co
 }
 
 /// Returns the option from the passed in options tuple for type T.
-pub fn findMatchingStructOption(T: type, struct_options: anytype) ?StructOptions(T) {
+pub fn findMatchingStructOption(T: type, field_name: []const u8, struct_options: anytype) ?StructOptions(T) {
     inline for (struct_options) |struct_option| {
         if (@TypeOf(struct_option).StructT == T) {
-            return struct_option;
+            // Check if these options are for a specific field.
+            if (struct_option.for_field_name) |for_name| {
+                if (std.mem.eql(u8, field_name, for_name)) {
+                    return struct_option;
+                }
+            } else {
+                return struct_option;
+            }
         }
     }
     return null;

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -285,7 +285,14 @@ pub const NumberFieldOptions = struct {
     customDisplayFn: ?*const fn ([]const u8, *anyopaque, bool, *dvui.Alignment) void = null,
 
     /// For .read_write, display as either a text entry box or as a slider.
-    widget_type: enum { number_entry, slider, slider_entry } = .number_entry,
+    widget_type: enum {
+        number_entry,
+        slider,
+        slider_entry,
+        // Apply a number only when the user presses enter.
+        // Display the value as a placeholder if no value is being entered.
+        number_placeholder,
+    } = .number_entry,
     /// Minimum value - required if widget_type is slider.
     min: ?f64 = null,
     /// Maximum value - required if widget_type is slider.
@@ -415,6 +422,36 @@ pub fn numberFieldWidget(
             if (!defaults.narrow or read_only)
                 dvui.label(@src(), "{d}", .{field_value_ptr.*}, .{ .margin = .{ .y = 4 } });
         },
+        .number_placeholder => {
+            var box = dvui.box(src, .{ .dir = .horizontal }, .{});
+            defer box.deinit();
+
+            dvui.label(@src(), "{s}", .{opt.label orelse field_name}, .{ .margin = .{ .y = 4 } });
+
+            var enter_pressed = dvui.dataGetDefault(null, box.data().id, "_enter_pressed", bool, false);
+            defer dvui.dataSet(null, box.data().id, "_enter_pressed", enter_pressed);
+
+            var hbox_aligned = dvui.box(@src(), .{ .dir = .horizontal }, .{ .margin = alignment.margin(box.data().id) });
+            defer hbox_aligned.deinit();
+            alignment.record(box.data().id, hbox_aligned.data());
+
+            if (!read_only) {
+                const value_str = std.fmt.allocPrint(dvui.currentWindow().lifo(), "{d}", .{field_value_ptr.*}) catch "";
+                defer dvui.currentWindow().lifo().free(value_str);
+                const maybe_num = dvui.textEntryNumber(@src(), T, .{
+                    .text = if (enter_pressed) "" else null,
+                    .placeholder = value_str,
+                }, .{});
+                if (maybe_num.value == .Valid and maybe_num.enter_pressed) {
+                    field_value_ptr.* = maybe_num.value.Valid;
+                    enter_pressed = true;
+                } else {
+                    enter_pressed = false;
+                }
+            }
+            if (!defaults.narrow or read_only)
+                dvui.label(@src(), "{d}", .{field_value_ptr.*}, .{ .margin = .{ .y = 4 } });
+        },
         .slider => {
             var box = dvui.box(src, .{ .dir = .horizontal }, .{});
             defer box.deinit();
@@ -511,7 +548,7 @@ pub fn numberFieldWidgetOptional(
             if (!defaults.narrow or read_only)
                 dvui.label(@src(), "{?d}", .{field_value_optional_ptr.*}, .{ .margin = .{ .y = 4 } });
         },
-        .slider, .slider_entry => {
+        .slider, .slider_entry, .number_placeholder => {
             unreachable;
         },
     }

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -1082,6 +1082,10 @@ pub fn optionalFieldWidget(
 /// Display a field within a container.
 /// displayField can be used when iterating through a list of fields of varying types.
 /// it will call the correct display function based on the type of the field.
+/// NOTE: Inlining this slightly speeds up Debug compile times and also reduces binary
+/// size in optimization modes, except ReleaseSmall
+/// (With inline)    - ReleaseSmall 7737856 sdl3-standalone.exe
+/// (without inline) - ReleaseSmall 7683072 sdl3-standalone.exe
 pub inline fn displayField(
     src: std.builtin.SourceLocation,
     comptime ContainerT: type,

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -190,6 +190,7 @@ pub const FieldOptions = union(enum) {
             inline else => |fo| return fo.customDisplayFn != null,
         }
     }
+
     pub fn customDisplayFn(self: FieldOptions, field_name: []const u8, field_value_ptr: *anyopaque, read_only: bool, alignment: *dvui.Alignment) void {
         switch (self) {
             inline else => |fo| if (fo.customDisplayFn) |displayFn| displayFn(field_name, field_value_ptr, read_only, alignment),
@@ -201,18 +202,7 @@ pub const FieldOptions = union(enum) {
             inline else => |*fo| fo.display = .constant,
         }
     }
-
-    pub fn isReadOnly(self: FieldOptions) bool {
-        return switch (self.displayMode()) {
-            .read_only, .constant => true,
-            else => false,
-        };
-    }
 };
-
-fn isReadOnly(self: anytype) bool {
-    return self.display == .read_only or self.display == .constant;
-}
 
 /// Standard field options allow control of the display mode and
 /// option to provide an alternative label.
@@ -487,7 +477,7 @@ pub fn numberFieldWidget(
     if (opt.display == .none) return;
 
     const T = @TypeOf(field_value_ptr.*);
-    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or isReadOnly(opt);
+    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or opt.display != .read_write;
 
     switch (opt.widget_type) {
         .number_entry => {
@@ -621,7 +611,7 @@ pub fn numberFieldWidgetOptional(
     if (opt.display == .none) return;
 
     const T = @TypeOf(field_value_optional_ptr.*.?);
-    const read_only = @typeInfo(@TypeOf(field_value_optional_ptr)).pointer.is_const or isReadOnly(opt);
+    const read_only = @typeInfo(@TypeOf(field_value_optional_ptr)).pointer.is_const or opt.display != .read_write;
 
     switch (opt.widget_type) {
         .number_entry => {
@@ -669,7 +659,7 @@ pub fn enumFieldWidget(
 
     const T = @TypeOf(field_value_ptr.*);
     const exhaustive = @typeInfo(T).@"enum".is_exhaustive;
-    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or isReadOnly(opt);
+    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or opt.display != .read_write;
     if (!read_only and !exhaustive) {
         // TODO: Display these as numbers and do the enum<->int conversion.
         log.debug("non-exhaustive enum {s}.{s} can only be displayed read-only", .{ @typeName(T), field_name });
@@ -712,7 +702,7 @@ pub fn enumFieldWidgetOptional(
     if (opt.display == .none) return;
 
     const T = @TypeOf(field_value_optional_ptr.*.?);
-    const read_only = @typeInfo(@TypeOf(field_value_optional_ptr)).pointer.is_const or isReadOnly(opt);
+    const read_only = @typeInfo(@TypeOf(field_value_optional_ptr)).pointer.is_const or opt.display != .read_write;
     var box = dvui.box(src, .{ .dir = .horizontal }, .{ .expand = .horizontal });
     defer box.deinit();
 
@@ -766,7 +756,7 @@ pub fn boolFieldWidget(
     validateFieldPtrType(null, &.{.bool}, "boolFieldWidget", @TypeOf(field_value_ptr));
     if (opt.display == .none) return;
 
-    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or isReadOnly(opt);
+    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or opt.display != .read_write;
 
     var box = dvui.box(src, .{ .dir = .horizontal }, .{});
     defer box.deinit();
@@ -841,7 +831,7 @@ pub fn boolFieldWidgetOptional(
     validateFieldPtrType(null, &.{.bool}, "boolFieldWidgetOptional", @TypeOf(&field_value_optional_ptr.*.?));
     if (opt.display == .none) return;
 
-    const read_only = @typeInfo(@TypeOf(field_value_optional_ptr)).pointer.is_const or isReadOnly(opt);
+    const read_only = @typeInfo(@TypeOf(field_value_optional_ptr)).pointer.is_const or opt.display != .read_write;
 
     var box = dvui.box(src, .{ .dir = .horizontal }, .{});
     defer box.deinit();
@@ -907,7 +897,7 @@ pub fn textFieldWidget(
 
     const sentinel_terminated = @typeInfo(T).pointer.sentinel_ptr != null;
 
-    var read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or isReadOnly(opt);
+    var read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or opt.display != .read_write;
 
     if (opt.display == .read_write and read_only) {
         // Note all string arrays are currently treated as read-only, even if they are var.
@@ -997,7 +987,7 @@ pub fn unionFieldWidget(
     if (opt.displayMode() == .none) {
         return field_value_ptr.*;
     }
-    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or opt.isReadOnly();
+    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or opt.displayMode() != .read_write;
 
     var box = dvui.box(src, .{ .dir = .vertical }, .{});
     defer box.deinit();
@@ -1068,7 +1058,7 @@ pub fn optionalFieldWidget(
     validateFieldPtrType(null, &.{.optional}, "optionalFieldWidget", @TypeOf(field_value_ptr));
 
     // Display mode is ignored. It controls whether the optional value is read_only, not the optional itself.
-    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or isReadOnly(opts);
+    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or opts.display != .read_write;
 
     var choice: usize = if (field_value_ptr.* == null) 0 else 1; // 0 = Null, 1 = Not Null
 
@@ -1113,7 +1103,7 @@ pub inline fn displayField(
     // 3. Display using the default display functions.
 
     if (field_option.hasCustomDisplayFn()) {
-        const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.isReadOnly();
+        const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.displayMode() != .read_write;
         field_option.customDisplayFn(field_name, @ptrCast(@constCast(field_value_ptr)), read_only, al);
         return;
     }
@@ -1123,7 +1113,7 @@ pub inline fn displayField(
             const struct_options = findMatchingStructOption(@TypeOf(field_value_ptr.*), field_name, options);
             if (struct_options) |so| {
                 if (so.customDisplayFn) |displayFn| {
-                    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.isReadOnly();
+                    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.displayMode() != .read_write;
                     displayFn(field_name, @ptrCast(@constCast(field_value_ptr)), read_only, al);
                     return;
                 }
@@ -1305,7 +1295,7 @@ pub fn displayUnion(
     }
     if (!validFieldOptionsType(field_name, field_option, .standard)) return;
     const current_choice = std.meta.activeTag(field_value_ptr.*);
-    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.isReadOnly();
+    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.displayMode() != .read_write;
 
     if (displayContainer(src, field_option.displayLabel(field_name))) |vbox| {
         defer vbox.deinit();
@@ -1401,7 +1391,7 @@ pub fn displayOptional(
         else => {},
     }
 
-    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.isReadOnly();
+    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.displayMode() != .read_write;
     if (optionalFieldWidget(src, field_name, field_value_ptr, field_option.optionOptional(field_name), al)) {
         if (!read_only) {
             if (field_value_ptr.* == null) {

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -264,8 +264,8 @@ pub fn StructOptions(Struct: type) type {
         /// If `for_field_name` is set, these options will only apply to fields
         /// field with that field name.
         ///
-        /// Useful for common struct such as dvui.Point where you want to display
-        /// different fields of the same type using different widgets.
+        /// Useful for dealing with common struct such as dvui.Point where you want
+        /// to display different fields of the same type using different widgets.
         ///
         /// NOTE: Ordering is important. If there are multiple options for the same struct type
         /// order the field_name variants before the generic struct options.

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -35,7 +35,17 @@ const log = std.log.scoped(.struct_ui);
 /// - customDisplayFn: ?*const fn(field_name: []const u8, field_value_ptr: *anyopaque, read_only: bool, al: *dvui.Alignment)
 pub const FieldOptions = union(enum) {
     /// Control if the field should be displayed and if it is editable.
-    const DisplayMode = enum { none, read_only, read_write };
+    const DisplayMode = enum {
+        /// do not display
+        none,
+        /// display only
+        read_only,
+        /// editable
+        read_write,
+        /// read-only for this field and all children
+        /// treats the field as if it is const
+        constant,
+    };
     standard: StandardFieldOptions,
     number: NumberFieldOptions,
     text: TextFieldOptions,
@@ -51,7 +61,7 @@ pub const FieldOptions = union(enum) {
     pub const defaultBool: FieldOptions = .{ .boolean = .{} };
     pub const defaultHidden: FieldOptions = .{ .standard = .{ .display = .none } };
     pub const defaultReadOnly: FieldOptions = .{ .standard = .{ .display = .read_only } };
-
+    pub const defaultConst: FieldOptions = .{ .standard = .{ .display = .constant } };
     pub fn optionStandard(self: FieldOptions, field_name: []const u8) StandardFieldOptions {
         return switch (self) {
             .standard => |fo| fo,
@@ -137,12 +147,22 @@ pub const FieldOptions = union(enum) {
     }
 
     pub fn markConst(self: *FieldOptions) void {
-        // TODO: Track const separately to read-only.
         switch (self.*) {
-            inline else => |*fo| fo.display = .read_only,
+            inline else => |*fo| fo.display = .constant,
         }
     }
+
+    pub fn isReadOnly(self: FieldOptions) bool {
+        return switch (self.displayMode()) {
+            .read_only, .constant => true,
+            else => false,
+        };
+    }
 };
+
+fn isReadOnly(self: anytype) bool {
+    return self.display == .read_only or self.display == .constant;
+}
 
 /// Standard field options allow control of the display mode and
 /// option to provide an alternative label.
@@ -417,7 +437,7 @@ pub fn numberFieldWidget(
     if (opt.display == .none) return;
 
     const T = @TypeOf(field_value_ptr.*);
-    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or opt.display == .read_only;
+    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or isReadOnly(opt);
 
     switch (opt.widget_type) {
         .number_entry => {
@@ -551,7 +571,7 @@ pub fn numberFieldWidgetOptional(
     if (opt.display == .none) return;
 
     const T = @TypeOf(field_value_optional_ptr.*.?);
-    const read_only = @typeInfo(@TypeOf(field_value_optional_ptr)).pointer.is_const or opt.display == .read_only;
+    const read_only = @typeInfo(@TypeOf(field_value_optional_ptr)).pointer.is_const or isReadOnly(opt);
 
     switch (opt.widget_type) {
         .number_entry => {
@@ -599,7 +619,7 @@ pub fn enumFieldWidget(
 
     const T = @TypeOf(field_value_ptr.*);
     const exhaustive = @typeInfo(T).@"enum".is_exhaustive;
-    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or opt.display == .read_only;
+    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or isReadOnly(opt);
     if (!read_only and !exhaustive) {
         // TODO: Display these as numbers and do the enum<->int conversion.
         log.debug("non-exhaustive enum {s}.{s} can only be displayed read-only", .{ @typeName(T), field_name });
@@ -642,7 +662,7 @@ pub fn enumFieldWidgetOptional(
     if (opt.display == .none) return;
 
     const T = @TypeOf(field_value_optional_ptr.*.?);
-    const read_only = @typeInfo(@TypeOf(field_value_optional_ptr)).pointer.is_const or opt.display == .read_only;
+    const read_only = @typeInfo(@TypeOf(field_value_optional_ptr)).pointer.is_const or isReadOnly(opt);
     var box = dvui.box(src, .{ .dir = .horizontal }, .{ .expand = .horizontal });
     defer box.deinit();
 
@@ -696,7 +716,7 @@ pub fn boolFieldWidget(
     validateFieldPtrType(null, &.{.bool}, "boolFieldWidget", @TypeOf(field_value_ptr));
     if (opt.display == .none) return;
 
-    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or opt.display == .read_only;
+    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or isReadOnly(opt);
 
     var box = dvui.box(src, .{ .dir = .horizontal }, .{});
     defer box.deinit();
@@ -771,7 +791,7 @@ pub fn boolFieldWidgetOptional(
     validateFieldPtrType(null, &.{.bool}, "boolFieldWidgetOptional", @TypeOf(&field_value_optional_ptr.*.?));
     if (opt.display == .none) return;
 
-    const read_only = @typeInfo(@TypeOf(field_value_optional_ptr)).pointer.is_const or opt.display == .read_only;
+    const read_only = @typeInfo(@TypeOf(field_value_optional_ptr)).pointer.is_const or isReadOnly(opt);
 
     var box = dvui.box(src, .{ .dir = .horizontal }, .{});
     defer box.deinit();
@@ -837,8 +857,7 @@ pub fn textFieldWidget(
 
     const sentinel_terminated = @typeInfo(T).pointer.sentinel_ptr != null;
 
-    var read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or
-        opt.display == .read_only;
+    var read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or isReadOnly(opt);
 
     if (opt.display == .read_write and read_only) {
         // Note all string arrays are currently treated as read-only, even if they are var.
@@ -928,7 +947,7 @@ pub fn unionFieldWidget(
     if (opt.displayMode() == .none) {
         return field_value_ptr.*;
     }
-    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or opt.displayMode() == .read_only;
+    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or opt.isReadOnly();
 
     var box = dvui.box(src, .{ .dir = .vertical }, .{});
     defer box.deinit();
@@ -984,7 +1003,7 @@ pub fn optionalFieldWidget(
     validateFieldPtrType(null, &.{.optional}, "optionalFieldWidget", @TypeOf(field_value_ptr));
 
     // Display mode is ignored. It controls whether the optional value is read_only, not the optional itself.
-    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or opts.displayMode() == .read_only;
+    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or opts.isReadOnly();
 
     var choice: usize = if (field_value_ptr.* == null) 0 else 1; // 0 = Null, 1 = Not Null
 
@@ -1029,7 +1048,7 @@ pub inline fn displayField(
     // 3. Display using the default display functions.
 
     if (field_option.hasCustomDisplayFn()) {
-        const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.displayMode() == .read_only;
+        const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.isReadOnly();
         field_option.customDisplayFn(field_name, @ptrCast(@constCast(field_value_ptr)), read_only, al);
         return;
     }
@@ -1039,7 +1058,7 @@ pub inline fn displayField(
             const struct_options = findMatchingStructOption(@TypeOf(field_value_ptr.*), field_name, options);
             if (struct_options) |so| {
                 if (so.customDisplayFn) |displayFn| {
-                    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.displayMode() == .read_only;
+                    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.isReadOnly();
                     displayFn(field_name, @ptrCast(@constCast(field_value_ptr)), read_only, al);
                     return;
                 }
@@ -1221,7 +1240,7 @@ pub fn displayUnion(
     }
     if (!validFieldOptionsType(field_name, field_option, .standard)) return;
     const current_choice = std.meta.activeTag(field_value_ptr.*);
-    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.displayMode() == .read_only;
+    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.isReadOnly();
 
     if (displayContainer(src, field_option.displayLabel(field_name))) |vbox| {
         defer vbox.deinit();
@@ -1260,7 +1279,11 @@ pub fn displayUnion(
                 defer alignment.deinit();
 
                 // Will only display if an option exists for this field.
-                if (struct_options.field_options.get(active_tag)) |union_field_option| {
+                if (struct_options.field_options.get(active_tag)) |union_field_option_| {
+                    var union_field_option = union_field_option_;
+                    if (field_option.displayMode() == .constant and union_field_option.displayMode() != .none) {
+                        union_field_option.markConst();
+                    }
                     displayField(@src(), UnionT, @tagName(active_tag), active, depth, union_field_option, options, &alignment);
                 }
             },
@@ -1313,7 +1336,7 @@ pub fn displayOptional(
         else => {},
     }
 
-    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.displayMode() == .read_only;
+    const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const or field_option.isReadOnly();
     if (optionalFieldWidget(src, field_name, field_value_ptr, field_option, al)) {
         if (!read_only) {
             if (field_value_ptr.* == null) {
@@ -1348,10 +1371,10 @@ pub fn displayPointer(
 ) void {
     validateFieldPtrType(field_name, &.{.pointer}, "displayPointer", @TypeOf(field_value_ptr));
 
-    // TODO: Need a better way of propagating constness. Currently we are just updating the field_option to be .read_only.
     const field_option = blk: {
         const read_only = @typeInfo(@TypeOf(field_value_ptr)).pointer.is_const;
         if (read_only and field_option_.displayMode() == .read_write) {
+            // Everything pointed to by a pointer to const must be const.
             var field_option = field_option_;
             field_option.markConst();
             break :blk field_option;
@@ -1419,8 +1442,6 @@ pub fn displayStruct(
         }
     }
     if (field_option.standard.display == .none) return null;
-    // TODO: If the struct field is marked read-only, then make sure all of the fields in the struct are read-only as well.
-    // Potentially introduce a "const" options that propgates read-only to all children.
 
     const StructT = @TypeOf(field_value_ptr.*);
     const struct_options: StructOptions(StructT) = findMatchingStructOption(StructT, field_name orelse "", options) orelse .initWithDefaults(.{}, null);
@@ -1434,7 +1455,11 @@ pub fn displayStruct(
 
         inline for (0..struct_options.field_options.values.len) |field_num| {
             const field = comptime @TypeOf(struct_options.field_options).Indexer.keyForIndex(field_num);
-            if (struct_options.field_options.contains(field)) {
+            if (struct_options.field_options.get(field)) |child_option_| {
+                var child_option = child_option_;
+                if (field_option.displayMode() == .constant and child_option.displayMode() != .none) {
+                    child_option.markConst();
+                }
                 var box = dvui.box(@src(), .{ .dir = .vertical }, .{ .id_extra = field_num });
                 defer box.deinit();
                 displayField(
@@ -1443,7 +1468,7 @@ pub fn displayStruct(
                     @tagName(field),
                     &@field(field_value_ptr, @tagName(field)),
                     depth,
-                    struct_options.field_options.getAssertContains(field),
+                    child_option,
                     options,
                     alignment,
                 );

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -1077,16 +1077,12 @@ pub fn optionalFieldWidget(
         }
     }
     return choice == 1; // Not null
-} //
+}
 
 /// Display a field within a container.
 /// displayField can be used when iterating through a list of fields of varying types.
 /// it will call the correct display function based on the type of the field.
-/// NOTE: Inlining this slightly speeds up Debug compile times and also reduces binary
-/// size in all optimization modes, except ReleaseSmall (~55k for demo at time of testing)
-/// (With inline)    - ReleaseSmall 7737856 sdl3-standalone.exe
-/// (without inline) - ReleaseSmall 7683072 sdl3-standalone.exe
-pub inline fn displayField(
+pub fn displayField(
     src: std.builtin.SourceLocation,
     comptime ContainerT: type,
     comptime field_name: []const u8,

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -438,13 +438,23 @@ pub fn numberFieldWidget(
             if (!read_only) {
                 const value_str = std.fmt.allocPrint(dvui.currentWindow().lifo(), "{d}", .{field_value_ptr.*}) catch "";
                 defer dvui.currentWindow().lifo().free(value_str);
+                var te_wd: dvui.WidgetData = undefined;
                 const maybe_num = dvui.textEntryNumber(@src(), T, .{
                     .text = if (enter_pressed) "" else null,
                     .placeholder = value_str,
-                }, .{});
+                }, .{ .data_out = &te_wd });
                 if (maybe_num.value == .Valid and maybe_num.enter_pressed) {
-                    field_value_ptr.* = maybe_num.value.Valid;
+                    field_value_ptr.* = std.math.clamp(
+                        maybe_num.value.Valid,
+                        opt.minValue(T),
+                        opt.maxValue(T),
+                    );
                     enter_pressed = true;
+                } else if (maybe_num.value == .Valid and !maybe_num.enter_pressed) {
+                    dvui.tooltip(@src(), .{
+                        .active_rect = te_wd.borderRectScale().r,
+                        .position = .vertical,
+                    }, "Press Enter to set value", .{}, .{});
                 } else {
                     enter_pressed = false;
                 }
@@ -493,6 +503,7 @@ pub fn numberFieldWidget(
                     dvui.tooltip(@src(), .{
                         .active_rect = se_wd.borderRectScale().r,
                         .delay = 1_000_000,
+                        .position = .vertical,
                     }, "Press Enter to type a value", .{}, .{});
                 }
             } else {

--- a/src/struct_ui.zig
+++ b/src/struct_ui.zig
@@ -26,6 +26,7 @@ const log = std.log.scoped(.struct_ui);
 /// Use NumberFieldOptions for any numbers, allowing setting of min and max ranges and other options
 /// Use BooleanFieldOptions for any bools.
 /// Use StandardFieldOptions can be used for any field to give a default layout.
+/// Use OptionalFieldOptions to use different field options for the optional vs the optional's value.
 /// If a custom display function is supplied, they will be used to display the struct instead of
 /// the struct_ui default functions.
 ///
@@ -189,7 +190,7 @@ pub const FieldOptions = union(enum) {
     /// For container fields, controls whether the field is displayed expanded or collapsed.
     pub fn defaultExpanded(self: FieldOptions) bool {
         return switch (self) {
-            inline else => |*fo| fo.default_expanded orelse defaults.display_expanded,
+            inline else => |fo| fo.default_expanded orelse defaults.display_expanded,
         };
     }
 
@@ -222,7 +223,7 @@ pub const StandardFieldOptions = struct {
 
     label: ?[]const u8 = null,
     // For container fields, controls if the container displayed expanded or collapsed.
-    // If not set uses defaults.display_expnaded.
+    // If not set uses defaults.display_expanded.
     default_expanded: ?bool = null,
 };
 
@@ -877,7 +878,7 @@ pub const TextFieldOptions = struct {
     display: FieldOptions.DisplayMode = .read_write,
     label: ?[]const u8 = null,
     customDisplayFn: ?*const fn ([]const u8, *anyopaque, bool, *dvui.Alignment) void = null,
-    default_expanded: ?bool = false,
+    default_expanded: ?bool = null,
     multiline: bool = false,
 
     /// Set to true if the string is heap allocated and should be


### PR DESCRIPTION
widgetpedia:
- Add a splitter between the widget box and widget controls
- floatingWindow()
- windowHeader()
- paned()
- scrollArea (in progress)

Options editor:
- Default color chooser to the theme color for each null color on the Style tab, previously the color picker defaulted to white for all null Style values.