### PR TITLE
defer rendering for overlapping widgets

### DIFF
--- a/src/Examples/scroll_canvas.zig
+++ b/src/Examples/scroll_canvas.zig
@@ -97,9 +97,10 @@ pub fn scrollCanvas() void {
     }
 
     for (boxes, 0..) |*b, i| {
-        const pt = dataRectScale.rectToPhysical(.{ .x = b.x, .y = b.y });
+        const phys = dataRectScale.rectToPhysical(.{ .x = b.x, .y = b.y });
+        const nat = dvui.currentWindow().rectScale().rectFromPhysical(phys);
         var fc: dvui.FloatingWidget = undefined;
-        fc.init(@src(), .{}, .{ .id_extra = i, .rect = .cast(pt) });
+        fc.init(@src(), .{}, .{ .id_extra = i, .rect = nat });
         defer fc.deinit();
         var dragBox = dvui.box(@src(), .{}, .{
             .expand = .both,

--- a/src/Examples/scroll_canvas.zig
+++ b/src/Examples/scroll_canvas.zig
@@ -97,9 +97,12 @@ pub fn scrollCanvas() void {
     }
 
     for (boxes, 0..) |*b, i| {
-        var dr: dvui.DeferRender = undefined;
-        dr.init();
-        defer dr.deinit();
+        // This makes clicks interact with the box that is visually on top, by
+        // reversing the draw order.
+        var ftb: dvui.RenderFrontToBack = undefined;
+        ftb.init();
+        defer ftb.deinit();
+
         var dragBox = dvui.box(@src(), .{}, .{
             .id_extra = i,
             .rect = dvui.Rect{ .x = b.x, .y = b.y },

--- a/src/Examples/scroll_canvas.zig
+++ b/src/Examples/scroll_canvas.zig
@@ -97,9 +97,12 @@ pub fn scrollCanvas() void {
     }
 
     for (boxes, 0..) |*b, i| {
+        const pt = dataRectScale.rectToPhysical(.{ .x = b.x, .y = b.y });
+        var fc: dvui.FloatingWidget = undefined;
+        fc.init(@src(), .{}, .{ .id_extra = i, .rect = .cast(pt) });
+        defer fc.deinit();
         var dragBox = dvui.box(@src(), .{}, .{
-            .id_extra = i,
-            .rect = dvui.Rect{ .x = b.x, .y = b.y },
+            .expand = .both,
             .padding = .{ .h = 5, .w = 5, .x = 5, .y = 5 },
             .background = true,
             .style = .window,

--- a/src/Examples/scroll_canvas.zig
+++ b/src/Examples/scroll_canvas.zig
@@ -97,13 +97,12 @@ pub fn scrollCanvas() void {
     }
 
     for (boxes, 0..) |*b, i| {
-        const phys = dataRectScale.rectToPhysical(.{ .x = b.x, .y = b.y });
-        const nat = dvui.currentWindow().rectScale().rectFromPhysical(phys);
-        var fc: dvui.FloatingWidget = undefined;
-        fc.init(@src(), .{}, .{ .id_extra = i, .rect = nat });
-        defer fc.deinit();
+        var dr: dvui.DeferRender = undefined;
+        dr.init();
+        defer dr.deinit();
         var dragBox = dvui.box(@src(), .{}, .{
-            .expand = .both,
+            .id_extra = i,
+            .rect = dvui.Rect{ .x = b.x, .y = b.y },
             .padding = .{ .h = 5, .w = 5, .x = 5, .y = 5 },
             .background = true,
             .style = .window,

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -14,6 +14,8 @@ backend: dvui.Backend,
 previous_window: ?*Window = null,
 
 subwindows: dvui.Subwindows = .{},
+defer_render_cmds: ?*std.ArrayList(dvui.RenderCommand) = null,
+defer_render_cmds_after: ?*std.ArrayList(dvui.RenderCommand) = null,
 
 last_focused_id_this_frame: Id = .zero,
 last_focused_id_in_subwindow: Id = .zero,
@@ -1260,11 +1262,11 @@ pub fn addRenderCommand(self: *Self, cmd: dvui.RenderCommand.Command, after: boo
         .cmd = cmd,
     };
     if (after) {
-        sw.render_cmds_after.append(self.arena(), render_cmd) catch |err| {
+        (self.defer_render_cmds_after orelse &sw.render_cmds_after).append(self.arena(), render_cmd) catch |err| {
             dvui.logError(@src(), err, "Could not append to render_cmds_after", .{});
         };
     } else {
-        sw.render_cmds.append(self.arena(), render_cmd) catch |err| {
+        (self.defer_render_cmds orelse &sw.render_cmds).append(self.arena(), render_cmd) catch |err| {
             dvui.logError(@src(), err, "Could not append to render_cmds", .{});
         };
     }

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5236,20 +5236,27 @@ pub fn plotXY(src: std.builtin.SourceLocation, init_opts: PlotXYOptions, opts: O
     p.deinit();
 }
 
-/// Defers a whole block of rendering.  Useful if you have overlapping widgets
-/// and want the event handling to match the visual order.
-pub const DeferRender = struct {
+/// Reverse the normal back-to-front rendering order.  Rendering inside is
+/// deferred until after normal rendering.  Multiple RenderFrontToBack blocks are
+/// ordered in reverse, so the first one is rendered last.
+///
+/// Use with overlapping widgets to have event handling match the visual
+/// order (click is handled by the first to run, which will be rendered last
+/// (visually on top).
+pub const RenderFrontToBack = struct {
     /// Uses `arena` allocator
     render_cmds: std.ArrayList(dvui.RenderCommand) = .empty,
     /// Uses `arena` allocator
     render_cmds_after: std.ArrayList(dvui.RenderCommand) = .empty,
 
+    prev_rendering: bool,
     prev_dr_cmds: ?*std.ArrayList(dvui.RenderCommand),
     prev_dr_cmds_after: ?*std.ArrayList(dvui.RenderCommand),
 
-    pub fn init(self: *DeferRender) void {
+    pub fn init(self: *RenderFrontToBack) void {
         const cw = dvui.currentWindow();
         self.* = .{
+            .prev_rendering = renderingSet(false),
             .prev_dr_cmds = cw.defer_render_cmds,
             .prev_dr_cmds_after = cw.defer_render_cmds_after,
         };
@@ -5257,20 +5264,32 @@ pub const DeferRender = struct {
         cw.defer_render_cmds_after = &self.render_cmds_after;
     }
 
-    pub fn deinit(self: *DeferRender) void {
+    pub fn initReset(self: *RenderFrontToBack) void {
+        const cw = dvui.currentWindow();
+        self.* = .{
+            .prev_rendering = renderingSet(false),
+            .prev_dr_cmds = cw.defer_render_cmds,
+            .prev_dr_cmds_after = cw.defer_render_cmds_after,
+        };
+        cw.defer_render_cmds = null;
+        cw.defer_render_cmds_after = null;
+    }
+
+    pub fn deinit(self: *RenderFrontToBack) void {
         const cw = dvui.currentWindow();
 
         // restore previous queues
+        _ = renderingSet(self.prev_rendering);
         cw.defer_render_cmds = self.prev_dr_cmds;
         cw.defer_render_cmds_after = self.prev_dr_cmds_after;
 
         // everything goes into the after queue
         var sw = cw.subwindows.current() orelse &cw.subwindows.stack.items[0];
         (cw.defer_render_cmds_after orelse &sw.render_cmds_after).insertSlice(cw.arena(), 0, self.render_cmds_after.items) catch |err| {
-            dvui.logError(@src(), err, "DeferRender could not insert after to render_cmds_after", .{});
+            dvui.logError(@src(), err, "RenderFrontToBack could not insert after to render_cmds_after", .{});
         };
         (cw.defer_render_cmds_after orelse &sw.render_cmds_after).insertSlice(cw.arena(), 0, self.render_cmds.items) catch |err| {
-            dvui.logError(@src(), err, "DeferRender could not insert normal to render_cmds_after", .{});
+            dvui.logError(@src(), err, "RenderFrontToBack could not insert normal to render_cmds_after", .{});
         };
 
         self.render_cmds.clearAndFree(cw.arena());

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5236,6 +5236,48 @@ pub fn plotXY(src: std.builtin.SourceLocation, init_opts: PlotXYOptions, opts: O
     p.deinit();
 }
 
+/// Defers a whole block of rendering.  Useful if you have overlapping widgets
+/// and want the event handling to match the visual order.
+pub const DeferRender = struct {
+    /// Uses `arena` allocator
+    render_cmds: std.ArrayList(dvui.RenderCommand) = .empty,
+    /// Uses `arena` allocator
+    render_cmds_after: std.ArrayList(dvui.RenderCommand) = .empty,
+
+    prev_dr_cmds: ?*std.ArrayList(dvui.RenderCommand),
+    prev_dr_cmds_after: ?*std.ArrayList(dvui.RenderCommand),
+
+    pub fn init(self: *DeferRender) void {
+        const cw = dvui.currentWindow();
+        self.* = .{
+            .prev_dr_cmds = cw.defer_render_cmds,
+            .prev_dr_cmds_after = cw.defer_render_cmds_after,
+        };
+        cw.defer_render_cmds = &self.render_cmds;
+        cw.defer_render_cmds_after = &self.render_cmds_after;
+    }
+
+    pub fn deinit(self: *DeferRender) void {
+        const cw = dvui.currentWindow();
+
+        // restore previous queues
+        cw.defer_render_cmds = self.prev_dr_cmds;
+        cw.defer_render_cmds_after = self.prev_dr_cmds_after;
+
+        // everything goes into the after queue
+        var sw = cw.subwindows.current() orelse &cw.subwindows.stack.items[0];
+        (cw.defer_render_cmds_after orelse &sw.render_cmds_after).insertSlice(cw.arena(), 0, self.render_cmds_after.items) catch |err| {
+            dvui.logError(@src(), err, "DeferRender could not insert after to render_cmds_after", .{});
+        };
+        (cw.defer_render_cmds_after orelse &sw.render_cmds_after).insertSlice(cw.arena(), 0, self.render_cmds.items) catch |err| {
+            dvui.logError(@src(), err, "DeferRender could not insert normal to render_cmds_after", .{});
+        };
+
+        self.render_cmds.clearAndFree(cw.arena());
+        self.render_cmds_after.clearAndFree(cw.arena());
+    }
+};
+
 /// Display a struct and allow the user to edit values
 ///
 /// Refer to struct_ui.zig for full API.

--- a/src/widgets/FloatingMenuWidget.zig
+++ b/src/widgets/FloatingMenuWidget.zig
@@ -51,7 +51,7 @@ pub const InitOptions = struct {
     avoid: FloatingMenuAvoid = .auto,
 };
 
-prev_rendering: bool,
+render_ftb: dvui.RenderFrontToBack,
 wd: WidgetData,
 prev_windowId: dvui.Id = .zero,
 prev_last_focus: dvui.Id,
@@ -75,8 +75,7 @@ pub fn init(self: *FloatingMenuWidget, src: std.builtin.SourceLocation, init_opt
         // get scale from parent
         .scale_val = dvui.parentGet().screenRectScale(Rect{}).s / dvui.windowNaturalScale(),
 
-        // SAFETY: The following fields must be set in `postInit`
-        .prev_rendering = undefined,
+        .render_ftb = undefined,
         .prev_last_focus = undefined,
         .prevClip = undefined,
         .menu = undefined,
@@ -87,7 +86,7 @@ pub fn init(self: *FloatingMenuWidget, src: std.builtin.SourceLocation, init_opt
     const options = defaults.themeOverride(opts.theme).override(opts);
     // NOTE: options is really for our embedded ScrollAreaWidget
 
-    self.prev_rendering = dvui.renderingSet(false);
+    self.render_ftb.initReset();
 
     dvui.parentSet(self.widget());
 
@@ -274,7 +273,7 @@ pub fn deinit(self: *FloatingMenuWidget) void {
     dvui.currentWindow().last_focused_id_this_frame = self.prev_last_focus;
     _ = dvui.subwindowCurrentSet(self.prev_windowId, null);
     dvui.clipSet(self.prevClip);
-    _ = dvui.renderingSet(self.prev_rendering);
+    self.render_ftb.deinit();
 }
 
 test {

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -54,7 +54,7 @@ pub const InitOptions = struct {
 
 parent_tooltip: ?*FloatingTooltipWidget = null,
 /// SAFETY: Set by `install`
-prev_rendering: bool = undefined,
+render_ftb: dvui.RenderFrontToBack = undefined,
 wd: WidgetData,
 /// SAFETY: Set by `install`
 prev_windowId: dvui.Id = undefined,
@@ -177,7 +177,7 @@ pub fn shown(self: *FloatingTooltipWidget) bool {
 pub fn install(self: *FloatingTooltipWidget) void {
     self.installed = true;
     self.data().register();
-    self.prev_rendering = dvui.renderingSet(false);
+    self.render_ftb.initReset();
 
     dvui.parentSet(self.widget());
 
@@ -256,7 +256,7 @@ pub fn deinit(self: *FloatingTooltipWidget) void {
     dvui.parentReset(self.data().id, self.data().parent);
     _ = dvui.subwindowCurrentSet(self.prev_windowId, null);
     dvui.clipSet(self.prevClip);
-    _ = dvui.renderingSet(self.prev_rendering);
+    self.render_ftb.deinit();
 }
 
 // Return 0 until 80% of time then fade in remaining 20% linearly.

--- a/src/widgets/FloatingWidget.zig
+++ b/src/widgets/FloatingWidget.zig
@@ -28,7 +28,7 @@ pub const InitOptions = struct {
 };
 
 init_opts: InitOptions,
-prev_rendering: bool = undefined,
+render_ftb: dvui.RenderFrontToBack = undefined,
 wd: WidgetData,
 prev_windowId: dvui.Id = undefined,
 prevClip: Rect.Physical = undefined,
@@ -77,7 +77,7 @@ pub fn init(self: *FloatingWidget, src: std.builtin.SourceLocation, init_opts: I
         }
     }
 
-    self.prev_rendering = dvui.renderingSet(false);
+    self.render_ftb.initReset();
     self.data().register();
 
     dvui.parentSet(self.widget());
@@ -130,7 +130,7 @@ pub fn deinit(self: *FloatingWidget) void {
     dvui.parentReset(self.data().id, self.data().parent);
     _ = dvui.subwindowCurrentSet(self.prev_windowId, null);
     dvui.clipSet(self.prevClip);
-    _ = dvui.renderingSet(self.prev_rendering);
+    self.render_ftb.deinit();
 }
 
 test {

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -81,7 +81,7 @@ const DragPart = enum {
     }
 };
 
-prev_rendering: bool = undefined,
+render_ftb: dvui.RenderFrontToBack = undefined,
 wd: WidgetData,
 init_options: InitOptions,
 /// options is for our embedded BoxWidget
@@ -218,7 +218,7 @@ pub fn init(self: *FloatingWindowWidget, src: std.builtin.SourceLocation, init_o
     }
 
     self.data().register();
-    self.prev_rendering = dvui.renderingSet(false);
+    self.render_ftb.initReset();
 
     if (dvui.firstFrame(self.data().id)) {
         dvui.focusSubwindow(self.data().id, null);
@@ -601,7 +601,7 @@ pub fn deinit(self: *FloatingWindowWidget) void {
     dvui.currentWindow().last_focused_id_this_frame = self.prev_last_focus;
     _ = dvui.subwindowCurrentSet(self.prev_windowInfo.id, self.prev_windowInfo.rect);
     dvui.clipSet(self.prevClip);
-    _ = dvui.renderingSet(self.prev_rendering);
+    self.render_ftb.deinit();
 }
 
 test {


### PR DESCRIPTION
fixes #783

Problem:
* load the scroll canvas demo
* move the boxes on top of each other
* try to click-drag the boxes back off each other
* a click on both boxes drags the *bottom* one

When rendering multiple overlapping widgets, the first one you run gets events first, but also draws first.

This PR adds `dvui.DeferRender` which records all drawing commands, and then in `deinit()` inserts them at the beginning of the "after" render command queue.  This way it inverts the draw order of the widgets (while maintaining of the order within the DeferRender extent).

Todo

- [x] integrate with floating windows/widgets (since they also defer their rendering - make sure a floating window inside a DeferRender works, and also the other way around)
- [x] @foxnne needed `renderingSet(false)` because they were drawing in the main window (not a subwindow), make sure that works without needing that workaround