### PR TITLE
TabIndexGroup

### DIFF
--- a/examples/sdl-standalone.zig
+++ b/examples/sdl-standalone.zig
@@ -103,75 +103,85 @@ pub fn main() !void {
     }
 }
 
+// pretending to be some library widget
+fn libWidget(tab_index: ?u16) void {
+    var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = tab_index });
+    defer tig.deinit();
+
+    _ = dvui.button(@src(), "libWidget Focus 2", .{}, .{ .tab_index = 2 });
+    _ = dvui.button(@src(), "libWidget Focus 1", .{}, .{ .tab_index = 1 });
+}
+
 // both dvui and SDL drawing
 // return false if user wants to exit the app
 fn gui_frame() bool {
     const backend = g_backend orelse return false;
+    if (false) {
+        {
+            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .style = .window, .background = true, .expand = .horizontal, .name = "main" });
+            defer hbox.deinit();
 
-    {
-        var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .style = .window, .background = true, .expand = .horizontal, .name = "main" });
-        defer hbox.deinit();
+            var m = dvui.menu(@src(), .horizontal, .{});
+            defer m.deinit();
 
-        var m = dvui.menu(@src(), .horizontal, .{});
-        defer m.deinit();
+            if (dvui.menuItemLabel(@src(), "File", .{ .submenu = true }, .{})) |r| {
+                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+                defer fw.deinit();
 
-        if (dvui.menuItemLabel(@src(), "File", .{ .submenu = true }, .{})) |r| {
-            var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
-            defer fw.deinit();
+                if (dvui.menuItemLabel(@src(), "Close Menu", .{}, .{ .expand = .horizontal }) != null) {
+                    m.close();
+                }
 
-            if (dvui.menuItemLabel(@src(), "Close Menu", .{}, .{ .expand = .horizontal }) != null) {
-                m.close();
+                if (dvui.menuItemLabel(@src(), "Exit", .{}, .{ .expand = .horizontal }) != null) {
+                    return false;
+                }
             }
 
-            if (dvui.menuItemLabel(@src(), "Exit", .{}, .{ .expand = .horizontal }) != null) {
-                return false;
+            if (dvui.menuItemLabel(@src(), "Edit", .{ .submenu = true }, .{})) |r| {
+                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+                defer fw.deinit();
+                _ = dvui.menuItemLabel(@src(), "Dummy", .{}, .{ .expand = .horizontal });
+                _ = dvui.menuItemLabel(@src(), "Dummy Long", .{}, .{ .expand = .horizontal });
+                _ = dvui.menuItemLabel(@src(), "Dummy Super Long", .{}, .{ .expand = .horizontal });
             }
         }
 
-        if (dvui.menuItemLabel(@src(), "Edit", .{ .submenu = true }, .{})) |r| {
-            var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
-            defer fw.deinit();
-            _ = dvui.menuItemLabel(@src(), "Dummy", .{}, .{ .expand = .horizontal });
-            _ = dvui.menuItemLabel(@src(), "Dummy Long", .{}, .{ .expand = .horizontal });
-            _ = dvui.menuItemLabel(@src(), "Dummy Super Long", .{}, .{ .expand = .horizontal });
+        var scroll = dvui.scrollArea(@src(), .{}, .{ .expand = .both });
+        defer scroll.deinit();
+
+        var tl = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal, .font = .theme(.title) });
+        const lorem = "This example shows how to use dvui in a normal application.";
+        tl.addText(lorem, .{});
+        tl.deinit();
+
+        var tl2 = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal });
+        tl2.addText(
+            \\DVUI
+            \\- paints the entire window
+            \\- can show floating windows and dialogs
+            \\- example menu at the top of the window
+            \\- rest of the window is a scroll area
+            \\
+            \\
+        , .{});
+        tl2.addText("Framerate is variable and adjusts as needed for input events and animations.\n\n", .{});
+        if (vsync) {
+            tl2.addText("Framerate is capped by vsync.\n", .{});
+        } else {
+            tl2.addText("Framerate is uncapped.\n", .{});
         }
+        tl2.addText("\n", .{});
+        tl2.addText("Cursor is always being set by dvui.\n\n", .{});
+        if (dvui.useFreeType) {
+            tl2.addText("Fonts are being rendered by FreeType 2.", .{});
+        } else {
+            tl2.addText("Fonts are being rendered by stb_truetype.", .{});
+        }
+        tl2.deinit();
     }
-
-    var scroll = dvui.scrollArea(@src(), .{}, .{ .expand = .both });
-    defer scroll.deinit();
-
-    var tl = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal, .font = .theme(.title) });
-    const lorem = "This example shows how to use dvui in a normal application.";
-    tl.addText(lorem, .{});
-    tl.deinit();
-
-    var tl2 = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal });
-    tl2.addText(
-        \\DVUI
-        \\- paints the entire window
-        \\- can show floating windows and dialogs
-        \\- example menu at the top of the window
-        \\- rest of the window is a scroll area
-        \\
-        \\
-    , .{});
-    tl2.addText("Framerate is variable and adjusts as needed for input events and animations.\n\n", .{});
-    if (vsync) {
-        tl2.addText("Framerate is capped by vsync.\n", .{});
-    } else {
-        tl2.addText("Framerate is uncapped.\n", .{});
-    }
-    tl2.addText("\n", .{});
-    tl2.addText("Cursor is always being set by dvui.\n\n", .{});
-    if (dvui.useFreeType) {
-        tl2.addText("Fonts are being rendered by FreeType 2.", .{});
-    } else {
-        tl2.addText("Fonts are being rendered by stb_truetype.", .{});
-    }
-    tl2.deinit();
 
     const label = if (dvui.Examples.show_demo_window) "Hide Demo Window" else "Show Demo Window";
-    if (dvui.button(@src(), label, .{}, .{})) {
+    if (dvui.button(@src(), label, .{}, .{ .tag = "show-demo-btn" })) {
         dvui.Examples.show_demo_window = !dvui.Examples.show_demo_window;
     }
 
@@ -179,7 +189,55 @@ fn gui_frame() bool {
         dvui.toggleDebugWindow();
     }
 
+    _ = dvui.button(@src(), "Focus 5", .{}, .{});
+    _ = dvui.button(@src(), "Focus 6", .{}, .{});
+
+    // locally reorder a few things
     {
+        var tig = dvui.tabIndexGroup(@src(), .{});
+        defer tig.deinit();
+
+        _ = dvui.button(@src(), "Focus 8", .{}, .{ .tab_index = 2 });
+        _ = dvui.button(@src(), "Focus 7", .{}, .{ .tab_index = 1 });
+    }
+
+    {
+        var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = 2 });
+        defer tig.deinit();
+
+        _ = dvui.button(@src(), "Focus 4", .{}, .{ .tab_index = 2 });
+        _ = dvui.button(@src(), "Focus 3", .{}, .{ .tab_index = 1 });
+
+        var group = dvui.radioGroup(@src(), .{}, .{ .label = .{ .text = "Radio buttons" } });
+        defer group.deinit();
+
+        var tig2 = dvui.tabIndexGroup(@src(), .{ .tab_index = 4 });
+        _ = dvui.radio(@src(), false, "Radio 3", .{ .tab_index = 2 });
+        _ = dvui.radio(@src(), false, "Radio 2", .{ .tab_index = 1 });
+        tig2.deinit();
+
+        _ = dvui.radio(@src(), false, "Radio 1", .{ .tab_index = 3 });
+    }
+
+    {
+        var b = dvui.box(@src(), .{}, .{ .border = .all(1) });
+        defer b.deinit();
+
+        dvui.label(@src(), "These are all tab index 1", .{}, .{});
+
+        libWidget(1);
+    }
+
+    {
+        var b = dvui.box(@src(), .{}, .{ .border = .all(1) });
+        defer b.deinit();
+
+        dvui.label(@src(), "These are all tab index 10", .{}, .{});
+
+        libWidget(10);
+    }
+
+    if (false) {
         var scaler = dvui.scale(@src(), .{ .scale = &scale_val }, .{ .expand = .horizontal });
         defer scaler.deinit();
 

--- a/examples/sdl-standalone.zig
+++ b/examples/sdl-standalone.zig
@@ -103,85 +103,75 @@ pub fn main() !void {
     }
 }
 
-// pretending to be some library widget
-fn libWidget(tab_index: ?u16) void {
-    var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = tab_index });
-    defer tig.deinit();
-
-    _ = dvui.button(@src(), "libWidget Focus 2", .{}, .{ .tab_index = 2 });
-    _ = dvui.button(@src(), "libWidget Focus 1", .{}, .{ .tab_index = 1 });
-}
-
 // both dvui and SDL drawing
 // return false if user wants to exit the app
 fn gui_frame() bool {
     const backend = g_backend orelse return false;
-    if (false) {
-        {
-            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .style = .window, .background = true, .expand = .horizontal, .name = "main" });
-            defer hbox.deinit();
 
-            var m = dvui.menu(@src(), .horizontal, .{});
-            defer m.deinit();
+    {
+        var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .style = .window, .background = true, .expand = .horizontal, .name = "main" });
+        defer hbox.deinit();
 
-            if (dvui.menuItemLabel(@src(), "File", .{ .submenu = true }, .{})) |r| {
-                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
-                defer fw.deinit();
+        var m = dvui.menu(@src(), .horizontal, .{});
+        defer m.deinit();
 
-                if (dvui.menuItemLabel(@src(), "Close Menu", .{}, .{ .expand = .horizontal }) != null) {
-                    m.close();
-                }
+        if (dvui.menuItemLabel(@src(), "File", .{ .submenu = true }, .{})) |r| {
+            var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+            defer fw.deinit();
 
-                if (dvui.menuItemLabel(@src(), "Exit", .{}, .{ .expand = .horizontal }) != null) {
-                    return false;
-                }
+            if (dvui.menuItemLabel(@src(), "Close Menu", .{}, .{ .expand = .horizontal }) != null) {
+                m.close();
             }
 
-            if (dvui.menuItemLabel(@src(), "Edit", .{ .submenu = true }, .{})) |r| {
-                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
-                defer fw.deinit();
-                _ = dvui.menuItemLabel(@src(), "Dummy", .{}, .{ .expand = .horizontal });
-                _ = dvui.menuItemLabel(@src(), "Dummy Long", .{}, .{ .expand = .horizontal });
-                _ = dvui.menuItemLabel(@src(), "Dummy Super Long", .{}, .{ .expand = .horizontal });
+            if (dvui.menuItemLabel(@src(), "Exit", .{}, .{ .expand = .horizontal }) != null) {
+                return false;
             }
         }
 
-        var scroll = dvui.scrollArea(@src(), .{}, .{ .expand = .both });
-        defer scroll.deinit();
-
-        var tl = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal, .font = .theme(.title) });
-        const lorem = "This example shows how to use dvui in a normal application.";
-        tl.addText(lorem, .{});
-        tl.deinit();
-
-        var tl2 = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal });
-        tl2.addText(
-            \\DVUI
-            \\- paints the entire window
-            \\- can show floating windows and dialogs
-            \\- example menu at the top of the window
-            \\- rest of the window is a scroll area
-            \\
-            \\
-        , .{});
-        tl2.addText("Framerate is variable and adjusts as needed for input events and animations.\n\n", .{});
-        if (vsync) {
-            tl2.addText("Framerate is capped by vsync.\n", .{});
-        } else {
-            tl2.addText("Framerate is uncapped.\n", .{});
+        if (dvui.menuItemLabel(@src(), "Edit", .{ .submenu = true }, .{})) |r| {
+            var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+            defer fw.deinit();
+            _ = dvui.menuItemLabel(@src(), "Dummy", .{}, .{ .expand = .horizontal });
+            _ = dvui.menuItemLabel(@src(), "Dummy Long", .{}, .{ .expand = .horizontal });
+            _ = dvui.menuItemLabel(@src(), "Dummy Super Long", .{}, .{ .expand = .horizontal });
         }
-        tl2.addText("\n", .{});
-        tl2.addText("Cursor is always being set by dvui.\n\n", .{});
-        if (dvui.useFreeType) {
-            tl2.addText("Fonts are being rendered by FreeType 2.", .{});
-        } else {
-            tl2.addText("Fonts are being rendered by stb_truetype.", .{});
-        }
-        tl2.deinit();
     }
 
+    var scroll = dvui.scrollArea(@src(), .{}, .{ .expand = .both });
+    defer scroll.deinit();
+
+    var tl = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal, .font = .theme(.title) });
+    const lorem = "This example shows how to use dvui in a normal application.";
+    tl.addText(lorem, .{});
+    tl.deinit();
+
+    var tl2 = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal });
+    tl2.addText(
+        \\DVUI
+        \\- paints the entire window
+        \\- can show floating windows and dialogs
+        \\- example menu at the top of the window
+        \\- rest of the window is a scroll area
+        \\
+        \\
+    , .{});
+    tl2.addText("Framerate is variable and adjusts as needed for input events and animations.\n\n", .{});
+    if (vsync) {
+        tl2.addText("Framerate is capped by vsync.\n", .{});
+    } else {
+        tl2.addText("Framerate is uncapped.\n", .{});
+    }
+    tl2.addText("\n", .{});
+    tl2.addText("Cursor is always being set by dvui.\n\n", .{});
+    if (dvui.useFreeType) {
+        tl2.addText("Fonts are being rendered by FreeType 2.", .{});
+    } else {
+        tl2.addText("Fonts are being rendered by stb_truetype.", .{});
+    }
+    tl2.deinit();
+
     const label = if (dvui.Examples.show_demo_window) "Hide Demo Window" else "Show Demo Window";
-    if (dvui.button(@src(), label, .{}, .{ .tag = "show-demo-btn" })) {
+    if (dvui.button(@src(), label, .{}, .{})) {
         dvui.Examples.show_demo_window = !dvui.Examples.show_demo_window;
     }
 
@@ -189,55 +179,7 @@ fn gui_frame() bool {
         dvui.toggleDebugWindow();
     }
 
-    _ = dvui.button(@src(), "Focus 5", .{}, .{});
-    _ = dvui.button(@src(), "Focus 6", .{}, .{});
-
-    // locally reorder a few things
     {
-        var tig = dvui.tabIndexGroup(@src(), .{});
-        defer tig.deinit();
-
-        _ = dvui.button(@src(), "Focus 8", .{}, .{ .tab_index = 2 });
-        _ = dvui.button(@src(), "Focus 7", .{}, .{ .tab_index = 1 });
-    }
-
-    {
-        var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = 2 });
-        defer tig.deinit();
-
-        _ = dvui.button(@src(), "Focus 4", .{}, .{ .tab_index = 2 });
-        _ = dvui.button(@src(), "Focus 3", .{}, .{ .tab_index = 1 });
-
-        var group = dvui.radioGroup(@src(), .{}, .{ .label = .{ .text = "Radio buttons" } });
-        defer group.deinit();
-
-        var tig2 = dvui.tabIndexGroup(@src(), .{ .tab_index = 4 });
-        _ = dvui.radio(@src(), false, "Radio 3", .{ .tab_index = 2 });
-        _ = dvui.radio(@src(), false, "Radio 2", .{ .tab_index = 1 });
-        tig2.deinit();
-
-        _ = dvui.radio(@src(), false, "Radio 1", .{ .tab_index = 3 });
-    }
-
-    {
-        var b = dvui.box(@src(), .{}, .{ .border = .all(1) });
-        defer b.deinit();
-
-        dvui.label(@src(), "These are all tab index 1", .{}, .{});
-
-        libWidget(1);
-    }
-
-    {
-        var b = dvui.box(@src(), .{}, .{ .border = .all(1) });
-        defer b.deinit();
-
-        dvui.label(@src(), "These are all tab index 10", .{}, .{});
-
-        libWidget(10);
-    }
-
-    if (false) {
         var scaler = dvui.scale(@src(), .{ .scale = &scale_val }, .{ .expand = .horizontal });
         defer scaler.deinit();
 

--- a/src/Examples/grid.zig
+++ b/src/Examples/grid.zig
@@ -15,8 +15,8 @@ pub fn gridStyling() void {
     var outer_hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .role = .tab_panel });
     defer outer_hbox.deinit();
 
-    var tigOuter = dvui.tabIndexGroup(@src(), .{});
-    defer tigOuter.deinit();
+    var tig_outer = dvui.tabIndexGroup(@src(), .{});
+    defer tig_outer.deinit();
 
     {
         var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = 2 });
@@ -332,8 +332,8 @@ pub fn gridLayouts() void {
         };
     };
 
-    var tigOuter = dvui.tabIndexGroup(@src(), .{});
-    defer tigOuter.deinit();
+    var tig_outer = dvui.tabIndexGroup(@src(), .{});
+    defer tig_outer.deinit();
 
     {
         var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = 2 });
@@ -758,7 +758,11 @@ pub fn gridSelection() void {
     };
     var outer_vbox = dvui.box(@src(), .{}, .{ .expand = .both });
     defer outer_vbox.deinit();
+    var tg_outer = dvui.tabIndexGroup(@src(), .{});
+    defer tg_outer.deinit();
     {
+        var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = 1 });
+        defer tig.deinit();
         var top_controls = dvui.box(@src(), .{ .dir = .horizontal }, .{ .gravity_y = 0 });
         defer top_controls.deinit();
         dvui.labelNoFmt(@src(), "Filter (contains): ", .{}, .{ .margin = dvui.TextEntryWidget.defaults.margin });
@@ -772,6 +776,8 @@ pub fn gridSelection() void {
         defer text.deinit();
     }
     {
+        var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = 3 });
+        defer tig.deinit();
         var vbox = dvui.box(@src(), .{}, .{ .gravity_y = 1.0 });
         defer vbox.deinit();
         if (dvui.expander(@src(), "Options", .{ .default_expanded = true }, .{ .expand = .horizontal })) {
@@ -788,13 +794,15 @@ pub fn gridSelection() void {
         }
     }
     {
+        var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = 2 });
+        defer tig.deinit();
+
         // This is sort of subtle. We need to reset the kb select before the grid is created, so that grid focus is included in select all
         local.kb_select.reset();
 
         var grid = dvui.grid(@src(), .numCols(6), .{ .scroll_opts = .{ .horizontal_bar = .auto } }, .{ .expand = .both, .background = true });
         defer grid.deinit();
         if (!local.initialized) {
-            dvui.focusWidget(grid.data().id, null, null);
             local.initialized = true;
         }
 
@@ -1038,6 +1046,8 @@ pub fn gridNavigation() void {
         }
     };
 
+    var main_tig = dvui.tabIndexGroup(@src(), .{});
+    defer main_tig.deinit();
     var main_box = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .both, .style = .window, .background = true, .border = dvui.Rect.all(1) });
     defer main_box.deinit();
     if (dvui.firstFrame(main_box.data().id)) {
@@ -1051,6 +1061,9 @@ pub fn gridNavigation() void {
         var vbox = dvui.box(@src(), .{}, .{ .expand = .vertical, .border = dvui.Rect.all(1) });
         defer vbox.deinit();
         {
+            var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = 3 });
+            defer tig.deinit();
+
             var bottom_panel = dvui.box(@src(), .{}, .{ .gravity_y = 1.0 });
             defer bottom_panel.deinit();
             {
@@ -1092,6 +1105,9 @@ pub fn gridNavigation() void {
             }
         }
         {
+            var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = 1 });
+            defer tig.deinit();
+
             var top_panel = dvui.box(@src(), .{ .dir = .horizontal }, .{ .gravity_y = 0 });
             defer top_panel.deinit();
             dvui.labelNoFmt(@src(), "Plot Title:", .{}, .{ .margin = dvui.TextEntryWidget.defaults.margin });
@@ -1104,6 +1120,9 @@ pub fn gridNavigation() void {
             local.plot_title = text.getText();
         }
         {
+            var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = 2 });
+            defer tig.deinit();
+
             var grid = dvui.grid(@src(), .{ .col_widths = &local.col_widths }, .{ .scroll_opts = .{ .vertical_bar = .show } }, .{ .expand = .vertical, .border = dvui.Rect.all(1) });
             defer grid.deinit();
 

--- a/src/Examples/grid.zig
+++ b/src/Examples/grid.zig
@@ -15,7 +15,13 @@ pub fn gridStyling() void {
     var outer_hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .role = .tab_panel });
     defer outer_hbox.deinit();
 
+    var tigOuter = dvui.tabIndexGroup(@src(), .{});
+    defer tigOuter.deinit();
+
     {
+        var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = 2 });
+        defer tig.deinit();
+
         var outer_vbox = dvui.box(@src(), .{}, .{
             .min_size_content = grid_panel_size,
             .max_size_content = .size(grid_panel_size),
@@ -93,6 +99,9 @@ pub fn gridStyling() void {
     const row_background = local.banding != .none or local.borders.nonZero();
 
     {
+        var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = 1 });
+        defer tig.deinit();
+
         var grid = dvui.grid(@src(), .colWidths(&local.col_widths), .{
             .resize_rows = local.resize_rows,
         }, .{
@@ -322,7 +331,14 @@ pub fn gridLayouts() void {
             .{ .model = "Mustang with a really long name", .make = "Ford", .year = 2020, .mileage = 24000, .condition = .Good, .description = "Makes you feel 20% cooler just sitting in it." },
         };
     };
+
+    var tigOuter = dvui.tabIndexGroup(@src(), .{});
+    defer tigOuter.deinit();
+
     {
+        var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = 2 });
+        defer tig.deinit();
+
         var outer_vbox = dvui.box(@src(), .{}, .{
             .expand = .horizontal,
             .border = Rect.all(1),
@@ -373,6 +389,9 @@ pub fn gridLayouts() void {
     }
 
     {
+        var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = 1 });
+        defer tig.deinit();
+
         const all_cars = local.all_cars[0..];
         const banded: GridWidget.CellStyle.Banded = .{
             .opts = .{

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -2663,6 +2663,76 @@ const DisplayTabs = struct {
     }
 };
 
+const DisplayTabGroup = struct {
+    const name: []const u8 = "tabIndexGroup()";
+
+    // TODO: Both of these stay undefined, because there are no
+    // options. Next widgetpedia PR will have ability to hanlde widgets without options.
+    var wd: dvui.WidgetData = undefined;
+    var options: dvui.Options = undefined;
+
+    var active_tab: usize = undefined;
+    var tab_group_index: struct {
+        @".tab_index (red)": u16,
+        @".tab_index (green)": u16,
+        @".tab_index (blue)": u16,
+    } = undefined;
+
+    pub fn displayFn(reset: bool) void {
+        if (reset) resetWidget();
+        displayWidgetTemplate(@This());
+    }
+
+    pub fn resetWidget() void {
+        options = .{};
+        active_tab = 0;
+        tab_group_index = .{
+            .@".tab_index (red)" = 1,
+            .@".tab_index (green)" = 2,
+            .@".tab_index (blue)" = 3,
+        };
+    }
+
+    pub fn layoutWidget() void {
+        var tig_outer = dvui.tabIndexGroup(@src(), .{});
+        defer tig_outer.deinit();
+        {
+            var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = tab_group_index.@".tab_index (red)" });
+            defer tig.deinit();
+            var box = dvui.box(@src(), .{}, .{ .border = .all(2), .margin = .all(1), .color_border = .red, .expand = .horizontal });
+            defer box.deinit();
+            _ = dvui.button(@src(), "One", .{}, .{ .expand = .horizontal, .color_text = .red });
+            _ = dvui.button(@src(), "Two", .{}, .{ .expand = .horizontal, .color_text = .red });
+        }
+        defer tig_outer.deinit();
+        {
+            var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = tab_group_index.@".tab_index (green)" });
+            defer tig.deinit();
+            var box = dvui.box(@src(), .{}, .{ .border = .all(2), .margin = .all(1), .color_border = .green, .expand = .horizontal });
+            defer box.deinit();
+            var fg = dvui.focusGroup(@src(), .{ .nav_key_dir = .vertical, .wrap = true }, .{});
+            defer fg.deinit();
+            var gbox = dvui.groupBox(@src(), "in focus group", .{ .expand = .horizontal });
+            defer gbox.deinit();
+            _ = dvui.button(@src(), "One", .{}, .{ .expand = .horizontal, .color_text = .green });
+            _ = dvui.button(@src(), "Two", .{}, .{ .expand = .horizontal, .color_text = .green });
+        }
+        defer tig_outer.deinit();
+        {
+            var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = tab_group_index.@".tab_index (blue)" });
+            defer tig.deinit();
+            var box = dvui.box(@src(), .{}, .{ .border = .all(2), .margin = .all(1), .color_border = .blue, .expand = .horizontal });
+            defer box.deinit();
+            _ = dvui.button(@src(), "Two", .{}, .{ .expand = .horizontal, .color_text = .blue, .tab_index = 2 });
+            _ = dvui.button(@src(), "One", .{}, .{ .expand = .horizontal, .color_text = .blue, .tab_index = 1 });
+        }
+    }
+
+    pub fn layoutWidgetControls() void {
+        dvui.structUI(@src(), test_options_label, &tab_group_index, 1, .{}, .{});
+    }
+};
+
 const DisplayTextEntry = struct {
     const name: []const u8 = "textEntry()";
 
@@ -3209,6 +3279,7 @@ const widget_hierarchy = [_]WidgetHierarchy{
     .{ .name = "spinner", .displayFn = DisplaySpinner.displayFn, .children = null },
     .{ .name = "suggestion", .displayFn = displayEmpty, .children = null },
     .{ .name = "tabs", .displayFn = DisplayTabs.displayFn, .children = null },
+    .{ .name = "tabGroup", .displayFn = DisplayTabGroup.displayFn, .children = null },
 
     .{ .name = "textEntries", .displayFn = displayEmpty, .children = &.{
         .{ .name = "textEntry", .displayFn = DisplayTextEntry.displayFn, .children = null },

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -48,8 +48,11 @@ gravity_x: ?f32 = null,
 // [0, 1] default is 0 (top)
 gravity_y: ?f32 = null,
 
-// used to override the tab order, lower numbers first, null means highest
-// possible number, same tab_index goes in install() order, 0 disables
+/// Specify focus order within the current TabIndexGroup.
+/// * lower numbers first
+/// * null means highest possible
+/// * same tab_index go in processed order
+/// * 0 disables (cannot focus via keyboard navigation)
 tab_index: ?u16 = null,
 
 // Used to override the style/theme.

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1105,6 +1105,9 @@ pub fn begin(
     self.last_focused_id_this_frame = .zero;
     self.last_focused_id_in_subwindow = .zero;
 
+    // just in case something went wrong, start at zero
+    dvui.TabIndexGroup.current = .zero;
+
     self.debug.reset(self.gpa);
 
     self.data_store.reset(self.gpa);

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2183,6 +2183,9 @@ pub fn tabIndexPrevEx(event_num: ?u16, tabidxs: []dvui.TabIndex, base_tig: Id) v
     }
 }
 
+/// Creates a nested group for Options.tab_index values.  tab_index controls
+/// focus order within the group. The group as a whole is ordered by its
+/// tab_index.
 pub const TabIndexGroup = struct {
     pub var current: Id = .zero;
 

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1923,12 +1923,17 @@ pub fn scrollDrag(scroll_drag: ScrollDragOptions) void {
 pub const TabIndex = struct {
     windowId: Id,
     widgetId: Id,
+    tab_index_group: Id,
     tabIndex: u16,
 
     // If true, prevents tabbing to this entry.  This is used to be able to
     // look up a widget inside a focus group so we know where to start, but
     // don't want to be able to tab inside a focus group.
-    shadow: bool = false,
+    in_focus_group: bool = false,
+
+    // If true, this entry represents a tab group.  We don't focus it directly,
+    // but use this to move in/out of the group.
+    tab_group: bool = false,
 };
 
 /// Set the tab order for this widget.  `tab_index` values are visited starting
@@ -1945,11 +1950,21 @@ pub const TabIndex = struct {
 ///
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn tabIndexSet(widget_id: Id, tab_index: ?u16) void {
+    tabIndexSetEx(widget_id, tab_index, false);
+}
+
+pub fn tabIndexSetEx(widget_id: Id, tab_index: ?u16, tab_group: bool) void {
     if (tab_index != null and tab_index.? == 0)
         return;
 
     var cw = currentWindow();
-    var ti = TabIndex{ .windowId = cw.subwindows.current_id, .widgetId = widget_id, .tabIndex = (tab_index orelse math.maxInt(u16)) };
+    var ti = TabIndex{
+        .windowId = cw.subwindows.current_id,
+        .widgetId = widget_id,
+        .tab_index_group = TabIndexGroup.current,
+        .tabIndex = (tab_index orelse math.maxInt(u16)),
+        .tab_group = tab_group,
+    };
 
     if (cw.subwindows.get(cw.subwindows.current_id)) |sw| {
         if (sw.focus_group) |fg| {
@@ -1958,7 +1973,7 @@ pub fn tabIndexSet(widget_id: Id, tab_index: ?u16) void {
             };
 
             // now modify the TabIndex so that we can look it up in the global order
-            ti.shadow = true;
+            ti.in_focus_group = true;
             ti.tabIndex = fg.data().options.tab_index orelse math.maxInt(u16);
         }
     }
@@ -1975,51 +1990,91 @@ pub fn tabIndexSet(widget_id: Id, tab_index: ?u16) void {
 ///
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn tabIndexNext(event_num: ?u16) void {
-    tabIndexNextEx(event_num, currentWindow().tab_index_prev.items);
+    tabIndexNextEx(event_num, currentWindow().tab_index_prev.items, .zero);
 }
 
-pub fn tabIndexNextEx(event_num: ?u16, tabidxs: []dvui.TabIndex) void {
+pub fn tabIndexNextEx(event_num: ?u16, tabidxs: []dvui.TabIndex, base_tig: Id) void {
     const cw = currentWindow();
-    const widgetId = focusedWidgetId();
+    var widgetId = focusedWidgetId();
     var oldtab: ?u16 = null;
-    if (widgetId != null) {
-        for (tabidxs) |ti| {
-            if (ti.windowId == cw.subwindows.focused_id and ti.widgetId == widgetId.?) {
-                oldtab = ti.tabIndex;
-                break;
-            }
-        }
-    }
-
-    // find the first widget with a tabindex greater than oldtab
-    // or the first widget with lowest tabindex if oldtab is null
-    var newtab: u16 = math.maxInt(u16);
+    var tig: Id = base_tig;
     var newId: ?Id = null;
-    var foundFocus = false;
-
-    for (tabidxs) |ti| {
-        if (ti.windowId == cw.subwindows.focused_id) {
-            if (ti.widgetId == widgetId) {
-                foundFocus = true;
-                continue;
-            }
-
-            if (ti.shadow) continue;
-
-            if (foundFocus == true and oldtab != null and ti.tabIndex == oldtab.?) {
-                // found the first widget after current that has the same tabindex
-                newtab = ti.tabIndex;
-                newId = ti.widgetId;
-                break;
-            } else if (oldtab == null or ti.tabIndex > oldtab.?) {
-                // tabidxs is ordered by insertion, not tab index, so have to
-                // search all of them to find the lowest that is above oldtab
-                if (newId == null or ti.tabIndex < newtab) {
-                    newtab = ti.tabIndex;
-                    newId = ti.widgetId;
+    var ran_off: bool = false;
+    outer: while (true) {
+        if (widgetId != null) {
+            for (tabidxs) |ti| {
+                if (ti.windowId == cw.subwindows.focused_id and ti.widgetId == widgetId.?) {
+                    oldtab = ti.tabIndex;
+                    tig = ti.tab_index_group;
+                    break;
                 }
             }
         }
+
+        if (ran_off and oldtab == null) {
+            // We ran off the tab index group, but couldn't find the entry for
+            // itself, return null.  This means we are in a focus group where
+            // the tab index group we searched for is outside the focus group.
+            break :outer;
+        }
+
+        ran_off = false;
+
+        // find the first widget with a tabindex greater than oldtab
+        // or the first widget with lowest tabindex if oldtab is null
+        var newtab: u16 = math.maxInt(u16);
+        var isTig: bool = false;
+        var foundFocus = false;
+
+        for (tabidxs) |ti| {
+            if (ti.windowId == cw.subwindows.focused_id and ti.tab_index_group == tig) {
+                if (ti.widgetId == widgetId) {
+                    foundFocus = true;
+                    continue;
+                }
+
+                if (ti.in_focus_group) continue;
+
+                if (foundFocus == true and oldtab != null and ti.tabIndex == oldtab.?) {
+                    // found the first widget after current that has the same tabindex
+                    newtab = ti.tabIndex;
+                    newId = ti.widgetId;
+                    isTig = ti.tab_group;
+                    break;
+                } else if (oldtab == null or ti.tabIndex > oldtab.?) {
+                    // tabidxs is ordered by insertion, not tab index, so have to
+                    // search all of them to find the lowest that is above oldtab
+                    if (newId == null or ti.tabIndex < newtab) {
+                        newtab = ti.tabIndex;
+                        newId = ti.widgetId;
+                        isTig = ti.tab_group;
+                    }
+                }
+            }
+        }
+
+        if (newId == null and tig != base_tig) {
+            // ran off the end of the tab index group, recur starting at the
+            // tab index group itself
+            widgetId = tig;
+            oldtab = null;
+            ran_off = true;
+            tig = base_tig;
+
+            continue :outer;
+        }
+
+        if (isTig) {
+            // we are moving into this tab index group
+            widgetId = null;
+            oldtab = null;
+            tig = newId.?;
+            newId = null;
+
+            continue :outer;
+        }
+
+        break :outer;
     }
 
     focusWidget(newId, null, event_num);
@@ -2032,51 +2087,90 @@ pub fn tabIndexNextEx(event_num: ?u16, tabidxs: []dvui.TabIndex) void {
 ///
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn tabIndexPrev(event_num: ?u16) void {
-    tabIndexPrevEx(event_num, currentWindow().tab_index_prev.items);
+    tabIndexPrevEx(event_num, currentWindow().tab_index_prev.items, .zero);
 }
 
-pub fn tabIndexPrevEx(event_num: ?u16, tabidxs: []dvui.TabIndex) void {
+pub fn tabIndexPrevEx(event_num: ?u16, tabidxs: []dvui.TabIndex, base_tig: Id) void {
     const cw = currentWindow();
-    const widgetId = focusedWidgetId();
+    var widgetId = focusedWidgetId();
     var oldtab: ?u16 = null;
     var oldshadow: bool = false;
-    if (widgetId != null) {
-        for (tabidxs) |ti| {
-            if (ti.windowId == cw.subwindows.focused_id and ti.widgetId == widgetId.?) {
-                oldtab = ti.tabIndex;
-                oldshadow = ti.shadow;
-                break;
-            }
-        }
-    }
-
-    // find the last widget with a tabindex less than oldtab
-    // or the last widget with highest tabindex if oldtab is null
-    var newtab: u16 = 1;
+    var tig: Id = base_tig;
     var newId: ?Id = null;
-    var foundFocus = false;
-
-    for (tabidxs) |ti| {
-        if (ti.windowId == cw.subwindows.focused_id) {
-            if (ti.widgetId == widgetId) {
-                foundFocus = true;
-
-                if (oldtab != null and newtab == oldtab.?) {
-                    // use last widget before that has the same tabindex
-                    // might be none before so we'll go to null
+    var ran_off: bool = false;
+    outer: while (true) {
+        if (widgetId != null) {
+            for (tabidxs) |ti| {
+                if (ti.windowId == cw.subwindows.focused_id and ti.widgetId == widgetId.?) {
+                    oldtab = ti.tabIndex;
+                    tig = ti.tab_index_group;
+                    oldshadow = ti.in_focus_group;
                     break;
                 }
-            } else if (!ti.shadow) {
-                // tabidxs is ordered by insertion, not tab index, so have to
-                // search all of them to find the highest that is below oldtab
-                if (oldtab == null or ti.tabIndex < oldtab.? or (!foundFocus and ti.tabIndex == oldtab.?)) {
-                    if (ti.tabIndex >= newtab) {
-                        newtab = ti.tabIndex;
-                        newId = ti.widgetId;
+            }
+        }
+
+        if (ran_off and oldtab == null) {
+            // We ran off the tab index group, but couldn't find the entry for
+            // itself, return null.  This means we are in a focus group where
+            // the tab index group we searched for is outside the focus group.
+            break :outer;
+        }
+
+        ran_off = false;
+
+        // find the last widget with a tabindex less than oldtab
+        // or the last widget with highest tabindex if oldtab is null
+        var newtab: u16 = 1;
+        var isTig: bool = false;
+        var foundFocus = false;
+
+        for (tabidxs) |ti| {
+            if (ti.windowId == cw.subwindows.focused_id and ti.tab_index_group == tig) {
+                if (ti.widgetId == widgetId) {
+                    foundFocus = true;
+
+                    if (oldtab != null and newtab == oldtab.?) {
+                        // use last widget before that has the same tabindex
+                        // might be none before so we'll go to null
+                        break;
+                    }
+                } else if (!ti.in_focus_group) {
+                    // tabidxs is ordered by insertion, not tab index, so have to
+                    // search all of them to find the highest that is below oldtab
+                    if (oldtab == null or ti.tabIndex < oldtab.? or (!foundFocus and ti.tabIndex == oldtab.?)) {
+                        if (ti.tabIndex >= newtab) {
+                            newtab = ti.tabIndex;
+                            newId = ti.widgetId;
+                            isTig = ti.tab_group;
+                        }
                     }
                 }
             }
         }
+
+        if (newId == null and tig != base_tig) {
+            // ran off the end of the tab index group, recur starting at the
+            // tab index group itself
+            widgetId = tig;
+            oldtab = null;
+            ran_off = true;
+            tig = base_tig;
+
+            continue :outer;
+        }
+
+        if (isTig) {
+            // we are moving into this tab index group
+            widgetId = null;
+            oldtab = null;
+            tig = newId.?;
+            newId = null;
+
+            continue :outer;
+        }
+
+        break :outer;
     }
 
     focusWidget(newId, null, event_num);
@@ -2085,8 +2179,43 @@ pub fn tabIndexPrevEx(event_num: ?u16, tabidxs: []dvui.TabIndex) void {
         // If we shift-tabbed from inside a focusGroup, we will always focus
         // the focusGroup itself, so do this again to focus the widget before
         // the focusGroup.
-        tabIndexPrevEx(event_num, tabidxs);
+        tabIndexPrevEx(event_num, tabidxs, base_tig);
     }
+}
+
+pub const TabIndexGroup = struct {
+    pub var current: Id = .zero;
+
+    prev: Id,
+
+    pub const Options = struct {
+        id_extra: ?usize = null,
+        tab_index: ?u16 = null,
+    };
+
+    pub fn init(self: *TabIndexGroup, src: std.builtin.SourceLocation, opts: TabIndexGroup.Options) void {
+        self.* = .{
+            .prev = TabIndexGroup.current,
+        };
+
+        const id = dvui.parentGet().extendId(src, opts.id_extra orelse 0);
+
+        tabIndexSetEx(id, opts.tab_index, true);
+
+        TabIndexGroup.current = id;
+    }
+
+    pub fn deinit(self: *TabIndexGroup) void {
+        defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
+        defer self.* = undefined;
+        TabIndexGroup.current = self.prev;
+    }
+};
+
+pub fn tabIndexGroup(src: std.builtin.SourceLocation, opts: TabIndexGroup.Options) *TabIndexGroup {
+    var ret = widgetAlloc(TabIndexGroup);
+    ret.init(src, opts);
+    return ret;
 }
 
 /// Widgets that accept text input should call this on frames they have focus.

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -3371,9 +3371,10 @@ pub fn gridHeadingSortable(
     gridHeadingSeparator(resize_opts);
 
     const sort_changed = switch (g.colSortOrder(col_num)) {
-        .unsorted => button(@src(), heading, .{ .draw_focus = false }, heading_opts),
-        .ascending => buttonLabelAndIcon(@src(), .{ .label = heading, .tvg_bytes = icon_ascending, .button_opts = .{ .draw_focus = false } }, heading_opts),
-        .descending => buttonLabelAndIcon(@src(), .{ .label = heading, .tvg_bytes = icon_descending, .button_opts = .{ .draw_focus = false } }, heading_opts),
+        // Use same src for each button so they get the same id and can retain focus accross frames.
+        .unsorted => button(src, heading, .{}, heading_opts),
+        .ascending => buttonLabelAndIcon(src, .{ .label = heading, .tvg_bytes = icon_ascending, .button_opts = .{} }, heading_opts),
+        .descending => buttonLabelAndIcon(src, .{ .label = heading, .tvg_bytes = icon_descending, .button_opts = .{} }, heading_opts),
     };
 
     if (sort_changed) {

--- a/src/widgets/FocusGroupWidget.zig
+++ b/src/widgets/FocusGroupWidget.zig
@@ -54,7 +54,9 @@ pub fn init(self: *FocusGroupWidget, src: std.builtin.SourceLocation, init_opts:
         if (sw.focus_group == null) {
 
             // put ourselves in the tab index so the whole focus group can be focused by tab
-            dvui.tabIndexSet(self.data().id, self.data().options.tab_index);
+            // but only if we contain focusable widgets
+            if (self.tab_index_prev.len > 0)
+                dvui.tabIndexSet(self.data().id, self.data().options.tab_index);
 
             if (self.data().id == dvui.focusedWidgetId()) {
                 // if we got focused, focus our remembered focus or first id

--- a/src/widgets/FocusGroupWidget.zig
+++ b/src/widgets/FocusGroupWidget.zig
@@ -22,6 +22,7 @@ last_focus: dvui.Id,
 remember_focus: ?dvui.Id,
 tab_index_prev: []dvui.TabIndex,
 tab_index: std.ArrayListUnmanaged(dvui.TabIndex) = .empty,
+tab_index_group: dvui.Id,
 
 pub const InitOptions = struct {
     /// If true wrap focus around the first/last.  If false, focus stops at
@@ -42,6 +43,7 @@ pub fn init(self: *FocusGroupWidget, src: std.builtin.SourceLocation, init_opts:
         .last_focus = dvui.lastFocusedIdInFrame(),
         .tab_index_prev = dvui.dataGetSlice(null, id, "_tab_prev", []dvui.TabIndex) orelse &.{},
         .remember_focus = dvui.dataGet(null, id, "_remember_focus", dvui.Id) orelse null,
+        .tab_index_group = dvui.TabIndexGroup.current,
     };
     dvui.parentSet(self.widget());
     self.data().register();
@@ -59,7 +61,7 @@ pub fn init(self: *FocusGroupWidget, src: std.builtin.SourceLocation, init_opts:
                 if (self.remember_focus) |focused_id| {
                     dvui.focusWidget(focused_id, null, null);
                 } else {
-                    dvui.tabIndexNextEx(null, self.tab_index_prev);
+                    self.focusNext(null);
                 }
             }
 
@@ -67,6 +69,14 @@ pub fn init(self: *FocusGroupWidget, src: std.builtin.SourceLocation, init_opts:
             //std.debug.print("subwindow {x} focus group {x}\n", .{ sw.id.asU64(), self.data().id.asU64() });
         }
     }
+}
+
+pub fn focusNext(self: *FocusGroupWidget, event_num: ?u16) void {
+    dvui.tabIndexNextEx(event_num, self.tab_index_prev, self.tab_index_group);
+}
+
+pub fn focusPrev(self: *FocusGroupWidget, event_num: ?u16) void {
+    dvui.tabIndexPrevEx(event_num, self.tab_index_prev, self.tab_index_group);
 }
 
 pub fn widget(self: *FocusGroupWidget) Widget {
@@ -123,26 +133,26 @@ pub fn deinit(self: *FocusGroupWidget) void {
                         const key_dir = self.init_opts.nav_key_dir;
                         if ((ke.code == .up and key_dir != .horizontal) or (ke.code == .left and key_dir != .vertical)) {
                             e.handle(@src(), self.data());
-                            dvui.tabIndexPrevEx(e.num, self.tab_index_prev);
+                            self.focusPrev(e.num);
                             if (dvui.focusedWidgetId() == null) {
                                 if (self.init_opts.wrap) {
                                     // wrap around
-                                    dvui.tabIndexPrevEx(e.num, self.tab_index_prev);
+                                    self.focusPrev(e.num);
                                 } else {
                                     // go back to where we were
-                                    dvui.tabIndexNextEx(e.num, self.tab_index_prev);
+                                    self.focusNext(e.num);
                                 }
                             }
                         } else if ((ke.code == .down and key_dir != .horizontal) or (ke.code == .right and key_dir != .vertical)) {
                             e.handle(@src(), self.data());
-                            dvui.tabIndexNextEx(e.num, self.tab_index_prev);
+                            self.focusNext(e.num);
                             if (dvui.focusedWidgetId() == null) {
                                 if (self.init_opts.wrap) {
                                     // wrap around
-                                    dvui.tabIndexNextEx(e.num, self.tab_index_prev);
+                                    self.focusNext(e.num);
                                 } else {
                                     // go back to where we were
-                                    dvui.tabIndexPrevEx(e.num, self.tab_index_prev);
+                                    self.focusPrev(e.num);
                                 }
                             }
                         }

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -364,7 +364,7 @@ pub const Branch = struct {
                         .right => {
                             e.handle(@src(), self.button.data());
                             if (self.expanded) {
-                                dvui.tabIndexNextEx(e.num, self.tree.group.tab_index_prev);
+                                self.tree.group.focusNext(e.num);
                             } else {
                                 self.expanded = true;
                             }
@@ -378,9 +378,9 @@ pub const Branch = struct {
                             } else {
                                 // no parent, so focus the first branch of the tree
                                 while (dvui.focusedWidgetId() != null) {
-                                    dvui.tabIndexPrevEx(e.num, self.tree.group.tab_index_prev);
+                                    self.tree.group.focusPrev(e.num);
                                 }
-                                dvui.tabIndexNextEx(e.num, self.tree.group.tab_index_prev);
+                                self.tree.group.focusNext(e.num);
                             }
                         },
                         else => {},


### PR DESCRIPTION
Makes tab_index a local order within the current TabIndexGroup, which can have its own tab_index.

This allows things like locally reordering the tab indexes of some widgets without globally changing anything.

Or a set of widgets with weird tab orders wrapped in a function that can be given a single tab_index.