### PR TITLE
demo: add simple search box to view source

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -574,7 +574,8 @@ fn displayZigSourceCode(filename: []const u8, source: []const u8, showing: *bool
                     var hbox_inner = dvui.box(@src(), .{ .dir = .horizontal }, .{
                         .gravity_x = 1.0,
                         .background = true,
-                        .margin = .{ .x = 0, .y = 4, .w = 4, .h = 4 },
+                        .margin = .{ .x = -1, .y = 4, .w = 4, .h = 4 },
+                        .padding = .{ .x = 4 },
                         .corner_radius = .{ .x = 0, .y = 5, .w = 5, .h = 0 },
                         .border = .{ .x = 0, .y = 1, .w = 1, .h = 1 },
                     });

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -536,31 +536,17 @@ fn displayZigSourceCode(filename: []const u8, source: []const u8, showing: *bool
             defer hbox.deinit();
             {
                 var search_entry: dvui.TextEntryWidget = undefined;
-                defer search_entry.deinit();
-                // TODO: This 26 char limit is to prevent horizontal scrolling of the prev/next buttons. Needs a better solution.
-                search_entry.init(@src(), .{ .placeholder = "Search ...", .text = .{ .internal = .{ .limit = 26 } } }, .{ .expand = .horizontal, .margin = .{ .x = 4, .y = 4, .w = 4, .h = 0 } });
-                {
-                    var hhbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .gravity_x = 1.0 });
-                    defer hhbox.deinit();
-                    if (dvui.buttonIcon(@src(), "previous", dvui.entypo.chevron_small_up, .{}, .{}, .{ .expand = .ratio })) {
-                        const range: Range = global.highlight_range orelse .{ .start = 0, .end = 0 };
-                        const text = search_entry.getText();
-                        if (std.mem.lastIndexOf(u8, global.source_code_stripped[0..range.start], text)) |idx| {
-                            global.highlight_range = .{ .start = idx, .end = idx + text.len };
-                            range_changed = true;
-                        }
-                    }
-                    if (dvui.buttonIcon(@src(), "next", dvui.entypo.chevron_small_down, .{}, .{}, .{ .expand = .ratio })) {
-                        const range: Range = global.highlight_range orelse .{ .start = 0, .end = 0 };
-                        const text = search_entry.getText();
-                        if (std.mem.indexOfPos(u8, global.source_code_stripped, range.end, text)) |idx| {
-                            global.highlight_range = .{ .start = idx, .end = idx + text.len };
-                            range_changed = true;
-                        }
-                    }
-                }
+                search_entry.init(@src(), .{ .placeholder = "Search ...", .text = .{ .internal = .{ .limit = 1024 } } }, .{
+                    .expand = .horizontal,
+                    .margin = .{ .x = 4, .y = 4, .w = 0, .h = 0 },
+                    .corner_radius = .{ .x = 5, .y = 0, .w = 0, .h = 5 },
+                    .border = .{ .x = 1, .y = 1, .w = 0, .h = 1 },
+                });
                 search_entry.processEvents();
                 search_entry.draw();
+                const search_entry_wid = search_entry.data().id;
+                const wd = search_entry.textLayout.data();
+                const icon_size: Size = .{ .h = wd.contentRect().h - 4, .w = wd.contentRect().h - 4 }; // Subtract top margin.
                 if (search_entry.enter_pressed) {
                     const range: Range = global.highlight_range orelse .{ .start = 0, .end = 0 };
                     const text = search_entry.getText();
@@ -582,6 +568,41 @@ fn displayZigSourceCode(filename: []const u8, source: []const u8, showing: *bool
                         range_changed = true;
                     }
                 }
+                const search_text = search_entry.getText();
+                search_entry.deinit();
+                {
+                    var hbox_inner = dvui.box(@src(), .{ .dir = .horizontal }, .{
+                        .gravity_x = 1.0,
+                        .background = true,
+                        .margin = .{ .x = 0, .y = 4, .w = 4, .h = 4 },
+                        .corner_radius = .{ .x = 0, .y = 5, .w = 5, .h = 0 },
+                        .border = .{ .x = 0, .y = 1, .w = 1, .h = 1 },
+                    });
+                    defer hbox_inner.deinit();
+                    if (dvui.focusedWidgetId() == search_entry_wid) {
+                        hbox_inner.data().focusBorder();
+                    }
+                    if (dvui.buttonIcon(@src(), "previous", dvui.entypo.chevron_small_up, .{}, .{}, .{
+                        .min_size_content = icon_size,
+                        .max_size_content = .cast(icon_size),
+                    })) {
+                        const range: Range = global.highlight_range orelse .{ .start = 0, .end = 0 };
+                        if (std.mem.lastIndexOf(u8, global.source_code_stripped[0..range.start], search_text)) |idx| {
+                            global.highlight_range = .{ .start = idx, .end = idx + search_text.len };
+                            range_changed = true;
+                        }
+                    }
+                    if (dvui.buttonIcon(@src(), "next", dvui.entypo.chevron_small_down, .{}, .{}, .{
+                        .min_size_content = icon_size,
+                        .max_size_content = .cast(icon_size),
+                    })) {
+                        const range: Range = global.highlight_range orelse .{ .start = 0, .end = 0 };
+                        if (std.mem.indexOfPos(u8, global.source_code_stripped, range.end, search_text)) |idx| {
+                            global.highlight_range = .{ .start = idx, .end = idx + search_text.len };
+                            range_changed = true;
+                        }
+                    }
+                }
             }
         }
         var te: dvui.TextEntryWidget = undefined;
@@ -589,12 +610,7 @@ fn displayZigSourceCode(filename: []const u8, source: []const u8, showing: *bool
             .multiline = true,
             .cache_layout = true,
             .text = .{ .internal = .{ .limit = 1_000_000 } },
-            .tree_sitter = .{
-                .language = global.tree_sitter_zig(),
-                .queries = queries,
-                .highlights = highlights,
-                .log_captures = false,
-            },
+            .tree_sitter = .{ .language = global.tree_sitter_zig(), .queries = queries, .highlights = highlights, .log_captures = false },
         }, .{
             .expand = .both,
         });

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -491,14 +491,18 @@ fn displayZigSourceCode(filename: []const u8, source: []const u8, showing: *bool
         defer fwin.deinit();
         fwin.dragAreaSet(dvui.windowHeader("View Zig Source", filename, showing));
 
+        const Range = struct {
+            start: usize,
+            end: usize,
+        };
+
         const global = struct {
             extern fn tree_sitter_zig() callconv(.c) *dvui.c.TSLanguage;
             var source_code: []const u8 = "";
             var source_code_stripped: []const u8 = "";
-            var highlight_range: ?struct {
-                start: usize,
-                end: usize,
-            } = null;
+            var highlight_range: ?Range = null;
+            var cursor_pos: usize = 0;
+            var cursor_moved: bool = false;
         };
 
         var vbox = dvui.box(@src(), .{}, .{});
@@ -523,31 +527,60 @@ fn displayZigSourceCode(filename: []const u8, source: []const u8, showing: *bool
         };
 
         var range_changed = false;
+        if (global.cursor_moved) {
+            global.highlight_range = .{ .start = global.cursor_pos, .end = global.cursor_pos };
+            global.cursor_moved = false;
+        }
         {
-            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .padding = .{ .y = 6 } });
+            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });
             defer hbox.deinit();
-            dvui.icon(@src(), "search", dvui.entypo.magnifying_glass, .{}, .{ .expand = .ratio, .gravity_x = 1.0, .padding = .all(6) });
-            var search_entry = dvui.textEntry(@src(), .{ .placeholder = "Search ..." }, .{ .expand = .horizontal });
-            defer search_entry.deinit();
-            if (search_entry.enter_pressed) {
-                const range: @TypeOf(global.highlight_range.?) = global.highlight_range orelse .{ .start = 0, .end = 0 };
-                const text = search_entry.getText();
-                if (std.mem.indexOfPos(u8, global.source_code_stripped, range.end, text)) |idx| {
-                    global.highlight_range = .{ .start = idx, .end = idx + text.len };
-                    range_changed = true;
+            {
+                var search_entry: dvui.TextEntryWidget = undefined;
+                defer search_entry.deinit();
+                // TODO: This 26 char limit is to prevent horizontal scrolling of the prev/next buttons. Needs a better solution.
+                search_entry.init(@src(), .{ .placeholder = "Search ...", .text = .{ .internal = .{ .limit = 26 } } }, .{ .expand = .horizontal, .margin = .{ .x = 4, .y = 4, .w = 4, .h = 0 } });
+                {
+                    var hhbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .gravity_x = 1.0 });
+                    defer hhbox.deinit();
+                    if (dvui.buttonIcon(@src(), "previous", dvui.entypo.chevron_small_up, .{}, .{}, .{ .expand = .ratio })) {
+                        const range: Range = global.highlight_range orelse .{ .start = 0, .end = 0 };
+                        const text = search_entry.getText();
+                        if (std.mem.lastIndexOf(u8, global.source_code_stripped[0..range.start], text)) |idx| {
+                            global.highlight_range = .{ .start = idx, .end = idx + text.len };
+                            range_changed = true;
+                        }
+                    }
+                    if (dvui.buttonIcon(@src(), "next", dvui.entypo.chevron_small_down, .{}, .{}, .{ .expand = .ratio })) {
+                        const range: Range = global.highlight_range orelse .{ .start = 0, .end = 0 };
+                        const text = search_entry.getText();
+                        if (std.mem.indexOfPos(u8, global.source_code_stripped, range.end, text)) |idx| {
+                            global.highlight_range = .{ .start = idx, .end = idx + text.len };
+                            range_changed = true;
+                        }
+                    }
                 }
-            } else if (search_entry.text_changed) {
-                const range: @TypeOf(global.highlight_range.?) = global.highlight_range orelse .{ .start = 0, .end = 0 };
-                const text = search_entry.getText();
-                if (std.mem.indexOfPos(u8, global.source_code_stripped, range.start, text)) |idx| {
-                    global.highlight_range = .{ .start = idx, .end = idx + text.len };
-                    range_changed = true;
-                } else if (std.mem.indexOf(u8, global.source_code_stripped, text)) |idx| {
-                    global.highlight_range = .{ .start = idx, .end = idx + text.len };
-                    range_changed = true;
-                } else {
-                    global.highlight_range = null;
-                    range_changed = true;
+                search_entry.processEvents();
+                search_entry.draw();
+                if (search_entry.enter_pressed) {
+                    const range: Range = global.highlight_range orelse .{ .start = 0, .end = 0 };
+                    const text = search_entry.getText();
+                    if (std.mem.indexOfPos(u8, global.source_code_stripped, range.end, text)) |idx| {
+                        global.highlight_range = .{ .start = idx, .end = idx + text.len };
+                        range_changed = true;
+                    }
+                } else if (search_entry.text_changed) {
+                    const range: Range = global.highlight_range orelse .{ .start = 0, .end = 0 };
+                    const text = search_entry.getText();
+                    if (std.mem.indexOfPos(u8, global.source_code_stripped, range.start, text)) |idx| {
+                        global.highlight_range = .{ .start = idx, .end = idx + text.len };
+                        range_changed = true;
+                    } else if (std.mem.indexOf(u8, global.source_code_stripped, text)) |idx| {
+                        global.highlight_range = .{ .start = idx, .end = idx + text.len };
+                        range_changed = true;
+                    } else {
+                        global.highlight_range = .{ .start = global.cursor_pos, .end = global.cursor_pos };
+                        range_changed = true;
+                    }
                 }
             }
         }
@@ -566,7 +599,6 @@ fn displayZigSourceCode(filename: []const u8, source: []const u8, showing: *bool
             .expand = .both,
         });
         defer te.deinit();
-
         if (dvui.firstFrame(te.data().id) or source.ptr != global.source_code.ptr) {
             // Need to strip out CR on windows.
             const stripped = dvui.currentWindow().lifo().alloc(u8, std.mem.replacementSize(u8, source, "\r", "")) catch @panic("OOM");
@@ -580,8 +612,8 @@ fn displayZigSourceCode(filename: []const u8, source: []const u8, showing: *bool
         }
         if (range_changed) {
             if (global.highlight_range) |range| {
-                te.textLayout.selection.moveCursor(range.start, false);
-                te.textLayout.selection.moveCursor(range.end, true);
+                te.textLayout.selection.moveCursor(range.end, false);
+                te.textLayout.selection.moveCursor(range.start, true);
                 te.textLayout.scroll_to_cursor = true;
             } else {
                 // Select nothing.
@@ -590,6 +622,10 @@ fn displayZigSourceCode(filename: []const u8, source: []const u8, showing: *bool
         }
         te.textLayout.processEvents();
         te.draw();
+        if (te.textLayout.selection.cursor != global.cursor_pos and !range_changed) {
+            global.cursor_moved = true;
+        }
+        global.cursor_pos = te.textLayout.selection.cursor;
     } else {
         if (showing.*) {
             var url: std.io.Writer.Allocating = .init(dvui.currentWindow().arena());

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -494,10 +494,15 @@ fn displayZigSourceCode(filename: []const u8, source: []const u8, showing: *bool
         const global = struct {
             extern fn tree_sitter_zig() callconv(.c) *dvui.c.TSLanguage;
             var source_code: []const u8 = "";
+            var source_code_stripped: []const u8 = "";
+            var highlight_range: ?struct {
+                start: usize,
+                end: usize,
+            } = null;
         };
 
-        var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
-        defer hbox.deinit();
+        var vbox = dvui.box(@src(), .{}, .{});
+        defer vbox.deinit();
 
         const queries = @embedFile("Examples/tree_sitter_zig_queries.scm");
 
@@ -517,6 +522,35 @@ fn displayZigSourceCode(filename: []const u8, source: []const u8, showing: *bool
             .{ .name = "error", .opts = .{ .color_text = .fromHex("F44747") } },
         };
 
+        var range_changed = false;
+        {
+            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .padding = .{ .y = 6 } });
+            defer hbox.deinit();
+            dvui.icon(@src(), "search", dvui.entypo.magnifying_glass, .{}, .{ .expand = .ratio, .gravity_x = 1.0, .padding = .all(6) });
+            var search_entry = dvui.textEntry(@src(), .{ .placeholder = "Search ..." }, .{ .expand = .horizontal });
+            defer search_entry.deinit();
+            if (search_entry.enter_pressed) {
+                const range: @TypeOf(global.highlight_range.?) = global.highlight_range orelse .{ .start = 0, .end = 0 };
+                const text = search_entry.getText();
+                if (std.mem.indexOfPos(u8, global.source_code_stripped, range.end, text)) |idx| {
+                    global.highlight_range = .{ .start = idx, .end = idx + text.len };
+                    range_changed = true;
+                }
+            } else if (search_entry.text_changed) {
+                const range: @TypeOf(global.highlight_range.?) = global.highlight_range orelse .{ .start = 0, .end = 0 };
+                const text = search_entry.getText();
+                if (std.mem.indexOfPos(u8, global.source_code_stripped, range.start, text)) |idx| {
+                    global.highlight_range = .{ .start = idx, .end = idx + text.len };
+                    range_changed = true;
+                } else if (std.mem.indexOf(u8, global.source_code_stripped, text)) |idx| {
+                    global.highlight_range = .{ .start = idx, .end = idx + text.len };
+                    range_changed = true;
+                } else {
+                    global.highlight_range = null;
+                    range_changed = true;
+                }
+            }
+        }
         var te: dvui.TextEntryWidget = undefined;
         te.init(@src(), .{
             .multiline = true,
@@ -534,11 +568,26 @@ fn displayZigSourceCode(filename: []const u8, source: []const u8, showing: *bool
         defer te.deinit();
 
         if (dvui.firstFrame(te.data().id) or source.ptr != global.source_code.ptr) {
-            te.textSet(source, false);
+            // Need to strip out CR on windows.
+            const stripped = dvui.currentWindow().lifo().alloc(u8, std.mem.replacementSize(u8, source, "\r", "")) catch @panic("OOM");
+            defer dvui.currentWindow().lifo().free(stripped);
+            _ = std.mem.replace(u8, source, "\r", "", stripped);
+
+            te.textSet(stripped, false);
             te.textLayout.selection.moveCursor(0, false); // keep from scrolling to the bottom
             global.source_code = source;
+            global.source_code_stripped = te.getText();
         }
-
+        if (range_changed) {
+            if (global.highlight_range) |range| {
+                te.textLayout.selection.moveCursor(range.start, false);
+                te.textLayout.selection.moveCursor(range.end, true);
+                te.textLayout.scroll_to_cursor = true;
+            } else {
+                // Select nothing.
+                te.textLayout.selection.moveCursor(te.textLayout.selection.cursor, false);
+            }
+        }
         te.textLayout.processEvents();
         te.draw();
     } else {


### PR DESCRIPTION
Adds a search box. I found this handy when I wanted to look or a particular widget in the source.

I put the prev and next buttons in the search box, because I thought it looked nicer. But there isn't really a way to stop the buttons scrolling off to the right, as far as I can tell? Most people won't see it, so maybe it's fine for now?