### PR TITLE
keyboard nav restart at closest widget

### DIFF
--- a/src/Subwindows.zig
+++ b/src/Subwindows.zig
@@ -16,6 +16,9 @@ pub const Subwindow = struct {
     rect: Rect,
     rect_pixels: Rect.Physical,
     focused_widget_id: ?Id = null,
+    /// Set when an unhandled click sets focus to null (or a widget without
+    /// tab_index), used to restart keyboard nav.
+    kb_restart_widget_id: ?Id = null,
     /// Uses `arena` allocator
     render_cmds: std.ArrayList(dvui.RenderCommand) = .empty,
     /// Uses `arena` allocator

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -459,8 +459,16 @@ pub fn focusWidget(self: *Self, id: ?Id, subwindow_id: ?Id, event_num: ?u16) voi
         }
         self.refreshWindow(@src(), null);
 
+        var kb_nav = false;
+
         if (id) |wid| {
             self.scroll_to_focused = true;
+
+            for (self.tab_index_prev.items) |ti| {
+                if (ti.windowId == sw.id and ti.widgetId == wid) {
+                    kb_nav = true;
+                }
+            }
 
             if (self.last_registered_id_this_frame == wid) {
                 self.last_focused_id_this_frame = wid;
@@ -473,6 +481,24 @@ pub fn focusWidget(self: *Self, id: ?Id, subwindow_id: ?Id, event_num: ?u16) voi
                         self.last_focused_id_this_frame = wid;
                         self.last_focused_id_in_subwindow = wid;
                         break;
+                    }
+                }
+            }
+        }
+
+        if (!kb_nav) {
+            var closest: Point.Physical = .{};
+            for (self.tab_index_prev.items) |ti| {
+                if (ti.windowId == sw.id) {
+                    if (sw.kb_restart_widget_id == null) {
+                        sw.kb_restart_widget_id = ti.widgetId;
+                        closest = self.mouse_pt.diff(ti.pt);
+                    } else {
+                        const diff = self.mouse_pt.diff(ti.pt);
+                        if (@abs(diff.x) + @abs(diff.y) < @abs(closest.x) + @abs(closest.y)) {
+                            sw.kb_restart_widget_id = ti.widgetId;
+                            closest = diff;
+                        }
                     }
                 }
             }

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -487,17 +487,22 @@ pub fn focusWidget(self: *Self, id: ?Id, subwindow_id: ?Id, event_num: ?u16) voi
         }
 
         if (!kb_nav) {
-            var closest: Point.Physical = .{};
+            var closest: f32 = 0;
+            var found_left: bool = false;
             for (self.tab_index_prev.items) |ti| {
                 if (ti.windowId == sw.id) {
-                    if (sw.kb_restart_widget_id == null) {
-                        sw.kb_restart_widget_id = ti.widgetId;
-                        closest = self.mouse_pt.diff(ti.pt);
-                    } else {
-                        const diff = self.mouse_pt.diff(ti.pt);
-                        if (@abs(diff.x) + @abs(diff.y) < @abs(closest.x) + @abs(closest.y)) {
+                    const diff = self.mouse_pt.diff(ti.pt);
+                    const d = diff.x * diff.x + diff.y * diff.y;
+                    if (diff.x >= 0 and ((diff.y >= 0 and diff.y <= diff.x) or (diff.y < 0 and @abs(diff.y) <= diff.x * 0.1))) {
+                        if (sw.kb_restart_widget_id == null or !found_left or d < closest) {
                             sw.kb_restart_widget_id = ti.widgetId;
-                            closest = diff;
+                            closest = d;
+                        }
+                        found_left = true;
+                    } else if (!found_left) {
+                        if (sw.kb_restart_widget_id == null or d < closest) {
+                            sw.kb_restart_widget_id = ti.widgetId;
+                            closest = d;
                         }
                     }
                 }

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1962,7 +1962,7 @@ pub fn tabIndexSetEx(widget_id: Id, tab_index: ?u16, rect: ?Rect.Physical, tab_g
     var ti = TabIndex{
         .windowId = cw.subwindows.current_id,
         .widgetId = widget_id,
-        .pt = if (rect) |r| r.center() else .{},
+        .pt = if (rect) |r| r.topLeft() else .{},
         .tab_index_group = TabIndexGroup.current,
         .tabIndex = (tab_index orelse math.maxInt(u16)),
         .tab_group = tab_group,

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1923,6 +1923,7 @@ pub fn scrollDrag(scroll_drag: ScrollDragOptions) void {
 pub const TabIndex = struct {
     windowId: Id,
     widgetId: Id,
+    pt: Point.Physical,
     tab_index_group: Id,
     tabIndex: u16,
 
@@ -1949,11 +1950,11 @@ pub const TabIndex = struct {
 /// keys instead of tab.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn tabIndexSet(widget_id: Id, tab_index: ?u16) void {
-    tabIndexSetEx(widget_id, tab_index, false);
+pub fn tabIndexSet(widget_id: Id, tab_index: ?u16, rect: ?Rect.Physical) void {
+    tabIndexSetEx(widget_id, tab_index, rect, false);
 }
 
-pub fn tabIndexSetEx(widget_id: Id, tab_index: ?u16, tab_group: bool) void {
+pub fn tabIndexSetEx(widget_id: Id, tab_index: ?u16, rect: ?Rect.Physical, tab_group: bool) void {
     if (tab_index != null and tab_index.? == 0)
         return;
 
@@ -1961,6 +1962,7 @@ pub fn tabIndexSetEx(widget_id: Id, tab_index: ?u16, tab_group: bool) void {
     var ti = TabIndex{
         .windowId = cw.subwindows.current_id,
         .widgetId = widget_id,
+        .pt = if (rect) |r| r.center() else .{},
         .tab_index_group = TabIndexGroup.current,
         .tabIndex = (tab_index orelse math.maxInt(u16)),
         .tab_group = tab_group,
@@ -1990,16 +1992,17 @@ pub fn tabIndexSetEx(widget_id: Id, tab_index: ?u16, tab_group: bool) void {
 ///
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn tabIndexNext(event_num: ?u16) void {
-    tabIndexNextEx(event_num, currentWindow().tab_index_prev.items, .zero);
+    tabIndexNextEx(event_num, currentWindow().tab_index_prev.items, .zero, false);
 }
 
-pub fn tabIndexNextEx(event_num: ?u16, tabidxs: []dvui.TabIndex, base_tig: Id) void {
+pub fn tabIndexNextEx(event_num: ?u16, tabidxs: []dvui.TabIndex, base_tig: Id, in_focus_group: bool) void {
     const cw = currentWindow();
     var widgetId = focusedWidgetId();
     var oldtab: ?u16 = null;
     var tig: Id = base_tig;
     var newId: ?Id = null;
     var ran_off: bool = false;
+    var first: bool = true;
     outer: while (true) {
         if (widgetId != null) {
             for (tabidxs) |ti| {
@@ -2010,6 +2013,17 @@ pub fn tabIndexNextEx(event_num: ?u16, tabidxs: []dvui.TabIndex, base_tig: Id) v
                 }
             }
         }
+
+        if (first and !in_focus_group and oldtab == null) {
+            if (cw.subwindows.focused()) |sw| {
+                if (sw.kb_restart_widget_id) |id| {
+                    newId = id;
+                    sw.kb_restart_widget_id = null;
+                    break :outer;
+                }
+            }
+        }
+        first = false;
 
         if (ran_off and oldtab == null) {
             // We ran off the tab index group, but couldn't find the entry for
@@ -2078,6 +2092,13 @@ pub fn tabIndexNextEx(event_num: ?u16, tabidxs: []dvui.TabIndex, base_tig: Id) v
     }
 
     focusWidget(newId, null, event_num);
+
+    if (newId == null) {
+        // intentionally moving to the null focus state, don't try to recover
+        if (cw.subwindows.focused()) |sw| {
+            sw.kb_restart_widget_id = null;
+        }
+    }
 }
 
 /// Move focus to the previous widget in tab index order.  Uses the tab index values from last frame.
@@ -2087,10 +2108,10 @@ pub fn tabIndexNextEx(event_num: ?u16, tabidxs: []dvui.TabIndex, base_tig: Id) v
 ///
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn tabIndexPrev(event_num: ?u16) void {
-    tabIndexPrevEx(event_num, currentWindow().tab_index_prev.items, .zero);
+    tabIndexPrevEx(event_num, currentWindow().tab_index_prev.items, .zero, false);
 }
 
-pub fn tabIndexPrevEx(event_num: ?u16, tabidxs: []dvui.TabIndex, base_tig: Id) void {
+pub fn tabIndexPrevEx(event_num: ?u16, tabidxs: []dvui.TabIndex, base_tig: Id, in_focus_group: bool) void {
     const cw = currentWindow();
     var widgetId = focusedWidgetId();
     var oldtab: ?u16 = null;
@@ -2098,6 +2119,7 @@ pub fn tabIndexPrevEx(event_num: ?u16, tabidxs: []dvui.TabIndex, base_tig: Id) v
     var tig: Id = base_tig;
     var newId: ?Id = null;
     var ran_off: bool = false;
+    var first: bool = true;
     outer: while (true) {
         if (widgetId != null) {
             for (tabidxs) |ti| {
@@ -2109,6 +2131,17 @@ pub fn tabIndexPrevEx(event_num: ?u16, tabidxs: []dvui.TabIndex, base_tig: Id) v
                 }
             }
         }
+
+        if (first and !in_focus_group and oldtab == null) {
+            if (cw.subwindows.focused()) |sw| {
+                if (sw.kb_restart_widget_id) |id| {
+                    newId = id;
+                    sw.kb_restart_widget_id = null;
+                    break :outer;
+                }
+            }
+        }
+        first = false;
 
         if (ran_off and oldtab == null) {
             // We ran off the tab index group, but couldn't find the entry for
@@ -2179,7 +2212,14 @@ pub fn tabIndexPrevEx(event_num: ?u16, tabidxs: []dvui.TabIndex, base_tig: Id) v
         // If we shift-tabbed from inside a focusGroup, we will always focus
         // the focusGroup itself, so do this again to focus the widget before
         // the focusGroup.
-        tabIndexPrevEx(event_num, tabidxs, base_tig);
+        tabIndexPrevEx(event_num, tabidxs, base_tig, false);
+    }
+
+    if (newId == null) {
+        // intentionally moving to the null focus state, don't try to recover
+        if (cw.subwindows.focused()) |sw| {
+            sw.kb_restart_widget_id = null;
+        }
     }
 }
 
@@ -2203,7 +2243,7 @@ pub const TabIndexGroup = struct {
 
         const id = dvui.parentGet().extendId(src, opts.id_extra orelse 0);
 
-        tabIndexSetEx(id, opts.tab_index, true);
+        tabIndexSetEx(id, opts.tab_index, null, true);
 
         TabIndexGroup.current = id;
     }
@@ -2970,7 +3010,7 @@ pub fn expander(src: std.builtin.SourceLocation, label_str: []const u8, init_opt
     var b = box(src, .{ .dir = .horizontal }, options);
     defer b.deinit();
 
-    dvui.tabIndexSet(b.data().id, b.data().options.tab_index);
+    dvui.tabIndexSet(b.data().id, b.data().options.tab_index, b.data().rectScale().r);
 
     var expanded: bool = init_opts.default_expanded;
     if (dvui.dataGet(null, b.data().id, "_expand", bool)) |e| {
@@ -3677,7 +3717,7 @@ pub fn labelClick(src: std.builtin.SourceLocation, comptime fmt: []const u8, arg
     lw.init(src, fmt, args, init_opts.label_opts, defaults.override(opts));
     // draw border and background
 
-    dvui.tabIndexSet(lw.data().id, lw.data().options.tab_index);
+    dvui.tabIndexSet(lw.data().id, lw.data().options.tab_index, lw.data().rectScale().r);
 
     var ret = false;
     if (dvui.clickedEx(lw.data(), .{ .buttons = .any })) |click_event| {
@@ -4021,7 +4061,7 @@ pub fn slider(src: std.builtin.SourceLocation, init_opts: SliderInitOptions, opt
         AccessKit.nodeSetNumericValueJump(ak_node, 0.10);
     }
 
-    tabIndexSet(b.data().id, options.tab_index);
+    tabIndexSet(b.data().id, options.tab_index, b.data().rectScale().r);
 
     var hovered: bool = false;
     var ret = false;
@@ -4236,7 +4276,7 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
         }
     }
 
-    tabIndexSet(b.data().id, options.tab_index);
+    tabIndexSet(b.data().id, options.tab_index, b.data().rectScale().r);
 
     const br = b.data().contentRect();
     const knobsize = @min(br.w, br.h);
@@ -4667,7 +4707,7 @@ pub fn checkboxEx(src: std.builtin.SourceLocation, target: *bool, label_str: ?[]
     var b = box(src, .{ .dir = .horizontal }, options);
     defer b.deinit();
 
-    dvui.tabIndexSet(b.data().id, b.data().options.tab_index);
+    dvui.tabIndexSet(b.data().id, b.data().options.tab_index, b.data().rectScale().r);
 
     var hovered: bool = false;
     if (dvui.clicked(b.data(), .{ .hovered = &hovered })) {
@@ -4761,7 +4801,7 @@ pub fn radio(src: std.builtin.SourceLocation, active: bool, label_str: ?[]const 
     var b = box(src, .{ .dir = .horizontal }, options);
     defer b.deinit();
 
-    dvui.tabIndexSet(b.data().id, b.data().options.tab_index);
+    dvui.tabIndexSet(b.data().id, b.data().options.tab_index, b.data().rectScale().r);
 
     var hovered: bool = false;
     if (dvui.clicked(b.data(), .{ .hovered = &hovered })) {

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -42,7 +42,7 @@ pub fn init(self: *ButtonWidget, src: std.builtin.SourceLocation, init_options: 
     self.data().register();
     dvui.parentSet(self.widget());
 
-    dvui.tabIndexSet(self.data().id, self.data().options.tab_index);
+    dvui.tabIndexSet(self.data().id, self.data().options.tab_index, self.data().rectScale().r);
 
     if (self.data().accesskit_node()) |ak_node| {
         dvui.AccessKit.nodeAddAction(ak_node, dvui.AccessKit.Action.focus);

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -69,7 +69,7 @@ pub fn valueSaturationBox(src: std.builtin.SourceLocation, hsv: *Color.HSV, opts
     // Accessibility TODO: Needs 2d-slider support from AccessKit. It's not possible to attach
     // a horizontal and vertical value to a single widget.
 
-    dvui.tabIndexSet(b.data().id, options.tab_index);
+    dvui.tabIndexSet(b.data().id, options.tab_index, b.data().rectScale().r);
 
     const rs = b.data().contentRectScale();
 
@@ -208,7 +208,7 @@ pub fn hueSlider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hue
         AccessKit.nodeSetNumericValue(ak_node, hue.*);
     }
 
-    dvui.tabIndexSet(b.data().id, options.tab_index);
+    dvui.tabIndexSet(b.data().id, options.tab_index, b.data().rectScale().r);
 
     const br = b.data().contentRect();
     const knobsize: dvui.Size = switch (dir) {

--- a/src/widgets/FocusGroupWidget.zig
+++ b/src/widgets/FocusGroupWidget.zig
@@ -56,7 +56,7 @@ pub fn init(self: *FocusGroupWidget, src: std.builtin.SourceLocation, init_opts:
             // put ourselves in the tab index so the whole focus group can be focused by tab
             // but only if we contain focusable widgets
             if (self.tab_index_prev.len > 0)
-                dvui.tabIndexSet(self.data().id, self.data().options.tab_index);
+                dvui.tabIndexSet(self.data().id, self.data().options.tab_index, self.data().rectScale().r);
 
             if (self.data().id == dvui.focusedWidgetId()) {
                 // if we got focused, focus our remembered focus or first id
@@ -74,11 +74,11 @@ pub fn init(self: *FocusGroupWidget, src: std.builtin.SourceLocation, init_opts:
 }
 
 pub fn focusNext(self: *FocusGroupWidget, event_num: ?u16) void {
-    dvui.tabIndexNextEx(event_num, self.tab_index_prev, self.tab_index_group);
+    dvui.tabIndexNextEx(event_num, self.tab_index_prev, self.tab_index_group, true);
 }
 
 pub fn focusPrev(self: *FocusGroupWidget, event_num: ?u16) void {
-    dvui.tabIndexPrevEx(event_num, self.tab_index_prev, self.tab_index_group);
+    dvui.tabIndexPrevEx(event_num, self.tab_index_prev, self.tab_index_group, true);
 }
 
 pub fn widget(self: *FocusGroupWidget) Widget {

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -48,7 +48,7 @@ pub fn init(self: *MenuItemWidget, src: std.builtin.SourceLocation, init_opts: I
 
     self.data().register();
 
-    dvui.tabIndexSet(self.data().id, self.data().options.tab_index);
+    dvui.tabIndexSet(self.data().id, self.data().options.tab_index, self.data().rectScale().r);
 
     self.data().borderAndBackground(.{});
 

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -275,7 +275,7 @@ pub fn init(self: *TextEntryWidget, src: std.builtin.SourceLocation, init_opts: 
 
     self.data().register();
 
-    dvui.tabIndexSet(self.data().id, self.data().options.tab_index);
+    dvui.tabIndexSet(self.data().id, self.data().options.tab_index, self.data().rectScale().r);
 
     dvui.parentSet(self.widget());
 


### PR DESCRIPTION
fixes #789 

The intent is to allow the user to click in an approximate place to get keyboard nav in the right area without having to keyboard nav through all widgets or actually click on a focusable widget.

This changes `tabIndexSet` to also take a `?Rect.Physical` representing (if any) the rect of the widget for this tab index.

If focus moves to null (from a click) or to a widget that does not have a tab index (like a scroll area), then when tab is pressed we search for the closest given rect and focus that widget.