### PR TITLE
Support separate render backends

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -82,6 +82,8 @@ pub fn build(b: *std.Build) !void {
     const stb_image_option = b.option(bool, "stb-image", "Build stb_image (default is backend specific, some include stb_image)");
     const tree_sitter_option = b.option(bool, "tree-sitter", "Build tree sitter (default is backend specific)");
 
+    const wio_unix_backends = b.option([]const u8, "wio_unix_backends", "List of wio backends for Unix (default: all)");
+
     // This option is triggered only if it involved with raylib backend of any kind
     var linux_display_backend: ?LinuxDisplayBackend = null;
     if (back_to_build == null or back_to_build.? == .raylib or back_to_build.? == .raylib_zig) {
@@ -159,6 +161,7 @@ pub fn build(b: *std.Build) !void {
         .linux_display_backend = linux_display_backend,
         .stb_image = stb_image_option,
         .tree_sitter = tree_sitter_option,
+        .wio_unix_backends = wio_unix_backends,
     };
 
     if (back_to_build) |backend| {
@@ -793,7 +796,8 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
             if (b.lazyDependency("wio", .{
                 .target = target,
                 .optimize = optimize,
-                .features = "opengl",
+                .enable_opengl = (dvui_opts.render_backend == .opengl),
+                .unix_backends = dvui_opts.wio_unix_backends,
                 .win32_manifest = false,
             })) |wio| {
                 wio_backend_mod.addImport("wio", wio.module("wio"));
@@ -841,6 +845,7 @@ const DvuiModuleOptions = struct {
     linux_display_backend: ?LinuxDisplayBackend = null,
     stb_image: ?bool,
     tree_sitter: ?bool,
+    wio_unix_backends: ?[]const u8 = null,
 
     pub const DefaultOptions = struct {
         libc: bool,

--- a/build.zig
+++ b/build.zig
@@ -315,7 +315,7 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                 .backend_name = "testing-backend",
                 .backend_mod = testing_mod,
             };
-            addExample("testing-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
+            _ = addExample("testing-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
         },
         .sdl2 => {
             dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true, .tree_sitter = true });
@@ -398,9 +398,9 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                 .backend_name = "sdl-backend",
                 .backend_mod = sdl_mod,
             };
-            addExample("sdl2-standalone", b.path("examples/sdl-standalone.zig"), true, example_opts, dvui_opts);
-            addExample("sdl2-ontop", b.path("examples/sdl-ontop.zig"), true, example_opts, dvui_opts);
-            addExample("sdl2-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
+            _ = addExample("sdl2-standalone", b.path("examples/sdl-standalone.zig"), true, example_opts, dvui_opts);
+            _ = addExample("sdl2-ontop", b.path("examples/sdl-ontop.zig"), true, example_opts, dvui_opts);
+            _ = addExample("sdl2-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
         },
         .sdl3gpu => {
             dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true, .tree_sitter = true });
@@ -433,8 +433,8 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                 .backend_name = "sdl3gpu-backend",
                 .backend_mod = sdl_mod,
             };
-            addExample("sdl3gpu-standalone", b.path("examples/sdl3gpu-standalone.zig"), true, example_opts, dvui_opts);
-            addExample("sdl3gpu-ontop", b.path("examples/sdl3gpu-ontop.zig"), true, example_opts, dvui_opts);
+            _ = addExample("sdl3gpu-standalone", b.path("examples/sdl3gpu-standalone.zig"), true, example_opts, dvui_opts);
+            _ = addExample("sdl3gpu-ontop", b.path("examples/sdl3gpu-ontop.zig"), true, example_opts, dvui_opts);
         },
         .sdl3 => {
             dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true, .tree_sitter = true });
@@ -469,9 +469,9 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                 .backend_name = "sdl-backend",
                 .backend_mod = sdl_mod,
             };
-            addExample("sdl3-standalone", b.path("examples/sdl-standalone.zig"), true, example_opts, dvui_opts);
-            addExample("sdl3-ontop", b.path("examples/sdl-ontop.zig"), true, example_opts, dvui_opts);
-            addExample("sdl3-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
+            _ = addExample("sdl3-standalone", b.path("examples/sdl-standalone.zig"), true, example_opts, dvui_opts);
+            _ = addExample("sdl3-ontop", b.path("examples/sdl-ontop.zig"), true, example_opts, dvui_opts);
+            _ = addExample("sdl3-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
         },
         .raylib => {
             if (dvui_opts.vertex_index != .u16) {
@@ -539,9 +539,9 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                 .backend_mod = raylib_backend_mod,
             };
 
-            addExample("raylib-standalone", b.path("examples/raylib-standalone.zig"), true, example_opts, dvui_opts);
-            addExample("raylib-ontop", b.path("examples/raylib-ontop.zig"), true, example_opts, dvui_opts);
-            addExample("raylib-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
+            _ = addExample("raylib-standalone", b.path("examples/raylib-standalone.zig"), true, example_opts, dvui_opts);
+            _ = addExample("raylib-ontop", b.path("examples/raylib-ontop.zig"), true, example_opts, dvui_opts);
+            _ = addExample("raylib-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
         },
         .raylib_zig => {
             if (dvui_opts.vertex_index != .u16) {
@@ -598,9 +598,9 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                 .backend_mod = raylib_backend_mod,
             };
 
-            addExample("raylib-zig-standalone", b.path("examples/raylib-zig-standalone.zig"), true, example_opts, dvui_opts);
-            addExample("raylib-zig-ontop", b.path("examples/raylib-zig-ontop.zig"), true, example_opts, dvui_opts);
-            addExample("raylib-zig-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
+            _ = addExample("raylib-zig-standalone", b.path("examples/raylib-zig-standalone.zig"), true, example_opts, dvui_opts);
+            _ = addExample("raylib-zig-ontop", b.path("examples/raylib-zig-ontop.zig"), true, example_opts, dvui_opts);
+            _ = addExample("raylib-zig-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
         },
         .dx11 => {
             if (dvui_opts.vertex_index != .u16) {
@@ -635,37 +635,24 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                     .backend_name = "dx11-backend",
                     .backend_mod = dx11_mod,
                 };
-                addExample("dx11-standalone", b.path("examples/dx11-standalone.zig"), true, example_opts, dvui_opts);
-                addExample("dx11-ontop", b.path("examples/dx11-ontop.zig"), true, example_opts, dvui_opts);
-                addExample("dx11-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
+                _ = addExample("dx11-standalone", b.path("examples/dx11-standalone.zig"), true, example_opts, dvui_opts);
+                _ = addExample("dx11-ontop", b.path("examples/dx11-ontop.zig"), true, example_opts, dvui_opts);
+                _ = addExample("dx11-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
             }
         },
-        .glfw_opengl => {
+        .glfw => {
             dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .stb_image = true, .tiny_file_dialogs = true, .tree_sitter = true });
 
-            const glfw_opengl_mod = b.addModule("glfw-opengl", .{
-                .root_source_file = b.path("src/backends/glfw-opengl.zig"),
+            if (dvui_opts.render_backend == .default) {
+                dvui_opts.render_backend = .opengl;
+            }
+
+            const glfw_mod = b.addModule("glfw", .{
+                .root_source_file = b.path("src/backends/glfw.zig"),
                 .target = target,
                 .optimize = optimize,
                 .link_libc = true,
             });
-            const maybe_zgl = b.lazyDependency("zgl", .{
-                .target = target,
-                .optimize = optimize,
-            });
-
-            if (maybe_zgl) |zgl| {
-                glfw_opengl_mod.addImport("zgl", zgl.module("zgl"));
-                switch (target.result.os.tag) {
-                    .windows => glfw_opengl_mod.linkSystemLibrary("opengl32", .{}),
-                    .linux => glfw_opengl_mod.linkSystemLibrary("GL", .{}),
-                    .macos => {
-                        glfw_opengl_mod.linkFramework("OpenGL", .{});
-                        glfw_opengl_mod.linkFramework("Cocoa", .{});
-                    },
-                    else => {},
-                }
-            }
 
             const maybe_glfw = b.lazyDependency(
                 "zglfw",
@@ -676,20 +663,38 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
             );
 
             if (maybe_glfw) |glfw| {
-                glfw_opengl_mod.addImport("zglfw", glfw.module("root"));
-                glfw_opengl_mod.linkLibrary(glfw.artifact("glfw"));
+                glfw_mod.addImport("zglfw", glfw.module("root"));
+                glfw_mod.linkLibrary(glfw.artifact("glfw"));
             }
 
-            const dvui_glfw_opengl = addDvuiModule("dvui-glfw-opengl", dvui_opts);
-            linkBackend(dvui_glfw_opengl, glfw_opengl_mod);
+            const dvui_glfw = addDvuiModule("dvui-glfw", dvui_opts);
+            linkBackend(dvui_glfw, glfw_mod);
 
             const example_opts: ExampleOptions = .{
-                .dvui_mod = dvui_glfw_opengl,
-                .backend_name = "glfw-opengl-backend",
-                .backend_mod = glfw_opengl_mod,
+                .dvui_mod = dvui_glfw,
+                .backend_name = "glfw-backend",
+                .backend_mod = glfw_mod,
             };
-            addExample("glfw-opengl-ontop", b.path("examples/glfw-opengl-ontop.zig"), test_dvui_and_app, example_opts, dvui_opts);
-            addExample("glfw-opengl-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
+            _ = addExample("glfw-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
+            const glfw_opengl_ontop = addExample("glfw-opengl-ontop", b.path("examples/glfw-opengl-ontop.zig"), test_dvui_and_app, example_opts, dvui_opts);
+
+            const maybe_zgl = b.lazyDependency("zgl", .{
+                .target = target,
+                .optimize = optimize,
+            });
+            if (maybe_zgl) |zgl| {
+                const zgl_mod = zgl.module("zgl");
+                switch (target.result.os.tag) {
+                    .windows => zgl_mod.linkSystemLibrary("opengl32", .{}),
+                    .linux => zgl_mod.linkSystemLibrary("GL", .{}),
+                    .macos => {
+                        zgl_mod.linkFramework("OpenGL", .{});
+                        zgl_mod.linkFramework("Cocoa", .{});
+                    },
+                    else => {},
+                }
+                glfw_opengl_ontop.addImport("zgl", zgl_mod);
+            }
         },
         .web => {
             if (dvui_opts.vertex_index != .u16) {
@@ -807,7 +812,7 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                 .backend_name = "wio-backend",
                 .backend_mod = wio_backend_mod,
             };
-            addExample("wio-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
+            _ = addExample("wio-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
         },
     }
 }
@@ -1102,7 +1107,7 @@ fn addExample(
     add_tests: bool,
     example_opts: ExampleOptions,
     opts: DvuiModuleOptions,
-) void {
+) *std.Build.Module {
     const b = opts.b;
 
     const mod = b.createModule(.{
@@ -1163,6 +1168,8 @@ fn addExample(
 
     const run_step = b.step(name, "Run " ++ name);
     run_step.dependOn(&run_cmd.step);
+
+    return mod;
 }
 
 fn addWebExample(

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const enums_backend = @import("src/enums_backend.zig");
 pub const Backend = enums_backend.Backend;
+const RenderBackend = enums_backend.RenderBackend;
 const Pkg = std.Build.Pkg;
 const Compile = std.Build.Step.Compile;
 
@@ -60,6 +61,7 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
     var back_to_build = b.option(Backend, "backend", "Backend to build");
+    const render_backend = b.option(RenderBackend, "render-backend", "Render backend to build (default: implied by backend)") orelse .default;
 
     const test_step = b.step("test", "Test the dvui codebase");
     const check_step = b.step("check", "Check that the entire dvui codebase has no syntax errors");
@@ -149,6 +151,7 @@ pub fn build(b: *std.Build) !void {
         .use_lld = use_lld,
         .accesskit = accesskit,
         .build_options = build_options,
+        .render_backend = render_backend,
         .vertex_index = vertex_index,
         .libc = libc_option,
         .freetype = freetype_option,
@@ -734,6 +737,7 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                     }),
                     .optimize = optimize,
                     .build_options = dvui_opts.build_options,
+                    .render_backend = .default,
                     .vertex_index = .u16,
                     .test_filters = dvui_opts.test_filters,
                     .accesskit = .off,
@@ -769,6 +773,10 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
             // workaround for https://github.com/ziglang/zig/issues/24140
             dvui_opts.use_llvm = true;
 
+            if (dvui_opts.render_backend == .default) {
+                dvui_opts.render_backend = .opengl;
+            }
+
             const wio_backend_mod = b.addModule("wio", .{
                 .root_source_file = b.path("src/backends/wio.zig"),
                 .target = target,
@@ -784,14 +792,6 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                 .win32_manifest = false,
             })) |wio| {
                 wio_backend_mod.addImport("wio", wio.module("wio"));
-            }
-
-            if (b.lazyDependency("opengl", .{
-                .major_version = 3,
-                .minor_version = 2,
-                .profile = .core,
-            })) |opengl| {
-                wio_backend_mod.addImport("gl", opengl.module("opengl"));
             }
 
             const dvui_wio = addDvuiModule("dvui_wio", dvui_opts);
@@ -828,6 +828,7 @@ const DvuiModuleOptions = struct {
     use_lld: ?bool = null,
     accesskit: AccesskitOptions = .off,
     build_options: *std.Build.Step.Options,
+    render_backend: RenderBackend,
     vertex_index: VertexIndex,
     libc: ?bool,
     tiny_file_dialogs: ?bool,
@@ -962,6 +963,26 @@ pub fn addDvuiModule(
         .target = target,
         .optimize = optimize,
     }).module("svg2tvg"));
+
+    const renderer_mod = b.addModule("render_backend", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    switch (opts.render_backend) {
+        .default => renderer_mod.root_source_file = b.path("src/backends/render/default.zig"),
+        .opengl => {
+            renderer_mod.root_source_file = b.path("src/backends/render/opengl.zig");
+            if (b.lazyDependency("opengl", .{
+                .major_version = 3,
+                .minor_version = 2,
+                .profile = .core,
+            })) |opengl| {
+                renderer_mod.addImport("gl", opengl.module("opengl"));
+            }
+        },
+    }
+    renderer_mod.addImport("dvui", dvui_mod);
+    dvui_mod.addImport("render_backend", renderer_mod);
 
     // the system integration option check has to always occur even if accesskit is disabled for
     // it to be displayed in the build help

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -26,8 +26,8 @@
             .lazy = true,
         },
         .wio = .{
-            .url = "https://github.com/ypsvlq/wio/archive/665305435019fce313c55c6c3cfb1f9e9f89058a.tar.gz",
-            .hash = "wio-0.0.0-8xHrr-cvBQA6pUTUXtUwKvoKRNKk3QboY8Vw7XSg8-JI",
+            .url = "https://github.com/ypsvlq/wio/archive/8aecae4e3b63dbdcdecde6fcc0c474902e4e23d8.tar.gz",
+            .hash = "wio-0.0.0-8xHrr01dBQDLwISVPogLZjCYuQsuVECb8CO5Jq5uTCIU",
             .lazy = true,
         },
         .opengl = .{

--- a/examples/glfw-opengl-ontop.zig
+++ b/examples/glfw-opengl-ontop.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const dvui = @import("dvui");
-const Backend = @import("glfw-opengl-backend");
+const Backend = @import("glfw-backend");
+const zgl = @import("zgl");
 const zglfw = Backend.zglfw;
-const zgl = Backend.zgl;
 
 // This can optionally be added in source file to manage how opengl
 // errors are handled.
@@ -24,6 +24,8 @@ pub fn main() !void {
 }
 
 pub fn app_init() !void {
+    if (dvui.render_backend.kind != .opengl) @compileError("unsupported renderer");
+
     try zglfw.init();
     //Recommended hints
     zglfw.windowHint(.context_version_major, 3);
@@ -38,16 +40,15 @@ pub fn app_init() !void {
     zglfw.makeContextCurrent(window);
     zglfw.swapInterval(1);
 
-    // The backend currently initializes zgl context in Backend.init in case the
-    // user doesn't use zgl. Therefore, the user doesn't have to initialize it
-    // themselves, but doing so results in no error.
-    // const proc: zglfw.GlProc = undefined;
-    // try zgl.loadExtensions(proc, glGetProcAddress);
+    const proc: zglfw.GlProc = undefined;
+    try zgl.loadExtensions(proc, glGetProcAddress);
+
+    var renderer = try dvui.render_backend.init(gpa, zglfw.getProcAddress, "330");
 
     var impl = Backend.init(gpa, window);
     defer impl.deinit();
 
-    const backend = dvui.Backend.init(&impl);
+    const backend = dvui.Backend.init(&impl, &renderer);
     var win = try dvui.Window.init(@src(), gpa, backend, .{});
     defer win.deinit();
 

--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -16,9 +16,16 @@ pub const TextureError = GenericError || error{ TextureCreate, TextureRead, Text
 pub const kind = Implementation.kind;
 
 impl: *Implementation,
+render_impl: if (dvui.render_backend.kind == .default) void else *dvui.render_backend,
 
-pub fn init(impl: *Implementation) Backend {
-    return .{ .impl = impl };
+pub const init = if (dvui.render_backend.kind == .default) initDefault else initRenderer;
+
+fn initDefault(impl: *Implementation) Backend {
+    return .{ .impl = impl, .render_impl = {} };
+}
+
+fn initRenderer(impl: *Implementation, render_impl: *dvui.render_backend) Backend {
+    return .{ .impl = impl, .render_impl = render_impl };
 }
 
 /// Get monotonic nanosecond timestamp. Doesn't have to be system time.
@@ -34,12 +41,14 @@ pub fn sleep(self: Backend, ns: u64) void {
 /// arg is cleared before `dvui.Window.begin` is called next, useful for any
 /// temporary allocations needed only for this frame.
 pub fn begin(self: Backend, arena: std.mem.Allocator) GenericError!void {
-    return self.impl.begin(arena);
+    try self.impl.begin(arena);
+    if (dvui.render_backend.kind != .default) try self.render_impl.begin(arena);
 }
 
 /// Called during `dvui.Window.end` before freeing any memory for the current frame.
 pub fn end(self: Backend) GenericError!void {
-    return self.impl.end();
+    if (dvui.render_backend.kind != .default) try self.render_impl.end();
+    try self.impl.end();
 }
 
 /// Return size of the window in physical pixels.  For a 300x200 retina
@@ -67,21 +76,25 @@ pub fn contentScale(self: Backend) f32 {
 /// physical pixels.  If `texture` is given, the vertexes uv coords are
 /// normalized (0-1). `clipr` (if given) has whole pixel values.
 pub fn drawClippedTriangles(self: Backend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, clipr: ?dvui.Rect.Physical) GenericError!void {
-    return self.impl.drawClippedTriangles(texture, vtx, idx, clipr);
+    if (dvui.render_backend.kind == .default) {
+        try self.impl.drawClippedTriangles(texture, vtx, idx, clipr);
+    } else {
+        try self.renderer().drawClippedTriangles(self.impl.pixelSize(), texture, vtx, idx, clipr);
+    }
 }
 
 /// Create a `dvui.Texture` from premultiplied alpha `pixels` in RGBA.  The
 /// returned pointer is what will later be passed to `drawClippedTriangles`.
 pub fn textureCreate(self: Backend, pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) TextureError!dvui.Texture {
-    return self.impl.textureCreate(pixels, width, height, interpolation, format);
+    return self.renderer().textureCreate(pixels, width, height, interpolation, format);
 }
 
 /// Update a `dvui.Texture` from premultiplied alpha `pixels` in RGBA.  The
 /// passed in texture must be created  with textureCreate
 pub fn textureUpdate(self: Backend, texture: dvui.Texture, pixels: [*]const u8) TextureError!void {
     // we can handle backends that dont support textureUpdate by using destroy and create again!
-    if (comptime !@hasDecl(Implementation, "textureUpdate")) return TextureError.NotImplemented else {
-        return self.impl.textureUpdate(texture, pixels);
+    if (comptime !@hasDecl(@TypeOf(self.renderer().*), "textureUpdate")) return TextureError.NotImplemented else {
+        return self.renderer().textureUpdate(texture, pixels);
     }
 }
 
@@ -89,49 +102,56 @@ pub fn textureUpdate(self: Backend, texture: dvui.Texture, pixels: [*]const u8) 
 /// pointer will not be used by dvui.
 pub fn textureDestroy(self: Backend, texture: dvui.Texture) void {
     // std.debug.print("destroy ptr {} w: {}, h:{}\n", .{ @intFromPtr(texture.ptr), texture.width, texture.height });
-    return self.impl.textureDestroy(texture);
+    return self.renderer().textureDestroy(texture);
 }
 
 /// Create a `dvui.Texture` that can be rendered to with `renderTarget`.  The
 /// returned pointer is what will later be passed to `drawClippedTriangles`.
 pub fn textureCreateTarget(self: Backend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) TextureError!dvui.TextureTarget {
-    return self.impl.textureCreateTarget(width, height, interpolation, format);
+    return self.renderer().textureCreateTarget(width, height, interpolation, format);
 }
 
 /// Read pixel data (RGBA) from `texture` into `pixels_out`.
 pub fn textureReadTarget(self: Backend, texture: dvui.TextureTarget, pixels_out: [*]u8) TextureError!void {
-    return self.impl.textureReadTarget(texture, pixels_out);
+    return self.renderer().textureReadTarget(texture, pixels_out);
 }
 
 /// Destroy `texture` made with `Target.Create`. After this call, this texture
 /// pointer will not be used by dvui.
 pub fn textureClearTarget(self: Backend, texture: dvui.Texture.Target) void {
-    return self.impl.textureClearTarget(texture);
+    return self.renderer().textureClearTarget(texture);
 }
 
 /// Destroy `texture` made with `Target.Create`. After this call, this texture
 /// pointer will not be used by dvui.
 pub fn textureDestroyTarget(self: Backend, texture: dvui.Texture.Target) void {
-    return self.impl.textureDestroyTarget(texture);
+    return self.renderer().textureDestroyTarget(texture);
 }
 
 /// Convert `target` made with `textureCreateTarget` into return texture
 /// as if made by `textureCreate`.  target will be destroyed.
 pub fn textureFromTarget(self: Backend, target: dvui.TextureTarget) TextureError!dvui.Texture {
-    return self.impl.textureFromTarget(target);
+    return self.renderer().textureFromTarget(target);
 }
 
 /// Get a temporary drawable texture from this target, as if made by
 /// `textureCreate` and then passed to `textureDestroyLater`.  target is not
 /// destroyed.
 pub fn textureFromTargetTemp(self: Backend, target: dvui.TextureTarget) TextureError!dvui.Texture {
-    return self.impl.textureFromTargetTemp(target);
+    return self.renderer().textureFromTargetTemp(target);
 }
 
 /// Render future `drawClippedTriangles` to the passed `texture` (or screen
 /// if null).
 pub fn renderTarget(self: Backend, texture: ?dvui.TextureTarget) GenericError!void {
-    return self.impl.renderTarget(texture);
+    return self.renderer().renderTarget(texture);
+}
+
+fn renderer(self: Backend) if (dvui.render_backend.kind == .default) *Implementation else *dvui.render_backend {
+    return if (dvui.render_backend.kind == .default)
+        self.impl
+    else
+        self.render_impl;
 }
 
 /// Get clipboard content (text only)

--- a/src/Examples/animations.zig
+++ b/src/Examples/animations.zig
@@ -203,7 +203,7 @@ pub fn animations() void {
             .web => dvui.label(@src(), "web: updated when not interrupted by event", .{}, .{}),
             .raylib, .raylib_zig => dvui.label(@src(), "raylib: only updated if non-null passed to waitTime", .{}, .{}),
             .dx11 => dvui.label(@src(), "dx11: only updated if non-null passed to waitTime", .{}, .{}),
-            .sdl, .custom, .testing, .glfw_opengl, .wio => {},
+            .sdl, .custom, .testing, .glfw, .wio => {},
         }
     }
 

--- a/src/backends/glfw.zig
+++ b/src/backends/glfw.zig
@@ -1,11 +1,10 @@
 const std = @import("std");
 const dvui = @import("dvui");
-pub const zgl = @import("zgl");
 pub const zglfw = @import("zglfw");
 
-pub const kind: dvui.enums.Backend = .glfw_opengl;
+pub const kind: dvui.enums.Backend = .glfw;
 
-const log = std.log.scoped(.glfw_opengl_backend);
+const log = std.log.scoped(.glfw_backend);
 
 const BYTES_PER_VERTEX = 20;
 // Max events we can process one frame
@@ -19,12 +18,7 @@ vsync: bool,
 gpa: std.mem.Allocator,
 arena: std.heap.ArenaAllocator,
 
-vao: zgl.VertexArray,
-el_buf: zgl.Buffer,
-vtx_buf: zgl.Buffer,
-program: zgl.Program,
 state: ?State,
-fb: ?dvui.TextureTarget,
 cursor: ?*zglfw.Cursor,
 
 userKeyCallback: ?zglfw.KeyFn,
@@ -34,43 +28,7 @@ userCursorPosCallback: ?zglfw.CursorPosFn,
 userFramebufferSizeCallback: ?zglfw.FramebufferSizeFn,
 userScrollCallback: ?zglfw.ScrollFn,
 
-framebuf_map: std.AutoHashMapUnmanaged(zgl.Texture, zgl.Framebuffer),
-
 window: *zglfw.Window,
-
-// Using vec4 for better compatability than vec3
-const vertex_source =
-    \\#version 330
-    \\in vec2 vertexPosition;
-    \\in vec2 vertexTexCoord;
-    \\in vec4 vertexColor;
-    \\out vec2 fragTexCoord;
-    \\out vec4 fragColor;
-    \\uniform mat4 mvp;
-    \\void main()
-    \\{
-    \\    fragTexCoord = vec2(vertexTexCoord.x, vertexTexCoord.y);
-    \\    fragColor = vertexColor / 255.0;
-    \\    gl_Position = mvp*vec4(vertexPosition.xy, 0.0, 1.0);
-    \\}
-;
-
-const frag_source =
-    \\#version 330
-    \\in vec2 fragTexCoord;
-    \\in vec4 fragColor;
-    \\out vec4 finalColor;
-    \\uniform sampler2D texture0;
-    \\uniform bool useTex;
-    \\void main()
-    \\{
-    \\    if (useTex) {
-    \\        finalColor = texture(texture0, fragTexCoord) * fragColor;
-    \\    } else {
-    \\        finalColor = fragColor;
-    \\    }
-    \\}
-;
 
 pub const State = struct {
     pub fn save(window: *zglfw.Window) State {
@@ -114,53 +72,6 @@ pub const InitOptions = struct {
 pub fn init(gpa: std.mem.Allocator, window_: *anyopaque) @This() {
     const window: *zglfw.Window = @ptrCast(window_);
 
-    // Make sure that OpenGL functions are loaded,
-    // shouldn't matter if it's loaded twice.
-    const fns = struct {
-        pub fn glGetProcAddress(p: zglfw.GlProc, proc: [:0]const u8) ?zgl.binding.FunctionPointer {
-            _ = p;
-            return @alignCast(zglfw.getProcAddress(proc));
-        }
-    };
-    const proc: zglfw.GlProc = undefined;
-    // This is not necessarily an error. Since the `zgl` version is
-    // 4.6, but we only require 3.3, some functions won't be loaded
-    // in case the machine doesn't support 4.6.
-    zgl.loadExtensions(proc, fns.glGetProcAddress) catch |err| {
-        log.warn("Not all functions were loaded. This is not necessarily a problem. Err: {}", .{err});
-    };
-
-    const vao = zgl.VertexArray.gen();
-    const vtx_buf = zgl.Buffer.gen();
-    vao.bind();
-    vtx_buf.bind(.array_buffer);
-
-    zgl.enableVertexAttribArray(0);
-    zgl.enableVertexAttribArray(1);
-    zgl.enableVertexAttribArray(2);
-    zgl.vertexAttribPointer(0, 2, .float, false, BYTES_PER_VERTEX, 0);
-    zgl.vertexAttribPointer(1, 2, .float, false, BYTES_PER_VERTEX, 8);
-    zgl.vertexAttribPointer(2, 4, .unsigned_byte, false, BYTES_PER_VERTEX, 16);
-    const el_buf = zgl.Buffer.gen();
-    el_buf.bind(.element_array_buffer);
-
-    // Don't want our state changed by external code
-    zgl.bindVertexArray(.invalid);
-
-    const v_shader = zgl.Shader.create(.vertex);
-    defer v_shader.delete();
-    v_shader.source(1, &.{vertex_source});
-    v_shader.compile();
-    const f_shader = zgl.Shader.create(.fragment);
-    defer f_shader.delete();
-    f_shader.source(1, &.{frag_source});
-    f_shader.compile();
-
-    const program = zgl.Program.create();
-    program.attach(v_shader);
-    program.attach(f_shader);
-
-    program.link();
     events = std.ArrayList(GlfwEvent).initCapacity(gpa, MAX_EVENT_BUFFER_SIZE) catch @panic("OOM");
 
     return .{
@@ -168,13 +79,7 @@ pub fn init(gpa: std.mem.Allocator, window_: *anyopaque) @This() {
         .window = window,
         .gpa = gpa,
         .arena = .init(gpa),
-        .vao = vao,
-        .vtx_buf = vtx_buf,
-        .el_buf = el_buf,
-        .program = program,
-        .framebuf_map = .empty,
         .state = null,
-        .fb = null,
         .cursor = null,
         .userKeyCallback = window.setKeyCallback(&glfwKeyCallback),
         .userCharCallback = window.setCharCallback(&glfwCharCallback),
@@ -186,17 +91,7 @@ pub fn init(gpa: std.mem.Allocator, window_: *anyopaque) @This() {
 }
 
 pub fn deinit(ctx: *@This()) void {
-    ctx.vao.delete();
-    ctx.program.delete();
-    ctx.vtx_buf.delete();
-    ctx.el_buf.delete();
     if (ctx.cursor) |cur| cur.destroy();
-    var it = ctx.framebuf_map.iterator();
-    while (it.next()) |kv| {
-        kv.key_ptr.delete();
-        kv.value_ptr.delete();
-    }
-    ctx.framebuf_map.clearAndFree(ctx.gpa);
     ctx.arena.deinit();
     if (events) |*_events| _events.deinit(ctx.gpa);
     _ = ctx.window.setKeyCallback(ctx.userKeyCallback);
@@ -259,203 +154,6 @@ pub fn contentScale(ctx: *@This()) f32 {
     _ = ctx;
     // Figure out what to do here
     return 1;
-}
-
-pub fn drawClippedTriangles(
-    ctx: *@This(),
-    texture: ?dvui.Texture,
-    vtx: []const dvui.Vertex,
-    idx: []const dvui.Vertex.Index,
-    clipr_in: ?dvui.Rect.Physical,
-) !void {
-    if (clipr_in) |clip_rect| {
-        zgl.enable(.scissor_test);
-        const sz = ctx.pixelSize();
-        const clip_y = if (ctx.fb == null) sz.h - clip_rect.y - clip_rect.h else clip_rect.y;
-        zgl.scissor(
-            @intFromFloat(clip_rect.x),
-            @intFromFloat(clip_y),
-            @intFromFloat(clip_rect.w),
-            @intFromFloat(clip_rect.h),
-        );
-    }
-    zgl.blendFunc(.one, .one_minus_src_alpha);
-    zgl.enable(.blend);
-    const aa = ctx.arena.allocator();
-
-    const vertex_buffer = try aa.alloc(u8, BYTES_PER_VERTEX * vtx.len);
-    defer aa.free(vertex_buffer);
-    for (vtx, 0..) |v, index| {
-        const i = index * BYTES_PER_VERTEX;
-        vertex_buffer[i..][0..4].* = @bitCast(v.pos.x);
-        vertex_buffer[i..][4..8].* = @bitCast(v.pos.y);
-        vertex_buffer[i..][8..16].* = @bitCast(v.uv);
-        vertex_buffer[i..][16..20].* = @bitCast(v.col);
-    }
-    ctx.vao.bind();
-    zgl.bufferData(.array_buffer, u8, vertex_buffer, .stream_draw);
-    zgl.bufferData(.element_array_buffer, dvui.Vertex.Index, idx, .stream_draw);
-
-    ctx.program.use();
-    const usetex_loc = ctx.program.uniformLocation("useTex");
-    zgl.uniform1ui(usetex_loc, if (texture) |_| 1 else 0);
-    if (texture) |tex| {
-        const txt: zgl.Texture = @enumFromInt(@intFromPtr(tex.ptr));
-        txt.bind(.@"2d");
-        zgl.activeTexture(.texture_0);
-        const tex_loc = ctx.program.uniformLocation("texture0") orelse blk: {
-            log.err("Couldn't find uniform location!", .{});
-            break :blk null;
-        };
-        zgl.uniform1i(tex_loc, 0);
-    }
-
-    const sz: dvui.Size.Physical = if (ctx.fb) |fb_tex| .{ .h = @floatFromInt(fb_tex.height), .w = @floatFromInt(fb_tex.width) } else ctx.pixelSize();
-    const sgn: f32 = if (ctx.fb) |_| -1.0 else 1.0;
-    const mat = [4][4]f32{
-        .{ 2 / sz.w, 0, 0, 0 },
-        .{ 0, -sgn * 2 / sz.h, 0, 0 },
-        .{ 0, 0, 1, 0 },
-        .{ -1, sgn, 0, 1 },
-    };
-
-    const mat_loc = ctx.program.uniformLocation("mvp");
-    zgl.uniformMatrix4fv(mat_loc, false, &.{mat});
-    zgl.drawElements(.triangles, idx.len, switch (dvui.Vertex.Index) {
-        u16 => .unsigned_short,
-        u32 => .unsigned_int,
-        else => @compileError("Critical change in dvui internal API, notify maintainer."),
-    }, 0);
-    zgl.disable(.scissor_test);
-}
-
-pub fn textureCreate(
-    _: *@This(),
-    pixels: [*]const u8,
-    width: u32,
-    height: u32,
-    interpolation: dvui.enums.TextureInterpolation,
-    format: dvui.enums.TexturePixelFormat,
-) !dvui.Texture {
-    if (format != .rgba_32) {
-        log.err("textureCreate currently only supports pixel format .rgba_32", .{});
-        return dvui.Backend.TextureError.TextureCreate;
-    }
-    const tex = zgl.Texture.gen();
-    tex.bind(.@"2d");
-    zgl.texParameter(.@"2d", .min_filter, if (interpolation == .nearest) .nearest else .linear);
-    zgl.texParameter(.@"2d", .mag_filter, if (interpolation == .nearest) .nearest else .linear);
-    zgl.textureImage2D(.@"2d", 0, .rgba8, width, height, .rgba, .unsigned_int_8_8_8_8, pixels);
-    zgl.bindTexture(.invalid, .@"2d");
-    return .{
-        .ptr = @ptrFromInt(@intFromEnum(tex)),
-        .height = height,
-        .width = width,
-        .format = .rgba_32,
-    };
-}
-
-pub fn textureUpdate(_: *@This(), texture: dvui.Texture, pixels: [*]const u8) !void {
-    const tex: zgl.Texture = @enumFromInt(@intFromPtr(texture.ptr));
-    tex.bind(.@"2d");
-    zgl.texSubImage2D(.@"2d", 0, 0, 0, texture.width, texture.height, .rgba, .unsigned_int_8_8_8_8, pixels);
-}
-
-pub fn textureCreateTarget(
-    ctx: *@This(),
-    width: u32,
-    height: u32,
-    interpolation: dvui.enums.TextureInterpolation,
-    format: dvui.enums.TexturePixelFormat,
-) !dvui.TextureTarget {
-    if (format != .rgba_32) {
-        log.err("textureCreateTarget currently only supports pixel format .rgba_32", .{});
-        return dvui.Backend.TextureError.TextureCreate;
-    }
-    const tex = zgl.Texture.gen();
-    tex.bind(.@"2d");
-    zgl.texParameter(.@"2d", .min_filter, if (interpolation == .nearest) .nearest else .linear);
-    zgl.texParameter(.@"2d", .mag_filter, if (interpolation == .nearest) .nearest else .linear);
-    zgl.texParameter(.@"2d", .wrap_s, .clamp_to_border);
-    zgl.texParameter(.@"2d", .wrap_t, .clamp_to_border);
-    zgl.textureImage2D(.@"2d", 0, .rgba8, width, height, .rgba, .unsigned_int_8_8_8_8, null);
-    const framebuf = zgl.Framebuffer.gen();
-    framebuf.texture2D(.draw_buffer, .color0, .@"2d", tex, 0);
-    ctx.framebuf_map.put(ctx.gpa, tex, framebuf) catch |err| {
-        tex.delete();
-        framebuf.delete();
-        return err;
-    };
-    const target: dvui.Texture.Target = .{
-        .ptr = @ptrFromInt(@intFromEnum(tex)),
-        .height = height,
-        .width = width,
-        .format = .rgba_32,
-    };
-    ctx.textureClearTarget(target);
-    return target;
-}
-
-pub fn textureClearTarget(self: *@This(), texture: dvui.TextureTarget) void {
-    self.renderTarget(texture) catch return;
-    zgl.clearColor(0, 0, 0, 0);
-    zgl.clear(.{ .color = true });
-    self.renderTarget(null) catch return;
-}
-
-pub fn textureFromTarget(_: *@This(), texture: dvui.TextureTarget) !dvui.Texture {
-    return .{
-        .ptr = texture.ptr,
-        .height = texture.height,
-        .width = texture.width,
-        .format = texture.format,
-    };
-}
-
-pub fn textureFromTargetTemp(_: *@This(), texture: dvui.TextureTarget) !dvui.Texture {
-    return .{
-        .ptr = texture.ptr,
-        .height = texture.height,
-        .width = texture.width,
-        .format = texture.format,
-    };
-}
-
-pub fn textureReadTarget(_: *@This(), texture: dvui.TextureTarget, pixels_out: [*]u8) !void {
-    const tex: zgl.Texture = @enumFromInt(@intFromPtr(texture.ptr));
-    tex.bind(.@"2d");
-    zgl.getTexImage(.@"2d", 0, .rgba, .unsigned_int_8_8_8_8, pixels_out);
-}
-
-pub fn renderTarget(ctx: *@This(), texture: ?dvui.TextureTarget) !void {
-    if (texture == null) {
-        zgl.bindFramebuffer(.invalid, .draw_buffer);
-        const sz = ctx.pixelSize();
-        zgl.viewport(0, 0, @intFromFloat(sz.w), @intFromFloat(sz.h));
-        ctx.fb = null;
-        return;
-    }
-    const tex: zgl.Texture = @enumFromInt(@intFromPtr(texture.?.ptr));
-    const fb = ctx.framebuf_map.get(tex) orelse return error.BackendError;
-    fb.bind(.draw_buffer);
-    zgl.viewport(0, 0, texture.?.width, texture.?.height);
-    ctx.fb = texture;
-}
-
-pub fn textureDestroy(ctx: *@This(), texture: dvui.Texture) void {
-    const tex: zgl.Texture = @enumFromInt(@intFromPtr(texture.ptr));
-    tex.delete();
-    if (ctx.framebuf_map.fetchRemove(tex)) |kv| {
-        kv.value.delete();
-    }
-}
-
-pub fn textureDestroyTarget(ctx: *@This(), texture: dvui.Texture.Target) void {
-    const tex: zgl.Texture = @enumFromInt(@intFromPtr(texture.ptr));
-    tex.delete();
-    if (ctx.framebuf_map.fetchRemove(tex)) |kv| {
-        kv.value.delete();
-    }
 }
 
 /// Get clipboard content (text only)
@@ -853,7 +551,6 @@ fn handleFramebufferSizeEvent(
     width: c_int,
     height: c_int,
 ) void {
-    zgl.viewport(0, 0, @intCast(width), @intCast(height));
     const ctx: *@This() = dvui_window.backend.impl;
     if (ctx.userFramebufferSizeCallback) |callback| callback(window, width, height);
 }
@@ -868,33 +565,40 @@ pub fn main() !void {
 
     try zglfw.init();
 
-    zglfw.windowHint(.context_version_major, 3);
-    zglfw.windowHint(.context_version_minor, 3);
-    zglfw.windowHint(.opengl_profile, .opengl_core_profile);
-    zglfw.windowHint(.opengl_forward_compat, true);
-    zglfw.windowHint(.client_api, .opengl_api);
+    if (dvui.render_backend.kind == .opengl) {
+        zglfw.windowHint(.context_version_major, 3);
+        zglfw.windowHint(.context_version_minor, 3);
+        zglfw.windowHint(.opengl_profile, .opengl_core_profile);
+        zglfw.windowHint(.opengl_forward_compat, true);
+        zglfw.windowHint(.client_api, .opengl_api);
+    }
     window = try zglfw.Window.create(
         @intFromFloat(config.size.w),
         @intFromFloat(config.size.h),
         config.title,
         null,
     );
-    zglfw.makeContextCurrent(window);
-    if (config.vsync) zglfw.swapInterval(1) else zglfw.swapInterval(0);
+
+    var renderer = blk: switch (dvui.render_backend.kind) {
+        .opengl => {
+            zglfw.makeContextCurrent(window);
+            if (config.vsync) zglfw.swapInterval(1) else zglfw.swapInterval(0);
+            break :blk try dvui.render_backend.init(gpa, zglfw.getProcAddress, "330");
+        },
+        else => @compileError("unsupported renderer for backend"),
+    };
 
     var impl = init(gpa, window);
     defer impl.deinit();
 
-    const backend = dvui.Backend.init(&impl);
+    const backend = dvui.Backend.init(&impl, &renderer);
     var win = try dvui.Window.init(@src(), gpa, backend, .{});
     defer win.deinit();
-    const size = backend.pixelSize();
-    zgl.viewport(0, 0, @intFromFloat(size.w), @intFromFloat(size.h));
 
     while (!window.shouldClose()) {
         impl.addAllEvents(&win);
-        zgl.clearColor(0.1, 0.4, 0.25, 1.0);
-        zgl.clear(.{ .color = true, .stencil = true, .depth = true });
+        // zgl.clearColor(0.1, 0.4, 0.25, 1.0);
+        // zgl.clear(.{ .color = true, .stencil = true, .depth = true });
         try win.begin(std.time.nanoTimestamp());
 
         var res = try app.frameFn();

--- a/src/backends/raylib-c.zig
+++ b/src/backends/raylib-c.zig
@@ -120,11 +120,11 @@ pub fn createWindow(options: InitOptions) void {
 
 //==========DVUI MANAGEMENT FUNCTIONS==========
 
-pub fn begin(self: *RaylibBackend, arena: std.mem.Allocator) void {
+pub fn begin(self: *RaylibBackend, arena: std.mem.Allocator) !void {
     self.arena = arena;
 }
 
-pub fn end(_: *RaylibBackend) void {}
+pub fn end(_: *RaylibBackend) !void {}
 
 pub fn clear(_: *RaylibBackend) void {
     c.ClearBackground(c.BLANK);

--- a/src/backends/raylib-zig.zig
+++ b/src/backends/raylib-zig.zig
@@ -114,11 +114,11 @@ pub fn createWindow(options: InitOptions) void {
 
 //==========DVUI MANAGEMENT FUNCTIONS==========
 
-pub fn begin(self: *RaylibBackend, arena: std.mem.Allocator) void {
+pub fn begin(self: *RaylibBackend, arena: std.mem.Allocator) !void {
     self.arena = arena;
 }
 
-pub fn end(_: *RaylibBackend) void {}
+pub fn end(_: *RaylibBackend) !void {}
 
 pub fn clear(_: *RaylibBackend) void {
     raylib.clearBackground(raylib.Color.blank);

--- a/src/backends/render/default.zig
+++ b/src/backends/render/default.zig
@@ -1,0 +1,3 @@
+//! Placeholder which indicates rendering is provided by the main backend.
+const dvui = @import("dvui");
+pub const kind: dvui.enums.RenderBackend = .default;

--- a/src/backends/render/opengl.zig
+++ b/src/backends/render/opengl.zig
@@ -1,0 +1,311 @@
+//! OpenGL 3.0+ renderer.
+//!
+//! After rendering, the following state will be changed:
+//! - GL_CURRENT_PROGRAM
+//! - GL_VERTEX_ARRAY_BINDING
+//! - GL_VIEWPORT
+//! - GL_ACTIVE_TEXTURE
+//! - GL_TEXTURE_BINDING_2D
+//! - GL_DRAW_FRAMEBUFFER_BINDING
+//! - GL_BLEND
+//! - GL_BLEND_SRC_RGB
+//! - GL_BLEND_SRC_ALPHA
+//! - GL_BLEND_DST_RGB
+//! - GL_BLEND_DST_ALPHA
+//! - GL_SCISSOR_TEST
+
+const std = @import("std");
+const dvui = @import("dvui");
+const gl = @import("gl");
+const log = std.log.scoped(.dvui_opengl);
+
+pub const kind: dvui.enums.RenderBackend = .opengl;
+
+allocator: std.mem.Allocator,
+program: u32,
+uniforms: struct {
+    projection: i32,
+    sampler: i32,
+    use_sampler: i32,
+},
+vao: u32,
+vbo: u32,
+ebo: u32,
+framebuffers: std.AutoHashMapUnmanaged(u32, u32) = .empty,
+render_target_size: ?dvui.Size.Physical = null,
+
+pub fn init(allocator: std.mem.Allocator, getProcAddress: anytype, comptime glsl_version: []const u8) !@This() {
+    try gl.load(getProcAddress);
+
+    const sources = shaderSources(glsl_version);
+
+    const vertex_shader = gl.createShader(gl.VERTEX_SHADER);
+    defer gl.deleteShader(vertex_shader);
+    gl.shaderSource(vertex_shader, 1, &[_][*]const u8{sources.vertex}, &[_]i32{sources.vertex.len});
+    gl.compileShader(vertex_shader);
+
+    const fragment_shader = gl.createShader(gl.FRAGMENT_SHADER);
+    defer gl.deleteShader(fragment_shader);
+    gl.shaderSource(fragment_shader, 1, &[_][*]const u8{sources.fragment}, &[_]i32{sources.fragment.len});
+    gl.compileShader(fragment_shader);
+
+    const program = gl.createProgram();
+    gl.attachShader(program, vertex_shader);
+    gl.attachShader(program, fragment_shader);
+    gl.linkProgram(program);
+
+    const position: u32 = @bitCast(gl.getAttribLocation(program, "v_position"));
+    const color: u32 = @bitCast(gl.getAttribLocation(program, "v_color"));
+    const uv: u32 = @bitCast(gl.getAttribLocation(program, "v_uv"));
+
+    const projection = gl.getUniformLocation(program, "projection");
+    const sampler = gl.getUniformLocation(program, "sampler");
+    const use_sampler = gl.getUniformLocation(program, "use_sampler");
+
+    var vao: u32 = undefined;
+    gl.genVertexArrays(1, &vao);
+
+    var buffers: [2]u32 = undefined;
+    gl.genBuffers(buffers.len, &buffers);
+    const vbo = buffers[0];
+    const ebo = buffers[1];
+
+    gl.bindVertexArray(vao);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ebo);
+
+    gl.enableVertexAttribArray(position);
+    gl.enableVertexAttribArray(color);
+    gl.enableVertexAttribArray(uv);
+    gl.vertexAttribPointer(position, 2, gl.FLOAT, gl.FALSE, @sizeOf(dvui.Vertex), @ptrFromInt(@offsetOf(dvui.Vertex, "pos")));
+    gl.vertexAttribPointer(color, 4, gl.UNSIGNED_BYTE, gl.FALSE, @sizeOf(dvui.Vertex), @ptrFromInt(@offsetOf(dvui.Vertex, "col")));
+    gl.vertexAttribPointer(uv, 2, gl.FLOAT, gl.FALSE, @sizeOf(dvui.Vertex), @ptrFromInt(@offsetOf(dvui.Vertex, "uv")));
+
+    gl.bindVertexArray(0);
+
+    return .{
+        .allocator = allocator,
+        .program = program,
+        .uniforms = .{
+            .projection = projection,
+            .sampler = sampler,
+            .use_sampler = use_sampler,
+        },
+        .vao = vao,
+        .vbo = vbo,
+        .ebo = ebo,
+    };
+}
+
+pub fn deinit(self: *@This()) void {
+    self.framebuffers.deinit(self.allocator);
+    const buffers = [_]u32{ self.vbo, self.ebo };
+    gl.deleteBuffers(buffers.len, &buffers);
+    gl.deleteVertexArrays(1, &self.vao);
+    gl.deleteProgram(self.program);
+}
+
+pub fn begin(self: *@This(), _: std.mem.Allocator) !void {
+    gl.useProgram(self.program);
+    gl.bindVertexArray(self.vao);
+
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+}
+
+pub fn end(_: *@This()) !void {}
+
+pub fn drawClippedTriangles(self: *@This(), physical_size: dvui.Size.Physical, maybe_texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, maybe_clipr: ?dvui.Rect.Physical) !void {
+    const size = self.render_target_size orelse physical_size;
+    gl.viewport(0, 0, @intFromFloat(size.w), @intFromFloat(size.h));
+
+    if (maybe_clipr) |clipr| {
+        gl.enable(gl.SCISSOR_TEST);
+        gl.scissor(
+            @intFromFloat(clipr.x),
+            @intFromFloat(if (self.render_target_size == null) physical_size.h - clipr.y - clipr.h else clipr.y),
+            @intFromFloat(clipr.w),
+            @intFromFloat(clipr.h),
+        );
+    }
+
+    gl.bufferData(gl.ARRAY_BUFFER, @bitCast(vtx.len * @sizeOf(dvui.Vertex)), vtx.ptr, gl.STREAM_DRAW);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, @bitCast(idx.len * @sizeOf(dvui.Vertex.Index)), idx.ptr, gl.STREAM_DRAW);
+
+    if (maybe_texture) |texture| {
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, @intCast(@intFromPtr(texture.ptr)));
+        gl.uniform1i(self.uniforms.use_sampler, 1);
+        gl.uniform1i(self.uniforms.sampler, 0);
+    } else {
+        gl.uniform1i(self.uniforms.use_sampler, 0);
+    }
+
+    const sign: f32 = if (self.render_target_size != null) -1 else 1;
+    gl.uniformMatrix4fv(self.uniforms.projection, 1, gl.FALSE, &[_]f32{
+        2 / size.w, 0,                  0,  0,
+        0,          -sign * 2 / size.h, 0,  0,
+        0,          0,                  1,  0,
+        -1,         sign * 1,           -1, 1,
+    });
+
+    const index_type = switch (dvui.Vertex.Index) {
+        u16 => gl.UNSIGNED_SHORT,
+        u32 => gl.UNSIGNED_INT,
+        else => @compileError("invalid vertex index type"),
+    };
+    gl.drawElements(gl.TRIANGLES, @intCast(idx.len), index_type, null);
+
+    if (maybe_clipr != null) {
+        gl.disable(gl.SCISSOR_TEST);
+    }
+}
+
+pub fn textureCreate(_: *@This(), pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.Texture {
+    return .{ .ptr = @ptrFromInt(try createTexture(pixels, width, height, interpolation, format)), .width = width, .height = height, .format = format };
+}
+
+pub fn textureUpdate(_: *@This(), texture: dvui.Texture, pixels: [*]const u8) !void {
+    gl.bindTexture(gl.TEXTURE_2D, @intCast(@intFromPtr(texture.ptr)));
+    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, @bitCast(texture.width), @bitCast(texture.height), gl.RGBA, gl.UNSIGNED_INT_8_8_8_8, pixels);
+}
+
+pub fn textureDestroy(self: *@This(), texture: dvui.Texture) void {
+    const handle: u32 = @intCast(@intFromPtr(texture.ptr));
+    gl.deleteTextures(1, &handle);
+    if (self.framebuffers.fetchRemove(handle)) |kv| {
+        gl.deleteFramebuffers(1, &kv.value);
+    }
+}
+
+pub fn textureCreateTarget(self: *@This(), width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.TextureTarget {
+    const texture = try createTexture(null, width, height, interpolation, format);
+    errdefer gl.deleteTextures(1, &texture);
+
+    var framebuffer: u32 = undefined;
+    gl.genFramebuffers(1, &framebuffer);
+    errdefer gl.deleteFramebuffers(1, &framebuffer);
+
+    try self.framebuffers.put(self.allocator, texture, framebuffer);
+
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, framebuffer);
+    gl.framebufferTexture2D(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, 0);
+
+    return .{ .ptr = @ptrFromInt(texture), .width = width, .height = height, .format = format };
+}
+
+pub fn textureReadTarget(_: *@This(), texture: dvui.TextureTarget, pixels_out: [*]u8) !void {
+    gl.bindTexture(gl.TEXTURE_2D, @intCast(@intFromPtr(texture.ptr)));
+    gl.getTexImage(gl.TEXTURE_2D, 0, gl.RGBA, gl.UNSIGNED_INT_8_8_8_8, pixels_out);
+}
+
+pub fn textureClearTarget(self: *@This(), texture: dvui.Texture.Target) void {
+    self.renderTarget(texture) catch return;
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    self.renderTarget(null) catch return;
+}
+
+pub fn textureDestroyTarget(self: *@This(), texture: dvui.Texture.Target) void {
+    const handle: u32 = @intCast(@intFromPtr(texture.ptr));
+    gl.deleteTextures(1, &handle);
+    if (self.framebuffers.fetchRemove(handle)) |kv| {
+        gl.deleteFramebuffers(1, &kv.value);
+    }
+}
+
+pub fn textureFromTarget(_: *@This(), target: dvui.TextureTarget) !dvui.Texture {
+    return .{ .ptr = target.ptr, .height = target.height, .width = target.width, .format = target.format };
+}
+
+pub fn textureFromTargetTemp(self: *@This(), target: dvui.TextureTarget) !dvui.Texture {
+    return self.textureFromTarget(target);
+}
+
+pub fn renderTarget(self: *@This(), maybe_texture: ?dvui.TextureTarget) !void {
+    if (maybe_texture) |texture| {
+        const fbo = self.framebuffers.get(@intCast(@intFromPtr(texture.ptr))).?;
+        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fbo);
+        self.render_target_size = .{ .w = @floatFromInt(texture.width), .h = @floatFromInt(texture.height) };
+    } else {
+        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, 0);
+        self.render_target_size = null;
+    }
+}
+
+fn createTexture(pixels: ?[*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !u32 {
+    if (format != .rgba_32) {
+        log.err("unsupported texture format", .{});
+        return dvui.Backend.TextureError.TextureCreate;
+    }
+
+    var texture: u32 = undefined;
+    gl.genTextures(1, &texture);
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, @bitCast(width), @bitCast(height), 0, gl.RGBA, gl.UNSIGNED_INT_8_8_8_8, pixels);
+
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+    switch (interpolation) {
+        .linear => {
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        },
+        .nearest => {
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        },
+    }
+
+    return texture;
+}
+
+fn shaderSources(version: []const u8) type {
+    return struct {
+        const vertex =
+            "#version " ++ version ++ "\n" ++
+            \\
+            \\in vec2 v_position;
+            \\in vec4 v_color;
+            \\in vec2 v_uv;
+            \\
+            \\out vec4 f_color;
+            \\out vec2 f_uv;
+            \\
+            \\uniform mat4 projection;
+            \\
+            \\void main() {
+            \\    gl_Position = projection * vec4(v_position, 0.0, 1.0);
+            \\    f_color = v_color / 255.0;
+            \\    f_uv = v_uv;
+            \\}
+            \\
+            ;
+
+        const fragment =
+            "#version " ++ version ++ "\n" ++
+            \\
+            \\in vec4 f_color;
+            \\in vec2 f_uv;
+            \\
+            \\out vec4 color;
+            \\
+            \\uniform sampler2D sampler;
+            \\uniform bool use_sampler;
+            \\
+            \\void main() {
+            \\    if (use_sampler) {
+            \\        color = texture(sampler, f_uv) * f_color;
+            \\    } else {
+            \\        color = f_color;
+            \\    }
+            \\}
+            \\
+            ;
+    };
+}

--- a/src/backends/wio.zig
+++ b/src/backends/wio.zig
@@ -134,11 +134,11 @@ pub fn addEvent(self: *@This(), win: *dvui.Window, event: wio.Event) !bool {
             try win.addEventWindow(.{ .action = .close });
             return false;
         },
-        .size => |size| {
+        .size_logical => |size| {
             self.size_natural = .{ .w = @floatFromInt(size.width), .h = @floatFromInt(size.height) };
             return false;
         },
-        .framebuffer => |size| {
+        .size_physical => |size| {
             self.size_physical = .{ .w = @floatFromInt(size.width), .h = @floatFromInt(size.height) };
             return false;
         },

--- a/src/backends/wio.zig
+++ b/src/backends/wio.zig
@@ -2,8 +2,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 const dvui = @import("dvui");
 const wio = @import("wio");
-const gl = @import("gl");
-const log = std.log.scoped(.dvui_wio);
 
 pub const kind: dvui.enums.Backend = .wio;
 
@@ -12,15 +10,13 @@ size_natural: dvui.Size.Natural,
 size_physical: dvui.Size.Physical,
 arena: std.mem.Allocator = undefined, // assigned in begin()
 mod: dvui.enums.Mod = .none,
-renderer: *OpenGLRenderer,
 
-pub fn backend(self: *@This()) dvui.Backend {
-    return .init(self);
+pub fn backend(self: *@This(), renderer: *dvui.render_backend) dvui.Backend {
+    return .init(self, renderer);
 }
 
 pub const InitOptions = struct {
     window: wio.Window,
-    renderer: *OpenGLRenderer,
     /// Will be corrected by `addEvent()`, but should be set manually if events were already processed.
     size: wio.Size = .{ .width = 640, .height = 480 },
     /// Will be corrected by `addEvent()`, but should be set manually if events were already processed.
@@ -32,7 +28,6 @@ pub fn init(options: InitOptions) !@This() {
         .window = options.window,
         .size_natural = .{ .w = @floatFromInt(options.size.width), .h = @floatFromInt(options.size.height) },
         .size_physical = .{ .w = @floatFromInt(options.framebuffer.width), .h = @floatFromInt(options.framebuffer.height) },
-        .renderer = options.renderer,
     };
 }
 
@@ -48,12 +43,9 @@ pub fn sleep(_: *@This(), ns: u64) void {
 
 pub fn begin(self: *@This(), arena: std.mem.Allocator) !void {
     self.arena = arena;
-    try self.renderer.begin();
 }
 
-pub fn end(self: *@This()) !void {
-    try self.renderer.end();
-}
+pub fn end(_: *@This()) !void {}
 
 pub fn pixelSize(self: *@This()) dvui.Size.Physical {
     return self.size_physical;
@@ -65,50 +57,6 @@ pub fn windowSize(self: *@This()) dvui.Size.Natural {
 
 pub fn contentScale(_: *@This()) f32 {
     return 1;
-}
-
-pub fn drawClippedTriangles(self: *@This(), texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, clipr: ?dvui.Rect.Physical) !void {
-    try self.renderer.drawClippedTriangles(self.size_physical, texture, vtx, idx, clipr);
-}
-
-pub fn textureCreate(self: *@This(), pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.Texture {
-    return self.renderer.textureCreate(pixels, width, height, interpolation, format);
-}
-
-pub fn textureUpdate(self: *@This(), texture: dvui.Texture, pixels: [*]const u8) !void {
-    try self.renderer.textureUpdate(texture, pixels);
-}
-
-pub fn textureDestroy(self: *@This(), texture: dvui.Texture) void {
-    self.renderer.textureDestroy(texture);
-}
-
-pub fn textureCreateTarget(self: *@This(), width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.TextureTarget {
-    return self.renderer.textureCreateTarget(width, height, interpolation, format);
-}
-
-pub fn textureReadTarget(self: *@This(), texture: dvui.TextureTarget, pixels_out: [*]u8) !void {
-    try self.renderer.textureReadTarget(texture, pixels_out);
-}
-
-pub fn textureClearTarget(self: *@This(), texture: dvui.Texture.Target) void {
-    self.renderer.textureClearTarget(texture);
-}
-
-pub fn textureDestroyTarget(self: *@This(), texture: dvui.Texture.Target) void {
-    self.renderer.textureDestroyTarget(texture);
-}
-
-pub fn textureFromTarget(self: *@This(), target: dvui.TextureTarget) !dvui.Texture {
-    return self.renderer.textureFromTarget(target);
-}
-
-pub fn textureFromTargetTemp(self: *@This(), target: dvui.TextureTarget) !dvui.Texture {
-    return self.renderer.textureFromTargetTemp(target);
-}
-
-pub fn renderTarget(self: *@This(), texture: ?dvui.TextureTarget) !void {
-    try self.renderer.renderTarget(texture);
 }
 
 pub fn clipboardText(self: *@This()) ![]const u8 {
@@ -270,26 +218,29 @@ pub fn main() !void {
         .title = config.title,
         .size = .{ .width = @intFromFloat(config.size.w), .height = @intFromFloat(config.size.h) },
         .scale = 1,
-        .opengl = .{
+        .opengl = if (dvui.render_backend.kind == .opengl) .{
             .major_version = 3,
             .minor_version = 2,
             .profile = .core,
-        },
+        } else null,
     });
     defer window.destroy();
 
-    window.makeContextCurrent();
-    if (config.vsync) {
-        window.swapInterval(1);
-    }
+    var renderer = blk: switch (dvui.render_backend.kind) {
+        .opengl => {
+            window.makeContextCurrent();
+            if (config.vsync) {
+                window.swapInterval(1);
+            }
+            break :blk try dvui.render_backend.init(allocator, wio.glGetProcAddress, "150");
+        },
+        else => @compileError("unsupported renderer for backend"),
+    };
 
-    var renderer = try OpenGLRenderer.init(allocator, wio.glGetProcAddress, "150");
-    defer renderer.deinit();
+    var dvui_wio = try @This().init(.{ .window = window });
+    defer dvui_wio.deinit();
 
-    var back = try @This().init(.{ .window = window, .renderer = &renderer });
-    defer back.deinit();
-
-    var win = try dvui.Window.init(@src(), allocator, back.backend(), config.window_init_options);
+    var win = try dvui.Window.init(@src(), allocator, dvui_wio.backend(&renderer), config.window_init_options);
     defer win.deinit();
 
     if (app.initFn) |initFn| {
@@ -302,7 +253,7 @@ pub fn main() !void {
     while (true) {
         wio.update();
         while (window.getEvent()) |event| {
-            _ = try back.addEvent(&win, event);
+            _ = try dvui_wio.addEvent(&win, event);
         }
 
         const time = win.beginWait(true);
@@ -316,321 +267,15 @@ pub fn main() !void {
         const end_ms = try win.end(.{});
         if (res != .ok) break;
 
-        back.setTextInputRect(win.textInputRequested());
-        back.setCursor(win.cursorRequested());
+        dvui_wio.setTextInputRect(win.textInputRequested());
+        dvui_wio.setCursor(win.cursorRequested());
 
         window.swapBuffers();
 
         const wait_ms = win.waitTime(end_ms);
-        back.waitEventTimeout(wait_ms);
+        dvui_wio.waitEventTimeout(wait_ms);
     }
 }
-
-/// OpenGL 3.0+ renderer.
-///
-/// After rendering, the following state will be changed:
-/// - GL_CURRENT_PROGRAM
-/// - GL_VERTEX_ARRAY_BINDING
-/// - GL_VIEWPORT
-/// - GL_ACTIVE_TEXTURE
-/// - GL_TEXTURE_BINDING_2D
-/// - GL_DRAW_FRAMEBUFFER_BINDING
-/// - GL_BLEND
-/// - GL_BLEND_SRC_RGB
-/// - GL_BLEND_SRC_ALPHA
-/// - GL_BLEND_DST_RGB
-/// - GL_BLEND_DST_ALPHA
-/// - GL_SCISSOR_TEST
-pub const OpenGLRenderer = struct {
-    allocator: std.mem.Allocator,
-    render_target_size: ?dvui.Size.Physical = null,
-    program: u32,
-    uniforms: struct {
-        projection: i32,
-        sampler: i32,
-        use_sampler: i32,
-    },
-    vao: u32,
-    vbo: u32,
-    ebo: u32,
-    framebuffers: std.AutoHashMapUnmanaged(u32, u32) = .empty,
-
-    pub fn init(allocator: std.mem.Allocator, getProcAddress: anytype, comptime glsl_version: []const u8) !@This() {
-        try gl.load(getProcAddress);
-
-        const sources = shaderSources(glsl_version);
-
-        const vertex_shader = gl.createShader(gl.VERTEX_SHADER);
-        defer gl.deleteShader(vertex_shader);
-        gl.shaderSource(vertex_shader, 1, &[_][*]const u8{sources.vertex}, &[_]i32{sources.vertex.len});
-        gl.compileShader(vertex_shader);
-
-        const fragment_shader = gl.createShader(gl.FRAGMENT_SHADER);
-        defer gl.deleteShader(fragment_shader);
-        gl.shaderSource(fragment_shader, 1, &[_][*]const u8{sources.fragment}, &[_]i32{sources.fragment.len});
-        gl.compileShader(fragment_shader);
-
-        const program = gl.createProgram();
-        gl.attachShader(program, vertex_shader);
-        gl.attachShader(program, fragment_shader);
-        gl.linkProgram(program);
-
-        const position: u32 = @bitCast(gl.getAttribLocation(program, "v_position"));
-        const color: u32 = @bitCast(gl.getAttribLocation(program, "v_color"));
-        const uv: u32 = @bitCast(gl.getAttribLocation(program, "v_uv"));
-
-        const projection = gl.getUniformLocation(program, "projection");
-        const sampler = gl.getUniformLocation(program, "sampler");
-        const use_sampler = gl.getUniformLocation(program, "use_sampler");
-
-        var vao: u32 = undefined;
-        gl.genVertexArrays(1, &vao);
-
-        var buffers: [2]u32 = undefined;
-        gl.genBuffers(buffers.len, &buffers);
-        const vbo = buffers[0];
-        const ebo = buffers[1];
-
-        gl.bindVertexArray(vao);
-
-        gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
-        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ebo);
-
-        gl.enableVertexAttribArray(position);
-        gl.enableVertexAttribArray(color);
-        gl.enableVertexAttribArray(uv);
-        gl.vertexAttribPointer(position, 2, gl.FLOAT, gl.FALSE, @sizeOf(dvui.Vertex), @ptrFromInt(@offsetOf(dvui.Vertex, "pos")));
-        gl.vertexAttribPointer(color, 4, gl.UNSIGNED_BYTE, gl.FALSE, @sizeOf(dvui.Vertex), @ptrFromInt(@offsetOf(dvui.Vertex, "col")));
-        gl.vertexAttribPointer(uv, 2, gl.FLOAT, gl.FALSE, @sizeOf(dvui.Vertex), @ptrFromInt(@offsetOf(dvui.Vertex, "uv")));
-
-        gl.bindVertexArray(0);
-
-        return .{
-            .allocator = allocator,
-            .program = program,
-            .uniforms = .{
-                .projection = projection,
-                .sampler = sampler,
-                .use_sampler = use_sampler,
-            },
-            .vao = vao,
-            .vbo = vbo,
-            .ebo = ebo,
-        };
-    }
-
-    pub fn deinit(self: *@This()) void {
-        self.framebuffers.deinit(self.allocator);
-        const buffers = [_]u32{ self.vbo, self.ebo };
-        gl.deleteBuffers(buffers.len, &buffers);
-        gl.deleteVertexArrays(1, &self.vao);
-        gl.deleteProgram(self.program);
-    }
-
-    pub fn begin(self: *@This()) !void {
-        gl.useProgram(self.program);
-        gl.bindVertexArray(self.vao);
-
-        gl.enable(gl.BLEND);
-        gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
-    }
-
-    pub fn end(_: *@This()) !void {}
-
-    pub fn drawClippedTriangles(self: *@This(), size_physical: dvui.Size.Physical, maybe_texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, maybe_clipr: ?dvui.Rect.Physical) !void {
-        const size = self.render_target_size orelse size_physical;
-        gl.viewport(0, 0, @intFromFloat(size.w), @intFromFloat(size.h));
-
-        if (maybe_clipr) |clipr| {
-            gl.enable(gl.SCISSOR_TEST);
-            gl.scissor(
-                @intFromFloat(clipr.x),
-                @intFromFloat(if (self.render_target_size == null) size_physical.h - clipr.y - clipr.h else clipr.y),
-                @intFromFloat(clipr.w),
-                @intFromFloat(clipr.h),
-            );
-        }
-
-        gl.bufferData(gl.ARRAY_BUFFER, @bitCast(vtx.len * @sizeOf(dvui.Vertex)), vtx.ptr, gl.STREAM_DRAW);
-        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, @bitCast(idx.len * @sizeOf(dvui.Vertex.Index)), idx.ptr, gl.STREAM_DRAW);
-
-        if (maybe_texture) |texture| {
-            gl.activeTexture(gl.TEXTURE0);
-            gl.bindTexture(gl.TEXTURE_2D, @intCast(@intFromPtr(texture.ptr)));
-            gl.uniform1i(self.uniforms.use_sampler, 1);
-            gl.uniform1i(self.uniforms.sampler, 0);
-        } else {
-            gl.uniform1i(self.uniforms.use_sampler, 0);
-        }
-
-        const sign: f32 = if (self.render_target_size != null) -1 else 1;
-        gl.uniformMatrix4fv(self.uniforms.projection, 1, gl.FALSE, &[_]f32{
-            2 / size.w, 0,                  0,  0,
-            0,          -sign * 2 / size.h, 0,  0,
-            0,          0,                  1,  0,
-            -1,         sign * 1,           -1, 1,
-        });
-
-        const index_type = switch (dvui.Vertex.Index) {
-            u16 => gl.UNSIGNED_SHORT,
-            u32 => gl.UNSIGNED_INT,
-            else => @compileError("invalid vertex index type"),
-        };
-        gl.drawElements(gl.TRIANGLES, @intCast(idx.len), index_type, null);
-
-        if (maybe_clipr != null) {
-            gl.disable(gl.SCISSOR_TEST);
-        }
-    }
-
-    pub fn textureCreate(_: *@This(), pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.Texture {
-        return .{ .ptr = @ptrFromInt(try createTexture(pixels, width, height, interpolation, format)), .width = width, .height = height, .format = format };
-    }
-
-    pub fn textureUpdate(_: *@This(), texture: dvui.Texture, pixels: [*]const u8) !void {
-        gl.bindTexture(gl.TEXTURE_2D, @intCast(@intFromPtr(texture.ptr)));
-        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, @bitCast(texture.width), @bitCast(texture.height), gl.RGBA, gl.UNSIGNED_INT_8_8_8_8, pixels);
-    }
-
-    pub fn textureDestroy(self: *@This(), texture: dvui.Texture) void {
-        const handle: u32 = @intCast(@intFromPtr(texture.ptr));
-        gl.deleteTextures(1, &handle);
-        if (self.framebuffers.fetchRemove(handle)) |kv| {
-            gl.deleteFramebuffers(1, &kv.value);
-        }
-    }
-
-    pub fn textureCreateTarget(self: *@This(), width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.TextureTarget {
-        const texture = try createTexture(null, width, height, interpolation, format);
-        errdefer gl.deleteTextures(1, &texture);
-
-        var framebuffer: u32 = undefined;
-        gl.genFramebuffers(1, &framebuffer);
-        errdefer gl.deleteFramebuffers(1, &framebuffer);
-
-        try self.framebuffers.put(self.allocator, texture, framebuffer);
-
-        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, framebuffer);
-        gl.framebufferTexture2D(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
-        gl.clearColor(0, 0, 0, 0);
-        gl.clear(gl.COLOR_BUFFER_BIT);
-        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, 0);
-
-        return .{ .ptr = @ptrFromInt(texture), .width = width, .height = height, .format = format };
-    }
-
-    pub fn textureReadTarget(_: *@This(), texture: dvui.TextureTarget, pixels_out: [*]u8) !void {
-        gl.bindTexture(gl.TEXTURE_2D, @intCast(@intFromPtr(texture.ptr)));
-        gl.getTexImage(gl.TEXTURE_2D, 0, gl.RGBA, gl.UNSIGNED_INT_8_8_8_8, pixels_out);
-    }
-
-    pub fn textureClearTarget(self: *@This(), texture: dvui.Texture.Target) void {
-        self.renderTarget(texture) catch return;
-        gl.clearColor(0, 0, 0, 0);
-        gl.clear(gl.COLOR_BUFFER_BIT);
-        self.renderTarget(null) catch return;
-    }
-
-    pub fn textureDestroyTarget(self: *@This(), texture: dvui.Texture.Target) void {
-        const handle: u32 = @intCast(@intFromPtr(texture.ptr));
-        gl.deleteTextures(1, &handle);
-        if (self.framebuffers.fetchRemove(handle)) |kv| {
-            gl.deleteFramebuffers(1, &kv.value);
-        }
-    }
-
-    pub fn textureFromTarget(_: *@This(), target: dvui.TextureTarget) !dvui.Texture {
-        return .{ .ptr = target.ptr, .height = target.height, .width = target.width, .format = target.format };
-    }
-
-    pub fn textureFromTargetTemp(self: *@This(), target: dvui.TextureTarget) !dvui.Texture {
-        return self.textureFromTarget(target);
-    }
-
-    pub fn renderTarget(self: *@This(), maybe_texture: ?dvui.TextureTarget) !void {
-        if (maybe_texture) |texture| {
-            const fbo = self.framebuffers.get(@intCast(@intFromPtr(texture.ptr))).?;
-            gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fbo);
-            self.render_target_size = .{ .w = @floatFromInt(texture.width), .h = @floatFromInt(texture.height) };
-        } else {
-            gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, 0);
-            self.render_target_size = null;
-        }
-    }
-
-    fn createTexture(pixels: ?[*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !u32 {
-        if (format != .rgba_32) {
-            log.err("unsupported texture format", .{});
-            return dvui.Backend.TextureError.TextureCreate;
-        }
-
-        var texture: u32 = undefined;
-        gl.genTextures(1, &texture);
-        gl.bindTexture(gl.TEXTURE_2D, texture);
-        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, @bitCast(width), @bitCast(height), 0, gl.RGBA, gl.UNSIGNED_INT_8_8_8_8, pixels);
-
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-
-        switch (interpolation) {
-            .linear => {
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-            },
-            .nearest => {
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-            },
-        }
-
-        return texture;
-    }
-
-    fn shaderSources(version: []const u8) type {
-        return struct {
-            const vertex =
-                "#version " ++ version ++ "\n" ++
-                \\
-                \\in vec2 v_position;
-                \\in vec4 v_color;
-                \\in vec2 v_uv;
-                \\
-                \\out vec4 f_color;
-                \\out vec2 f_uv;
-                \\
-                \\uniform mat4 projection;
-                \\
-                \\void main() {
-                \\    gl_Position = projection * vec4(v_position, 0.0, 1.0);
-                \\    f_color = v_color / 255.0;
-                \\    f_uv = v_uv;
-                \\}
-                \\
-                ;
-
-            const fragment =
-                "#version " ++ version ++ "\n" ++
-                \\
-                \\in vec4 f_color;
-                \\in vec2 f_uv;
-                \\
-                \\out vec4 color;
-                \\
-                \\uniform sampler2D sampler;
-                \\uniform bool use_sampler;
-                \\
-                \\void main() {
-                \\    if (use_sampler) {
-                \\        color = texture(sampler, f_uv) * f_color;
-                \\    } else {
-                \\        color = f_color;
-                \\    }
-                \\}
-                \\
-                ;
-        };
-    }
-};
 
 fn buttonToDvuiKey(button: wio.Button) dvui.enums.Key {
     return switch (button) {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -32,6 +32,7 @@ const std = @import("std");
 /// const Backend = @import("backend");
 /// ```
 pub const backend = @import("backend");
+pub const render_backend = @import("render_backend");
 const tvg = @import("svg2tvg");
 
 pub const math = std.math;

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -4,6 +4,7 @@ const dvui = @import("dvui.zig");
 const enums_backend = @import("enums_backend.zig");
 
 pub const Backend = enums_backend.Backend;
+pub const RenderBackend = enums_backend.RenderBackend;
 
 pub const DialogButtonOrder = enum {
     cancel_ok,

--- a/src/enums_backend.zig
+++ b/src/enums_backend.zig
@@ -12,7 +12,7 @@ pub const Backend = enum {
     raylib,
     raylib_zig,
     dx11,
-    glfw_opengl,
+    glfw,
     web,
     wio,
     /// Does no rendering!

--- a/src/enums_backend.zig
+++ b/src/enums_backend.zig
@@ -18,3 +18,8 @@ pub const Backend = enum {
     /// Does no rendering!
     testing,
 };
+
+pub const RenderBackend = enum {
+    default,
+    opengl,
+};


### PR DESCRIPTION
With these changes:

- `-Drender-backend=default` will use the render code in the main backend (status quo)
- `-Drender-backend=opengl` will use the OpenGL renderer if supported by the main backend, currently implemented for GLFW and wio

This enables separating the SDL backends in the future, and implementing other shared renderers such as Vulkan.

CC @Carboxide68 for the GLFW backend changes, I can revert them if you would prefer.