### PR TITLE
Reduce text jitter when smoothly scaling text with snap to pixels off…

### DIFF
--- a/src/Examples/scroll_canvas.zig
+++ b/src/Examples/scroll_canvas.zig
@@ -3,6 +3,21 @@ pub fn scrollCanvas() void {
     var vbox = dvui.box(@src(), .{}, .{ .expand = .both });
     defer vbox.deinit();
 
+    var fractional_font_cache_ref_scale: bool = dvui.fractionalFontCacheRefScale() != 1.0;
+    var snap_to_pixels: bool = dvui.snapToPixels();
+
+    if (dvui.checkbox(
+        @src(),
+        &fractional_font_cache_ref_scale,
+        "Fractional Font Cache Ref Scale",
+        .{},
+    )) {
+        _ = dvui.fractionalFontCacheRefScaleSet(if (fractional_font_cache_ref_scale) 32.0 else 1.0);
+    }
+    if (dvui.checkbox(@src(), &snap_to_pixels, "Snap to Pixels", .{})) {
+        _ = dvui.snapToPixelsSet(snap_to_pixels);
+    }
+
     const scroll_info = dvui.dataGetPtrDefault(null, vbox.data().id, "scroll_info", ScrollInfo, .{ .vertical = .given, .horizontal = .given });
     const origin = dvui.dataGetPtrDefault(null, vbox.data().id, "origin", Point, .{});
     const scale = dvui.dataGetPtrDefault(null, vbox.data().id, "scale", f32, 1.0);
@@ -322,6 +337,8 @@ pub fn scrollCanvas() void {
                         zoom *= zs;
                         zoomP = me.p;
                     }
+                } else if (me.action == .wheel_x) {
+                    e.handle(@src(), scrollContainer.data());
                 }
             },
             else => {},

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -295,11 +295,11 @@ pub fn textSizeEx(self: Font, text: []const u8, opts: TextSizeOptions) Size {
     // might give us a slightly smaller font
     const fce = dvui.fontCacheGet(sized_font) catch return .{ .w = 10, .h = 10 };
 
-    // this must be synced with dvui.renderText()
+    // this must be synced with dvui.renderText() (`target_size / fce.em_height` when snap is off)
     const target_fraction = if (cw.snap_to_pixels)
         1.0 / ss
     else
-        self.size / fce.em_height;
+        (self.size * ss) / fce.em_height;
 
     var options = opts;
     if (opts.max_width) |mwidth| {
@@ -314,7 +314,14 @@ pub fn textSizeEx(self: Font, text: []const u8, opts: TextSizeOptions) Size {
     if (ask_size == 0.0) return Size{};
 
     // convert size back from font units
-    return s.scale(target_fraction, Size);
+    var out = s.scale(target_fraction, Size);
+    if (!cw.snap_to_pixels) {
+        // Fractional cache + target_fraction can leave measured width slightly
+        // below rendered extent; TextLayout clips to contentRect and trims text.
+        out.w = @ceil(out.w) + 0.5;
+        out.h = @ceil(out.h) + 0.5;
+    }
+    return out;
 }
 
 pub const Cache = struct {

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -284,10 +284,14 @@ pub fn textSizeEx(self: Font, text: []const u8, opts: TextSizeOptions) Size {
     // ask for a font that matches the natural display pixels so we get a more
     // accurate size
     const ss = dvui.parentGet().screenRectScale(Rect{}).s;
-    const ask_size = self.size * ss;
-    const sized_font = self.withSize(ask_size);
-
     const cw = dvui.currentWindow();
+
+    // When snap_to_pixels is false (fractional scaling mode), use only the
+    // window DPI scale for the cache lookup so the font entry stays fixed
+    // across zoom levels — target_fraction handles the rest smoothly.
+    const font_ss = if (cw.snap_to_pixels) ss else dvui.windowNaturalScale();
+    const ask_size = self.size * font_ss;
+    const sized_font = self.withSize(ask_size);
 
     // might give us a slightly smaller font
     const fce = dvui.fontCacheGet(sized_font) catch return .{ .w = 10, .h = 10 };

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -286,14 +286,10 @@ pub fn textSizeEx(self: Font, text: []const u8, opts: TextSizeOptions) Size {
     const ss = dvui.parentGet().screenRectScale(Rect{}).s;
     const cw = dvui.currentWindow();
 
-    // When snap_to_pixels is false (fractional scaling mode), use only the
-    // window DPI scale for the cache lookup so the font entry stays fixed
-    // across zoom levels — target_fraction handles the rest smoothly.
-    const font_ss = if (cw.snap_to_pixels)
-        ss
+    const ask_size = if (cw.snap_to_pixels)
+        self.size * ss
     else
-        dvui.windowNaturalScale() * dvui.fractionalFontRefScale();
-    const ask_size = self.size * font_ss;
+        self.size * 16;
     const sized_font = self.withSize(ask_size);
 
     // might give us a slightly smaller font

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -299,7 +299,7 @@ pub fn textSizeEx(self: Font, text: []const u8, opts: TextSizeOptions) Size {
     const target_fraction = if (cw.snap_to_pixels)
         1.0 / ss
     else
-        (self.size * ss) / fce.em_height;
+        self.size / fce.em_height;
 
     var options = opts;
     if (opts.max_width) |mwidth| {

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -289,14 +289,17 @@ pub fn textSizeEx(self: Font, text: []const u8, opts: TextSizeOptions) Size {
     const ask_size = if (cw.snap_to_pixels)
         self.size * ss
     else
-        self.size * 16;
+        self.size * dvui.fractionalFontCacheRefScale() * dvui.windowNaturalScale();
     const sized_font = self.withSize(ask_size);
 
     // might give us a slightly smaller font
     const fce = dvui.fontCacheGet(sized_font) catch return .{ .w = 10, .h = 10 };
 
     // this must be synced with dvui.renderText()
-    const target_fraction = if (cw.snap_to_pixels) 1.0 / ss else self.size / fce.em_height;
+    const target_fraction = if (cw.snap_to_pixels)
+        1.0 / ss
+    else
+        self.size / fce.em_height;
 
     var options = opts;
     if (opts.max_width) |mwidth| {

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -289,7 +289,10 @@ pub fn textSizeEx(self: Font, text: []const u8, opts: TextSizeOptions) Size {
     // When snap_to_pixels is false (fractional scaling mode), use only the
     // window DPI scale for the cache lookup so the font entry stays fixed
     // across zoom levels — target_fraction handles the rest smoothly.
-    const font_ss = if (cw.snap_to_pixels) ss else dvui.windowNaturalScale();
+    const font_ss = if (cw.snap_to_pixels)
+        ss
+    else
+        dvui.windowNaturalScale() * dvui.fractionalFontRefScale();
     const ask_size = self.size * font_ss;
     const sized_font = self.withSize(ask_size);
 

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -28,9 +28,6 @@ scroll_to_focused: bool = false,
 text_input_rect: ?Rect.Natural = null,
 
 snap_to_pixels: bool = true,
-/// Multiplier used for fractional (snap_to_pixels=false) font cache lookup size.
-/// 1.0 means cache at theme size * natural DPI scale.
-fractional_font_ref_scale: f32 = 1.0,
 kerning: bool = true,
 /// The alpha value for all rendering. All colors alpha values will be
 /// multiplied by this value.

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -28,6 +28,9 @@ scroll_to_focused: bool = false,
 text_input_rect: ?Rect.Natural = null,
 
 snap_to_pixels: bool = true,
+/// Multiplier used for fractional (snap_to_pixels=false) font cache lookup size.
+/// 1.0 means cache at theme size * natural DPI scale.
+fractional_font_ref_scale: f32 = 1.0,
 kerning: bool = true,
 /// The alpha value for all rendering. All colors alpha values will be
 /// multiplied by this value.

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -28,6 +28,9 @@ scroll_to_focused: bool = false,
 text_input_rect: ?Rect.Natural = null,
 
 snap_to_pixels: bool = true,
+/// Multiplier for font cache raster size when `snap_to_pixels` is false.
+/// Effective cache size is `font.size * windowNaturalScale() * this`.
+fractional_font_cache_ref_scale: f32 = 1.0,
 kerning: bool = true,
 /// The alpha value for all rendering. All colors alpha values will be
 /// multiplied by this value.

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -926,6 +926,25 @@ pub fn snapToPixels() bool {
     return cw.snap_to_pixels;
 }
 
+/// Set multiplier for fractional (`snap_to_pixels = false`) font cache raster size.
+/// Cache size is `font.size * windowNaturalScale() * mult`. Returns previous value.
+///
+/// Only valid between `Window.begin`and `Window.end`.
+pub fn fractionalFontCacheRefScaleSet(mult: f32) f32 {
+    const cw = currentWindow();
+    const old = cw.fractional_font_cache_ref_scale;
+    cw.fractional_font_cache_ref_scale = @max(mult, 0.01);
+    return old;
+}
+
+/// Current fractional font cache reference scale. See `fractionalFontCacheRefScaleSet`.
+///
+/// Only valid between `Window.begin`and `Window.end`.
+pub fn fractionalFontCacheRefScale() f32 {
+    const cw = currentWindow();
+    return cw.fractional_font_cache_ref_scale;
+}
+
 /// Set kerning setting.  If true:
 /// * textSize includes kerning by default
 /// * renderText include kerning by default

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -926,6 +926,26 @@ pub fn snapToPixels() bool {
     return cw.snap_to_pixels;
 }
 
+/// Set reference scale multiplier for fractional text cache lookup
+/// (`snap_to_pixels = false`). Returns previous value.
+///
+/// Only valid between `Window.begin`and `Window.end`.
+pub fn fractionalFontRefScaleSet(mult: f32) f32 {
+    const cw = currentWindow();
+    const old = cw.fractional_font_ref_scale;
+    cw.fractional_font_ref_scale = @max(mult, 0.01);
+    return old;
+}
+
+/// Get current fractional font cache reference scale multiplier.
+/// See `fractionalFontRefScaleSet`.
+///
+/// Only valid between `Window.begin`and `Window.end`.
+pub fn fractionalFontRefScale() f32 {
+    const cw = currentWindow();
+    return cw.fractional_font_ref_scale;
+}
+
 /// Set kerning setting.  If true:
 /// * textSize includes kerning by default
 /// * renderText include kerning by default

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -926,26 +926,6 @@ pub fn snapToPixels() bool {
     return cw.snap_to_pixels;
 }
 
-/// Set reference scale multiplier for fractional text cache lookup
-/// (`snap_to_pixels = false`). Returns previous value.
-///
-/// Only valid between `Window.begin`and `Window.end`.
-pub fn fractionalFontRefScaleSet(mult: f32) f32 {
-    const cw = currentWindow();
-    const old = cw.fractional_font_ref_scale;
-    cw.fractional_font_ref_scale = @max(mult, 0.01);
-    return old;
-}
-
-/// Get current fractional font cache reference scale multiplier.
-/// See `fractionalFontRefScaleSet`.
-///
-/// Only valid between `Window.begin`and `Window.end`.
-pub fn fractionalFontRefScale() f32 {
-    const cw = currentWindow();
-    return cw.fractional_font_ref_scale;
-}
-
 /// Set kerning setting.  If true:
 /// * textSize includes kerning by default
 /// * renderText include kerning by default

--- a/src/render.zig
+++ b/src/render.zig
@@ -155,7 +155,10 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
     const target_size = opts.font.size * opts.rs.s;
     // When snap_to_pixels is false, use the window DPI scale for the cache
     // lookup (matching textSizeEx) so the font entry is stable across zoom.
-    const cache_size = if (cw.snap_to_pixels) target_size else opts.font.size * dvui.windowNaturalScale();
+    const cache_size = if (cw.snap_to_pixels)
+        target_size
+    else
+        opts.font.size * dvui.windowNaturalScale() * dvui.fractionalFontRefScale();
     const sized_font = opts.font.withSize(cache_size);
 
     // might get a slightly smaller font

--- a/src/render.zig
+++ b/src/render.zig
@@ -166,7 +166,7 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
         fce_ascent = @round(fce_ascent * opts.font.line_height_factor);
     }
 
-    // this must be synced with Font.textSizeEx()
+    // Physical scale from cache; Font.textSizeEx uses self.size/em for layout when snap is off.
     const target_fraction = if (cw.snap_to_pixels) 1.0 else target_size / fce.em_height;
 
     // make sure the cache has all the glyphs we need

--- a/src/render.zig
+++ b/src/render.zig
@@ -153,12 +153,10 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
     }
 
     const target_size = opts.font.size * opts.rs.s;
-    // When snap_to_pixels is false, use the window DPI scale for the cache
-    // lookup (matching textSizeEx) so the font entry is stable across zoom.
     const cache_size = if (cw.snap_to_pixels)
         target_size
     else
-        opts.font.size * dvui.windowNaturalScale() * dvui.fractionalFontRefScale();
+        opts.font.size * 16;
     const sized_font = opts.font.withSize(cache_size);
 
     // might get a slightly smaller font

--- a/src/render.zig
+++ b/src/render.zig
@@ -248,7 +248,9 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
 
         if (kerning and last_codepoint != 0 and i >= next_kern_byte) {
             const kk = fce.kern(last_codepoint, codepoint);
-            x += kk;
+            // Must match advance scaling (`nextx` below); textSizeEx scales the
+            // full measured width (including kerning) by target_fraction.
+            x += kk * target_fraction;
 
             if (opts.kern_in) |ki| {
                 if (next_kern_idx < ki.len) {

--- a/src/render.zig
+++ b/src/render.zig
@@ -153,7 +153,10 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
     }
 
     const target_size = opts.font.size * opts.rs.s;
-    const sized_font = opts.font.withSize(target_size);
+    // When snap_to_pixels is false, use the window DPI scale for the cache
+    // lookup (matching textSizeEx) so the font entry is stable across zoom.
+    const cache_size = if (cw.snap_to_pixels) target_size else opts.font.size * dvui.windowNaturalScale();
+    const sized_font = opts.font.withSize(cache_size);
 
     // might get a slightly smaller font
     var fce = try cw.fonts.getOrCreate(cw.gpa, sized_font);

--- a/src/render.zig
+++ b/src/render.zig
@@ -156,7 +156,7 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
     const cache_size = if (cw.snap_to_pixels)
         target_size
     else
-        opts.font.size * 16;
+        opts.font.size * dvui.fractionalFontCacheRefScale() * dvui.windowNaturalScale();
     const sized_font = opts.font.withSize(cache_size);
 
     // might get a slightly smaller font

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -1251,7 +1251,8 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
         // size.  Sometimes due to floating point this width will be very
         // slightly less than the width of the text that textSizeEx below sees,
         // causing a line break.  So give ourselves a tiny bit of extra room.
-        var linewidth = container_width + 0.001;
+        // (1 logical px: fractional font cache paths need more than 0.001.)
+        var linewidth = container_width + 1.0;
         var width = linewidth - self.insert_pt.x;
         var width_after: f32 = 0;
         for (self.corners, 0..) |corner, i| {


### PR DESCRIPTION
…, for cases when this is priority.

@david-vanderson 

Hi! I know we had talked about this before for graphl, I've been trying to find a way to smooth out text on nodes which determine node sizes, and generally reduce text jitter when scaling.

I found that these changes produced smooth and nice looking text for me, though I know this should sacrifice text clarity as we are no longer snapping to pixels. I think this is the only way to maintain smooth zooming, which I believe is a larger priority for us since the user can zoom in on the text. 

I'm a newb to text rendering though, and I know you've studied and worked on this type of thing a lot, so I wanted your input. If you'd like to see a before and after comparison of these changes for us, please let me know. I'm hoping since this is gated on snap to pixels that it would affect almost no one unless the goal is smoothly scaling text, which makes sense to me that you'd turn off snap to pixels if you want that type of smoothness. 

I was also thinking about potentially just temporarily turning off snap to pixels during a zoom, and returning it to on after the zoom is complete, which I think would solve all cases. Anyway. Please let me know what you think!