### PR TITLE
Scroll speed 2

### DIFF
--- a/src/Examples/scroll_canvas.zig
+++ b/src/Examples/scroll_canvas.zig
@@ -371,7 +371,7 @@ pub fn scrollCanvas() void {
     // when starting out)
     if (!scroll_info.viewport.empty()) {
         // add current viewport plus padding
-        const pad = 60;
+        const pad = 100;
         var bbox = scroll_info.viewport.outsetAll(pad);
         if (mbbox) |bb| {
             // convert bb from screen space to viewport space

--- a/src/Examples/scroll_canvas.zig
+++ b/src/Examples/scroll_canvas.zig
@@ -127,7 +127,13 @@ pub fn scrollCanvas() void {
             mbbox = boxRect;
         }
 
-        dvui.label(@src(), "Box {d} {d:0>3.0}x{d:0>3.0}", .{ i, b.x, b.y }, .{});
+        // This label controls the size of the box, but when zooming the box
+        // will use last frame's min size.  That means the label this frame
+        // might be slightly larger so will ellipsize.  We could turn that off
+        // with labelEx, but here we'll add extra space.
+        var label_wd: dvui.WidgetData = undefined;
+        dvui.label(@src(), "Box {d} {d:0>3.0}x{d:0>3.0}", .{ i, b.x, b.y }, .{ .data_out = &label_wd });
+        dragBox.data().minSizeMax(dragBox.data().options.padSize(label_wd.min_size.pad(.{ .w = 10 })));
 
         {
             var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
@@ -321,7 +327,7 @@ pub fn scrollCanvas() void {
                     }
                 } else if (me.action == .wheel_y and me.mod.matchBind("ctrl/cmd")) {
                     e.handle(@src(), scrollContainer.data());
-                    const base: f32 = 1.01;
+                    const base: f32 = 1.005;
                     const zs = @exp(@log(base) * me.action.wheel_y);
                     if (zs != 1.0) {
                         zoom *= zs;

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -205,6 +205,7 @@ export class Dvui {
      * The first number is x and second is y
      * @type {[number, number]} */
     lowest_scroll_delta = [99999, 99999];
+    lowest_scroll_ms = Date.now();
     /**
      * x y w h of on screen keyboard editing position, or empty if none
      *
@@ -1262,9 +1263,16 @@ export class Dvui {
             if (this.stopped) return;
             ev.preventDefault();
 
+            // If we haven't gotten a wheel event in a second, reset our delta
+            // because the user might have switched between mouse and touchpad.
+            if ((Date.now() - this.lowest_scroll_ms) > 1000) {
+                this.lowest_scroll_delta = [99999, 99999];
+            }
+            this.lowest_scroll_ms = Date.now();
+
             // deltaX/Y numbers less than this indicate a touchpad
             const touchpad_threshold = 4;
-            const touchpad_adj = 0.1;
+            const touchpad_adj = 0.025;
 
             if (ev.deltaX != 0) {
                 const min = Math.min(
@@ -1272,7 +1280,7 @@ export class Dvui {
                     this.lowest_scroll_delta[0],
                 );
                 this.lowest_scroll_delta[0] = min;
-                var ticks = ev.deltaX / min;
+                var ticks = -ev.deltaX / min;
                 if (min < touchpad_threshold) ticks *= touchpad_adj;
                 this.instance.exports.add_event(
                     4,
@@ -1291,6 +1299,11 @@ export class Dvui {
                 this.lowest_scroll_delta[1] = min;
                 var ticks = -ev.deltaY / min;
                 if (min < touchpad_threshold) ticks *= touchpad_adj;
+                if (min < touchpad_threshold) {
+                    console.log(-ev.deltaY + " touchpad " + ticks);
+                } else {
+                    console.log(-ev.deltaY + " wheel " + ticks);
+                }
                 this.instance.exports.add_event(
                     4,
                     1,

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -199,13 +199,19 @@ export class Dvui {
      * list of tuple (touch identifier, initial index)
      * @type {[number, number][]} */
     touches = [];
-    /** The lowest data seen, used to determine the delta for one "tick"
-     * of the scroll wheel
+    /** The lowest deltaX/Y seen, used to determine the delta for touchpads
      *
      * The first number is x and second is y
      * @type {[number, number]} */
-    lowest_scroll_delta = [99999, 99999];
-    lowest_scroll_ms = Date.now();
+    scroll_lowest = [99999, 99999];
+    /** The lowest deltaX/Y seen in this batch (resets if none in 1s).  Used to
+     * determine if we think a touchpad is being used and also as the delta for
+     * mouse wheels.
+     *
+     * The first number is x and second is y
+     * @type {[number, number]} */
+    scroll_lowest_batch = [99999, 99999];
+    scroll_last_ms = Date.now();
     /**
      * x y w h of on screen keyboard editing position, or empty if none
      *
@@ -1263,25 +1269,34 @@ export class Dvui {
             if (this.stopped) return;
             ev.preventDefault();
 
-            // If we haven't gotten a wheel event in a second, reset our delta
+            // If we haven't gotten a wheel event in a second, reset our first
             // because the user might have switched between mouse and touchpad.
-            if ((Date.now() - this.lowest_scroll_ms) > 1000) {
-                this.lowest_scroll_delta = [99999, 99999];
+            if ((Date.now() - this.scroll_last_ms) > 1000) {
+                this.scroll_lowest_batch = [99999, 99999];
             }
-            this.lowest_scroll_ms = Date.now();
+            this.scroll_last_ms = Date.now();
 
-            // deltaX/Y numbers less than this indicate a touchpad
-            const touchpad_threshold = 4;
             const touchpad_adj = 0.025;
 
             if (ev.deltaX != 0) {
-                const min = Math.min(
+                this.scroll_lowest[0] = Math.min(
                     Math.abs(ev.deltaX),
-                    this.lowest_scroll_delta[0],
+                    this.scroll_lowest[0],
                 );
-                this.lowest_scroll_delta[0] = min;
-                var ticks = -ev.deltaX / min;
-                if (min < touchpad_threshold) ticks *= touchpad_adj;
+                this.scroll_lowest_batch[0] = Math.min(
+                    Math.abs(ev.deltaX),
+                    this.scroll_lowest_batch[0],
+                );
+                var ticks = -ev.deltaX;
+                if ((this.scroll_lowest_batch[0] >= 100) || // most wheels
+                    (this.scroll_lowest_batch[0] === 16) || // mac firefox
+                    (this.scroll_lowest_batch[0] === 4.000244140625)) { // mac safari/chrome
+                    // assume this is a mouse wheel
+                    ticks /= this.scroll_lowest_batch[0];
+                } else {
+                    // assume touchpad
+                    ticks = ticks / this.scroll_lowest[0] * touchpad_adj;
+                }
                 this.instance.exports.add_event(
                     4,
                     0,
@@ -1292,17 +1307,25 @@ export class Dvui {
             }
             if (ev.deltaY != 0) {
                 //console.log("deltaMode: " + ev.deltaMode + " deltaY: " + ev.deltaY);
-                const min = Math.min(
+                this.scroll_lowest[1] = Math.min(
                     Math.abs(ev.deltaY),
-                    this.lowest_scroll_delta[1],
+                    this.scroll_lowest[1],
                 );
-                this.lowest_scroll_delta[1] = min;
-                var ticks = -ev.deltaY / min;
-                if (min < touchpad_threshold) ticks *= touchpad_adj;
-                if (min < touchpad_threshold) {
-                    console.log(-ev.deltaY + " touchpad " + ticks);
-                } else {
+                this.scroll_lowest_batch[1] = Math.min(
+                    Math.abs(ev.deltaY),
+                    this.scroll_lowest_batch[1],
+                );
+                var ticks = -ev.deltaY;
+                if ((this.scroll_lowest_batch[1] >= 100) || // most wheels
+                    (this.scroll_lowest_batch[1] === 16) || // mac firefox
+                    (this.scroll_lowest_batch[1] === 4.000244140625)) { // mac safari/chrome
+                    // assume this is a mouse wheel
+                    ticks /= this.scroll_lowest_batch[1];
                     console.log(-ev.deltaY + " wheel " + ticks);
+                } else {
+                    // assume touchpad
+                    ticks = ticks / this.scroll_lowest[1] * touchpad_adj;
+                    console.log(-ev.deltaY + " touchpad " + ticks);
                 }
                 this.instance.exports.add_event(
                     4,

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -1298,11 +1298,11 @@ export class Dvui {
                     if (this.scroll_lowest_batch[0] === 4.000244140625) {
                         ticks *= touchpad_adj; // mac safari/chrome scale wheel like touchpad
                     }
-                    console.log(-ev.deltaX + " wheelX " + ticks);
+                    console.log("wheelX -deltaX " + -ev.deltaX + " ticks " + ticks);
                 } else {
                     // assume touchpad
                     ticks = ticks / this.scroll_lowest[0] * touchpad_adj;
-                    console.log(-ev.deltaX + " touchpadX " + ticks);
+                    console.log("touchpadX -deltaX " + -ev.deltaX + " ticks " + ticks);
                 }
                 this.instance.exports.add_event(
                     4,
@@ -1331,11 +1331,11 @@ export class Dvui {
                     if (this.scroll_lowest_batch[1] === 4.000244140625) {
                         ticks *= touchpad_adj; // mac safari/chrome scale wheel like touchpad
                     }
-                    console.log(-ev.deltaY + " wheelY " + ticks);
+                    console.log("wheelY -deltaY " + -ev.deltaY + " ticks " + ticks);
                 } else {
                     // assume touchpad
                     ticks = ticks / this.scroll_lowest[1] * touchpad_adj;
-                    console.log(-ev.deltaY + " touchpadY " + ticks);
+                    console.log("touchpadY -deltaY " + -ev.deltaY + " ticks " + ticks);
                 }
                 this.instance.exports.add_event(
                     4,

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -1331,11 +1331,11 @@ export class Dvui {
                     if (this.scroll_lowest_batch[1] === 4.000244140625) {
                         ticks *= touchpad_adj; // mac safari/chrome scale wheel like touchpad
                     }
-                    console.log("wheelY -deltaY " + -ev.deltaY + " ticks " + ticks);
+                    //console.log("wheelY -deltaY " + -ev.deltaY + " ticks " + ticks);
                 } else {
                     // assume touchpad
                     ticks = ticks / this.scroll_lowest[1] * touchpad_adj;
-                    console.log("touchpadY -deltaY " + -ev.deltaY + " ticks " + ticks);
+                    //console.log("touchpadY -deltaY " + -ev.deltaY + " ticks " + ticks);
                 }
                 this.instance.exports.add_event(
                     4,

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -1290,12 +1290,19 @@ export class Dvui {
                 var ticks = -ev.deltaX;
                 if ((this.scroll_lowest_batch[0] >= 100) || // most wheels
                     (this.scroll_lowest_batch[0] === 16) || // mac firefox
+                    (this.scroll_lowest_batch[0] === 9) || // mac firefox holding shift
+                    (this.scroll_lowest_batch[0] === 40) || // mac safari/chrome holding shift
                     (this.scroll_lowest_batch[0] === 4.000244140625)) { // mac safari/chrome
                     // assume this is a mouse wheel
                     ticks /= this.scroll_lowest_batch[0];
+                    if (this.scroll_lowest_batch[0] === 4.000244140625) {
+                        ticks *= touchpad_adj; // mac safari/chrome scale wheel like touchpad
+                    }
+                    console.log(-ev.deltaX + " wheelX " + ticks);
                 } else {
                     // assume touchpad
                     ticks = ticks / this.scroll_lowest[0] * touchpad_adj;
+                    console.log(-ev.deltaX + " touchpadX " + ticks);
                 }
                 this.instance.exports.add_event(
                     4,
@@ -1321,11 +1328,14 @@ export class Dvui {
                     (this.scroll_lowest_batch[1] === 4.000244140625)) { // mac safari/chrome
                     // assume this is a mouse wheel
                     ticks /= this.scroll_lowest_batch[1];
-                    console.log(-ev.deltaY + " wheel " + ticks);
+                    if (this.scroll_lowest_batch[1] === 4.000244140625) {
+                        ticks *= touchpad_adj; // mac safari/chrome scale wheel like touchpad
+                    }
+                    console.log(-ev.deltaY + " wheelY " + ticks);
                 } else {
                     // assume touchpad
                     ticks = ticks / this.scroll_lowest[1] * touchpad_adj;
-                    console.log(-ev.deltaY + " touchpad " + ticks);
+                    console.log(-ev.deltaY + " touchpadY " + ticks);
                 }
                 this.instance.exports.add_event(
                     4,

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -291,7 +291,7 @@ pub const useTinyFileDialogs = @import("default_options").tiny_file_dialogs;
 pub const useTreeSitter = @import("default_options").tree_sitter;
 
 /// The amount of logical pixels to scroll per "tick" of the scroll wheel
-pub var scroll_speed: f32 = 40;
+pub var scroll_speed: f32 = 80;
 
 /// Used as a default maximum in various places:
 /// * Options.max_size_content


### PR DESCRIPTION
part of #711 

Everything:
* double mouse wheel speed
* demo: scroll canvas label pad and reduce zoom speed

Web:
* half touchpad speed
* fix horizontal touchpad direction
* 1s timeout for touchpad detection heuristic
* mac safari/chrome scale down wheel like touchpad
* mac firefox/safari/chrome handle wheel while shift is held


#### Data from my laptops

I don't see any momentum when using a mouse with a physical wheel - meaning the events stop as soon as the wheel stops.  For touchpads, linux has very little momentum, mac has a lot, and windows is in the middle.

SDL3 backend (all values are the raw ticks)
* mouse wheel
  * linux/win: 1 tick per wheel move, spinning fast can give 2
  * mac: 0.1 tick per wheel when going slow, spinning fast goes up to 15-20
    * seems to be based on the time between ticks (less time means larger number)
* touchpad
  * linux: 0.02 up to 2-4 (no momentum)
  * mac: 0.1 up to 25-30 (large momentum)
  * win: 0.01 up to 5-6 (med momentum)

On the web these values can be impacted by the browser zoom, all of these are at 100%

Web backend (all values are WheelEvent.deltaY, deltaMode was always 0)
* mouse wheel Y
  * linux firefox: 138 up to 276 (integer multiples)
  * linux chrome: 120 up to 240 (integer multiples)
  * mac firefox: 16 up to 160 (integer multiples, 16 is always the first event)
    * holding shift does deltaX 9 up to 90 (integer multiples, 9 always first)
  * mac safari/chrome: 4.000244140625 up to 400 (fractional multiples, 4.000... is always the first event)
    * holding shift does deltaX 40 up to 400 (integer multiples, 40 is always the first event)
  * win firefox: 108 up to 216 (integer multiples)
  * win chrome: 100 up to 200 (integer multiples)

* touchpad
  * linux firefox: 138 up to 690 (small momentum, integer multiples, works like mouse wheel)
  * linux chrome: 3.00980281829834 up to 600 (no momentum, integer multiples, can start > 200)
  * mac firefox/safari/chrome: 1 up to 400 (large momentum, integers, first event is usually < 10)
  * win firefox: ~1 (fraction) up to 400 (large momentum, fractional multiples, can start > 100)
  * win chrome: 1 up to 400 (med momentum, integers, can start > 100)
