### PR TITLE
reduce motion

### DIFF
--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -186,9 +186,9 @@ pub fn preferredColorScheme(self: Backend) ?dvui.enums.ColorScheme {
     return self.impl.preferredColorScheme();
 }
 
-/// Get the preferredMotionAmount if available
-pub fn preferredMotionAmount(self: Backend) ?dvui.enums.MotionAmount {
-    return self.impl.preferredMotionAmount();
+/// Get the prefersReducedMotion if available
+pub fn prefersReducedMotion(self: Backend) bool {
+    return self.impl.prefersReducedMotion();
 }
 
 /// Called by `dvui.refresh` when it is called from a background

--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -186,6 +186,11 @@ pub fn preferredColorScheme(self: Backend) ?dvui.enums.ColorScheme {
     return self.impl.preferredColorScheme();
 }
 
+/// Get the preferredMotionAmount if available
+pub fn preferredMotionAmount(self: Backend) ?dvui.enums.MotionAmount {
+    return self.impl.preferredMotionAmount();
+}
+
 /// Called by `dvui.refresh` when it is called from a background
 /// thread.  Used to wake up the gui thread.  It only has effect if you
 /// are using `dvui.Window.waitTime` or some other method of waiting until

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -159,14 +159,7 @@ pub fn show(self: *Debug) void {
 
         dvui.tooltip(@src(), .{ .active_rect = wd.borderRectScale().r, .position = .vertical }, "mouse drag will scroll\ntext layout/entry have draggables and menu", .{}, .{});
 
-        var reduce_motion = dvui.motion_amount != null and dvui.motion_amount == .reduced;
-        _ = dvui.checkbox(@src(), &reduce_motion, "Reduce Motion", .{ .data_out = &wd });
-        if (reduce_motion) {
-            dvui.motion_amount = .reduced;
-        }
-        if (!reduce_motion and dvui.motion_amount != null) {
-            dvui.motion_amount = .all;
-        }
+        _ = dvui.checkbox(@src(), &dvui.reduce_motion, "Reduce Motion", .{ .data_out = &wd });
 
         dvui.tooltip(@src(), .{ .active_rect = wd.borderRectScale().r, .position = .vertical }, "animations expire in one frame\ntimers not affected", .{}, .{});
     }

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -159,7 +159,14 @@ pub fn show(self: *Debug) void {
 
         dvui.tooltip(@src(), .{ .active_rect = wd.borderRectScale().r, .position = .vertical }, "mouse drag will scroll\ntext layout/entry have draggables and menu", .{}, .{});
 
-        _ = dvui.checkbox(@src(), &dvui.reduce_motion, "Reduce Motion", .{ .data_out = &wd });
+        var reduce_motion = dvui.motion_amount != null and dvui.motion_amount == .reduced;
+        _ = dvui.checkbox(@src(), &reduce_motion, "Reduce Motion", .{ .data_out = &wd });
+        if (reduce_motion) {
+            dvui.motion_amount = .reduced;
+        }
+        if (!reduce_motion and dvui.motion_amount != null) {
+            dvui.motion_amount = .all;
+        }
 
         dvui.tooltip(@src(), .{ .active_rect = wd.borderRectScale().r, .position = .vertical }, "animations expire in one frame\ntimers not affected", .{}, .{});
     }

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -155,9 +155,11 @@ pub fn show(self: *Debug) void {
         }
 
         var wd: dvui.WidgetData = undefined;
-        _ = dvui.checkbox(@src(), &dvui.currentWindow().debug.touch_simulate_events, "Simulate Touch With Mouse", .{ .data_out = &wd });
+        _ = dvui.checkbox(@src(), &dvui.currentWindow().debug.touch_simulate_events, "Simulate Touch", .{ .data_out = &wd });
 
-        dvui.tooltip(@src(), .{ .active_rect = wd.borderRectScale().r }, "mouse drag will scroll\ntext layout/entry have draggables and menu", .{}, .{});
+        dvui.tooltip(@src(), .{ .active_rect = wd.borderRectScale().r, .position = .vertical }, "mouse drag will scroll\ntext layout/entry have draggables and menu", .{}, .{});
+
+        _ = dvui.checkbox(@src(), &dvui.reduce_motion, "Reduce Motion", .{});
     }
 
     _ = dvui.spacer(@src(), .{ .min_size_content = .all(4) });

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -159,7 +159,9 @@ pub fn show(self: *Debug) void {
 
         dvui.tooltip(@src(), .{ .active_rect = wd.borderRectScale().r, .position = .vertical }, "mouse drag will scroll\ntext layout/entry have draggables and menu", .{}, .{});
 
-        _ = dvui.checkbox(@src(), &dvui.reduce_motion, "Reduce Motion", .{});
+        _ = dvui.checkbox(@src(), &dvui.reduce_motion, "Reduce Motion", .{ .data_out = &wd });
+
+        dvui.tooltip(@src(), .{ .active_rect = wd.borderRectScale().r, .position = .vertical }, "animations expire in one frame\ntimers not affected", .{}, .{});
     }
 
     _ = dvui.spacer(@src(), .{ .min_size_content = .all(4) });

--- a/src/Examples/animations.zig
+++ b/src/Examples/animations.zig
@@ -36,14 +36,7 @@ pub fn animations() void {
 
     var wd: dvui.WidgetData = undefined;
 
-    var reduce_motion = dvui.motion_amount != null and dvui.motion_amount == .reduced;
-    _ = dvui.checkbox(@src(), &reduce_motion, "Reduce Motion", .{ .data_out = &wd });
-    if (reduce_motion) {
-        dvui.motion_amount = .reduced;
-    }
-    if (!reduce_motion and dvui.motion_amount != null) {
-        dvui.motion_amount = .all;
-    }
+    _ = dvui.checkbox(@src(), &dvui.reduce_motion, "Reduce Motion", .{ .data_out = &wd });
 
     dvui.tooltip(@src(), .{ .active_rect = wd.borderRectScale().r, .position = .horizontal }, "animations expire in one frame\ntimers not affected", .{}, .{});
 

--- a/src/Examples/animations.zig
+++ b/src/Examples/animations.zig
@@ -308,6 +308,7 @@ const AnimatingDialog = struct {
 
         var win: FloatingWindowWidget = undefined;
         win.init(@src(), .{ .modal = modal }, .{ .id_extra = id.asUsize(), .max_size_content = .width(300) });
+        defer win.deinit();
 
         if (dvui.firstFrame(win.data().id)) {
             dvui.animation(win.data().id, "rect_percent", .{ .start_val = 0.0, .end_val = 1.0, .end_time = duration, .easing = easing });
@@ -340,7 +341,6 @@ const AnimatingDialog = struct {
             }
         }
 
-        defer win.deinit();
         win.processEventsBefore();
         win.drawBackground();
 

--- a/src/Examples/animations.zig
+++ b/src/Examples/animations.zig
@@ -34,6 +34,10 @@ pub fn animations() void {
         break :blk .{ out_fns, out_names };
     };
 
+    var wd: dvui.WidgetData = undefined;
+    _ = dvui.checkbox(@src(), &dvui.reduce_motion, "Reduce Motion", .{ .data_out = &wd });
+    dvui.tooltip(@src(), .{ .active_rect = wd.borderRectScale().r, .position = .horizontal }, "animations expire in one frame\ntimers not affected", .{}, .{});
+
     {
         var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
         defer hbox.deinit();

--- a/src/Examples/animations.zig
+++ b/src/Examples/animations.zig
@@ -35,7 +35,16 @@ pub fn animations() void {
     };
 
     var wd: dvui.WidgetData = undefined;
-    _ = dvui.checkbox(@src(), &dvui.reduce_motion, "Reduce Motion", .{ .data_out = &wd });
+
+    var reduce_motion = dvui.motion_amount != null and dvui.motion_amount == .reduced;
+    _ = dvui.checkbox(@src(), &reduce_motion, "Reduce Motion", .{ .data_out = &wd });
+    if (reduce_motion) {
+        dvui.motion_amount = .reduced;
+    }
+    if (!reduce_motion and dvui.motion_amount != null) {
+        dvui.motion_amount = .all;
+    }
+
     dvui.tooltip(@src(), .{ .active_rect = wd.borderRectScale().r, .position = .horizontal }, "animations expire in one frame\ntimers not affected", .{}, .{});
 
     {

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -1081,6 +1081,11 @@ pub fn openURL(self: Context, url: []const u8, _: bool) !void {
 pub fn preferredColorScheme(_: Context) ?dvui.enums.ColorScheme {
     return dvui.Backend.Common.windowsGetPreferredColorScheme();
 }
+
+pub fn preferredMotionAmount(_: Context) ?dvui.enums.MotionAmount {
+    return null;
+}
+
 pub fn cursorShow(_: Context, value: ?bool) !bool {
     var info: win32.CURSORINFO = undefined;
     info.cbSize = @sizeOf(win32.CURSORINFO);

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -1082,8 +1082,8 @@ pub fn preferredColorScheme(_: Context) ?dvui.enums.ColorScheme {
     return dvui.Backend.Common.windowsGetPreferredColorScheme();
 }
 
-pub fn preferredMotionAmount(_: Context) ?dvui.enums.MotionAmount {
-    return null;
+pub fn prefersReducedMotion(_: Context) bool {
+    return false;
 }
 
 pub fn cursorShow(_: Context, value: ?bool) !bool {

--- a/src/backends/glfw.zig
+++ b/src/backends/glfw.zig
@@ -210,6 +210,10 @@ pub fn preferredColorScheme(_: *@This()) ?dvui.enums.ColorScheme {
     return null;
 }
 
+pub fn preferredMotionAmount(_: *@This()) ?dvui.enums.MotionAmount {
+    return null;
+}
+
 pub fn pollEventsTimeout(_: *@This(), win: *dvui.Window, end_time: ?u32) void {
     const wt = win.waitTime(end_time);
     zglfw.waitEventsTimeout(@max(@as(f64, @floatFromInt(wt)) / std.time.us_per_s, 0));

--- a/src/backends/glfw.zig
+++ b/src/backends/glfw.zig
@@ -210,8 +210,8 @@ pub fn preferredColorScheme(_: *@This()) ?dvui.enums.ColorScheme {
     return null;
 }
 
-pub fn preferredMotionAmount(_: *@This()) ?dvui.enums.MotionAmount {
-    return null;
+pub fn prefersReducedMotion(_: *@This()) bool {
+    return false;
 }
 
 pub fn pollEventsTimeout(_: *@This(), win: *dvui.Window, end_time: ?u32) void {

--- a/src/backends/raylib-c.zig
+++ b/src/backends/raylib-c.zig
@@ -519,6 +519,10 @@ pub fn preferredColorScheme(_: *RaylibBackend) ?dvui.enums.ColorScheme {
     return null;
 }
 
+pub fn preferredMotionAmount(_: *@This()) ?dvui.enums.MotionAmount {
+    return null;
+}
+
 pub fn cursorShow(_: *RaylibBackend, value: ?bool) bool {
     const prev = !c.IsCursorHidden();
     if (value) |val| {

--- a/src/backends/raylib-c.zig
+++ b/src/backends/raylib-c.zig
@@ -519,8 +519,8 @@ pub fn preferredColorScheme(_: *RaylibBackend) ?dvui.enums.ColorScheme {
     return null;
 }
 
-pub fn preferredMotionAmount(_: *@This()) ?dvui.enums.MotionAmount {
-    return null;
+pub fn prefersReducedMotion(_: *@This()) bool {
+    return false;
 }
 
 pub fn cursorShow(_: *RaylibBackend, value: ?bool) bool {

--- a/src/backends/raylib-zig.zig
+++ b/src/backends/raylib-zig.zig
@@ -518,6 +518,10 @@ pub fn preferredColorScheme(_: *RaylibBackend) ?dvui.enums.ColorScheme {
     return null;
 }
 
+pub fn preferredMotionAmount(_: *@This()) ?dvui.enums.MotionAmount {
+    return null;
+}
+
 pub fn cursorShow(_: *RaylibBackend, value: ?bool) bool {
     const prev = !raylib.isCursorOnScreen();
     if (value) |val| {

--- a/src/backends/raylib-zig.zig
+++ b/src/backends/raylib-zig.zig
@@ -518,8 +518,8 @@ pub fn preferredColorScheme(_: *RaylibBackend) ?dvui.enums.ColorScheme {
     return null;
 }
 
-pub fn preferredMotionAmount(_: *@This()) ?dvui.enums.MotionAmount {
-    return null;
+pub fn prefersReducedMotion(_: *@This()) bool {
+    return false;
 }
 
 pub fn cursorShow(_: *RaylibBackend, value: ?bool) bool {

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -648,6 +648,10 @@ pub fn preferredColorScheme(_: *SDLBackend) ?dvui.enums.ColorScheme {
     return null;
 }
 
+pub fn preferredMotionAmount(_: *@This()) ?dvui.enums.MotionAmount {
+    return null;
+}
+
 pub fn begin(self: *SDLBackend, arena: std.mem.Allocator) !void {
     self.arena = arena;
     const size = self.pixelSize();

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -648,8 +648,8 @@ pub fn preferredColorScheme(_: *SDLBackend) ?dvui.enums.ColorScheme {
     return null;
 }
 
-pub fn preferredMotionAmount(_: *@This()) ?dvui.enums.MotionAmount {
-    return null;
+pub fn prefersReducedMotion(_: *@This()) bool {
+    return false;
 }
 
 pub fn begin(self: *SDLBackend, arena: std.mem.Allocator) !void {

--- a/src/backends/sdl3gpu.zig
+++ b/src/backends/sdl3gpu.zig
@@ -1066,6 +1066,10 @@ pub fn preferredColorScheme(_: *SDLBackend) ?dvui.enums.ColorScheme {
     };
 }
 
+pub fn preferredMotionAmount(_: *@This()) ?dvui.enums.MotionAmount {
+    return null;
+}
+
 pub fn begin(self: *SDLBackend, arena: std.mem.Allocator) !void {
     self.arena = arena;
     self.frame_uploads.reset();

--- a/src/backends/sdl3gpu.zig
+++ b/src/backends/sdl3gpu.zig
@@ -1066,8 +1066,8 @@ pub fn preferredColorScheme(_: *SDLBackend) ?dvui.enums.ColorScheme {
     };
 }
 
-pub fn preferredMotionAmount(_: *@This()) ?dvui.enums.MotionAmount {
-    return null;
+pub fn prefersReducedMotion(_: *@This()) bool {
+    return false;
 }
 
 pub fn begin(self: *SDLBackend, arena: std.mem.Allocator) !void {

--- a/src/backends/testing.zig
+++ b/src/backends/testing.zig
@@ -155,8 +155,8 @@ pub fn preferredColorScheme(_: *TestingBackend) ?dvui.enums.ColorScheme {
     return null;
 }
 
-pub fn preferredMotionAmount(_: *@This()) ?dvui.enums.MotionAmount {
-    return null;
+pub fn prefersReducedMotion(_: *@This()) bool {
+    return false;
 }
 
 /// Called by dvui.refresh() when it is called from a background

--- a/src/backends/testing.zig
+++ b/src/backends/testing.zig
@@ -101,8 +101,7 @@ pub fn textureCreateTarget(_: *TestingBackend, _: u32, _: u32, _: dvui.enums.Tex
     return error.TextureCreate;
 }
 
-pub fn textureClearTarget(_: *TestingBackend, _: dvui.TextureTarget) void {
-}
+pub fn textureClearTarget(_: *TestingBackend, _: dvui.TextureTarget) void {}
 
 /// Read pixel data (RGBA) from texture into pixel.
 pub fn textureReadTarget(_: *TestingBackend, texture: dvui.TextureTarget, pixels: [*]u8) !void {
@@ -118,8 +117,7 @@ pub fn textureDestroy(self: *TestingBackend, texture: dvui.Texture) void {
     self.allocator.free(ptr[0..(texture.width * texture.height * 4)]);
 }
 
-pub fn textureDestroyTarget(_: *TestingBackend, _: dvui.Texture.Target) void {
-}
+pub fn textureDestroyTarget(_: *TestingBackend, _: dvui.Texture.Target) void {}
 
 pub fn textureFromTarget(_: *TestingBackend, texture: dvui.TextureTarget) !dvui.Texture {
     return .{ .ptr = texture.ptr, .width = texture.width, .height = texture.height, .format = texture.format };
@@ -154,6 +152,10 @@ pub fn clipboardTextSet(self: *TestingBackend, text: []const u8) std.mem.Allocat
 pub fn openURL(_: *TestingBackend, _: []const u8, _: bool) std.mem.Allocator.Error!void {}
 
 pub fn preferredColorScheme(_: *TestingBackend) ?dvui.enums.ColorScheme {
+    return null;
+}
+
+pub fn preferredMotionAmount(_: *@This()) ?dvui.enums.MotionAmount {
     return null;
 }
 

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -845,16 +845,16 @@ export class Dvui {
                 }
                 return 0;
             },
-            wasm_preferred_motion: () => {
+            wasm_prefers_reduced_motion: () => {
                 if (
                     window.matchMedia("(prefers-reduced-motion: no-preference)").matches
                 ) {
-                    return 1;
+                    return 0;
                 }
                 if (
                     window.matchMedia("(prefers-reduced-motion: reduce)").matches
                 ) {
-                    return 2;
+                    return 1;
                 }
                 return 0;
             },

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -845,6 +845,19 @@ export class Dvui {
                 }
                 return 0;
             },
+            wasm_preferred_motion: () => {
+                if (
+                    window.matchMedia("(prefers-reduced-motion: no-preference)").matches
+                ) {
+                    return 1;
+                }
+                if (
+                    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+                ) {
+                    return 2;
+                }
+                return 0;
+            },
             wasm_download_data: (
                 name_ptr,
                 name_len,
@@ -1202,7 +1215,7 @@ export class Dvui {
             this.requestRender();
         } else if (millis_to_wait > 0) {
             this.renderTimeoutId = setTimeout(
-                function () {
+                function() {
                     this.renderTimeoutId = 0;
                     this.requestRender();
                 }.bind(this),

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -60,7 +60,7 @@ pub const wasm = if (!builtin.is_test) struct {
     pub extern "dvui" fn wasm_text_input(x: f32, y: f32, w: f32, h: f32) void;
     pub extern "dvui" fn wasm_open_url(ptr: [*]const u8, len: usize, new_window: bool) void;
     pub extern "dvui" fn wasm_preferred_color_scheme() u8;
-    pub extern "dvui" fn wasm_preferred_motion() u8;
+    pub extern "dvui" fn wasm_prefers_reduced_motion() u8;
     pub extern "dvui" fn wasm_download_data(name_ptr: [*]const u8, name_len: usize, data_ptr: [*]const u8, data_len: usize) void;
     pub extern "dvui" fn wasm_clipboardTextSet(ptr: [*]const u8, len: usize) void;
 
@@ -121,7 +121,7 @@ pub const wasm = if (!builtin.is_test) struct {
     pub fn wasm_preferred_color_scheme() u8 {
         return undefined;
     }
-    pub fn wasm_preferred_motion() u8 {
+    pub fn wasm_prefers_reduced_motion() u8 {
         return undefined;
     }
     pub fn wasm_download_data(_: [*]const u8, _: usize, _: [*]const u8, _: usize) void {}
@@ -722,11 +722,10 @@ pub fn preferredColorScheme(_: *WebBackend) ?dvui.enums.ColorScheme {
     };
 }
 
-pub fn preferredMotionAmount(_: *WebBackend) ?dvui.enums.MotionAmount {
-    return switch (wasm.wasm_preferred_motion()) {
-        1 => .all,
-        2 => .reduced,
-        else => null,
+pub fn prefersReducedMotion(_: *WebBackend) bool {
+    return switch (wasm.wasm_prefers_reduced_motion()) {
+        1 => true,
+        else => false,
     };
 }
 
@@ -942,7 +941,7 @@ fn dvui_init(platform_ptr: [*]const u8, platform_len: usize) callconv(.c) i32 {
         return 1;
     };
 
-    dvui.motion_amount = back.preferredMotionAmount();
+    dvui.reduce_motion = back.prefersReducedMotion();
 
     var win_opts = init_opts.window_init_options;
     if (win_opts.button_order == null) {

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -60,6 +60,7 @@ pub const wasm = if (!builtin.is_test) struct {
     pub extern "dvui" fn wasm_text_input(x: f32, y: f32, w: f32, h: f32) void;
     pub extern "dvui" fn wasm_open_url(ptr: [*]const u8, len: usize, new_window: bool) void;
     pub extern "dvui" fn wasm_preferred_color_scheme() u8;
+    pub extern "dvui" fn wasm_preferred_motion() u8;
     pub extern "dvui" fn wasm_download_data(name_ptr: [*]const u8, name_len: usize, data_ptr: [*]const u8, data_len: usize) void;
     pub extern "dvui" fn wasm_clipboardTextSet(ptr: [*]const u8, len: usize) void;
 
@@ -118,6 +119,9 @@ pub const wasm = if (!builtin.is_test) struct {
     pub fn wasm_text_input(_: f32, _: f32, _: f32, _: f32) void {}
     pub fn wasm_open_url(_: [*]const u8, _: usize, _: bool) void {}
     pub fn wasm_preferred_color_scheme() u8 {
+        return undefined;
+    }
+    pub fn wasm_preferred_motion() u8 {
         return undefined;
     }
     pub fn wasm_download_data(_: [*]const u8, _: usize, _: [*]const u8, _: usize) void {}
@@ -718,6 +722,14 @@ pub fn preferredColorScheme(_: *WebBackend) ?dvui.enums.ColorScheme {
     };
 }
 
+pub fn preferredMotionAmount(_: *WebBackend) ?dvui.enums.MotionAmount {
+    return switch (wasm.wasm_preferred_motion()) {
+        1 => .all,
+        2 => .reduced,
+        else => null,
+    };
+}
+
 pub fn downloadData(name: []const u8, data: []const u8) !void {
     wasm.wasm_download_data(name.ptr, name.len, data.ptr, data.len);
 }
@@ -929,6 +941,8 @@ fn dvui_init(platform_ptr: [*]const u8, platform_len: usize) callconv(.c) i32 {
     back = WebBackend.init() catch {
         return 1;
     };
+
+    dvui.motion_amount = back.preferredMotionAmount();
 
     var win_opts = init_opts.window_init_options;
     if (win_opts.button_order == null) {

--- a/src/backends/wio.zig
+++ b/src/backends/wio.zig
@@ -76,8 +76,8 @@ pub fn preferredColorScheme(_: *@This()) ?dvui.enums.ColorScheme {
     return null;
 }
 
-pub fn preferredMotionAmount(_: *@This()) ?dvui.enums.MotionAmount {
-    return null;
+pub fn prefersReducedMotion(_: *@This()) bool {
+    return false;
 }
 
 pub fn refresh(_: *@This()) void {

--- a/src/backends/wio.zig
+++ b/src/backends/wio.zig
@@ -76,6 +76,10 @@ pub fn preferredColorScheme(_: *@This()) ?dvui.enums.ColorScheme {
     return null;
 }
 
+pub fn preferredMotionAmount(_: *@This()) ?dvui.enums.MotionAmount {
+    return null;
+}
+
 pub fn refresh(_: *@This()) void {
     wio.cancelWait();
 }

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -293,6 +293,8 @@ pub const useTreeSitter = @import("default_options").tree_sitter;
 /// The amount of logical pixels to scroll per "tick" of the scroll wheel
 pub var scroll_speed: f32 = 40;
 
+pub var reduce_motion: bool = false;
+
 /// Used as a default maximum in various places:
 /// * Options.max_size_content
 /// * Font.textSizeEx max_width
@@ -1829,7 +1831,9 @@ pub const Animation = struct {
 pub fn animation(id: Id, key: []const u8, a: Animation) void {
     var cw = currentWindow();
     const h = id.update(key);
-    cw.animations.put(cw.gpa, h, a) catch |err| switch (err) {
+    var aa = a;
+    if (reduce_motion) aa.end_time = aa.start_time + 1;
+    cw.animations.put(cw.gpa, h, aa) catch |err| switch (err) {
         error.OutOfMemory => {
             log.err("animation got {any} for id {x} key {s}\n", .{ err, id, key });
         },

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -293,9 +293,9 @@ pub const useTreeSitter = @import("default_options").tree_sitter;
 /// The amount of logical pixels to scroll per "tick" of the scroll wheel
 pub var scroll_speed: f32 = 40;
 
-/// When this is .reduced, `animation` overwrites end_time so animations expire next frame.
+/// When this is true, `animation` overwrites end_time so animations expire next frame.
 /// Timers are not affected.
-pub var motion_amount: ?dvui.enums.MotionAmount = null;
+pub var reduce_motion: bool = false;
 
 /// Used as a default maximum in various places:
 /// * Options.max_size_content
@@ -1837,7 +1837,7 @@ pub fn animation(id: Id, key: []const u8, a: Animation) void {
     var cw = currentWindow();
     const h = id.update(key);
     var aa = a;
-    if (motion_amount != null and motion_amount.? == .reduced) aa.end_time = aa.start_time + 1;
+    if (reduce_motion) aa.end_time = aa.start_time + 1;
     cw.animations.put(cw.gpa, h, aa) catch |err| switch (err) {
         error.OutOfMemory => {
             log.err("animation got {any} for id {x} key {s}\n", .{ err, id, key });

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -293,6 +293,8 @@ pub const useTreeSitter = @import("default_options").tree_sitter;
 /// The amount of logical pixels to scroll per "tick" of the scroll wheel
 pub var scroll_speed: f32 = 40;
 
+/// When true, `animation` overwrites end_time so animations expire next frame.
+/// Timers are not affected.
 pub var reduce_motion: bool = false;
 
 /// Used as a default maximum in various places:
@@ -1826,6 +1828,9 @@ pub const Animation = struct {
 };
 
 /// Add animation a to key associated with id.  See `Animation`.
+///
+/// If dvui.reduce_motion is true, overwites end_time so the animation will
+/// expire next frame.
 ///
 /// Only valid between `Window.begin` and `Window.end`.
 pub fn animation(id: Id, key: []const u8, a: Animation) void {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -293,9 +293,9 @@ pub const useTreeSitter = @import("default_options").tree_sitter;
 /// The amount of logical pixels to scroll per "tick" of the scroll wheel
 pub var scroll_speed: f32 = 40;
 
-/// When true, `animation` overwrites end_time so animations expire next frame.
+/// When this is .reduced, `animation` overwrites end_time so animations expire next frame.
 /// Timers are not affected.
-pub var reduce_motion: bool = false;
+pub var motion_amount: ?dvui.enums.MotionAmount = null;
 
 /// Used as a default maximum in various places:
 /// * Options.max_size_content
@@ -1837,7 +1837,7 @@ pub fn animation(id: Id, key: []const u8, a: Animation) void {
     var cw = currentWindow();
     const h = id.update(key);
     var aa = a;
-    if (reduce_motion) aa.end_time = aa.start_time + 1;
+    if (motion_amount != null and motion_amount.? == .reduced) aa.end_time = aa.start_time + 1;
     cw.animations.put(cw.gpa, h, aa) catch |err| switch (err) {
         error.OutOfMemory => {
             log.err("animation got {any} for id {x} key {s}\n", .{ err, id, key });

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -441,8 +441,6 @@ pub const Cursor = enum(u8) {
 
 pub const ColorScheme = enum { light, dark };
 
-pub const MotionAmount = enum { all, reduced };
-
 test {
     @import("std").testing.refAllDecls(@This());
 }

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -441,6 +441,8 @@ pub const Cursor = enum(u8) {
 
 pub const ColorScheme = enum { light, dark };
 
+pub const MotionAmount = enum { all, reduced };
+
 test {
     @import("std").testing.refAllDecls(@This());
 }

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -89,7 +89,7 @@ init_options: InitOptions,
 options: Options,
 prev_windowInfo: dvui.subwindowCurrentSetReturn = undefined,
 prev_last_focus: dvui.Id = undefined,
-layout: BoxWidget = undefined,
+layout: ?BoxWidget = null,
 prevClip: Rect.Physical = undefined,
 auto_pos: bool = false,
 auto_size: bool = false,
@@ -283,8 +283,9 @@ pub fn drawBackground(self: *FloatingWindowWidget) void {
     }
 
     // we are using BoxWidget to do border/background
-    self.layout.init(@src(), .{ .dir = .vertical }, self.options.override(.{ .expand = .both }));
-    self.layout.drawBackground();
+    self.layout = @as(BoxWidget, undefined);
+    self.layout.?.init(@src(), .{ .dir = .vertical }, self.options.override(.{ .expand = .both }));
+    self.layout.?.drawBackground();
 }
 
 fn dragPart(me: Event.Mouse, rs: RectScale) DragPart {
@@ -566,7 +567,7 @@ pub fn minSizeForChild(self: *FloatingWindowWidget, s: Size) void {
 pub fn deinit(self: *FloatingWindowWidget) void {
     defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
-    self.layout.deinit();
+    if (self.layout) |*l| l.deinit();
 
     if (self.auto_size_refresh_prev_value) |pv| {
         if (dvui.currentWindow().extra_frames_needed == 0) {


### PR DESCRIPTION
* add global reduce_motion bool
* add checkbox to debug window

When reduce_motion is true, animation() rewrites the end_time to be start_time+1, making the animation expire the next frame (and causing an immediate next frame).

Timers are exempted.