### PR TITLE
Improve OpenGL Backend

### DIFF
--- a/src/backends/render/opengl.zig
+++ b/src/backends/render/opengl.zig
@@ -157,6 +157,7 @@ pub fn begin(self: *@This(), _: std.mem.Allocator) !void {
     gl.disable(gl.DEPTH_TEST);
     gl.disable(gl.STENCIL_TEST);
     gl.disable(gl.CULL_FACE);
+    gl.disable(gl.SCISSOR_TEST);
 
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);

--- a/src/backends/render/opengl.zig
+++ b/src/backends/render/opengl.zig
@@ -34,25 +34,66 @@ ebo: u32,
 framebuffers: std.AutoHashMapUnmanaged(u32, u32) = .empty,
 render_target_size: ?dvui.Size.Physical = null,
 
+const ERROR_LOG_LENGTH = 4096;
+
 pub fn init(allocator: std.mem.Allocator, getProcAddress: anytype, comptime glsl_version: []const u8) !@This() {
     try gl.load(getProcAddress);
 
     const sources = shaderSources(glsl_version);
+
+    var status: i32 = undefined;
 
     const vertex_shader = gl.createShader(gl.VERTEX_SHADER);
     defer gl.deleteShader(vertex_shader);
     gl.shaderSource(vertex_shader, 1, &[_][*]const u8{sources.vertex}, &[_]i32{sources.vertex.len});
     gl.compileShader(vertex_shader);
 
+    gl.getShaderiv(vertex_shader, gl.COMPILE_STATUS, &status);
+    if (status != gl.TRUE) {
+        var error_log = std.mem.zeroes([ERROR_LOG_LENGTH]u8);
+        var log_length: i32 = 0;
+        gl.getShaderInfoLog(vertex_shader, ERROR_LOG_LENGTH, &log_length, &error_log);
+        log.err("Vertex shader failed to compile: {s}", .{error_log[0..@intCast(log_length)]});
+        return error.VertexShaderCompilationFailed;
+    }
+
     const fragment_shader = gl.createShader(gl.FRAGMENT_SHADER);
     defer gl.deleteShader(fragment_shader);
     gl.shaderSource(fragment_shader, 1, &[_][*]const u8{sources.fragment}, &[_]i32{sources.fragment.len});
     gl.compileShader(fragment_shader);
 
+    gl.getShaderiv(fragment_shader, gl.COMPILE_STATUS, &status);
+    if (status != gl.TRUE) {
+        var error_log = std.mem.zeroes([ERROR_LOG_LENGTH]u8);
+        var log_length: i32 = 0;
+        gl.getShaderInfoLog(fragment_shader, ERROR_LOG_LENGTH, &log_length, &error_log);
+        log.err("Fragment shader failed to compile: {s}", .{error_log[0..@intCast(log_length)]});
+        return error.FragmentShaderCompilationFailed;
+    }
+
     const program = gl.createProgram();
     gl.attachShader(program, vertex_shader);
     gl.attachShader(program, fragment_shader);
+
     gl.linkProgram(program);
+    gl.getProgramiv(program, gl.LINK_STATUS, &status);
+    if (status != gl.TRUE) {
+        var error_log = std.mem.zeroes([ERROR_LOG_LENGTH]u8);
+        var log_length: i32 = 0;
+        gl.getProgramInfoLog(program, ERROR_LOG_LENGTH, &log_length, &error_log);
+        log.err("Program failed to link: {s}", .{error_log[0..@intCast(log_length)]});
+        return error.ProgramLinkingFailed;
+    }
+
+    gl.validateProgram(program);
+    gl.getProgramiv(program, gl.VALIDATE_STATUS, &status);
+    if (status != gl.TRUE) {
+        var error_log = std.mem.zeroes([ERROR_LOG_LENGTH]u8);
+        var log_length: i32 = 0;
+        gl.getProgramInfoLog(program, ERROR_LOG_LENGTH, &log_length, &error_log);
+        log.warn("Program failed to validate: {s}", .{error_log[0..@intCast(log_length)]});
+        // Don't error out here. Apple's buggy OpenGL implementation can fail to validate a perfectly fine program.
+    }
 
     const position: u32 = @bitCast(gl.getAttribLocation(program, "v_position"));
     const color: u32 = @bitCast(gl.getAttribLocation(program, "v_color"));

--- a/src/backends/render/opengl.zig
+++ b/src/backends/render/opengl.zig
@@ -110,8 +110,18 @@ pub fn begin(self: *@This(), _: std.mem.Allocator) !void {
     gl.useProgram(self.program);
     gl.bindVertexArray(self.vao);
 
+    gl.bindBuffer(gl.ARRAY_BUFFER, self.vbo);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, self.ebo);
+
+    gl.disable(gl.DEPTH_TEST);
+    gl.disable(gl.STENCIL_TEST);
+    gl.disable(gl.CULL_FACE);
+
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+
+    gl.depthMask(gl.FALSE);
+    gl.colorMask(gl.TRUE, gl.TRUE, gl.TRUE, gl.TRUE);
 }
 
 pub fn end(_: *@This()) !void {}


### PR DESCRIPTION
I recently worked a little to get dvui running inside another application by hooking its render/event functions.

<img src="https://github.com/user-attachments/assets/6f27b70a-f430-472f-8759-3f7fd4bed0da" />
Here's it running in Minecraft Bedrock Edition (running under Linux through Android compatibility layers) :^)


I ran into 2 major problems, first of all during the `begin` function, the vbo and ebo is not rebound, meaning that since Minecraft binds its own buffers the entire thing just implodes (usually with some error inside nvidias glcore, or whatever the mesa equivalent is for that). Fixing this did not fix the crashes.

After resetting some states it finally didn't crash anymore, but it also didn't render anything.

I found out through sheer luck, that setting `#version 330` was wrong, but instead I needed `#version 330 core`. There was no error log, because dvui currently assumes shaders compile fine. So this PR also adds some nice error logs when shader compilation fails.