### PR TITLE
Fix: cursor not being captured on window leave

### DIFF
--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -1213,6 +1213,21 @@ pub fn wndProc(
                 },
                 else => unreachable,
             };
+
+            const is_button_down: bool = switch (msg) {
+                win32.WM_LBUTTONDOWN, win32.WM_RBUTTONDOWN, win32.WM_MBUTTONDOWN, win32.WM_XBUTTONDOWN => true,
+                else => false
+            };
+
+            // ensure mouse up signal is sent if cursor leaves window while held down
+            if (is_button_down) {
+                // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setcapture
+                _ = win32.SetCapture(hwnd);
+            } else {
+                // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-releasecapture
+                _ = win32.ReleaseCapture();
+            }
+
             _ = stateFromHwnd(hwnd).dvui_window.addEventMouseButton(
                 button,
                 switch (msg) {


### PR DESCRIPTION
This caused the mouse to be permanently 'held' until a new click event was sent.