### PR TITLE
Fix/dx11 texture bugs

### DIFF
--- a/src/Texture.zig
+++ b/src/Texture.zig
@@ -214,6 +214,9 @@ pub const ImageSource = union(enum) {
             if (invalidate == .always) {
                 var tex_mut = cached_texture;
                 try tex_mut.updateImageSource(self);
+                // if you don't add this to the cache, then it will never clean up the prev texture
+                // (it also won't cache this new texture, either, causing it to get it again from the cache, and try to double-free it)
+                dvui.textureAddToCache(key, tex_mut);
                 return tex_mut;
             } else return cached_texture;
         } else {
@@ -340,7 +343,6 @@ pub fn update(tex: *Texture, pma: []const Color.PMA, interpolation: TextureInter
         // texture update not supported by backend, destroy and create texture
         if (err == TextureError.NotImplemented) {
             const new_tex = try create(pma, tex.width, tex.height, interpolation);
-            destroyLater(tex.*);
             tex.* = new_tex;
         } else {
             return err;

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -679,7 +679,28 @@ pub fn textureCreate(self: Context, pixels: [*]const u8, width: u32, height: u32
 
     try state.texture_interpolation.put(state.dvui_window.gpa, texture, interpolation);
 
+    log.info("created texture @0x{x}", .{@intFromPtr(texture)});
+
     return dvui.Texture{ .ptr = texture, .width = width, .height = height };
+}
+
+pub fn textureUpdate(
+    self: Context,
+    texture: dvui.Texture,
+    pixels: [*]const u8,
+) dvui.Backend.TextureError!void {
+    const state = stateFromHwnd(hwndFromContext(self));
+    // cast to resource to please the compiler god
+    const tex: *win32.ID3D11Resource = @ptrCast(@alignCast(texture.ptr));
+
+    state.device_context.UpdateSubresource(
+        tex,
+        0, // subresource
+        null, // full region
+        pixels,
+        texture.width * 4,
+        0,
+    );
 }
 
 pub fn textureCreateTarget(self: Context, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation) !dvui.TextureTarget {
@@ -758,10 +779,14 @@ pub fn textureReadTarget(self: Context, texture: dvui.TextureTarget, pixels_out:
 }
 
 pub fn textureDestroy(self: Context, texture: dvui.Texture) void {
+    log.info("Destroying texture @0x{x}", .{@intFromPtr(texture.ptr)});
     const state = stateFromHwnd(hwndFromContext(self));
     const tex: *win32.ID3D11Texture2D = @ptrCast(@alignCast(texture.ptr));
     if (!state.texture_interpolation.remove(texture.ptr)) {
-        log.err("Destroyed texture that did not have a stored interpolation", .{});
+        log.err(
+            "Destroyed texture @0x{x} that did not have a stored interpolation",
+            .{@intFromPtr(texture.ptr)},
+        );
     }
     _ = tex.IUnknown.Release();
 }
@@ -775,9 +800,13 @@ pub fn textureFromTarget(self: Context, texture: dvui.TextureTarget) !dvui.Textu
     defer state.arena.free(pixels);
     try self.textureReadTarget(texture, pixels.ptr);
 
+    log.info("Destroying texture @0x{x}", .{@intFromPtr(texture.ptr)});
     const tex: *win32.ID3D11Texture2D = @ptrCast(@alignCast(texture.ptr));
     const interpolation = if (state.texture_interpolation.fetchRemove(texture.ptr)) |kv| kv.value else blk: {
-        log.err("Target texture destroyed that did not have a stored interpolation", .{});
+        log.err(
+            "Destroyed texture @0x{x} that did not have a stored interpolation",
+            .{@intFromPtr(texture.ptr)},
+        );
         break :blk .linear;
     };
     _ = tex.IUnknown.Release();
@@ -1603,7 +1632,7 @@ pub fn main() !void {
 
     const window_class = win32.L("DvuiWindow");
 
-    var gpa_instance = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa_instance: std.heap.DebugAllocator(.{}) = .init;
     const gpa = gpa_instance.allocator();
     defer _ = gpa_instance.deinit();
 

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -679,7 +679,7 @@ pub fn textureCreate(self: Context, pixels: [*]const u8, width: u32, height: u32
 
     try state.texture_interpolation.put(state.dvui_window.gpa, texture, interpolation);
 
-    log.info("created texture @0x{x}", .{@intFromPtr(texture)});
+    log.debug("created texture @0x{x}", .{@intFromPtr(texture)});
 
     return dvui.Texture{ .ptr = texture, .width = width, .height = height };
 }
@@ -779,7 +779,7 @@ pub fn textureReadTarget(self: Context, texture: dvui.TextureTarget, pixels_out:
 }
 
 pub fn textureDestroy(self: Context, texture: dvui.Texture) void {
-    log.info("Destroying texture @0x{x}", .{@intFromPtr(texture.ptr)});
+    log.debug("Destroying texture @0x{x}", .{@intFromPtr(texture.ptr)});
     const state = stateFromHwnd(hwndFromContext(self));
     const tex: *win32.ID3D11Texture2D = @ptrCast(@alignCast(texture.ptr));
     if (!state.texture_interpolation.remove(texture.ptr)) {
@@ -800,7 +800,7 @@ pub fn textureFromTarget(self: Context, texture: dvui.TextureTarget) !dvui.Textu
     defer state.arena.free(pixels);
     try self.textureReadTarget(texture, pixels.ptr);
 
-    log.info("Destroying texture @0x{x}", .{@intFromPtr(texture.ptr)});
+    log.debug("Destroying texture @0x{x}", .{@intFromPtr(texture.ptr)});
     const tex: *win32.ID3D11Texture2D = @ptrCast(@alignCast(texture.ptr));
     const interpolation = if (state.texture_interpolation.fetchRemove(texture.ptr)) |kv| kv.value else blk: {
         log.err(


### PR DESCRIPTION
These crashes were discovered when I was trying to skip the texture cache entirely and just have DVUI render every frame. The DX11 path was bugged, causing a double-free crash.

The texture cache logic was not written with optional bypass in mind, so the system only works with explicit calls to `textureUpdate()`, which was not implemented for dx11.

I verified that adding it to the cache avoids the error, but I also implemented a `textureUpdate()` function for dx11 since it didn't have one before.