### PR TITLE
Fix crash by using the correct pitch factor for the pixel formats in SDL backend

### DIFF
--- a/src/Examples/applets.zig
+++ b/src/Examples/applets.zig
@@ -15,6 +15,9 @@ pub fn applets() void {
     if (tabs.addTabLabel(active_tab.* == 2, "texture", .{})) {
         active_tab.* = 2;
     }
+    if (tabs.addTabLabel(active_tab.* == 3, "sub rect", .{})) {
+        active_tab.* = 3;
+    }
 
     tabs.deinit();
 
@@ -22,6 +25,7 @@ pub fn applets() void {
         0 => calculator(),
         1 => draw(),
         2 => texture(),
+        3 => textureSubRect(),
         else => {},
     }
 }
@@ -343,6 +347,63 @@ pub fn texture() void {
             };
             dvui.renderTexture(drawable, output.data().contentRectScale(), .{}) catch {};
         }
+    }
+}
+
+pub fn appletTextureDestroy(ptr: *anyopaque) void {
+    dvui.log.debug("appletTextureDestroy()", .{});
+    const tt: dvui.Texture = @as(*dvui.Texture, @ptrCast(@alignCast(ptr))).*;
+    tt.destroyLater();
+}
+
+pub fn textureSubRect() void {
+    dvui.label(@src(), "Randomly updates portions of a texture", .{}, .{});
+
+    var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+    defer hbox.deinit();
+
+    const size = 200;
+    const scale: f32 = hbox.data().contentRectScale().s;
+
+    var tex: dvui.Texture = dvui.dataGet(null, hbox.data().id, "tex", dvui.Texture) orelse blk: {
+        const pixels = dvui.currentWindow().arena().alloc(dvui.Color.PMA, @intFromFloat(size * size * scale * scale)) catch @panic("OOM");
+        for (pixels) |*p| {
+            p.* = .black;
+        }
+        const t = dvui.Texture.create(pixels, @intFromFloat(scale * size), @intFromFloat(scale * size), .linear, .rgba_32) catch {
+            dvui.log.debug("Can't create texture", .{});
+            return;
+        };
+        dvui.dataSet(null, hbox.data().id, "tex", t);
+        dvui.dataSetDeinitFunction(null, hbox.data().id, "tex", &appletTargetDestroy);
+        break :blk t;
+    };
+
+    {
+        var box = dvui.box(@src(), .{}, .{ .min_size_content = .all(size) });
+        defer box.deinit();
+        dvui.renderTexture(tex, box.data().contentRectScale(), .{}) catch {};
+    }
+
+    if (dvui.button(@src(), "Update", .{}, .{})) {
+        var rng: std.Random.DefaultPrng = .init(@intCast(dvui.frameTimeNS()));
+        var r = rng.random();
+        const x = r.intRangeLessThan(u32, 0, size);
+        const y = r.intRangeLessThan(u32, 0, size);
+        const w = r.intRangeLessThan(u32, 0, size - x);
+        const h = r.intRangeLessThan(u32, 0, size - y);
+
+        const pixels = dvui.currentWindow().arena().alloc(dvui.Color.PMA, @intFromFloat(size * size * scale * scale)) catch @panic("OOM");
+        var newp: dvui.Color.PMA = .{};
+        newp.r = r.intRangeLessThan(u8, 0, 255);
+        newp.g = r.intRangeLessThan(u8, 0, 255);
+        newp.b = r.intRangeLessThan(u8, 0, 255);
+        for (pixels) |*p| {
+            p.* = newp;
+        }
+        tex.updateSubRect(@ptrCast(pixels.ptr), x, y, w, h) catch |err| {
+            dvui.logError(@src(), err, "Could not updateSubRect", .{});
+        };
     }
 }
 

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -897,10 +897,9 @@ pub fn textureUpdate(_: *SDLBackend, texture: dvui.Texture, pixels: [*]const u8)
 pub fn textureUpdateSubRect(_: *SDLBackend, texture: dvui.Texture, pixels: [*]const u8, x: u32, y: u32, w: u32, h: u32) !void {
     if (comptime sdl3) {
         const tx: [*c]c.SDL_Texture = @ptrCast(@alignCast(texture.ptr));
-        const bpp: usize = texture.format.bytesPerPixel();
         const pitch_factor: usize = texture.format.pitchFactor();
         const row_pitch: usize = @as(usize, texture.width) * pitch_factor;
-        const offset: usize = @as(usize, y) * row_pitch + @as(usize, x) * bpp;
+        const offset: usize = @as(usize, y) * row_pitch + @as(usize, x) * pitch_factor;
         const rect: c.SDL_Rect = .{ .x = @intCast(x), .y = @intCast(y), .w = @intCast(w), .h = @intCast(h) };
         if (!c.SDL_UpdateTexture(tx, &rect, pixels + offset, @intCast(row_pitch))) return error.TextureUpdate;
     } else {

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -858,7 +858,7 @@ pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, width: u32, height:
             @as(c_int, @intCast(height)),
             sdl_format,
             @constCast(pixels),
-            @as(c_int, @intCast(width * format.bytesPerPixel())),
+            @as(c_int, @intCast(width * format.pitchFactor())),
         ) orelse return logErr("SDL_CreateSurfaceFrom in textureCreate")
     else
         c.SDL_CreateRGBSurfaceWithFormatFrom(
@@ -866,7 +866,7 @@ pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, width: u32, height:
             @as(c_int, @intCast(width)),
             @as(c_int, @intCast(height)),
             32,
-            @as(c_int, @intCast(width * format.bytesPerPixel())),
+            @as(c_int, @intCast(width * format.pitchFactor())),
             sdl_format,
         ) orelse return logErr("SDL_CreateRGBSurfaceWithFormatFrom in textureCreate");
 
@@ -888,7 +888,7 @@ pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, width: u32, height:
 pub fn textureUpdate(_: *SDLBackend, texture: dvui.Texture, pixels: [*]const u8) !void {
     if (comptime sdl3) {
         const tx: [*c]c.SDL_Texture = @ptrCast(@alignCast(texture.ptr));
-        if (!c.SDL_UpdateTexture(tx, null, pixels, @intCast(texture.width * 4))) return error.TextureUpdate;
+        if (!c.SDL_UpdateTexture(tx, null, pixels, @intCast(texture.width * texture.format.pitchFactor()))) return error.TextureUpdate;
     } else {
         return dvui.Backend.TextureError.NotImplemented;
     }
@@ -898,7 +898,8 @@ pub fn textureUpdateSubRect(_: *SDLBackend, texture: dvui.Texture, pixels: [*]co
     if (comptime sdl3) {
         const tx: [*c]c.SDL_Texture = @ptrCast(@alignCast(texture.ptr));
         const bpp: usize = texture.format.bytesPerPixel();
-        const row_pitch: usize = @as(usize, texture.width) * bpp;
+        const pitch_factor: usize = texture.format.pitchFactor();
+        const row_pitch: usize = @as(usize, texture.width) * pitch_factor;
         const offset: usize = @as(usize, y) * row_pitch + @as(usize, x) * bpp;
         const rect: c.SDL_Rect = .{ .x = @intCast(x), .y = @intCast(y), .w = @intCast(w), .h = @intCast(h) };
         if (!c.SDL_UpdateTexture(tx, &rect, pixels + offset, @intCast(row_pitch))) return error.TextureUpdate;

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -54,7 +54,39 @@ pub const TexturePixelFormat = enum {
     fourcc_uyvy,
     fourcc_yvyu,
 
-    pub fn bytesPerPixel(self: TexturePixelFormat) u32 {
+    pub fn bytesPerPixel(self: TexturePixelFormat) f32 {
+        return switch (self) {
+            .rgba_32,
+            .argb_32,
+            .bgra_32,
+            .abgr_32,
+            .rgbx_32,
+            .xrgb_32,
+            .bgrx_32,
+            .xbgr_32,
+            .rgba_8_8_8_8,
+            .argb_8_8_8_8,
+            .bgra_8_8_8_8,
+            .abgr_8_8_8_8,
+            .rgbx_8_8_8_8,
+            .xrgb_8_8_8_8,
+            .bgrx_8_8_8_8,
+            .xbgr_8_8_8_8,
+            => 4,
+
+            .fourcc_yv12,
+            .fourcc_iyuv,
+            => 1.5,
+
+            .fourcc_yuy2,
+            .fourcc_uyvy,
+            .fourcc_yvyu,
+            => 2,
+        };
+    }
+
+
+    pub fn pitchFactor(self: TexturePixelFormat) u32 {
         return switch (self) {
             .rgba_32,
             .argb_32,

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -54,38 +54,6 @@ pub const TexturePixelFormat = enum {
     fourcc_uyvy,
     fourcc_yvyu,
 
-    pub fn bytesPerPixel(self: TexturePixelFormat) f32 {
-        return switch (self) {
-            .rgba_32,
-            .argb_32,
-            .bgra_32,
-            .abgr_32,
-            .rgbx_32,
-            .xrgb_32,
-            .bgrx_32,
-            .xbgr_32,
-            .rgba_8_8_8_8,
-            .argb_8_8_8_8,
-            .bgra_8_8_8_8,
-            .abgr_8_8_8_8,
-            .rgbx_8_8_8_8,
-            .xrgb_8_8_8_8,
-            .bgrx_8_8_8_8,
-            .xbgr_8_8_8_8,
-            => 4,
-
-            .fourcc_yv12,
-            .fourcc_iyuv,
-            => 1.5,
-
-            .fourcc_yuy2,
-            .fourcc_uyvy,
-            .fourcc_yvyu,
-            => 2,
-        };
-    }
-
-
     pub fn pitchFactor(self: TexturePixelFormat) u32 {
         return switch (self) {
             .rgba_32,


### PR DESCRIPTION
Streaming yv12/iyuv frames into a texture through `backend.textureUpgrade` causes crashes with a segmentation fault. The crash was triggered by an incorrect pitch value passed as the last argument to SDL_UpdateTexture. Additionally, the bytes per pixel for yv12 and iyuv formats had an incorrect value, instead of 1.5 bytes (12 bits), 1 byte was being used.

This PR fixes both issues by introducing the proper function to calculate pitch values and fixing the wrong value!

**Affected version**
v0.4.0

**Operative system**
Arch Linux with wayland