### PR TITLE
Revert "update wio"

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -41,8 +41,8 @@
             .lazy = true,
         },
         .wio = .{
-            .url = "git+https://github.com/ypsvlq/wio#92a7a2eb0cc7a82b62bd3ca699c79ff50a9a5873",
-            .hash = "wio-0.0.0-8xHrrx8eBwBliteTXuvS4JKUbdquuaJabO7wMk5FZalf",
+            .url = "git+https://github.com/ypsvlq/wio?master#b8abff48c317348a1177998d07ce8d331a863ccc",
+            .hash = "wio-0.0.0-8xHrr2mRBgCezIa_g2nf07nUnrHf-PCo95tkge77ppgo",
             .lazy = true,
         },
         .opengl = .{

--- a/src/backends/wio.zig
+++ b/src/backends/wio.zig
@@ -258,21 +258,17 @@ pub fn main(main_init: std.process.Init) !void {
         .title = config.title,
         .size = .{ .width = @intFromFloat(config.size.w), .height = @intFromFloat(config.size.h) },
         .scale = 1,
-    });
-    defer window.destroy();
-
-    var context = if (dvui.render_backend.kind == .opengl) try window.glCreateContext(.{
-        .options = .{
+        .opengl = if (dvui.render_backend.kind == .opengl) .{
             .major_version = 3,
             .minor_version = 2,
             .profile = .core,
-        },
-    }) else null;
-    defer if (dvui.render_backend.kind == .opengl) context.destroy() else {};
-    
+        } else null,
+    });
+    defer window.destroy();
+
     var renderer = blk: switch (dvui.render_backend.kind) {
         .opengl => {
-            window.glMakeContextCurrent(context.?);
+            window.glMakeContextCurrent();
             if (config.vsync) {
                 window.glSwapInterval(1);
             }


### PR DESCRIPTION
Reverts david-vanderson/dvui#831

I was too hasty here.  On my mac I get first:
```
src/backends/wio.zig:275:48: error: expected optional type, found 'wio.GlContext'
            window.glMakeContextCurrent(context.?);
```

Then if I change the argument to just "context" it compiles but then I get:
```
dvanderson@Davids-Air dvui % ~/apps/zig16/zig build wio-app
error(dvui_opengl): Vertex shader failed to compile: 
error: VertexShaderCompilationFailed
/Users/dvanderson/code/dvui/src/backends/render/opengl.zig:57:9: 0x104d651b7 in init__anon_27749 (wio-app)
        return error.VertexShaderCompilationFailed;
        ^
/Users/dvanderson/code/dvui/src/backends/wio.zig:279:24: 0x104d6c6bf in main (wio-app)
            break :blk try dvui.render_backend.init(gpa, wio.glGetProcAddress, "150");
```