### PR TITLE
fix/windows: replace std.os.windows.FALSE with std.os.windows.BOOL.FALSE

### DIFF
--- a/src/backends/common.zig
+++ b/src/backends/common.zig
@@ -16,7 +16,7 @@ pub fn windowsAttachConsole() !void {
 
     const ATTACH_PARENT_PROCESS: std.os.windows.DWORD = 0xFFFFFFFF; //DWORD(-1)
     const res = winapi.AttachConsole(ATTACH_PARENT_PROCESS);
-    if (res == std.os.windows.FALSE) return error.CouldNotAttachConsole;
+    if (res == std.os.windows.BOOL.FALSE) return error.CouldNotAttachConsole;
 }
 
 /// Gets the preferred color scheme from the Windows registry


### PR DESCRIPTION
Hi,
I was trying to build my app and noticed that the build for Windows didn't work with Zig 0.16.0.

Apparently, in Zig 0.16.0 they moved `std.os.windows.FALSE` into the `std.os.windows.BOOL` enum.
This fix replaces `std.os.windows.FALSE` with `std.os.windows.BOOL.FALSE`.

Let me know if you have some questions!
Thank you