### PR TITLE
zig 0.17 compat : remove most @cImport

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -74,10 +74,10 @@ pub fn linkSdl3(
             .library_path = opts.sdl3_library_path,
         })) |sdl3| {
             if (opts.target.result.abi.isAndroid()) {
-                sdl_mod.addIncludePath(sdl3.path("include"));
+                sdl_mod.addIncludePath(sdl3.artifact("SDL3").getEmittedIncludeTree());
                 addAndroidLibC(sdl_mod, opts);
             } else {
-                sdl_translate_c.addIncludePath(sdl3.path("include"));
+                sdl_translate_c.addIncludePath(sdl3.artifact("SDL3").getEmittedIncludeTree());
                 sdl_mod.linkLibrary(sdl3.artifact("SDL3"));
             }
         }
@@ -405,13 +405,13 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                         .render_driver_ogl_es = false,
                     });
                     if (sdl_dep) |sd| {
-                        sdl_translate_c.addIncludePath(sd.path("include"));
+                        sdl_translate_c.addIncludePath(sd.artifact("SDL2").getEmittedIncludeTree());
                         sdl_mod.linkLibrary(sd.artifact("SDL2"));
                     }
                 } else {
                     const sdl_dep = b.lazyDependency("sdl", .{ .target = target, .optimize = optimize });
                     if (sdl_dep) |sd| {
-                        sdl_translate_c.addIncludePath(sd.path("include"));
+                        sdl_translate_c.addIncludePath(sd.artifact("SDL2").getEmittedIncludeTree());
                         sdl_mod.linkLibrary(sd.artifact("SDL2"));
                     }
                 }

--- a/build.zig
+++ b/build.zig
@@ -55,6 +55,7 @@ fn addAndroidLibC(
 
 pub fn linkSdl3(
     sdl_mod: *std.Build.Module,
+    sdl_translate_c: *std.Build.Step.TranslateC,
     sdl3_options: *std.Build.Step.Options,
     opts: DvuiModuleOptions,
 ) void {
@@ -75,7 +76,10 @@ pub fn linkSdl3(
             if (opts.target.result.abi.isAndroid()) {
                 sdl_mod.addIncludePath(sdl3.path("include"));
                 addAndroidLibC(sdl_mod, opts);
-            } else sdl_mod.linkLibrary(sdl3.artifact("SDL3"));
+            } else {
+                sdl_translate_c.addIncludePath(sdl3.path("include"));
+                sdl_mod.linkLibrary(sdl3.artifact("SDL3"));
+            }
         }
     }
     sdl_mod.addOptions("sdl_options", sdl3_options);
@@ -360,11 +364,23 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
         },
         .sdl2 => {
             dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true, .tree_sitter = true });
+
+            const sdl_translate_c = b.addTranslateC(.{
+                .root_source_file = b.path("src/backends/sdl2-c.h"),
+                .target = target,
+                .optimize = optimize,
+            });
             const sdl_mod = b.addModule("sdl2", .{
                 .root_source_file = b.path("src/backends/sdl.zig"),
                 .target = target,
                 .optimize = optimize,
                 .link_libc = true,
+                .imports = &.{
+                    .{
+                        .name = "sdl2-c",
+                        .module = sdl_translate_c.createModule(),
+                    },
+                },
             });
             dvui_opts.addChecks(sdl_mod, "sdl2-backend");
             dvui_opts.addTests(sdl_mod, "sdl2-backend");
@@ -389,11 +405,13 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                         .render_driver_ogl_es = false,
                     });
                     if (sdl_dep) |sd| {
+                        sdl_translate_c.addIncludePath(sd.path("include"));
                         sdl_mod.linkLibrary(sd.artifact("SDL2"));
                     }
                 } else {
                     const sdl_dep = b.lazyDependency("sdl", .{ .target = target, .optimize = optimize });
                     if (sdl_dep) |sd| {
+                        sdl_translate_c.addIncludePath(sd.path("include"));
                         sdl_mod.linkLibrary(sd.artifact("SDL2"));
                     }
                 }
@@ -445,11 +463,23 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
         },
         .sdl3gpu => {
             dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true, .tree_sitter = true });
+
+            const sdl_translate_c = b.addTranslateC(.{
+                .root_source_file = b.path("src/backends/sdl3-c.h"),
+                .target = target,
+                .optimize = optimize,
+            });
             const sdl_mod = b.addModule("sdl3", .{
                 .root_source_file = b.path("src/backends/sdl3gpu.zig"),
                 .target = target,
                 .optimize = optimize,
                 .link_libc = true,
+                .imports = &.{
+                    .{
+                        .name = "sdl3-c",
+                        .module = sdl_translate_c.createModule(),
+                    },
+                },
             });
             dvui_opts.addChecks(sdl_mod, "sdl3gpu-backend");
             dvui_opts.addTests(sdl_mod, "sdl3gpu-backend");
@@ -460,7 +490,7 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
             //     "callbacks",
             //     b.option(bool, "sdl3gpu-callbacks", "Use callbacks for live resizing on windows/mac"),
             // );
-            linkSdl3(sdl_mod, sdl3_options, dvui_opts_in);
+            linkSdl3(sdl_mod, sdl_translate_c, sdl3_options, dvui_opts_in);
 
             const dvui_sdl = addDvuiModule("dvui_sdl3gpu", dvui_opts);
             // dvui_opts.addChecks(dvui_sdl, "dvui_sdl3gpu");
@@ -483,11 +513,23 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
             } else {
                 dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true, .tree_sitter = true });
             }
+
+            const sdl_translate_c = b.addTranslateC(.{
+                .root_source_file = b.path("src/backends/sdl3-c.h"),
+                .target = target,
+                .optimize = optimize,
+            });
             const sdl_mod = b.addModule("sdl3", .{
                 .root_source_file = b.path("src/backends/sdl.zig"),
                 .target = target,
                 .optimize = optimize,
                 .link_libc = true,
+                .imports = &.{
+                    .{
+                        .name = "sdl3-c",
+                        .module = sdl_translate_c.createModule(),
+                    },
+                },
             });
 
             if (!target.result.abi.isAndroid()) {
@@ -501,7 +543,7 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                 b.option(bool, "sdl3-callbacks", "Use callbacks for live resizing on windows/mac"),
             );
 
-            linkSdl3(sdl_mod, sdl3_options, dvui_opts_in);
+            linkSdl3(sdl_mod, sdl_translate_c, sdl3_options, dvui_opts_in);
 
             const dvui_sdl = addDvuiModule("dvui_sdl3", dvui_opts);
             if (!target.result.abi.isAndroid()) {
@@ -531,11 +573,22 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
 
             dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = false, .tree_sitter = true });
 
+            const raylib_translate_c = b.addTranslateC(.{
+                .root_source_file = b.path("src/backends/raylib-c.h"),
+                .target = target,
+                .optimize = optimize,
+            });
             const raylib_backend_mod = b.addModule("raylib", .{
                 .root_source_file = b.path("src/backends/raylib-c.zig"),
                 .target = target,
                 .optimize = optimize,
                 .link_libc = true,
+                .imports = &.{
+                    .{
+                        .name = "raylib-c",
+                        .module = raylib_translate_c.createModule(),
+                    },
+                },
             });
             dvui_opts.addChecks(raylib_backend_mod, "raylib-backend");
             dvui_opts.addTests(raylib_backend_mod, "raylib-backend");
@@ -552,7 +605,7 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                 raylib_backend_mod.linkLibrary(ray.artifact("raylib"));
 
                 // This is to support variable framerate
-                raylib_backend_mod.addIncludePath(ray.path("src/external/glfw/include/GLFW"));
+                raylib_translate_c.addIncludePath(ray.path("src/external/glfw/include/GLFW"));
 
                 // This seems wonky to me, but is copied from raylib's src/build.zig
                 if (b.lazyDependency("raygui", .{})) |raygui_dep| {
@@ -571,7 +624,8 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                         raylib.root_module.addIncludePath(raygui_dep.path("src"));
                         raylib.root_module.addIncludePath(ray.path("src"));
 
-                        raylib.installHeader(raygui_dep.path("src/raygui.h"), "raygui.h");
+                        raylib_translate_c.addIncludePath(raygui_dep.path("src"));
+                        raylib_translate_c.addIncludePath(ray.path("src"));
                     }
                 }
             }
@@ -1014,11 +1068,26 @@ pub fn addDvuiModule(
     const b = opts.b;
     const target = opts.target;
     const optimize = opts.optimize;
+    const libc = opts.libc orelse @panic("libc was null");
+
+    const dvui_translate_c = b.addTranslateC(.{
+        .root_source_file = b.path("src/dvui-c.h"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = libc,
+    });
+    if (libc) dvui_translate_c.defineCMacro("DVUI_USE_LIBC", "1");
 
     const dvui_mod = b.addModule(name, .{
         .root_source_file = b.path("src/dvui.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{
+                .name = "dvui-c",
+                .module = dvui_translate_c.createModule(),
+            },
+        },
     });
     if (target.result.abi.isAndroid()) addAndroidLibC(dvui_mod, opts);
     dvui_mod.addOptions("build_options", opts.build_options);
@@ -1072,9 +1141,8 @@ pub fn addDvuiModule(
     }
 
     const stb_source = "vendor/stb/";
-    dvui_mod.addIncludePath(b.path(stb_source));
+    dvui_translate_c.addIncludePath(b.path(stb_source));
 
-    const libc = opts.libc orelse @panic("libc was null");
     const stb_flags: []const []const u8 = if (!libc)
         &.{ "-DINCLUDE_CUSTOM_LIBC_FUNCS=1", "-DSTBI_NO_STDLIB=1", "-DSTBIW_NO_STDLIB=1", "-DSTBI_NO_SIMD=1" }
     else
@@ -1093,7 +1161,9 @@ pub fn addDvuiModule(
 
     const freetype = opts.freetype orelse @panic("freetype was null");
     if (freetype) {
+        dvui_translate_c.defineCMacro("DVUI_USE_FREETYPE", "1");
         if (b.systemIntegrationOption("freetype", .{})) {
+            dvui_translate_c.linkSystemLibrary("freetype2", .{});
             dvui_mod.linkSystemLibrary("freetype2", .{});
         } else {
             const freetype_dep = b.lazyDependency("freetype", .{
@@ -1101,6 +1171,7 @@ pub fn addDvuiModule(
                 .optimize = optimize,
             });
             if (freetype_dep) |fd| {
+                dvui_translate_c.addIncludePath(fd.path("include"));
                 dvui_mod.linkLibrary(fd.artifact("freetype"));
             }
         }
@@ -1110,7 +1181,8 @@ pub fn addDvuiModule(
 
     const tfd = opts.tiny_file_dialogs orelse @panic("tiny_file_dialogs was null");
     if (tfd) {
-        dvui_mod.addIncludePath(b.path("vendor/tfd"));
+        dvui_translate_c.addIncludePath(b.path("vendor/tfd"));
+        dvui_translate_c.defineCMacro("DVUI_USE_TINYFILEDIALOGS", "1");
         dvui_mod.addCSourceFiles(.{ .files = &.{"vendor/tfd/tinyfiledialogs.c"} });
 
         if (target.result.os.tag == .windows) {
@@ -1127,6 +1199,8 @@ pub fn addDvuiModule(
             .optimize = optimize,
         });
         if (tree_sitter_dep) |tsd| {
+            dvui_translate_c.defineCMacro("DVUI_USE_TREESITTER", "1");
+            dvui_translate_c.addIncludePath(tsd.path("lib/include"));
             dvui_mod.linkLibrary(tsd.artifact("tree-sitter"));
         }
 

--- a/src/backends/raylib-c.h
+++ b/src/backends/raylib-c.h
@@ -1,0 +1,7 @@
+// Used by addTranslateC() in build.zig
+#include <raygui.h>
+#include <raylib.h>
+#include <raymath.h>
+#include <rlgl.h>
+
+#include <glfw3.h>

--- a/src/backends/raylib-c.zig
+++ b/src/backends/raylib-c.zig
@@ -2,14 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const dvui = @import("dvui");
 
-pub const c = @cImport({
-    @cInclude("raylib.h");
-    @cInclude("raymath.h");
-    @cInclude("rlgl.h");
-    @cInclude("raygui.h");
-
-    @cInclude("glfw3.h");
-});
+pub const c = @import("raylib-c");
 
 pub const kind: dvui.enums.Backend = .raylib;
 

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -4,24 +4,8 @@ const dvui = @import("dvui");
 
 const sdl_options = @import("sdl_options");
 pub const sdl3 = sdl_options.version.major == 3;
-pub const c = blk: {
-    if (sdl3) {
-        break :blk @cImport({
-            @cDefine("SDL_DISABLE_OLD_NAMES", {});
-            @cInclude("SDL3/SDL.h");
 
-            @cDefine("SDL_MAIN_HANDLED", {});
-            @cInclude("SDL3/SDL_main.h");
-        });
-    }
-    break :blk @cImport({
-        // Zig 0.16 bundled arm_vector_types.h uses __mfp8 builtin that
-        // translate-c can't resolve. Gate arm_neon.h include off.
-        @cDefine("SDL_DISABLE_ARM_NEON_H", "1");
-        @cInclude("SDL2/SDL_syswm.h");
-        @cInclude("SDL2/SDL.h");
-    });
-};
+pub const c = if (sdl3) @import("sdl3-c") else @import("sdl2-c");
 
 /// Only available in sdl2
 extern "SDL_config" fn MACOS_enable_scroll_momentum() callconv(.c) void;

--- a/src/backends/sdl2-c.h
+++ b/src/backends/sdl2-c.h
@@ -1,0 +1,8 @@
+// Used by addTranslateC() in build.zig
+
+// Zig 0.16 bundled arm_vector_types.h uses __mfp8 builtin that
+// translate-c can't resolve. Gate arm_neon.h include off.
+#define SDL_DISABLE_ARM_NEON_H 1
+
+#include "SDL2/SDL.h"
+#include "SDL2/SDL_syswm.h"

--- a/src/backends/sdl3-c.h
+++ b/src/backends/sdl3-c.h
@@ -1,0 +1,8 @@
+// Used by addTranslateC() in build.zig
+// NOTE : shared by sdl3 & sdl3gpu backends
+#define SDL_DISABLE_OLD_NAMES
+
+#include "SDL3/SDL.h"
+
+#define SDL_MAIN_HANDLED
+#include "SDL3/SDL_main.h"

--- a/src/backends/sdl3gpu.zig
+++ b/src/backends/sdl3gpu.zig
@@ -8,13 +8,7 @@ pub const sdl3 = sdl_options.version.major == 3;
 // Index buffer configuration based on build option
 pub const IndexElementSize = if (dvui.Vertex.Index == u32) c.SDL_GPU_INDEXELEMENTSIZE_32BIT else c.SDL_GPU_INDEXELEMENTSIZE_16BIT;
 
-pub const c = @cImport({
-    @cDefine("SDL_DISABLE_OLD_NAMES", {});
-    @cInclude("SDL3/SDL.h");
-
-    @cDefine("SDL_MAIN_HANDLED", {});
-    @cInclude("SDL3/SDL_main.h");
-});
+pub const c = @import("sdl3-c");
 
 extern "SDL_config" fn MACOS_enable_scroll_momentum() callconv(.c) void;
 

--- a/src/dvui-c.h
+++ b/src/dvui-c.h
@@ -1,0 +1,36 @@
+// Used by addTranslateC() in build.zig
+
+// musl fails to compile saying missing "bits/setjmp.h", and nobody should
+// be using setjmp anyway
+#define _SETJMP_H 1
+
+#ifdef DVUI_USE_FREETYPE
+#include "freetype/ftadvanc.h"
+#include "freetype/ftbbox.h"
+#include "freetype/ftbitmap.h"
+#include "freetype/ftcolor.h"
+#include "freetype/ftlcdfil.h"
+#include "freetype/ftsizes.h"
+#include "freetype/ftstroke.h"
+#include "freetype/fttrigon.h"
+#else
+#include "stb_truetype.h"
+#endif
+
+#ifndef DVUI_USE_LIBC
+#define STBI_NO_STDIO 1
+#define STBI_NO_STDLIB 1
+#define STBIW_NO_STDLIB 1
+#endif
+
+#include "stb_image.h"
+#include "stb_image_write.h"
+
+// Used by native dialogs
+#ifdef DVUI_USE_TINYFILEDIALOGS
+#include "tinyfiledialogs.h"
+#endif
+
+#ifdef DVUI_USE_TREESITTER
+#include "tree_sitter/api.h"
+#endif

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -314,41 +314,7 @@ pub var reduce_motion: bool = false;
 /// If positions/sizes are getting into this range, then likely something is going wrong.
 pub const max_float_safe: f32 = 2_000_000; // 2000000 and 2e6 for searchability
 
-pub const c = @cImport({
-    // musl fails to compile saying missing "bits/setjmp.h", and nobody should
-    // be using setjmp anyway
-    @cDefine("_SETJMP_H", "1");
-
-    if (useFreeType) {
-        @cInclude("freetype/ftadvanc.h");
-        @cInclude("freetype/ftbbox.h");
-        @cInclude("freetype/ftbitmap.h");
-        @cInclude("freetype/ftcolor.h");
-        @cInclude("freetype/ftlcdfil.h");
-        @cInclude("freetype/ftsizes.h");
-        @cInclude("freetype/ftstroke.h");
-        @cInclude("freetype/fttrigon.h");
-    } else {
-        @cInclude("stb_truetype.h");
-    }
-
-    if (!useLibc) {
-        @cDefine("STBI_NO_STDIO", "1");
-        @cDefine("STBI_NO_STDLIB", "1");
-        @cDefine("STBIW_NO_STDLIB", "1");
-    }
-    @cInclude("stb_image.h");
-    @cInclude("stb_image_write.h");
-
-    // Used by native dialogs
-    if (useTinyFileDialogs) {
-        @cInclude("tinyfiledialogs.h");
-    }
-
-    if (useTreeSitter) {
-        @cInclude("tree_sitter/api.h");
-    }
-});
+pub const c = @import("dvui-c");
 
 pub var ft2lib: if (useFreeType) c.FT_Library else void = undefined;
 


### PR DESCRIPTION
@cImport & friends are deprecated in 0.16 and should be integrated in the build system.

After this commit, c headers translation are moved to the build system, with the exception of the AcessKit stuff, partly because I don't know how it works and partly because I was bored to do this.