### PR TITLE
Add mouseTypeHint to Window, which apps can use to best-guess which the user is using

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -106,6 +106,28 @@ pub fn linkSdl3(
     sdl_mod.addOptions("sdl_options", sdl3_options);
 }
 
+/// Resolve the macOS SDK path via `xcrun --show-sdk-path`. Used to wire SDK include
+/// + framework paths into module-scoped C source. Errors if xcrun isn't on PATH or returns non-zero.
+fn resolveMacosSdkPath(b: *std.Build) ![]const u8 {
+    const argv: []const []const u8 = &.{ "xcrun", "--sdk", "macosx", "--show-sdk-path" };
+    const run = std.process.run(b.allocator, b.graph.io, .{
+        .argv = argv,
+        .stdout_limit = std.Io.Limit.limited(4096),
+        .stderr_limit = std.Io.Limit.limited(4096),
+    }) catch return error.MacosSdkPath;
+    defer {
+        b.allocator.free(run.stdout);
+        b.allocator.free(run.stderr);
+    }
+    switch (run.term) {
+        .exited => |code| if (code != 0) return error.MacosSdkPath,
+        else => return error.MacosSdkPath,
+    }
+    const path = std.mem.trimEnd(u8, run.stdout, " \t\r\n");
+    if (path.len == 0) return error.MacosSdkPath;
+    return b.dupePath(path);
+}
+
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -553,6 +575,22 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                     },
                 },
             });
+
+            // macOS scroll-source classifier — see src/backends/mac_scroll_monitor.m.
+            // The .m needs the macOS SDK include + framework paths because of <AppKit/AppKit.h>
+            // Module-scoped C sources don't inherit the consumer's
+            // top-level SDK paths, so resolve them here on a darwin host via xcrun. If
+            // xcrun is unavailable (cross-compile from a non-darwin host), skip the .m
+            // and fall back to the wheel-magnitude heuristic.
+            if (target.result.os.tag.isDarwin() and b.graph.host.result.os.tag.isDarwin()) add_monitor: {
+                const sdk = resolveMacosSdkPath(b) catch break :add_monitor;
+                sdl_mod.addSystemIncludePath(.{ .cwd_relative = b.pathJoin(&.{ sdk, "usr/include" }) });
+                sdl_mod.addSystemFrameworkPath(.{ .cwd_relative = b.pathJoin(&.{ sdk, "System/Library/Frameworks" }) });
+                sdl_mod.addCSourceFile(.{
+                    .file = b.path("src/backends/mac_scroll_monitor.m"),
+                    .language = .objective_c,
+                });
+            }
 
             if (!target.result.abi.isAndroid()) {
                 dvui_opts.addChecks(sdl_mod, "sdl3-backend");

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -313,8 +313,15 @@ pub fn show(self: *Debug) void {
         self.options_editor_open = false;
     }
 
-    if (dvui.button(@src(), if (debug_target == .mouse_until_click) "Stop (Or Left Click)" else "Debug Under Mouse (until click)", .{}, .{})) {
-        debug_target = if (debug_target == .mouse_until_click) .none else .mouse_until_click;
+    {
+        var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });
+        defer hbox.deinit();
+
+        dvui.label(@src(), "Mouse {any}", .{dvui.mouseType()}, .{ .gravity_x = 1.0 });
+
+        if (dvui.button(@src(), if (debug_target == .mouse_until_click) "Stop (Or Left Click)" else "Debug Under Mouse (until click)", .{}, .{})) {
+            debug_target = if (debug_target == .mouse_until_click) .none else .mouse_until_click;
+        }
     }
 
     if (dvui.button(@src(), if (debug_target == .mouse_until_esc) "Stop (Or Press Esc)" else "Debug Under Mouse (until esc)", .{}, .{})) {

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -43,9 +43,9 @@ event_num: u16 = 0,
 // Start off screen so nothing is highlighted on the first frame
 mouse_pt: Point.Physical = .{ .x = -1, .y = -1 },
 mouse_pt_prev: Point.Physical = .{ .x = -1, .y = -1 },
-mouse_type_hint: dvui.enums.MouseTypeHint = .unknown,
-mouse_type_hint_min: [2]f32 = .{ 99999, 99999 },
-mouse_type_hint_last_wheel_ns: ?i128 = null,
+mouse_type: dvui.enums.MouseType = .unknown,
+mouse_type_min: [2]f32 = .{ 99999, 99999 },
+mouse_type_last_wheel_ns: ?i128 = null,
 /// Holds the current state of the modifiers from the most
 /// recently added key event. Used for adding modifiers to
 /// mouse events
@@ -818,10 +818,6 @@ pub fn addEventPointer(self: *Self, opts: AddEventPointerOptions) std.mem.Alloca
     return ret;
 }
 
-pub fn mouseTypeHint(self: *const Self) dvui.enums.MouseTypeHint {
-    return self.mouse_type_hint;
-}
-
 fn scrollWheelIndicated(min_batch_seen: f32) bool {
     const eps: f32 = 0.008;
     if (min_batch_seen >= 99990.0) return false;
@@ -834,26 +830,24 @@ fn scrollWheelIndicated(min_batch_seen: f32) bool {
     return false;
 }
 
-fn determineMouseHint(self: *Self, dir: dvui.enums.Direction, raw_delta_abs_hint: f32) void {
-    if (std.math.isNan(raw_delta_abs_hint) or raw_delta_abs_hint <= 0) return;
+fn determineMouseType(self: *Self, dir: dvui.enums.Direction, raw_delta: f32) void {
+    const delta_abs = @abs(raw_delta);
+    if (std.math.isNan(delta_abs) or delta_abs == 0) return;
 
     const now = std.Io.Clock.boot.now(dvui.io).nanoseconds;
     const stale = blk: {
-        if (self.mouse_type_hint_last_wheel_ns) |prev| {
+        if (self.mouse_type_last_wheel_ns) |prev| {
             break :blk (now - prev > std.time.ns_per_s);
         } else break :blk true;
     };
-    self.mouse_type_hint_last_wheel_ns = now;
+    self.mouse_type_last_wheel_ns = now;
 
     if (stale)
-        self.mouse_type_hint_min = .{ 99999, 99999 };
+        self.mouse_type_min = .{ 99999, 99999 };
 
     const ax: usize = if (dir == .horizontal) 0 else 1;
-    self.mouse_type_hint_min[ax] = @min(self.mouse_type_hint_min[ax], raw_delta_abs_hint);
-
-    const b = self.mouse_type_hint_min;
-    const discrete = scrollWheelIndicated(b[0]) or scrollWheelIndicated(b[1]);
-    self.mouse_type_hint = if (discrete) .mouse else .trackpad;
+    self.mouse_type_min[ax] = @min(self.mouse_type_min[ax], delta_abs);
+    self.mouse_type = if (scrollWheelIndicated(self.mouse_type_min[ax])) .mouse else .trackpad;
 }
 
 /// Add a mouse wheel event.  Positive ticks means scrolling up / scrolling right.
@@ -861,17 +855,15 @@ fn determineMouseHint(self: *Self, dir: dvui.enums.Direction, raw_delta_abs_hint
 /// If the shift key is being held, any vertical scroll will be transformed to
 /// horizontal.
 ///
+/// When `raw_delta` is non-null, dvui will use it to guess the mouse type (see
+/// `dvui.mouseType`).  It should be the OS-reported magnitude
+/// (pixels/lines-equivalent wheel delta, same as DOM `wheel` events).
+///
 /// This can be called outside begin/end.  You should add all the events
 /// for a frame either before begin() or just after begin() and before
 /// calling normal dvui widgets.  end() clears the event list.
-pub fn addEventMouseWheel(self: *Self, ticks: f32, dir: dvui.enums.Direction) std.mem.Allocator.Error!bool {
-    return self.addEventMouseWheelWithHint(ticks, dir, null);
-}
-
-/// Same as `addEventMouseWheel`. When `raw_delta_abs_hint` is non-null, refines `mouseTypeHint` from the
-/// absolute OS-reported magnitude (pixels/lines-equivalent wheel delta, same conventions as DOM `wheel` events).
-pub fn addEventMouseWheelWithHint(self: *Self, ticks: f32, dir: dvui.enums.Direction, raw_delta_abs_hint: ?f32) std.mem.Allocator.Error!bool {
-    if (raw_delta_abs_hint) |h| determineMouseHint(self, dir, h);
+pub fn addEventMouseWheel(self: *Self, ticks: f32, dir: dvui.enums.Direction, raw_delta: ?f32) std.mem.Allocator.Error!bool {
+    if (raw_delta) |h| determineMouseType(self, dir, h);
 
     self.positionMouseEventRemove();
 

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -43,6 +43,9 @@ event_num: u16 = 0,
 // Start off screen so nothing is highlighted on the first frame
 mouse_pt: Point.Physical = .{ .x = -1, .y = -1 },
 mouse_pt_prev: Point.Physical = .{ .x = -1, .y = -1 },
+mouse_type_hint: dvui.enums.MouseTypeHint = .unknown,
+mouse_type_hint_min: [2]f32 = .{ 99999, 99999 },
+mouse_type_hint_last_wheel_ns: ?i128 = null,
 /// Holds the current state of the modifiers from the most
 /// recently added key event. Used for adding modifiers to
 /// mouse events
@@ -815,6 +818,44 @@ pub fn addEventPointer(self: *Self, opts: AddEventPointerOptions) std.mem.Alloca
     return ret;
 }
 
+pub fn mouseTypeHint(self: *const Self) dvui.enums.MouseTypeHint {
+    return self.mouse_type_hint;
+}
+
+fn scrollWheelIndicated(min_batch_seen: f32) bool {
+    const eps: f32 = 0.008;
+    if (min_batch_seen >= 99990.0) return false;
+    if (min_batch_seen >= 100.0) return true;
+    if (std.math.approxEqAbs(f32, min_batch_seen, 1.0, eps)) return true;
+    if (std.math.approxEqAbs(f32, min_batch_seen, 16, eps)) return true;
+    if (std.math.approxEqAbs(f32, min_batch_seen, 9, eps)) return true;
+    if (std.math.approxEqAbs(f32, min_batch_seen, 40, eps)) return true;
+    if (std.math.approxEqAbs(f32, min_batch_seen, 4.000244140625, eps)) return true;
+    return false;
+}
+
+fn determineMouseHint(self: *Self, dir: dvui.enums.Direction, raw_delta_abs_hint: f32) void {
+    if (std.math.isNan(raw_delta_abs_hint) or raw_delta_abs_hint <= 0) return;
+
+    const now = std.Io.Clock.boot.now(dvui.io).nanoseconds;
+    const stale = blk: {
+        if (self.mouse_type_hint_last_wheel_ns) |prev| {
+            break :blk (now - prev > std.time.ns_per_s);
+        } else break :blk true;
+    };
+    self.mouse_type_hint_last_wheel_ns = now;
+
+    if (stale)
+        self.mouse_type_hint_min = .{ 99999, 99999 };
+
+    const ax: usize = if (dir == .horizontal) 0 else 1;
+    self.mouse_type_hint_min[ax] = @min(self.mouse_type_hint_min[ax], raw_delta_abs_hint);
+
+    const b = self.mouse_type_hint_min;
+    const discrete = scrollWheelIndicated(b[0]) or scrollWheelIndicated(b[1]);
+    self.mouse_type_hint = if (discrete) .mouse else .trackpad;
+}
+
 /// Add a mouse wheel event.  Positive ticks means scrolling up / scrolling right.
 ///
 /// If the shift key is being held, any vertical scroll will be transformed to
@@ -824,6 +865,14 @@ pub fn addEventPointer(self: *Self, opts: AddEventPointerOptions) std.mem.Alloca
 /// for a frame either before begin() or just after begin() and before
 /// calling normal dvui widgets.  end() clears the event list.
 pub fn addEventMouseWheel(self: *Self, ticks: f32, dir: dvui.enums.Direction) std.mem.Allocator.Error!bool {
+    return self.addEventMouseWheelWithHint(ticks, dir, null);
+}
+
+/// Same as `addEventMouseWheel`. When `raw_delta_abs_hint` is non-null, refines `mouseTypeHint` from the
+/// absolute OS-reported magnitude (pixels/lines-equivalent wheel delta, same conventions as DOM `wheel` events).
+pub fn addEventMouseWheelWithHint(self: *Self, ticks: f32, dir: dvui.enums.Direction, raw_delta_abs_hint: ?f32) std.mem.Allocator.Error!bool {
+    if (raw_delta_abs_hint) |h| determineMouseHint(self, dir, h);
+
     self.positionMouseEventRemove();
 
     const winId = self.subwindows.windowFor(self.mouse_pt);

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -818,16 +818,20 @@ pub fn addEventPointer(self: *Self, opts: AddEventPointerOptions) std.mem.Alloca
     return ret;
 }
 
-fn scrollWheelIndicated(min_batch_seen: f32) bool {
+fn mouseTypeIndicated(min_batch_seen: f32) dvui.enums.MouseType {
+    // For normal desktop stuff at the start of a scroll:
+    // * mouse wheels generally report 1.0
+    // * touchpads usually report much less (like 0.01)
+    // * the rest of these are for web stuff
     const eps: f32 = 0.008;
-    if (min_batch_seen >= 99990.0) return false;
-    if (min_batch_seen >= 100.0) return true;
-    if (std.math.approxEqAbs(f32, min_batch_seen, 1.0, eps)) return true;
-    if (std.math.approxEqAbs(f32, min_batch_seen, 16, eps)) return true;
-    if (std.math.approxEqAbs(f32, min_batch_seen, 9, eps)) return true;
-    if (std.math.approxEqAbs(f32, min_batch_seen, 40, eps)) return true;
-    if (std.math.approxEqAbs(f32, min_batch_seen, 4.000244140625, eps)) return true;
-    return false;
+    if (min_batch_seen >= 99990.0) return .unknown; // didn't see anything
+    if (min_batch_seen >= 100.0) return .mouse; // most wheels on web
+    if (std.math.approxEqAbs(f32, min_batch_seen, 1.0, eps)) return .mouse; // desktop wheels
+    if (std.math.approxEqAbs(f32, min_batch_seen, 16, eps)) return .mouse; // mac firefox
+    if (std.math.approxEqAbs(f32, min_batch_seen, 9, eps)) return .mouse; // mac firefox holding shift
+    if (std.math.approxEqAbs(f32, min_batch_seen, 40, eps)) return .mouse; // mac safari/chrome holding shift
+    if (std.math.approxEqAbs(f32, min_batch_seen, 4.000244140625, eps)) return .mouse; // mac safari/chrome
+    return .trackpad;
 }
 
 fn determineMouseType(self: *Self, dir: dvui.enums.Direction, raw_delta: f32) void {
@@ -847,7 +851,7 @@ fn determineMouseType(self: *Self, dir: dvui.enums.Direction, raw_delta: f32) vo
 
     const ax: usize = if (dir == .horizontal) 0 else 1;
     self.mouse_type_min[ax] = @min(self.mouse_type_min[ax], delta_abs);
-    self.mouse_type = if (scrollWheelIndicated(self.mouse_type_min[ax])) .mouse else .trackpad;
+    self.mouse_type = mouseTypeIndicated(self.mouse_type_min[ax]);
 }
 
 /// Add a mouse wheel event.  Positive ticks means scrolling up / scrolling right.

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -818,6 +818,16 @@ pub fn addEventPointer(self: *Self, opts: AddEventPointerOptions) std.mem.Alloca
     return ret;
 }
 
+/// Heuristic for detecting MouseType for GLFW-based backends (like raylib)
+pub fn mouseTypeGLFW(batch_min: f32) dvui.enums.MouseType {
+    if (builtin.os.tag.isDarwin()) {
+        return if (batch_min == 0.1) .trackpad else .mouse;
+    }
+
+    // windows/linux - mouse is whole integers
+    return if (batch_min - @trunc(batch_min) == 0) .mouse else .trackpad;
+}
+
 /// This helps backends guess at the mouse type to pass to `addEventMouseWheel`.
 ///
 /// Backends can call this, passing the raw wheel amount, and getting back the

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -834,7 +834,7 @@ pub fn mouseTypeGLFW(batch_min: f32) dvui.enums.MouseType {
 /// smallest raw wheel amount seen in this batch.  First call you get the same
 /// thing back, batch resets if there is 1 second without data.
 pub fn mouseWheelBatch(self: *Self, dir: dvui.enums.Direction, raw_delta: f32) f32 {
-    dvui.log.debug("mouseWheelBatch: {any} {d}", .{ dir, raw_delta });
+    //dvui.log.debug("mouseWheelBatch: {any} {d}", .{ dir, raw_delta });
     const delta_abs = @abs(raw_delta);
 
     const now = std.Io.Clock.boot.now(dvui.io).nanoseconds;

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -45,7 +45,7 @@ mouse_pt: Point.Physical = .{ .x = -1, .y = -1 },
 mouse_pt_prev: Point.Physical = .{ .x = -1, .y = -1 },
 mouse_type: dvui.enums.MouseType = .unknown,
 mouse_type_min: [2]f32 = .{ 99999, 99999 },
-mouse_type_last_wheel_ns: ?i128 = null,
+mouse_type_last_wheel_ns: i128 = 0,
 /// Holds the current state of the modifiers from the most
 /// recently added key event. Used for adding modifiers to
 /// mouse events
@@ -818,40 +818,24 @@ pub fn addEventPointer(self: *Self, opts: AddEventPointerOptions) std.mem.Alloca
     return ret;
 }
 
-fn mouseTypeIndicated(min_batch_seen: f32) dvui.enums.MouseType {
-    // For normal desktop stuff at the start of a scroll:
-    // * mouse wheels generally report 1.0
-    // * touchpads usually report much less (like 0.01)
-    // * the rest of these are for web stuff
-    const eps: f32 = 0.008;
-    if (min_batch_seen >= 99990.0) return .unknown; // didn't see anything
-    if (min_batch_seen >= 100.0) return .mouse; // most wheels on web
-    if (std.math.approxEqAbs(f32, min_batch_seen, 1.0, eps)) return .mouse; // desktop wheels
-    if (std.math.approxEqAbs(f32, min_batch_seen, 16, eps)) return .mouse; // mac firefox
-    if (std.math.approxEqAbs(f32, min_batch_seen, 9, eps)) return .mouse; // mac firefox holding shift
-    if (std.math.approxEqAbs(f32, min_batch_seen, 40, eps)) return .mouse; // mac safari/chrome holding shift
-    if (std.math.approxEqAbs(f32, min_batch_seen, 4.000244140625, eps)) return .mouse; // mac safari/chrome
-    return .trackpad;
-}
-
-fn determineMouseType(self: *Self, dir: dvui.enums.Direction, raw_delta: f32) void {
+/// This helps backends guess at the mouse type to pass to `addEventMouseWheel`.
+///
+/// Backends can call this, passing the raw wheel amount, and getting back the
+/// smallest raw wheel amount seen in this batch.  First call you get the same
+/// thing back, batch resets if there is 1 second without data.
+pub fn mouseWheelBatch(self: *Self, dir: dvui.enums.Direction, raw_delta: f32) f32 {
+    dvui.log.debug("mouseWheelBatch: {any} {d}", .{ dir, raw_delta });
     const delta_abs = @abs(raw_delta);
-    if (std.math.isNan(delta_abs) or delta_abs == 0) return;
 
     const now = std.Io.Clock.boot.now(dvui.io).nanoseconds;
-    const stale = blk: {
-        if (self.mouse_type_last_wheel_ns) |prev| {
-            break :blk (now - prev > std.time.ns_per_s);
-        } else break :blk true;
-    };
-    self.mouse_type_last_wheel_ns = now;
-
-    if (stale)
+    if (now - self.mouse_type_last_wheel_ns > std.time.ns_per_s) {
         self.mouse_type_min = .{ 99999, 99999 };
+    }
+    self.mouse_type_last_wheel_ns = now;
 
     const ax: usize = if (dir == .horizontal) 0 else 1;
     self.mouse_type_min[ax] = @min(self.mouse_type_min[ax], delta_abs);
-    self.mouse_type = mouseTypeIndicated(self.mouse_type_min[ax]);
+    return self.mouse_type_min[ax];
 }
 
 /// Add a mouse wheel event.  Positive ticks means scrolling up / scrolling right.
@@ -859,15 +843,14 @@ fn determineMouseType(self: *Self, dir: dvui.enums.Direction, raw_delta: f32) vo
 /// If the shift key is being held, any vertical scroll will be transformed to
 /// horizontal.
 ///
-/// When `raw_delta` is non-null, dvui will use it to guess the mouse type (see
-/// `dvui.mouseType`).  It should be the OS-reported magnitude
-/// (pixels/lines-equivalent wheel delta, same as DOM `wheel` events).
+/// When `mouse_type` is non-null, it sets what `dvui.mouseType` returns. See
+/// `mouseWheelBatch`.
 ///
 /// This can be called outside begin/end.  You should add all the events
 /// for a frame either before begin() or just after begin() and before
 /// calling normal dvui widgets.  end() clears the event list.
-pub fn addEventMouseWheel(self: *Self, ticks: f32, dir: dvui.enums.Direction, raw_delta: ?f32) std.mem.Allocator.Error!bool {
-    if (raw_delta) |h| determineMouseType(self, dir, h);
+pub fn addEventMouseWheel(self: *Self, ticks: f32, dir: dvui.enums.Direction, mouse_type: ?dvui.enums.MouseType) std.mem.Allocator.Error!bool {
+    if (mouse_type) |mt| self.mouse_type = mt;
 
     self.positionMouseEventRemove();
 

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -1349,18 +1349,22 @@ pub fn wndProc(
             const float_delta: f32 = @floatFromInt(delta);
             const wheel_delta: f32 = @floatFromInt(win32.WHEEL_DELTA);
             const ticks = float_delta / wheel_delta * dvui.scroll_speed;
+            const dir: dvui.enums.Direction = switch (msg) {
+                    win32.WM_MOUSEWHEEL => .vertical,
+                    win32.WM_MOUSEHWHEEL => .horizontal,
+                    else => unreachable,
+                };
+
+            const min = stateFromHwnd(hwnd).dvui_window.mouseWheelBatch(dir, float_delta);
+            const mouse_type: dvui.enums.MouseType = if (min < 120) .trackpad else .mouse;
             _ = stateFromHwnd(hwnd).dvui_window.addEventMouseWheel(
                 switch (msg) {
                     win32.WM_MOUSEWHEEL => ticks,
                     win32.WM_MOUSEHWHEEL => -ticks,
                     else => unreachable,
                 },
-                switch (msg) {
-                    win32.WM_MOUSEWHEEL => .vertical,
-                    win32.WM_MOUSEHWHEEL => .horizontal,
-                    else => unreachable,
-                },
-                float_delta,
+                dir,
+                mouse_type,
             ) catch {};
             return 0;
         },

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -1349,7 +1349,7 @@ pub fn wndProc(
             const float_delta: f32 = @floatFromInt(delta);
             const wheel_delta: f32 = @floatFromInt(win32.WHEEL_DELTA);
             const ticks = float_delta / wheel_delta * dvui.scroll_speed;
-            _ = stateFromHwnd(hwnd).dvui_window.addEventMouseWheelWithHint(
+            _ = stateFromHwnd(hwnd).dvui_window.addEventMouseWheel(
                 switch (msg) {
                     win32.WM_MOUSEWHEEL => ticks,
                     win32.WM_MOUSEHWHEEL => -ticks,
@@ -1360,7 +1360,7 @@ pub fn wndProc(
                     win32.WM_MOUSEHWHEEL => .horizontal,
                     else => unreachable,
                 },
-                @abs(float_delta),
+                float_delta,
             ) catch {};
             return 0;
         },

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -1310,7 +1310,7 @@ pub fn wndProc(
 
             const is_button_down: bool = switch (msg) {
                 win32.WM_LBUTTONDOWN, win32.WM_RBUTTONDOWN, win32.WM_MBUTTONDOWN, win32.WM_XBUTTONDOWN => true,
-                else => false
+                else => false,
             };
 
             // ensure mouse up signal is sent if cursor leaves window while held down
@@ -1349,7 +1349,7 @@ pub fn wndProc(
             const float_delta: f32 = @floatFromInt(delta);
             const wheel_delta: f32 = @floatFromInt(win32.WHEEL_DELTA);
             const ticks = float_delta / wheel_delta * dvui.scroll_speed;
-            _ = stateFromHwnd(hwnd).dvui_window.addEventMouseWheel(
+            _ = stateFromHwnd(hwnd).dvui_window.addEventMouseWheelWithHint(
                 switch (msg) {
                     win32.WM_MOUSEWHEEL => ticks,
                     win32.WM_MOUSEHWHEEL => -ticks,
@@ -1360,6 +1360,7 @@ pub fn wndProc(
                     win32.WM_MOUSEHWHEEL => .horizontal,
                     else => unreachable,
                 },
+                @abs(float_delta),
             ) catch {};
             return 0;
         },

--- a/src/backends/glfw.zig
+++ b/src/backends/glfw.zig
@@ -523,7 +523,7 @@ fn handleScrollEvent(dvui_window: *dvui.Window, window: *zglfw.Window, xrel: f64
     if (xrel != 0) {
         const scrollx: f32 = @floatCast(xrel * dvui.scroll_speed);
         const min = dvui_window.mouseWheelBatch(.horizontal, @floatCast(xrel));
-        const mouse_type: dvui.enums.MouseType = if (min == 0.1) .trackpad else .mouse;
+        const mouse_type = dvui.Window.mouseTypeGLFW(min);
         consumed_x = dvui_window.addEventMouseWheel(scrollx, .horizontal, mouse_type) catch |err| {
             log.err("Encountered error when adding event! Err: {}", .{err});
             if (ctx.userScrollCallback) |callback| callback(window, xrel, yrel);
@@ -534,7 +534,7 @@ fn handleScrollEvent(dvui_window: *dvui.Window, window: *zglfw.Window, xrel: f64
     if (yrel != 0) {
         const scrolly: f32 = @floatCast(yrel * dvui.scroll_speed);
         const min = dvui_window.mouseWheelBatch(.vertical, @floatCast(yrel));
-        const mouse_type: dvui.enums.MouseType = if (min == 0.1) .trackpad else .mouse;
+        const mouse_type = dvui.Window.mouseTypeGLFW(min);
         consumed_y = dvui_window.addEventMouseWheel(scrolly, .vertical, mouse_type) catch |err| {
             log.err("Encountered error when adding event! Err: {}", .{err});
             if (ctx.userScrollCallback) |callback| callback(window, xrel, yrel);

--- a/src/backends/glfw.zig
+++ b/src/backends/glfw.zig
@@ -520,14 +520,14 @@ fn handleScrollEvent(dvui_window: *dvui.Window, window: *zglfw.Window, xrel: f64
     const ctx: *@This() = dvui_window.backend.impl;
     const scrollx: f32 = @floatCast(xrel * dvui.scroll_speed);
     const scrolly: f32 = @floatCast(yrel * dvui.scroll_speed);
-    const hint_x: ?f32 = if (xrel != 0.0) @abs(@as(f32, @floatCast(xrel))) else null;
-    const hint_y: ?f32 = if (yrel != 0.0) @abs(@as(f32, @floatCast(yrel))) else null;
-    const consumed_x = dvui_window.addEventMouseWheelWithHint(scrollx, .horizontal, hint_x) catch |err| {
+    const hint_x: ?f32 = if (xrel != 0.0) @as(f32, @floatCast(xrel)) else null;
+    const hint_y: ?f32 = if (yrel != 0.0) @as(f32, @floatCast(yrel)) else null;
+    const consumed_x = dvui_window.addEventMouseWheel(scrollx, .horizontal, hint_x) catch |err| {
         log.err("Encountered error when adding event! Err: {}", .{err});
         if (ctx.userScrollCallback) |callback| callback(window, xrel, yrel);
         return;
     };
-    const consumed_y = dvui_window.addEventMouseWheelWithHint(scrolly, .vertical, hint_y) catch |err| {
+    const consumed_y = dvui_window.addEventMouseWheel(scrolly, .vertical, hint_y) catch |err| {
         log.err("Encountered error when adding event! Err: {}", .{err});
         if (ctx.userScrollCallback) |callback| callback(window, xrel, yrel);
         return;

--- a/src/backends/glfw.zig
+++ b/src/backends/glfw.zig
@@ -520,12 +520,14 @@ fn handleScrollEvent(dvui_window: *dvui.Window, window: *zglfw.Window, xrel: f64
     const ctx: *@This() = dvui_window.backend.impl;
     const scrollx: f32 = @floatCast(xrel * dvui.scroll_speed);
     const scrolly: f32 = @floatCast(yrel * dvui.scroll_speed);
-    const consumed_x = dvui_window.addEventMouseWheel(scrollx, .horizontal) catch |err| {
+    const hint_x: ?f32 = if (xrel != 0.0) @abs(@as(f32, @floatCast(xrel))) else null;
+    const hint_y: ?f32 = if (yrel != 0.0) @abs(@as(f32, @floatCast(yrel))) else null;
+    const consumed_x = dvui_window.addEventMouseWheelWithHint(scrollx, .horizontal, hint_x) catch |err| {
         log.err("Encountered error when adding event! Err: {}", .{err});
         if (ctx.userScrollCallback) |callback| callback(window, xrel, yrel);
         return;
     };
-    const consumed_y = dvui_window.addEventMouseWheel(scrolly, .vertical) catch |err| {
+    const consumed_y = dvui_window.addEventMouseWheelWithHint(scrolly, .vertical, hint_y) catch |err| {
         log.err("Encountered error when adding event! Err: {}", .{err});
         if (ctx.userScrollCallback) |callback| callback(window, xrel, yrel);
         return;

--- a/src/backends/glfw.zig
+++ b/src/backends/glfw.zig
@@ -518,20 +518,29 @@ fn glfwScrollCallback(window: *zglfw.Window, xrel: f64, yrel: f64) callconv(.c) 
 
 fn handleScrollEvent(dvui_window: *dvui.Window, window: *zglfw.Window, xrel: f64, yrel: f64) void {
     const ctx: *@This() = dvui_window.backend.impl;
-    const scrollx: f32 = @floatCast(xrel * dvui.scroll_speed);
-    const scrolly: f32 = @floatCast(yrel * dvui.scroll_speed);
-    const hint_x: ?f32 = if (xrel != 0.0) @as(f32, @floatCast(xrel)) else null;
-    const hint_y: ?f32 = if (yrel != 0.0) @as(f32, @floatCast(yrel)) else null;
-    const consumed_x = dvui_window.addEventMouseWheel(scrollx, .horizontal, hint_x) catch |err| {
-        log.err("Encountered error when adding event! Err: {}", .{err});
-        if (ctx.userScrollCallback) |callback| callback(window, xrel, yrel);
-        return;
-    };
-    const consumed_y = dvui_window.addEventMouseWheel(scrolly, .vertical, hint_y) catch |err| {
-        log.err("Encountered error when adding event! Err: {}", .{err});
-        if (ctx.userScrollCallback) |callback| callback(window, xrel, yrel);
-        return;
-    };
+    var consumed_x: bool = false;
+    var consumed_y: bool = false;
+    if (xrel != 0) {
+        const scrollx: f32 = @floatCast(xrel * dvui.scroll_speed);
+        const min = dvui_window.mouseWheelBatch(.horizontal, @floatCast(xrel));
+        const mouse_type: dvui.enums.MouseType = if (min == 0.1) .trackpad else .mouse;
+        consumed_x = dvui_window.addEventMouseWheel(scrollx, .horizontal, mouse_type) catch |err| {
+            log.err("Encountered error when adding event! Err: {}", .{err});
+            if (ctx.userScrollCallback) |callback| callback(window, xrel, yrel);
+            return;
+        };
+    }
+
+    if (yrel != 0) {
+        const scrolly: f32 = @floatCast(yrel * dvui.scroll_speed);
+        const min = dvui_window.mouseWheelBatch(.vertical, @floatCast(yrel));
+        const mouse_type: dvui.enums.MouseType = if (min == 0.1) .trackpad else .mouse;
+        consumed_y = dvui_window.addEventMouseWheel(scrolly, .vertical, mouse_type) catch |err| {
+            log.err("Encountered error when adding event! Err: {}", .{err});
+            if (ctx.userScrollCallback) |callback| callback(window, xrel, yrel);
+            return;
+        };
+    }
 
     if (!(consumed_x and consumed_y)) {
         if (ctx.userScrollCallback) |callback| callback(

--- a/src/backends/mac_scroll_monitor.m
+++ b/src/backends/mac_scroll_monitor.m
@@ -13,8 +13,7 @@
  * scroll event, so users who switch between a trackpad and a mouse mid-session get
  * accurate classification on the very next scroll. */
 
-static int g_has_value = 0;
-static int g_is_precise = 0;
+static int g_is_precise = -1;
 
 void dvui_mac_scroll_monitor_install(void) {
     static int installed = 0;
@@ -23,7 +22,6 @@ void dvui_mac_scroll_monitor_install(void) {
     [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskScrollWheel
                                           handler:^NSEvent * _Nullable(NSEvent * _Nonnull event) {
         g_is_precise = [event hasPreciseScrollingDeltas] ? 1 : 0;
-        g_has_value = 1;
         return event;
     }];
 }
@@ -31,6 +29,5 @@ void dvui_mac_scroll_monitor_install(void) {
 /* Returns -1 if no scroll event has been seen yet, 0 for classic mouse wheel,
  * 1 for trackpad / Magic Trackpad / Magic Mouse (any precise-deltas source). */
 int dvui_mac_scroll_monitor_last_precise(void) {
-    if (!g_has_value) return -1;
     return g_is_precise;
 }

--- a/src/backends/mac_scroll_monitor.m
+++ b/src/backends/mac_scroll_monitor.m
@@ -1,0 +1,36 @@
+#import <AppKit/AppKit.h>
+
+/* macOS scroll-source classifier for the SDL3 backend.
+ *
+ * SDL3's wheel event doesn't expose `[NSEvent hasPreciseScrollingDeltas]`, and the
+ * magnitude-based heuristic in `Window.scrollWheelIndicated` can't reliably tell a
+ * classic mouse wheel from a trackpad on macOS — AppKit splits a single wheel click
+ * into many momentum-smoothed events, so the per-event delta isn't a stable signal.
+ *
+ * We install an NSEvent local monitor that runs ahead of SDL's event pump, reads the
+ * precision flag verbatim from the NSEvent, and stashes it for the Zig side to query.
+ * The handler returns the event unchanged so SDL still sees it. This updates per
+ * scroll event, so users who switch between a trackpad and a mouse mid-session get
+ * accurate classification on the very next scroll. */
+
+static int g_has_value = 0;
+static int g_is_precise = 0;
+
+void dvui_mac_scroll_monitor_install(void) {
+    static int installed = 0;
+    if (installed) return;
+    installed = 1;
+    [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskScrollWheel
+                                          handler:^NSEvent * _Nullable(NSEvent * _Nonnull event) {
+        g_is_precise = [event hasPreciseScrollingDeltas] ? 1 : 0;
+        g_has_value = 1;
+        return event;
+    }];
+}
+
+/* Returns -1 if no scroll event has been seen yet, 0 for classic mouse wheel,
+ * 1 for trackpad / Magic Trackpad / Magic Mouse (any precise-deltas source). */
+int dvui_mac_scroll_monitor_last_precise(void) {
+    if (!g_has_value) return -1;
+    return g_is_precise;
+}

--- a/src/backends/raylib-c.zig
+++ b/src/backends/raylib-c.zig
@@ -672,7 +672,7 @@ pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !void {
     const scroll_wheel = c.GetMouseWheelMoveV();
     if (scroll_wheel.x != 0) {
         const min = win.mouseWheelBatch(.horizontal, scroll_wheel.x);
-        const mouse_type: dvui.enums.MouseType = if (min == 0.1) .trackpad else .mouse;
+        const mouse_type = dvui.Window.mouseTypeGLFW(min);
         if (try win.addEventMouseWheel(scroll_wheel.x * dvui.scroll_speed, .horizontal, mouse_type)) disable_raylib_input = true;
 
         if (self.log_events) {
@@ -680,8 +680,8 @@ pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !void {
         }
     }
     if (scroll_wheel.y != 0) {
-        const min = win.mouseWheelBatch(.horizontal, scroll_wheel.y);
-        const mouse_type: dvui.enums.MouseType = if (min == 0.1) .trackpad else .mouse;
+        const min = win.mouseWheelBatch(.vertical, scroll_wheel.y);
+        const mouse_type = dvui.Window.mouseTypeGLFW(min);
         if (try win.addEventMouseWheel(scroll_wheel.y * dvui.scroll_speed, .vertical, mouse_type)) disable_raylib_input = true;
 
         if (self.log_events) {

--- a/src/backends/raylib-c.zig
+++ b/src/backends/raylib-c.zig
@@ -671,14 +671,14 @@ pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !void {
     //scroll wheel movement
     const scroll_wheel = c.GetMouseWheelMoveV();
     if (scroll_wheel.x != 0) {
-        if (try win.addEventMouseWheelWithHint(scroll_wheel.x * dvui.scroll_speed, .horizontal, @abs(scroll_wheel.x))) disable_raylib_input = true;
+        if (try win.addEventMouseWheel(scroll_wheel.x * dvui.scroll_speed, .horizontal, scroll_wheel.x)) disable_raylib_input = true;
 
         if (self.log_events) {
             std.debug.print("raylib event Mouse Wheel: {}\n", .{scroll_wheel});
         }
     }
     if (scroll_wheel.y != 0) {
-        if (try win.addEventMouseWheelWithHint(scroll_wheel.y * dvui.scroll_speed, .vertical, @abs(scroll_wheel.y))) disable_raylib_input = true;
+        if (try win.addEventMouseWheel(scroll_wheel.y * dvui.scroll_speed, .vertical, scroll_wheel.y)) disable_raylib_input = true;
 
         if (self.log_events) {
             std.debug.print("raylib event Mouse Wheel: {}\n", .{scroll_wheel});

--- a/src/backends/raylib-c.zig
+++ b/src/backends/raylib-c.zig
@@ -671,14 +671,18 @@ pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !void {
     //scroll wheel movement
     const scroll_wheel = c.GetMouseWheelMoveV();
     if (scroll_wheel.x != 0) {
-        if (try win.addEventMouseWheel(scroll_wheel.x * dvui.scroll_speed, .horizontal, scroll_wheel.x)) disable_raylib_input = true;
+        const min = win.mouseWheelBatch(.horizontal, scroll_wheel.x);
+        const mouse_type: dvui.enums.MouseType = if (min == 0.1) .trackpad else .mouse;
+        if (try win.addEventMouseWheel(scroll_wheel.x * dvui.scroll_speed, .horizontal, mouse_type)) disable_raylib_input = true;
 
         if (self.log_events) {
             std.debug.print("raylib event Mouse Wheel: {}\n", .{scroll_wheel});
         }
     }
     if (scroll_wheel.y != 0) {
-        if (try win.addEventMouseWheel(scroll_wheel.y * dvui.scroll_speed, .vertical, scroll_wheel.y)) disable_raylib_input = true;
+        const min = win.mouseWheelBatch(.horizontal, scroll_wheel.y);
+        const mouse_type: dvui.enums.MouseType = if (min == 0.1) .trackpad else .mouse;
+        if (try win.addEventMouseWheel(scroll_wheel.y * dvui.scroll_speed, .vertical, mouse_type)) disable_raylib_input = true;
 
         if (self.log_events) {
             std.debug.print("raylib event Mouse Wheel: {}\n", .{scroll_wheel});

--- a/src/backends/raylib-c.zig
+++ b/src/backends/raylib-c.zig
@@ -671,14 +671,14 @@ pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !void {
     //scroll wheel movement
     const scroll_wheel = c.GetMouseWheelMoveV();
     if (scroll_wheel.x != 0) {
-        if (try win.addEventMouseWheel(scroll_wheel.x * dvui.scroll_speed, .horizontal)) disable_raylib_input = true;
+        if (try win.addEventMouseWheelWithHint(scroll_wheel.x * dvui.scroll_speed, .horizontal, @abs(scroll_wheel.x))) disable_raylib_input = true;
 
         if (self.log_events) {
             std.debug.print("raylib event Mouse Wheel: {}\n", .{scroll_wheel});
         }
     }
     if (scroll_wheel.y != 0) {
-        if (try win.addEventMouseWheel(scroll_wheel.y * dvui.scroll_speed, .vertical)) disable_raylib_input = true;
+        if (try win.addEventMouseWheelWithHint(scroll_wheel.y * dvui.scroll_speed, .vertical, @abs(scroll_wheel.y))) disable_raylib_input = true;
 
         if (self.log_events) {
             std.debug.print("raylib event Mouse Wheel: {}\n", .{scroll_wheel});

--- a/src/backends/raylib-zig.zig
+++ b/src/backends/raylib-zig.zig
@@ -681,7 +681,7 @@ pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !void {
     const scroll_wheel = raylib.getMouseWheelMoveV();
     if (scroll_wheel.x != 0) {
         const min = win.mouseWheelBatch(.horizontal, scroll_wheel.x);
-        const mouse_type: dvui.enums.MouseType = if (min == 0.1) .trackpad else .mouse;
+        const mouse_type = dvui.Window.mouseTypeGLFW(min);
         if (try win.addEventMouseWheel(scroll_wheel.x * dvui.scroll_speed, .horizontal, mouse_type)) disable_raylib_input = true;
 
         if (self.log_events) {
@@ -689,8 +689,8 @@ pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !void {
         }
     }
     if (scroll_wheel.y != 0) {
-        const min = win.mouseWheelBatch(.horizontal, scroll_wheel.y);
-        const mouse_type: dvui.enums.MouseType = if (min == 0.1) .trackpad else .mouse;
+        const min = win.mouseWheelBatch(.vertical, scroll_wheel.y);
+        const mouse_type = dvui.Window.mouseTypeGLFW(min);
         if (try win.addEventMouseWheel(scroll_wheel.y * dvui.scroll_speed, .vertical, mouse_type)) disable_raylib_input = true;
 
         if (self.log_events) {

--- a/src/backends/raylib-zig.zig
+++ b/src/backends/raylib-zig.zig
@@ -680,14 +680,14 @@ pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !void {
     //scroll wheel movement
     const scroll_wheel = raylib.getMouseWheelMoveV();
     if (scroll_wheel.x != 0) {
-        if (try win.addEventMouseWheelWithHint(scroll_wheel.x * dvui.scroll_speed, .horizontal, @abs(scroll_wheel.x))) disable_raylib_input = true;
+        if (try win.addEventMouseWheel(scroll_wheel.x * dvui.scroll_speed, .horizontal, scroll_wheel.x)) disable_raylib_input = true;
 
         if (self.log_events) {
             std.debug.print("raylib event Mouse Wheel: {}\n", .{scroll_wheel});
         }
     }
     if (scroll_wheel.y != 0) {
-        if (try win.addEventMouseWheelWithHint(scroll_wheel.y * dvui.scroll_speed, .vertical, @abs(scroll_wheel.y))) disable_raylib_input = true;
+        if (try win.addEventMouseWheel(scroll_wheel.y * dvui.scroll_speed, .vertical, scroll_wheel.y)) disable_raylib_input = true;
 
         if (self.log_events) {
             std.debug.print("raylib event Mouse Wheel: {}\n", .{scroll_wheel});

--- a/src/backends/raylib-zig.zig
+++ b/src/backends/raylib-zig.zig
@@ -680,14 +680,18 @@ pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !void {
     //scroll wheel movement
     const scroll_wheel = raylib.getMouseWheelMoveV();
     if (scroll_wheel.x != 0) {
-        if (try win.addEventMouseWheel(scroll_wheel.x * dvui.scroll_speed, .horizontal, scroll_wheel.x)) disable_raylib_input = true;
+        const min = win.mouseWheelBatch(.horizontal, scroll_wheel.x);
+        const mouse_type: dvui.enums.MouseType = if (min == 0.1) .trackpad else .mouse;
+        if (try win.addEventMouseWheel(scroll_wheel.x * dvui.scroll_speed, .horizontal, mouse_type)) disable_raylib_input = true;
 
         if (self.log_events) {
             std.debug.print("raylib event Mouse Wheel: {}\n", .{scroll_wheel});
         }
     }
     if (scroll_wheel.y != 0) {
-        if (try win.addEventMouseWheel(scroll_wheel.y * dvui.scroll_speed, .vertical, scroll_wheel.y)) disable_raylib_input = true;
+        const min = win.mouseWheelBatch(.horizontal, scroll_wheel.y);
+        const mouse_type: dvui.enums.MouseType = if (min == 0.1) .trackpad else .mouse;
+        if (try win.addEventMouseWheel(scroll_wheel.y * dvui.scroll_speed, .vertical, mouse_type)) disable_raylib_input = true;
 
         if (self.log_events) {
             std.debug.print("raylib event Mouse Wheel: {}\n", .{scroll_wheel});

--- a/src/backends/raylib-zig.zig
+++ b/src/backends/raylib-zig.zig
@@ -680,14 +680,14 @@ pub fn addAllEvents(self: *RaylibBackend, win: *dvui.Window) !void {
     //scroll wheel movement
     const scroll_wheel = raylib.getMouseWheelMoveV();
     if (scroll_wheel.x != 0) {
-        if (try win.addEventMouseWheel(scroll_wheel.x * dvui.scroll_speed, .horizontal)) disable_raylib_input = true;
+        if (try win.addEventMouseWheelWithHint(scroll_wheel.x * dvui.scroll_speed, .horizontal, @abs(scroll_wheel.x))) disable_raylib_input = true;
 
         if (self.log_events) {
             std.debug.print("raylib event Mouse Wheel: {}\n", .{scroll_wheel});
         }
     }
     if (scroll_wheel.y != 0) {
-        if (try win.addEventMouseWheel(scroll_wheel.y * dvui.scroll_speed, .vertical)) disable_raylib_input = true;
+        if (try win.addEventMouseWheelWithHint(scroll_wheel.y * dvui.scroll_speed, .vertical, @abs(scroll_wheel.y))) disable_raylib_input = true;
 
         if (self.log_events) {
             std.debug.print("raylib event Mouse Wheel: {}\n", .{scroll_wheel});

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1227,25 +1227,19 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
             // On macOS we override the magnitude heuristic with the OS-side flag from
             // the NSEvent monitor (see init / mac_scroll_monitor.m). Updates per scroll
             // event so users switching between a trackpad and a mouse mid-session get
-            // the right classification immediately. Skip `addEventMouseWheelWithHint`
-            // on this branch so its heuristic doesn't clobber what we just set.
+            // the right classification immediately.
             const skip_heuristic = sdl3 and builtin.os.tag.isDarwin() and blk: {
                 const v = dvui_mac_scroll_monitor_last_precise();
                 if (v < 0) break :blk false;
-                win.mouse_type_hint = if (v != 0) .trackpad else .mouse;
+                win.mouse_type = if (v != 0) .trackpad else .mouse;
                 break :blk true;
             };
 
             var ret = false;
             // sdl says x positive means to the right, where as y positive
             // means up, so we negate x so that down and right match
-            if (skip_heuristic) {
-                if (ticks_x != 0) ret = try win.addEventMouseWheel(-ticks_x * dvui.scroll_speed * mac_wheel_scale, .horizontal);
-                if (ticks_y != 0) ret = try win.addEventMouseWheel(ticks_y * dvui.scroll_speed * mac_wheel_scale, .vertical);
-            } else {
-                if (ticks_x != 0) ret = try win.addEventMouseWheelWithHint(-ticks_x * dvui.scroll_speed * mac_wheel_scale, .horizontal, @abs(ticks_x));
-                if (ticks_y != 0) ret = try win.addEventMouseWheelWithHint(ticks_y * dvui.scroll_speed * mac_wheel_scale, .vertical, @abs(ticks_y));
-            }
+            if (ticks_x != 0) ret = try win.addEventMouseWheel(-ticks_x * dvui.scroll_speed * mac_wheel_scale, .horizontal, if (skip_heuristic) null else ticks_x);
+            if (ticks_y != 0) ret = try win.addEventMouseWheel(ticks_y * dvui.scroll_speed * mac_wheel_scale, .vertical, if (skip_heuristic) null else ticks_y);
             return ret;
         },
         if (sdl3) c.SDL_EVENT_FINGER_DOWN else c.SDL_FINGERDOWN => {

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -301,8 +301,14 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
 
 pub fn init(io: std.Io, window: *c.SDL_Window, renderer: *c.SDL_Renderer) SDLBackend {
     dvui.io = io;
+    if (sdl3 and builtin.os.tag.isDarwin()) {
+        dvui_mac_scroll_monitor_install();
+    }
     return SDLBackend{ .io = io, .window = window, .renderer = renderer };
 }
+
+extern "c" fn dvui_mac_scroll_monitor_install() void;
+extern "c" fn dvui_mac_scroll_monitor_last_precise() c_int;
 
 const SDL_ERROR = if (sdl3) bool else c_int;
 const SDL_SUCCESS: SDL_ERROR = if (sdl3) true else 0;
@@ -1218,11 +1224,28 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
                 break :blk 60.0 / hz;
             } else 1.0;
 
+            // On macOS we override the magnitude heuristic with the OS-side flag from
+            // the NSEvent monitor (see init / mac_scroll_monitor.m). Updates per scroll
+            // event so users switching between a trackpad and a mouse mid-session get
+            // the right classification immediately. Skip `addEventMouseWheelWithHint`
+            // on this branch so its heuristic doesn't clobber what we just set.
+            const skip_heuristic = sdl3 and builtin.os.tag.isDarwin() and blk: {
+                const v = dvui_mac_scroll_monitor_last_precise();
+                if (v < 0) break :blk false;
+                win.mouse_type_hint = if (v != 0) .trackpad else .mouse;
+                break :blk true;
+            };
+
             var ret = false;
             // sdl says x positive means to the right, where as y positive
             // means up, so we negate x so that down and right match
-            if (ticks_x != 0) ret = try win.addEventMouseWheel(-ticks_x * dvui.scroll_speed * mac_wheel_scale, .horizontal);
-            if (ticks_y != 0) ret = try win.addEventMouseWheel(ticks_y * dvui.scroll_speed * mac_wheel_scale, .vertical);
+            if (skip_heuristic) {
+                if (ticks_x != 0) ret = try win.addEventMouseWheel(-ticks_x * dvui.scroll_speed * mac_wheel_scale, .horizontal);
+                if (ticks_y != 0) ret = try win.addEventMouseWheel(ticks_y * dvui.scroll_speed * mac_wheel_scale, .vertical);
+            } else {
+                if (ticks_x != 0) ret = try win.addEventMouseWheelWithHint(-ticks_x * dvui.scroll_speed * mac_wheel_scale, .horizontal, @abs(ticks_x));
+                if (ticks_y != 0) ret = try win.addEventMouseWheelWithHint(ticks_y * dvui.scroll_speed * mac_wheel_scale, .vertical, @abs(ticks_y));
+            }
             return ret;
         },
         if (sdl3) c.SDL_EVENT_FINGER_DOWN else c.SDL_FINGERDOWN => {

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1228,18 +1228,32 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
             // the NSEvent monitor (see init / mac_scroll_monitor.m). Updates per scroll
             // event so users switching between a trackpad and a mouse mid-session get
             // the right classification immediately.
-            const skip_heuristic = sdl3 and builtin.os.tag.isDarwin() and blk: {
+            var mouse_type: dvui.enums.MouseType = .unknown;
+
+            if (sdl3 and builtin.os.tag.isDarwin()) {
                 const v = dvui_mac_scroll_monitor_last_precise();
-                if (v < 0) break :blk false;
-                win.mouse_type = if (v != 0) .trackpad else .mouse;
-                break :blk true;
-            };
+                if (v >= 0) {
+                    mouse_type = if (v != 0) .trackpad else .mouse;
+                }
+            }
 
             var ret = false;
             // sdl says x positive means to the right, where as y positive
             // means up, so we negate x so that down and right match
-            if (ticks_x != 0) ret = try win.addEventMouseWheel(-ticks_x * dvui.scroll_speed * mac_wheel_scale, .horizontal, if (skip_heuristic) null else ticks_x);
-            if (ticks_y != 0) ret = try win.addEventMouseWheel(ticks_y * dvui.scroll_speed * mac_wheel_scale, .vertical, if (skip_heuristic) null else ticks_y);
+            if (ticks_x != 0) {
+                if (mouse_type == .unknown) {
+                    const min = win.mouseWheelBatch(.horizontal, ticks_x);
+                    mouse_type = if (min == 1.0) .mouse else .trackpad;
+                }
+                ret = try win.addEventMouseWheel(-ticks_x * dvui.scroll_speed * mac_wheel_scale, .horizontal, mouse_type);
+            }
+            if (ticks_y != 0) {
+                if (mouse_type == .unknown) {
+                    const min = win.mouseWheelBatch(.vertical, ticks_y);
+                    mouse_type = if (min == 1.0) .mouse else .trackpad;
+                }
+                ret = try win.addEventMouseWheel(ticks_y * dvui.scroll_speed * mac_wheel_scale, .vertical, mouse_type);
+            }
             return ret;
         },
         if (sdl3) c.SDL_EVENT_FINGER_DOWN else c.SDL_FINGERDOWN => {

--- a/src/backends/sdl3gpu.zig
+++ b/src/backends/sdl3gpu.zig
@@ -1583,10 +1583,23 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
             }
 
             var ret = false;
+            var mouse_type: dvui.enums.MouseType = .unknown;
             // sdl says x positive means to the right, where as y positive
             // means up, so we negate x so that down and right match
-            if (ticks_x != 0) ret = try win.addEventMouseWheel(-ticks_x * dvui.scroll_speed, .horizontal, ticks_x);
-            if (ticks_y != 0) ret = try win.addEventMouseWheel(ticks_y * dvui.scroll_speed, .vertical, ticks_y);
+            if (ticks_x != 0) {
+                if (mouse_type == .unknown) {
+                    const min = win.mouseWheelBatch(.horizontal, ticks_x);
+                    mouse_type = if (min == 0.1) .trackpad else .mouse;
+                }
+                ret = try win.addEventMouseWheel(-ticks_x * dvui.scroll_speed, .horizontal, mouse_type);
+            }
+            if (ticks_y != 0) {
+                if (mouse_type == .unknown) {
+                    const min = win.mouseWheelBatch(.vertical, ticks_y);
+                    mouse_type = if (min == 0.1) .trackpad else .mouse;
+                }
+                ret = try win.addEventMouseWheel(ticks_y * dvui.scroll_speed, .vertical, mouse_type);
+            }
             return ret;
         },
         c.SDL_EVENT_FINGER_DOWN => {

--- a/src/backends/sdl3gpu.zig
+++ b/src/backends/sdl3gpu.zig
@@ -1585,8 +1585,8 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
             var ret = false;
             // sdl says x positive means to the right, where as y positive
             // means up, so we negate x so that down and right match
-            if (ticks_x != 0) ret = try win.addEventMouseWheelWithHint(-ticks_x * dvui.scroll_speed, .horizontal, @abs(ticks_x));
-            if (ticks_y != 0) ret = try win.addEventMouseWheelWithHint(ticks_y * dvui.scroll_speed, .vertical, @abs(ticks_y));
+            if (ticks_x != 0) ret = try win.addEventMouseWheel(-ticks_x * dvui.scroll_speed, .horizontal, ticks_x);
+            if (ticks_y != 0) ret = try win.addEventMouseWheel(ticks_y * dvui.scroll_speed, .vertical, ticks_y);
             return ret;
         },
         c.SDL_EVENT_FINGER_DOWN => {

--- a/src/backends/sdl3gpu.zig
+++ b/src/backends/sdl3gpu.zig
@@ -1585,8 +1585,8 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
             var ret = false;
             // sdl says x positive means to the right, where as y positive
             // means up, so we negate x so that down and right match
-            if (ticks_x != 0) ret = try win.addEventMouseWheel(-ticks_x * dvui.scroll_speed, .horizontal);
-            if (ticks_y != 0) ret = try win.addEventMouseWheel(ticks_y * dvui.scroll_speed, .vertical);
+            if (ticks_x != 0) ret = try win.addEventMouseWheelWithHint(-ticks_x * dvui.scroll_speed, .horizontal, @abs(ticks_x));
+            if (ticks_y != 0) ret = try win.addEventMouseWheelWithHint(ticks_y * dvui.scroll_speed, .vertical, @abs(ticks_y));
             return ret;
         },
         c.SDL_EVENT_FINGER_DOWN => {

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -1301,6 +1301,7 @@ export class Dvui {
                     this.scroll_lowest_batch[0],
                 );
                 var ticks = -ev.deltaX;
+                var trackpad = 0;
                 if ((this.scroll_lowest_batch[0] >= 100) || // most wheels
                     (this.scroll_lowest_batch[0] === 16) || // mac firefox
                     (this.scroll_lowest_batch[0] === 9) || // mac firefox holding shift
@@ -1314,15 +1315,16 @@ export class Dvui {
                     //console.log("wheelX -deltaX " + -ev.deltaX + " ticks " + ticks);
                 } else {
                     // assume touchpad
+                    trackpad = 1;
                     ticks = ticks / this.scroll_lowest[0] * touchpad_adj;
                     //console.log("touchpadX -deltaX " + -ev.deltaX + " ticks " + ticks);
                 }
                 this.instance.exports.add_event(
                     4,
                     0,
-                    1,
+                    trackpad,
                     ticks,
-                    Math.abs(ev.deltaX),
+                    0,
                 );
             }
             if (ev.deltaY != 0) {
@@ -1336,6 +1338,7 @@ export class Dvui {
                     this.scroll_lowest_batch[1],
                 );
                 var ticks = -ev.deltaY;
+                var trackpad = 0;
                 if ((this.scroll_lowest_batch[1] >= 100) || // most wheels
                     (this.scroll_lowest_batch[1] === 16) || // mac firefox
                     (this.scroll_lowest_batch[1] === 4.000244140625)) { // mac safari/chrome
@@ -1347,15 +1350,16 @@ export class Dvui {
                     //console.log("wheelY -deltaY " + -ev.deltaY + " ticks " + ticks);
                 } else {
                     // assume touchpad
+                    trackpad = 1;
                     ticks = ticks / this.scroll_lowest[1] * touchpad_adj;
                     //console.log("touchpadY -deltaY " + -ev.deltaY + " ticks " + ticks);
                 }
                 this.instance.exports.add_event(
                     4,
                     1,
-                    1,
+                    trackpad,
                     ticks,
-                    Math.abs(ev.deltaY),
+                    0,
                 );
             }
             this.requestRender();

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -1320,9 +1320,9 @@ export class Dvui {
                 this.instance.exports.add_event(
                     4,
                     0,
-                    0,
+                    1,
                     ticks,
-                    0,
+                    Math.abs(ev.deltaX),
                 );
             }
             if (ev.deltaY != 0) {
@@ -1353,9 +1353,9 @@ export class Dvui {
                 this.instance.exports.add_event(
                     4,
                     1,
-                    0,
+                    1,
                     ticks,
-                    0,
+                    Math.abs(ev.deltaY),
                 );
             }
             this.requestRender();

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -281,7 +281,7 @@ fn add_event_raw(w: *dvui.Window, which: u8, int1: u32, int2: u32, float1: f32, 
         1 => _ = try w.addEventMouseMotion(.{ .pt = .{ .x = float1, .y = float2 } }),
         2 => _ = try w.addEventMouseButton(buttonFromJS(int1), .press),
         3 => _ = try w.addEventMouseButton(buttonFromJS(int1), .release),
-        4 => _ = try w.addEventMouseWheel(float1 * dvui.scroll_speed, if (int1 > 0) .vertical else .horizontal, if (int2 != 0) float2 else null),
+        4 => _ = try w.addEventMouseWheel(float1 * dvui.scroll_speed, if (int1 > 0) .vertical else .horizontal, if (int2 == 0) .mouse else .trackpad),
         5 => {
             const str = @as([*]u8, @ptrFromInt(int1))[0..int2];
             _ = try w.addEventKey(.{

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -281,7 +281,7 @@ fn add_event_raw(w: *dvui.Window, which: u8, int1: u32, int2: u32, float1: f32, 
         1 => _ = try w.addEventMouseMotion(.{ .pt = .{ .x = float1, .y = float2 } }),
         2 => _ = try w.addEventMouseButton(buttonFromJS(int1), .press),
         3 => _ = try w.addEventMouseButton(buttonFromJS(int1), .release),
-        4 => _ = try w.addEventMouseWheel(float1 * dvui.scroll_speed, if (int1 > 0) .vertical else .horizontal),
+        4 => _ = try w.addEventMouseWheelWithHint(float1 * dvui.scroll_speed, if (int1 > 0) .vertical else .horizontal, if (int2 != 0) float2 else null),
         5 => {
             const str = @as([*]u8, @ptrFromInt(int1))[0..int2];
             _ = try w.addEventKey(.{

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -281,7 +281,7 @@ fn add_event_raw(w: *dvui.Window, which: u8, int1: u32, int2: u32, float1: f32, 
         1 => _ = try w.addEventMouseMotion(.{ .pt = .{ .x = float1, .y = float2 } }),
         2 => _ = try w.addEventMouseButton(buttonFromJS(int1), .press),
         3 => _ = try w.addEventMouseButton(buttonFromJS(int1), .release),
-        4 => _ = try w.addEventMouseWheelWithHint(float1 * dvui.scroll_speed, if (int1 > 0) .vertical else .horizontal, if (int2 != 0) float2 else null),
+        4 => _ = try w.addEventMouseWheel(float1 * dvui.scroll_speed, if (int1 > 0) .vertical else .horizontal, if (int2 != 0) float2 else null),
         5 => {
             const str = @as([*]u8, @ptrFromInt(int1))[0..int2];
             _ = try w.addEventKey(.{

--- a/src/backends/wio.zig
+++ b/src/backends/wio.zig
@@ -210,14 +210,8 @@ pub fn addEvent(self: *@This(), win: *dvui.Window, event: wio.Event) !bool {
             const scale = self.pixelSize().w / self.windowSize().w;
             return try win.addEventMouseMotion(.{ .pt = .{ .x = x * scale, .y = y * scale } });
         },
-        .scroll_vertical => |ticks| {
-            const t: f32 = @floatFromInt(ticks);
-            return try win.addEventMouseWheelWithHint(-t * dvui.scroll_speed, .vertical, @abs(t));
-        },
-        .scroll_horizontal => |ticks| {
-            const t: f32 = @floatFromInt(ticks);
-            return try win.addEventMouseWheelWithHint(-t * dvui.scroll_speed, .horizontal, @abs(t));
-        },
+        .scroll_vertical => |ticks| return try win.addEventMouseWheel(-ticks * dvui.scroll_speed, .vertical, ticks),
+        .scroll_horizontal => |ticks| return try win.addEventMouseWheel(-ticks * dvui.scroll_speed, .horizontal, ticks),
         .touch => |touch| {
             const button = touchIdToDvuiButton(touch.id) orelse return false;
             const xnorm = @as(f32, @floatFromInt(touch.x)) / self.size_natural.w;

--- a/src/backends/wio.zig
+++ b/src/backends/wio.zig
@@ -212,12 +212,14 @@ pub fn addEvent(self: *@This(), win: *dvui.Window, event: wio.Event) !bool {
         },
         .scroll_vertical => |ticks| {
             const min = win.mouseWheelBatch(.vertical, ticks);
-            const mouse_type: dvui.enums.MouseType = if (min < 1) .mouse else .trackpad;
+            const mouse_type = dvui.Window.mouseTypeGLFW(min);
             return try win.addEventMouseWheel(-ticks * dvui.scroll_speed, .vertical, mouse_type);
         },
         .scroll_horizontal => |ticks| {
-            // on mac trackpad looks identical to mouse wheel while holding shift
-            return try win.addEventMouseWheel(-ticks * dvui.scroll_speed, .horizontal, .unknown);
+            // on mac trackpad looks identical to mouse wheel while holding shift?
+            const min = win.mouseWheelBatch(.horizontal, ticks);
+            const mouse_type = dvui.Window.mouseTypeGLFW(min);
+            return try win.addEventMouseWheel(-ticks * dvui.scroll_speed, .horizontal, mouse_type);
         },
         .touch => |touch| {
             const button = touchIdToDvuiButton(touch.id) orelse return false;

--- a/src/backends/wio.zig
+++ b/src/backends/wio.zig
@@ -210,8 +210,15 @@ pub fn addEvent(self: *@This(), win: *dvui.Window, event: wio.Event) !bool {
             const scale = self.pixelSize().w / self.windowSize().w;
             return try win.addEventMouseMotion(.{ .pt = .{ .x = x * scale, .y = y * scale } });
         },
-        .scroll_vertical => |ticks| return try win.addEventMouseWheel(-ticks * dvui.scroll_speed, .vertical, ticks),
-        .scroll_horizontal => |ticks| return try win.addEventMouseWheel(-ticks * dvui.scroll_speed, .horizontal, ticks),
+        .scroll_vertical => |ticks| {
+            const min = win.mouseWheelBatch(.vertical, ticks);
+            const mouse_type: dvui.enums.MouseType = if (min < 1) .mouse else .trackpad;
+            return try win.addEventMouseWheel(-ticks * dvui.scroll_speed, .vertical, mouse_type);
+        },
+        .scroll_horizontal => |ticks| {
+            // on mac trackpad looks identical to mouse wheel while holding shift
+            return try win.addEventMouseWheel(-ticks * dvui.scroll_speed, .horizontal, .unknown);
+        },
         .touch => |touch| {
             const button = touchIdToDvuiButton(touch.id) orelse return false;
             const xnorm = @as(f32, @floatFromInt(touch.x)) / self.size_natural.w;

--- a/src/backends/wio.zig
+++ b/src/backends/wio.zig
@@ -210,8 +210,14 @@ pub fn addEvent(self: *@This(), win: *dvui.Window, event: wio.Event) !bool {
             const scale = self.pixelSize().w / self.windowSize().w;
             return try win.addEventMouseMotion(.{ .pt = .{ .x = x * scale, .y = y * scale } });
         },
-        .scroll_vertical => |ticks| return try win.addEventMouseWheel(-ticks * dvui.scroll_speed, .vertical),
-        .scroll_horizontal => |ticks| return try win.addEventMouseWheel(-ticks * dvui.scroll_speed, .horizontal),
+        .scroll_vertical => |ticks| {
+            const t: f32 = @floatFromInt(ticks);
+            return try win.addEventMouseWheelWithHint(-t * dvui.scroll_speed, .vertical, @abs(t));
+        },
+        .scroll_horizontal => |ticks| {
+            const t: f32 = @floatFromInt(ticks);
+            return try win.addEventMouseWheelWithHint(-t * dvui.scroll_speed, .horizontal, @abs(t));
+        },
         .touch => |touch| {
             const button = touchIdToDvuiButton(touch.id) orelse return false;
             const xnorm = @as(f32, @floatFromInt(touch.x)) / self.size_natural.w;

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -401,6 +401,13 @@ pub fn currentWindow() *Window {
     return current_window orelse @panic("current_window was null, most dvui functions must be between Window.begin/end");
 }
 
+/// Rolling best-effort pointer guess from wheel delta shapes (smooth vs discrete).
+/// Meaningful after backends pass raw delta magnitudes with `Window.addEventMouseWheelWithHint`.
+/// Only valid between `Window.begin` and `Window.end`.
+pub fn getMouseTypeHint() enums.MouseTypeHint {
+    return currentWindow().mouseTypeHint();
+}
+
 /// Allocates space for a widget to the alloc stack, or the arena
 /// if the stack overflows.
 ///

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -401,11 +401,16 @@ pub fn currentWindow() *Window {
     return current_window orelse @panic("current_window was null, most dvui functions must be between Window.begin/end");
 }
 
-/// Rolling best-effort pointer guess from wheel delta shapes (smooth vs discrete).
-/// Meaningful after backends pass raw delta magnitudes with `Window.addEventMouseWheelWithHint`.
+/// Guess which type of pointing device is being used (touchpad vs. mouse).
+/// Meaningful after a mouse wheel event when backends pass raw deltas to
+/// `Window.addEventMouseWheel`.
+///
+/// Some backends can detect a switch between touchpad and mouse instantly,
+/// others require a 1 second gap.
+///
 /// Only valid between `Window.begin` and `Window.end`.
-pub fn getMouseTypeHint() enums.MouseTypeHint {
-    return currentWindow().mouseTypeHint();
+pub fn mouseType() enums.MouseType {
+    return currentWindow().mouse_type;
 }
 
 /// Allocates space for a widget to the alloc stack, or the arena

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -402,7 +402,7 @@ pub fn currentWindow() *Window {
 }
 
 /// Guess which type of pointing device is being used (touchpad vs. mouse).
-/// Meaningful after a mouse wheel event when backends pass raw deltas to
+/// Meaningful after a mouse wheel event when backends pass mouse type to
 /// `Window.addEventMouseWheel`.
 ///
 /// Some backends can detect a switch between touchpad and mouse instantly,

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -11,6 +11,16 @@ pub const DialogButtonOrder = enum {
     ok_cancel,
 };
 
+/// Best-effort guess from scroll deltas (smooth trackpad-style vs discrete wheel ticks).
+/// Backend code should call `Window.addEventMouseWheelWithHint`; see `dvui.getMouseTypeHint`.
+pub const MouseTypeHint = enum {
+    unknown,
+    /// Classic mouse wheel-style quantization (within the accuracy of OS-reported deltas).
+    mouse,
+    /// Smooth scrolling (trackpad-like) per the heuristic shared with the web backend.
+    trackpad,
+};
+
 pub const Units = enum {
     /// None is the logical units. It's used for relative placements
     /// and other non-pixel use cases

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -11,9 +11,10 @@ pub const DialogButtonOrder = enum {
     ok_cancel,
 };
 
-/// Best-effort guess from scroll deltas (smooth trackpad-style vs discrete wheel ticks).
-/// Backend code should call `Window.addEventMouseWheelWithHint`; see `dvui.getMouseTypeHint`.
-pub const MouseTypeHint = enum {
+/// Set by backend through `Window.addEventMouseWheel`.  Usually a best-effort
+/// guess from scroll deltas (smooth trackpad-style vs discrete wheel ticks).
+/// See `dvui.mouseType`.
+pub const MouseType = enum {
     unknown,
     /// Classic mouse wheel-style quantization (within the accuracy of OS-reported deltas).
     mouse,


### PR DESCRIPTION
This is an attempt to make apps be able to read a heuristic DVUI implements already to determine if the scrolling of the mouse is coming from a trackpad or a mouse wheel. 

I called it just a hint, which may be the wrong wording, but I wanted it to be known it's just a hint and not an absolute certainty. 

Putting up in a draft so I can test.