### PR TITLE
Draft: Separate text styling from `Font`

### DIFF
--- a/examples/web-test.zig
+++ b/examples/web-test.zig
@@ -125,7 +125,7 @@ fn dvui_frame() !void {
     var scroll = dvui.scrollArea(@src(), .{}, .{ .expand = .both });
     defer scroll.deinit();
 
-    var tl = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal, .font = .theme(.title) });
+    var tl = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal });
     const lorem = "This example shows how to use dvui in a web canvas.";
     tl.addText(lorem, .{});
     tl.deinit();

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -228,7 +228,7 @@ pub fn show(self: *Debug) void {
             color = .average(opts.color(.text), opts.color(.fill));
         }
 
-        if (dvui.button(@src(), "Edit Options", .{}, .{ .gravity_x = 1, .color_text = color })) {
+        if (dvui.button(@src(), "Edit Options", .{}, .{ .gravity_x = 1, .text_style = .{ .fill = .{ .value = color } } })) {
             if (self.widget_id != .zero) {
                 self.options_editor_open = true;
             } else {
@@ -237,7 +237,7 @@ pub fn show(self: *Debug) void {
         }
 
         self.widget_panic = false;
-        if (dvui.button(@src(), "Panic", .{}, .{ .gravity_x = 1, .color_text = color })) {
+        if (dvui.button(@src(), "Panic", .{}, .{ .gravity_x = 1, .text_style = .{ .fill = .{ .value = color } } })) {
             if (self.widget_id != .zero) {
                 self.widget_panic = true;
             } else {
@@ -397,7 +397,7 @@ pub fn show(self: *Debug) void {
                 defer stack.deinit();
 
                 dvui.label(@src(), "{x} {s} (+{d})", .{ id, options.name orelse "???", options.idExtra() }, .{ .padding = .all(1) });
-                dvui.label(@src(), "{s}:{d}", .{ src.file, src.line }, .{ .font = dvui.themeGet().font_body.larger(-3), .padding = .all(1) });
+                dvui.label(@src(), "{s}:{d}", .{ src.file, src.line }, .{ .text_style = .{ .size = .{ .larger = -3 } }, .padding = .all(1) });
             }
         }
         if (remove_override_id) |id| {
@@ -843,13 +843,13 @@ fn stylePage(self: *Options, id: dvui.Id) bool {
                     active_color.* = color_ask;
                 }
 
-                var label_opts = tab.data().options.strip();
+                // var label_opts = tab.data().options.strip();
                 if (dvui.captured(tab.data().id)) {
-                    label_opts.color_text = label_opts.color(.text_press);
+                    // label_opts.text_style = label_opts.color(.text_press);
                 }
 
-                const field = "color_" ++ @tagName(color_ask);
-                const color = @field(self, field);
+                // const field = "color_" ++ @tagName(color_ask);
+                // const color = @field(self, field);
 
                 const color_indicator = dvui.overlay(@src(), .{
                     .expand = .ratio,
@@ -857,12 +857,12 @@ fn stylePage(self: *Options, id: dvui.Id) bool {
                     .corner_radius = .all(100),
                     .border = .all(1),
                     .background = true,
-                    .color_fill = color,
+                    // .color_fill = color,
                 });
                 const color_width = color_indicator.data().rectScale().r.w;
-                if (color == null) {
-                    dvui.labelNoFmt(@src(), "?", .{}, .{ .expand = .ratio, .gravity_x = 0.5, .gravity_y = 0.5 });
-                }
+                // if (color == null) {
+                dvui.labelNoFmt(@src(), "?", .{}, .{ .expand = .ratio, .gravity_x = 0.5, .gravity_y = 0.5 });
+                // }
                 color_indicator.deinit();
                 dvui.labelNoFmt(@src(), @tagName(color_ask), .{}, .{ .margin = .{ .x = color_width } });
             }
@@ -872,21 +872,22 @@ fn stylePage(self: *Options, id: dvui.Id) bool {
             var vbox = dvui.box(@src(), .{}, .{});
             defer vbox.deinit();
 
-            const field: *?dvui.Color, const default: dvui.Color = switch (active_color.*) {
+            var field: ?dvui.Color, const default: dvui.Color = switch (active_color.*) {
                 inline else => |c| .{
-                    &@field(self, "color_" ++ @tagName(c)),
+                    // &@field(self, "color_" ++ @tagName(c)),
+                    null,
                     self.color(std.meta.stringToEnum(dvui.Options.ColorAsk, @tagName(c)) orelse unreachable),
                 },
             };
-            var hsv = dvui.Color.HSV.fromColor(field.* orelse default);
+            var hsv = dvui.Color.HSV.fromColor(field orelse default);
             if (dvui.colorPicker(@src(), .{ .hsv = &hsv, .dir = .horizontal }, .{})) {
                 changed = true;
-                field.* = hsv.toColor();
+                field = hsv.toColor();
             }
 
-            if (field.* != null and dvui.button(@src(), "Set to null", .{}, .{})) {
+            if (field != null and dvui.button(@src(), "Set to null", .{}, .{})) {
                 changed = true;
-                field.* = null;
+                field = null;
             }
         }
     }
@@ -928,60 +929,62 @@ fn stylePage(self: *Options, id: dvui.Id) bool {
 }
 
 fn fontChanger(self: *Options) bool {
-    var changed = false;
+    _ = self;
+    return false;
+    // var changed = false;
 
-    const label_str = if (self.font == null) "font not set" else "font";
-    if (dvui.expander(@src(), label_str, .{ .default_expanded = self.font != null }, .{ .expand = .horizontal })) {
-        changed = self.font == null;
-        var edited_font = self.fontGet();
+    // const label_str = if (self.font == null) "font not set" else "font";
+    // if (dvui.expander(@src(), label_str, .{ .default_expanded = self.font != null }, .{ .expand = .horizontal })) {
+    //     changed = self.font == null;
+    //     var edited_font = self.fontGet();
 
-        var vbox = dvui.box(@src(), .{}, .{
-            .expand = .horizontal,
-            .border = .{ .x = 1 },
-            .background = true,
-            .margin = .{ .w = 12, .x = 12 },
-            .padding = Rect.all(6),
-        });
-        defer vbox.deinit();
+    //     var vbox = dvui.box(@src(), .{}, .{
+    //         .expand = .horizontal,
+    //         .border = .{ .x = 1 },
+    //         .background = true,
+    //         .margin = .{ .w = 12, .x = 12 },
+    //         .padding = Rect.all(6),
+    //     });
+    //     defer vbox.deinit();
 
-        var current_font_index: ?usize = null;
-        var current_font_name: []const u8 = "Unknown";
-        for (dvui.currentWindow().fonts.database.items, 0..) |dbs, i| {
-            if (std.mem.eql(u8, dbs.familyName(), edited_font.familyName())) {
-                current_font_index = i;
-                current_font_name = edited_font.familyName();
-            }
-        }
+    //     var current_font_index: ?usize = null;
+    //     var current_font_name: []const u8 = "Unknown";
+    //     for (dvui.currentWindow().fonts.database.items, 0..) |dbs, i| {
+    //         if (std.mem.eql(u8, dbs.familyName(), edited_font.familyName())) {
+    //             current_font_index = i;
+    //             current_font_name = edited_font.familyName();
+    //         }
+    //     }
 
-        var dd: dvui.DropdownWidget = undefined;
-        dd.init(@src(), .{ .selected_index = current_font_index, .label = current_font_name }, .{});
-        if (dd.dropped()) {
-            for (dvui.currentWindow().fonts.database.items) |dbs| {
-                const name = dbs.name(dvui.currentWindow().lifo());
-                defer dvui.currentWindow().lifo().free(name);
-                if (dd.addChoiceLabel(name)) {
-                    edited_font = edited_font.withFamily(dbs.familyName()).withStyle(dbs.style).withWeight(dbs.weight);
-                    changed = true;
-                }
-            }
-        }
-        dd.deinit();
-        if (dvui.sliderEntry(@src(), "Size: {d:0}", .{ .min = 4, .max = 100, .interval = 1, .value = &edited_font.size }, .{})) {
-            changed = true;
-        }
-        if (dvui.sliderEntry(@src(), "Line height: {d:0.1}", .{ .min = 0, .max = 10, .interval = 0.1, .value = &edited_font.line_height_factor }, .{})) {
-            changed = true;
-        }
+    //     var dd: dvui.DropdownWidget = undefined;
+    //     dd.init(@src(), .{ .selected_index = current_font_index, .label = current_font_name }, .{});
+    //     if (dd.dropped()) {
+    //         for (dvui.currentWindow().fonts.database.items) |dbs| {
+    //             const name = dbs.name(dvui.currentWindow().lifo());
+    //             defer dvui.currentWindow().lifo().free(name);
+    //             if (dd.addChoiceLabel(name)) {
+    //                 edited_font = edited_font.withFamily(dbs.familyName()).withStyle(dbs.style).withWeight(dbs.weight);
+    //                 changed = true;
+    //             }
+    //         }
+    //     }
+    //     dd.deinit();
+    //     if (dvui.sliderEntry(@src(), "Size: {d:0}", .{ .min = 4, .max = 100, .interval = 1, .value = &edited_font.size }, .{})) {
+    //         changed = true;
+    //     }
+    //     if (dvui.sliderEntry(@src(), "Line height: {d:0.1}", .{ .min = 0, .max = 10, .interval = 0.1, .value = &edited_font.line_height_factor }, .{})) {
+    //         changed = true;
+    //     }
 
-        if (changed) {
-            self.font = edited_font;
-        }
-    } else {
-        self.font = null;
-        changed = true;
-    }
+    //     if (changed) {
+    //         self.font = edited_font;
+    //     }
+    // } else {
+    //     self.font = null;
+    //     changed = true;
+    // }
 
-    return changed;
+    // return changed;
 }
 
 fn quickDisplayField(comptime src: std.builtin.SourceLocation, ContainerT: type, comptime field_name: []const u8, field_value_ptr: anytype, field_option: dvui.struct_ui.FieldOptions, al: *dvui.Alignment) void {

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -7,6 +7,8 @@ const Size = dvui.Size;
 const Texture = dvui.Texture;
 const Backend = dvui.Backend;
 
+const FontStyle = dvui.FontStyle;
+
 /// Font represents the parameters that dvui will try to satisfy when rendering
 /// text.  If a matching font is not found, dvui will log an error and use the
 /// internal fallback font.
@@ -35,53 +37,16 @@ pub fn string(s: *const [NAME_MAX_LEN:0]u8) [:0]const u8 {
     return std.mem.sliceTo(s, 0);
 }
 
-pub const Weight = enum {
-    normal,
-    bold,
-};
-
-pub const Style = enum {
-    normal,
-    italic,
-};
-
-pub const Underline = struct {
-    /// Percent of font size, will always be at least 1 logical pixel
-    thick: f32 = 0.1,
-};
-
-pub const Strike = struct {
-    /// Percent of font size, will always be at least 1 logical pixel
-    thick: f32 = 0.1,
-};
-
-/// Changing any of these might query for a font.
 family: [NAME_MAX_LEN:0]u8 = @splat(0),
-
-/// Height of a capital M in logical pixels.  After converting to physical
-/// pixels, the font will have an integer M height <= size.
-size: f32 = DefaultSize,
-weight: Weight = .normal,
-style: Style = .normal,
-
-/// Can be changed for any font, no query.
-line_height_factor: f32 = 1.2,
-underline: ?Underline = null,
-strike: ?Strike = null,
+weight: FontStyle.Weight = .regular,
+style: FontStyle.Style = .normal,
+default_line_height_factor: f32 = 1.2,
 
 pub const FindOptions = struct {
     family: []const u8,
-
-    /// Height of capital M in logical pixels.
-    size: f32 = DefaultSize,
-    weight: Weight = .normal,
-    style: Style = .normal,
-    line_height_factor: f32 = 1.2,
+    weight: FontStyle.Weight = .regular,
+    style: FontStyle.Style = .normal,
 };
-
-pub fn find(opts: FindOptions) Font {
-    return (Font{}).withFamily(opts.family).withSize(opts.size).withWeight(opts.weight).withStyle(opts.style).withLineHeight(opts.line_height_factor);
-}
 
 pub const ThemeFontName = enum {
     body,
@@ -117,33 +82,9 @@ pub fn larger(self: Font, ds: f32) Font {
     return r;
 }
 
-pub fn withWeight(self: Font, w: Weight) Font {
-    var r = self;
-    r.weight = w;
-    return r;
-}
-
-pub fn withStyle(self: Font, s: Style) Font {
-    var r = self;
-    r.style = s;
-    return r;
-}
-
 pub fn withLineHeight(self: Font, factor: f32) Font {
     var r = self;
     r.line_height_factor = factor;
-    return r;
-}
-
-pub fn withUnderline(self: Font, underline: Underline) Font {
-    var r = self;
-    r.underline = underline;
-    return r;
-}
-
-pub fn withStrike(self: Font, strike: Strike) Font {
-    var r = self;
-    r.strike = strike;
     return r;
 }
 
@@ -152,34 +93,21 @@ pub fn familyName(self: *const Font) []const u8 {
 }
 
 pub fn name(self: *const Font, allocator: std.mem.Allocator) []const u8 {
-    const weight = switch (self.weight) {
-        .normal => "",
-        .bold => " Bold",
-    };
-    const style = switch (self.style) {
-        .normal => "",
-        .italic => " Italic",
-    };
+    const weight = self.weight.toString();
+    const style = self.style.toString();
     return std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ self.familyName(), weight, style }) catch "";
 }
 
 pub fn format(self: *const Font, writer: *std.Io.Writer) !void {
-    const weight = switch (self.weight) {
-        .normal => "",
-        .bold => " Bold",
-    };
-    const style = switch (self.style) {
-        .normal => "",
-        .italic => " Italic",
-    };
-    try writer.print("{s}{s}{s} {d}", .{ self.familyName(), weight, style, self.size });
+    const weight = self.weight.toString();
+    const style = self.style.toString();
+    try writer.print("{s}{s}{s}", .{ self.familyName(), weight, style });
 }
 
 /// Fonts that hash the same value use the same glyphs (same Font.Entry).
 pub fn hash(self: *const Font) u64 {
     var h = dvui.fnv.init();
     h.update(&self.family);
-    h.update(std.mem.asBytes(&self.size));
     h.update(std.mem.asBytes(&self.weight));
     h.update(std.mem.asBytes(&self.style));
     return h.final();
@@ -192,10 +120,11 @@ pub fn findSource(self: *const Font) ?Source {
 }
 
 pub const Source = struct {
-    family: [NAME_MAX_LEN:0]u8 = @splat(0),
-    size: f32 = 0, // zero means this source can be any size
-    weight: Weight = .normal,
-    style: Style = .normal,
+    family: [NAME_MAX_LEN:0]u8,
+    variable: bool = false,
+    weight: FontStyle.Weight = .regular,
+    style: FontStyle.Style = .normal,
+    width: FontStyle.Width = .normal,
 
     // currently we assume that a single ttf only produces one
     bytes: []const u8, // points to ttf bytes
@@ -207,14 +136,8 @@ pub const Source = struct {
     }
 
     pub fn name(self: *const Source, allocator: std.mem.Allocator) []const u8 {
-        const weight = switch (self.weight) {
-            .normal => "",
-            .bold => " Bold",
-        };
-        const style = switch (self.style) {
-            .normal => "",
-            .italic => " Italic",
-        };
+        const weight = self.weight.toString();
+        const style = self.style.toString();
         return std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ self.familyName(), weight, style }) catch "";
     }
 
@@ -239,115 +162,6 @@ pub const Source = struct {
         .bytes = @embedFile("fonts/bitstream-vera/Vera.ttf"),
     };
 };
-
-pub fn textHeight(self: Font) f32 {
-    return self.sizeM(1, 1).h;
-}
-
-pub fn lineHeight(self: Font) f32 {
-    return self.textHeight() * self.line_height_factor;
-}
-
-pub fn sizeM(self: Font, wide: f32, tall: f32) Size {
-    const msize: Size = self.textSize("M");
-    return .{ .w = msize.w * wide, .h = msize.h * tall };
-}
-
-/// handles multiple lines
-///
-/// Only valid between `Window.begin`and `Window.end`.
-pub fn textSize(self: Font, text: []const u8) Size {
-    if (text.len == 0) {
-        // just want the normal text height
-        return .{ .w = 0, .h = self.textHeight() };
-    }
-
-    var ret = Size{};
-
-    var line_height_adj: f32 = 0.0;
-    var end: usize = 0;
-    while (end < text.len) {
-        if (end > 0) {
-            ret.h += line_height_adj;
-        }
-
-        var end_idx: usize = undefined;
-        var s = self.textSizeEx(text[end..], .{ .end_idx = &end_idx, .end_metric = .before });
-        if (self.line_height_factor >= 1.0) {
-            line_height_adj = s.h * (self.line_height_factor - 1.0);
-        } else {
-            s.h *= self.line_height_factor;
-        }
-        ret.h += s.h;
-        ret.w = @max(ret.w, s.w);
-
-        end += end_idx;
-    }
-
-    return ret;
-}
-
-pub const EndMetric = enum {
-    before, // end_idx stops before text goes past max_width
-    nearest, // end_idx stops at start of character closest to max_width
-};
-
-pub const TextSizeOptions = struct {
-    max_width: ?f32 = null,
-    end_idx: ?*usize = null,
-    end_metric: EndMetric = .before,
-    kerning: ?bool = null,
-    kern_in: ?[]u32 = null,
-    kern_out: ?[]u32 = null,
-    ascent_out: ?*f32 = null,
-};
-
-/// textSizeEx always stops at a newline, use textSize to get multiline sizes
-///
-/// Only valid between `Window.begin`and `Window.end`.
-pub fn textSizeEx(self: Font, text: []const u8, opts: TextSizeOptions) Size {
-    // ask for a font that matches the natural display pixels so we get a more
-    // accurate size
-    const ss = dvui.parentGet().screenRectScale(Rect{}).s;
-    const ask_size = self.size * ss;
-    const sized_font = self.withSize(ask_size);
-
-    const cw = dvui.currentWindow();
-
-    if (opts.ascent_out) |ao| ao.* = 10;
-
-    // might give us a slightly smaller font
-    const fce = dvui.fontCacheGet(sized_font) catch return .{ .w = 10, .h = 10 };
-
-    // this must be synced with dvui.renderText()
-    const target_fraction = if (cw.snap_to_pixels) 1.0 / ss else self.size / fce.em_height;
-
-    var options = opts;
-    if (opts.max_width) |mwidth| {
-        // convert max_width into font units
-        options.max_width = mwidth / target_fraction;
-    }
-    options.kerning = opts.kerning orelse cw.kerning;
-
-    var s = fce.textSizeRaw(cw.gpa, text, options) catch return .{ .w = 10, .h = 10 };
-
-    // do this check after calling textSizeRaw so that end_idx is set
-    if (ask_size == 0.0) {
-        if (opts.ascent_out) |ao| ao.* = 0;
-        return Size{};
-    }
-
-    if (opts.ascent_out) |ao| {
-        ao.* = fce.ascent;
-        if (self.line_height_factor < 1.0) {
-            ao.* = @round(ao.* * self.line_height_factor);
-        }
-        ao.* *= target_fraction;
-    }
-
-    // convert size back from font units
-    return s.scale(target_fraction, Size);
-}
 
 pub const Cache = struct {
     database: std.ArrayList(Source) = .empty,
@@ -381,7 +195,7 @@ pub const Cache = struct {
         var second_best: ?usize = null;
         for (self.database.items, 0..) |*source, i| {
             if (std.mem.eql(u8, font.familyName(), source.familyName())) {
-                if (font.weight == source.weight and font.style == source.style) {
+                if (font.weight == source.weight and std.meta.activeTag(font.style) == std.meta.activeTag(source.style)) {
                     return .{ source.*, null }; // exact match
                 }
 
@@ -402,7 +216,8 @@ pub const Cache = struct {
         return .{ null, null };
     }
 
-    pub fn getOrCreate(self: *Cache, gpa: std.mem.Allocator, font: Font) std.mem.Allocator.Error!*Entry {
+    pub fn getOrCreate(self: *Cache, gpa: std.mem.Allocator, style: FontStyle) std.mem.Allocator.Error!*Entry {
+        const font = style.getFont();
         const entry = try self.cache.getOrPut(gpa, font.hash());
         if (entry.found_existing) return entry.value_ptr;
 
@@ -425,12 +240,12 @@ pub const Cache = struct {
 
         //log.debug("FontCacheGet creating font hash {x} ptr {*} size {d} name \"{s}\"", .{ fontHash, bytes.ptr, font.size, font.name });
 
-        entry.value_ptr.* = Entry.init(gpa, source.bytes, font) catch |err| {
+        entry.value_ptr.* = Entry.init(gpa, source.bytes, style) catch |err| {
             dvui.log.err("Font {s} init got {any}, using fallback", .{ fname, err });
             // Remove the invalid font cache entry, something went wrong reading the ttf_bytes
             self.cache.map.removeByPtr(entry.key_ptr);
             // Substitute the known good fallback font
-            return self.getOrCreate(gpa, Source.fallback.font());
+            return self.getOrCreate(gpa, .{ .font_family = "Vera" });
         };
         //log.debug("- size {d} ascent {d} height {d}", .{ font.size, entry.ascent, entry.height });
         return entry.value_ptr;
@@ -460,9 +275,10 @@ pub const Cache = struct {
         };
 
         /// Load the underlying font at an integer size <= font.size (guaranteed to have a minimum pixel size of 1)
-        pub fn init(gpa: std.mem.Allocator, ttf_bytes: []const u8, font: Font) Error!Entry {
+        pub fn init(gpa: std.mem.Allocator, ttf_bytes: []const u8, style: FontStyle) Error!Entry {
             const min_pixel_size = 1;
 
+            const font = style.getFont();
             const fname = font.name(gpa);
             errdefer gpa.free(fname);
 
@@ -479,7 +295,7 @@ pub const Cache = struct {
 
                 // "pixel size" for freetype doesn't actually mean you'll get that height, it's more like using pts
                 // so we search for a font that has a height <= font.size
-                var pixel_size = @as(u32, @trunc(@max(min_pixel_size, @floor(font.size))));
+                var pixel_size = @as(u32, @trunc(@max(min_pixel_size, @floor(style.size))));
                 pixel_size += 20;
 
                 while (true) : (pixel_size -= 1) {
@@ -544,10 +360,10 @@ pub const Cache = struct {
 
                 const M = try entry.glyphInfoGenerate('M');
                 if (M.h <= 0) {
-                    dvui.log.warn("Font.Cache.Entry.init() stbtt error getting M font {s} size {d}\n", .{ fname, font.size });
+                    dvui.log.warn("Font.Cache.Entry.init() stbtt error getting M font {s} size {d}\n", .{ fname, style.size });
                     return error.FontError;
                 }
-                entry.scaleFactor = @max(min_pixel_size, @floor(font.size)) / M.h;
+                entry.scaleFactor = @max(min_pixel_size, @floor(style.size)) / M.h;
                 const ascender = entry.scaleFactor * @as(f32, @floatFromInt(face_ascent));
                 const descender = entry.scaleFactor * @as(f32, @floatFromInt(face_descent));
                 entry.ascent = @trunc(ascender); // cheat the ascent a bit, must be integer
@@ -845,7 +661,7 @@ pub const Cache = struct {
             self: *Entry,
             gpa: std.mem.Allocator,
             text: []const u8,
-            opts: Font.TextSizeOptions,
+            opts: FontStyle.TextSizeOptions,
         ) std.mem.Allocator.Error!Size {
             const mwidth = opts.max_width orelse dvui.max_float_safe;
 

--- a/src/FontStyle.zig
+++ b/src/FontStyle.zig
@@ -1,0 +1,266 @@
+const dvui = @import("dvui.zig");
+
+// Actually doing this made me realize that `Style`
+// might not be the best name for it.
+// Perhaps `FontOptions` or something among those lines?
+const FontStyle = @This();
+
+size: f32 = 10,
+// This might nto be the correct dvui builtin to use
+// The idea is for `scale` to be able to scale `x` and `y` individually using `size` as a base
+scale: ?dvui.Point = null,
+fill: dvui.Color = .white,
+outline: ?Outline = null,
+shadow: ?Shadow = null,
+spacing: f32 = 0,
+style: Style = .normal,
+weight: Weight = .normal,
+width: Width = .normal,
+line_height_factor: f32 = 1.2,
+decorations: []Decoration = &.{},
+// Synthesis should probably be a list as well...
+// You might want to allow style and caps synthesis for example
+synthesis: Synthesis = .auto,
+kerning: Kerning = .auto,
+
+pub const Shadow = struct {
+    color: dvui.Color = .black,
+
+    /// Shrink the shadow on all sides (before fade)
+    shrink: f32 = 0,
+
+    /// Offset down/right
+    offset: dvui.Point = .{ .x = 1, .y = 1 },
+
+    /// Extend the size of the transition to transparent at the edges
+    fade: f32 = 2,
+
+    /// Additional alpha multiply factor
+    alpha: f32 = 0.5,
+};
+
+pub const Outline = struct {
+    color: dvui.Color,
+    thickness: f32,
+};
+
+pub const Decoration = union(enum) {
+    underline: Definition,
+    overline: Definition,
+    /// Also known as `strike_through`
+    line_through: Definition,
+    /// `err` is a unique version of a wavy underline
+    /// thus the style property doesn't actually do anything.
+    err: Definition,
+
+    pub const Definition = struct {
+        /// `null` means inherit text color
+        color: ?dvui.Color = null,
+        style: Decoration.Style = .solid,
+        /// Percent of font size, will always be at least 1 logical pixel
+        thickness: f32 = 0.1,
+    };
+
+    pub const Style = enum {
+        solid,
+        double,
+        dotted,
+        dashed,
+        wavy,
+    };
+};
+
+pub const Kerning = enum {
+    auto,
+    normal,
+    none,
+};
+
+pub const Synthesis = enum {
+    none,
+    auto,
+    weight,
+    style,
+    oblique_only,
+    small_caps,
+    /// synthesize the subscript and superscript "position" typefaces
+    position,
+};
+
+pub const Style = union(enum) {
+    normal: void,
+    italic: void,
+    /// An angle between -90 and 90
+    /// If `0` is passed, the default (14) will be used
+    oblique: i8,
+};
+
+pub const Weight = enum(u10) {
+    thin = 100,
+    extra_light = 200,
+    light = 300,
+    normal = 400,
+    medium = 500,
+    semi_bold = 600,
+    bold = 700,
+    extra_bold = 800,
+    black = 900,
+    extra_black = 950,
+    _,
+
+    /// Supported range: [1,1000]
+    pub fn from(weight: u10) Weight {
+        return @enumFromInt(weight);
+    }
+
+    pub fn bolder(self: Weight) Weight {
+        return switch (self) {
+            0...399 => .normal,
+            .normal...699 => .bold,
+            else => .black,
+        };
+    }
+
+    pub fn lighter(self: Weight) Weight {
+        return switch (self) {
+            .extra_bold...1000 => .bold,
+            .semi_bold...799 => .normal,
+            else => .thin,
+        };
+    }
+
+    /// Normalizes the enum into a known variant
+    pub fn normalize(self: Weight) Weight {
+        return switch (self) {
+            0...149 => .thin,
+            150...249 => .extra_light,
+            250...349 => .light,
+            350...449 => .normal,
+            450...549 => .medium,
+            550...649 => .semi_bold,
+            650...749 => .bold,
+            750...849 => .extra_bold,
+            850...949 => .black,
+            else => .extra_black,
+        };
+    }
+};
+
+pub const Width = enum(f32) {
+    ultra_condensed = 0.5,
+    extra_condensed = 0.625,
+    condensed = 0.75,
+    semi_condensed = 0.875,
+    normal = 1,
+    semi_expanded = 1.125,
+    expanded = 1.25,
+    extra_expanded = 1.5,
+    ultra_expanded = 2,
+    _,
+
+    /// Supported range is usually [0.5, 2]
+    pub fn from(width: f32) Weight {
+        // This is probably unsafe...
+        return @bitCast(width);
+    }
+
+    /// Normalizes the enum into a known variant
+    // The values here are very much arbitrary
+    pub fn normalize(self: Weight) Weight {
+        return if (self < 0.6)
+            .ultra_condensed
+        else if (self < 0.72)
+            .extra_condensed
+        else if (self < 0.83)
+            .condensed
+        else if (self < 1.1)
+            .normal
+        else if (self < 1.225)
+            .semi_expanded
+        else if (self < 1.4)
+            .expanded
+        else if (self < 1.8)
+            .extra_expanded
+        else
+            .ultra_expanded;
+    }
+};
+
+// This needs a better name
+pub const Options = struct {
+    size: ?Size = null,
+    fill: ?Color = null,
+    style: ?Style = null,
+    weight: ?Weight = null,
+    width: ?Width = null,
+    line_height_factor: ?Size = null,
+    decorations: ?[]Decoration = null,
+    synthesis: ?Synthesis = null,
+    kerning: ?Kerning = null,
+
+    pub const Size = union(enum) {
+        value: f32,
+        larger: f32,
+    };
+
+    pub const Color = union(enum) {
+        value: dvui.Color,
+        darker: void,
+        lighter: void,
+    };
+};
+
+// This has a bit of manual work but it aids in providing some custom apis
+// that do not affect internals, only user facing code.
+pub fn override(self: *const FontStyle, over: Options) FontStyle {
+    var ret = self.*;
+
+    if (over.size) |size| {
+        switch (size) {
+            .value => |val| ret.size = val,
+            .larger => |val| ret.size += val,
+        }
+    }
+
+    if (over.fill) |fill| {
+        switch (fill) {
+            .value => |val| ret.fill = val,
+            .darker => @panic("TODO"),
+            .lighter => @panic("TODO"),
+        }
+    }
+
+    if (over.style) |style| {
+        ret.style = style;
+    }
+
+    if (over.weight) |weight| {
+        ret.weight = weight;
+    }
+
+    if (over.width) |width| {
+        ret.width = width;
+    }
+
+    if (over.line_height_factor) |line_height_factor| {
+        switch (line_height_factor) {
+            .value => |val| ret.line_height_factor = val,
+            .larger => |val| ret.line_height_factor += val,
+        }
+    }
+
+    // What would be the best way to merge decorations?
+    // Maybe they should be changed to a different api?
+
+    if (over.decorations) |_| {}
+
+    if (over.synthesis) |synthesis| {
+        ret.synthesis = synthesis;
+    }
+
+    if (over.kerning) |kerning| {
+        ret.kerning = kerning;
+    }
+
+    return ret;
+}

--- a/src/FontStyle.zig
+++ b/src/FontStyle.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 const dvui = @import("dvui.zig");
 
 const Rect = dvui.Rect;
@@ -8,12 +10,7 @@ const Size = dvui.Size;
 // Perhaps `FontOptions` or something among those lines?
 const FontStyle = @This();
 
-// Ideally the user would be able to pass a list of font families so fallbacks can be provided
-// For example, fonts like `Noto Sans` do not include emojis so the user
-// needs to provide something like `Noto Color Emoji` as a fallback
-// Currently dvui provides no way for fallbacks as far as im aware
-// so i don't know how this should look like.
-font_family: []const u8,
+families: []const []const u8,
 size: f32 = 10,
 // This might not be the correct dvui builtin to use
 // The idea is for `scale` to be able to scale `x` and `y` individually using `size` as a base
@@ -30,11 +27,34 @@ weight: Weight = .regular,
 width: Width = .normal,
 /// This overrides the font's default line height
 line_height_factor: ?f32 = null,
-decorations: []Decoration = &.{},
+decorations: Decorations,
 // Synthesis should probably be a list as well...
 // You might want to allow style and caps synthesis for example
 synthesis: Synthesis = .auto,
 kerning: Kerning = .auto,
+
+pub const Decorations = struct {
+    underline: ?Definition,
+    overline: ?Definition,
+    /// Also known as `strike_through`
+    line_through: ?Definition,
+
+    pub const Definition = struct {
+        /// `null` means inherit text color
+        color: ?dvui.Color = null,
+        style: Decorations.Style = .solid,
+        /// Percent of font size, will always be at least 1 logical pixel
+        thickness: f32 = 0.1,
+    };
+
+    pub const Style = enum {
+        solid,
+        double,
+        dotted,
+        dashed,
+        wavy,
+    };
+};
 
 pub const Shadow = struct {
     color: dvui.Color = .black,
@@ -55,32 +75,6 @@ pub const Shadow = struct {
 pub const Outline = struct {
     color: dvui.Color,
     thickness: f32,
-};
-
-pub const Decoration = union(enum) {
-    underline: Definition,
-    overline: Definition,
-    /// Also known as `strike_through`
-    line_through: Definition,
-    /// `err` is a unique version of a wavy underline
-    /// thus the style property doesn't actually do anything.
-    err: Definition,
-
-    pub const Definition = struct {
-        /// `null` means inherit text color
-        color: ?dvui.Color = null,
-        style: Decoration.Style = .solid,
-        /// Percent of font size, will always be at least 1 logical pixel
-        thickness: f32 = 0.1,
-    };
-
-    pub const Style = enum {
-        solid,
-        double,
-        dotted,
-        dashed,
-        wavy,
-    };
 };
 
 pub const Kerning = enum {
@@ -224,103 +218,223 @@ pub const Width = enum(u32) {
     }
 };
 
+pub fn withFamilies(self: FontStyle, families: []const []const u8) FontStyle {
+    var r: FontStyle = self;
+    r.families = families;
+    return r;
+}
+
+pub fn withSize(self: FontStyle, size: f32) FontStyle {
+    var r: FontStyle = self;
+    r.size = size;
+    return r;
+}
+
+pub fn larger(self: FontStyle, ds: f32) FontStyle {
+    var r: FontStyle = self;
+    r.size += ds;
+    return r;
+}
+
+pub fn withScale(self: FontStyle, scale: ?dvui.Point) FontStyle {
+    var r: FontStyle = self;
+    r.scale = scale;
+    return r;
+}
+
+pub fn withFill(self: FontStyle, fill: dvui.Color) FontStyle {
+    var r: FontStyle = self;
+    r.fill = fill;
+    return r;
+}
+
+pub fn withHover(self: FontStyle, hover: ?dvui.Color) FontStyle {
+    var r: FontStyle = self;
+    r.hover = hover;
+    return r;
+}
+
+pub fn withPress(self: FontStyle, press: ?dvui.Color) FontStyle {
+    var r: FontStyle = self;
+    r.press = press;
+    return r;
+}
+
+pub fn withSelect(self: FontStyle, select: ?dvui.Color) FontStyle {
+    var r: FontStyle = self;
+    r.select = select;
+    return r;
+}
+
+pub fn withOutline(self: FontStyle, outline: ?Outline) FontStyle {
+    var r: FontStyle = self;
+    r.outline = outline;
+    return r;
+}
+
+pub fn withShadow(self: FontStyle, shadow: ?Shadow) FontStyle {
+    var r: FontStyle = self;
+    r.shadow = shadow;
+    return r;
+}
+
+pub fn withSpacing(self: FontStyle, spacing: f32) FontStyle {
+    var r: FontStyle = self;
+    r.spacing = spacing;
+    return r;
+}
+
+pub fn withStyle(self: FontStyle, style: Style) FontStyle {
+    var r: FontStyle = self;
+    r.style = style;
+    return r;
+}
+
+pub fn withWeight(self: FontStyle, weight: Weight) FontStyle {
+    var r: FontStyle = self;
+    r.weight = weight;
+    return r;
+}
+
+pub fn withWidth(self: FontStyle, width: Width) FontStyle {
+    var r: FontStyle = self;
+    r.width = width;
+    return r;
+}
+
+pub fn withLineHeight(self: FontStyle, factor: f32) FontStyle {
+    var r: FontStyle = self;
+    r.line_height_factor = factor;
+    return r;
+}
+
+pub fn withKerning(self: FontStyle, kerning: Kerning) FontStyle {
+    var r: FontStyle = self;
+    r.kerning = kerning;
+    return r;
+}
+
+pub fn withSynthesis(self: FontStyle, synthesis: Synthesis) FontStyle {
+    var r: FontStyle = self;
+    r.synthesis = synthesis;
+    return r;
+}
+
+pub fn withDecorations(self: FontStyle, decorations: Decorations) FontStyle {
+    var r: FontStyle = self;
+    r.decorations = decorations;
+    return r;
+}
+
+pub fn withUnderline(self: FontStyle, underline: ?Decorations.Definition) FontStyle {
+    var r: FontStyle = self;
+    r.decorations.underline = underline;
+    return r;
+}
+
+pub fn withOverline(self: FontStyle, overline: ?Decorations.Definition) FontStyle {
+    var r: FontStyle = self;
+    r.decorations.overline = overline;
+    return r;
+}
+
+pub fn withLineThrough(self: FontStyle, line_through: ?Decorations.Definition) FontStyle {
+    var r: FontStyle = self;
+    r.decorations.line_through = line_through;
+    return r;
+}
+
 // This needs a better name
-pub const Options = struct {
-    size: ?Apply = null,
-    fill: ?Color = null,
-    style: ?Style = null,
-    weight: ?Weight = null,
-    width: ?Width = null,
-    line_height_factor: ?Apply = null,
-    // decorations: ?[]Decoration = null,
-    synthesis: ?Synthesis = null,
-    kerning: ?Kerning = null,
+// pub const Options = struct {
+//     size: ?Apply = null,
+//     fill: ?Color = null,
+//     style: ?Style = null,
+//     weight: ?Weight = null,
+//     width: ?Width = null,
+//     line_height_factor: ?Apply = null,
+//     // decorations: ?[]Decoration = null,
+//     synthesis: ?Synthesis = null,
+//     kerning: ?Kerning = null,
 
-    pub const Apply = union(enum) {
-        value: f32,
-        larger: f32,
-    };
+//     pub const Apply = union(enum) {
+//         value: f32,
+//         larger: f32,
+//     };
 
-    pub const Color = union(enum) {
-        value: ?dvui.Color,
-        darker: void,
-        lighter: void,
-    };
-};
+//     pub const Color = union(enum) {
+//         value: ?dvui.Color,
+//         darker: void,
+//         lighter: void,
+//     };
+// };
 
 // This has a bit of manual work but it aids in providing some custom apis
 // that do not affect internals, only user facing code.
-pub fn override(self: *const FontStyle, over: Options) FontStyle {
-    var ret = self.*;
+// pub fn override(self: FontStyle, over: Options) FontStyle {
+//     var ret = self;
 
-    if (over.size) |size| {
-        switch (size) {
-            .value => |val| ret.size = val,
-            .larger => |val| ret.size += val,
-        }
-    }
+//     if (over.size) |size| {
+//         switch (size) {
+//             .value => |val| ret.size = val,
+//             .larger => |val| ret.size += val,
+//         }
+//     }
 
-    if (over.fill) |fill| {
-        switch (fill) {
-            .value => |val| {
-                if (val) |color| ret.fill = color;
-            },
-            .darker => @panic("TODO"),
-            .lighter => @panic("TODO"),
-        }
-    }
+//     if (over.fill) |fill| {
+//         switch (fill) {
+//             .value => |val| {
+//                 if (val) |color| ret.fill = color;
+//             },
+//             .darker => @panic("TODO"),
+//             .lighter => @panic("TODO"),
+//         }
+//     }
 
-    if (over.style) |style| {
-        ret.style = style;
-    }
+//     if (over.style) |style| {
+//         ret.style = style;
+//     }
 
-    if (over.weight) |weight| {
-        ret.weight = weight;
-    }
+//     if (over.weight) |weight| {
+//         ret.weight = weight;
+//     }
 
-    if (over.width) |width| {
-        ret.width = width;
-    }
+//     if (over.width) |width| {
+//         ret.width = width;
+//     }
 
-    if (over.line_height_factor) |line_height_factor| {
-        switch (line_height_factor) {
-            .value => |val| ret.line_height_factor = val,
-            .larger => |val| {
-                if (ret.line_height_factor != null)
-                    ret.line_height_factor.? += val
-                else
-                    ret.line_height_factor = val;
-            },
-        }
-    }
+//     if (over.line_height_factor) |line_height_factor| {
+//         switch (line_height_factor) {
+//             .value => |val| ret.line_height_factor = val,
+//             .larger => |val| {
+//                 if (ret.line_height_factor != null)
+//                     ret.line_height_factor.? += val
+//                 else
+//                     ret.line_height_factor = val;
+//             },
+//         }
+//     }
 
-    // What would be the best way to merge decorations?
-    // Maybe they should be changed to a different api?
+//     // What would be the best way to merge decorations?
+//     // Maybe they should be changed to a different api?
 
-    // if (over.decorations) |_| {}
+//     // if (over.decorations) |_| {}
 
-    if (over.synthesis) |synthesis| {
-        ret.synthesis = synthesis;
-    }
+//     if (over.synthesis) |synthesis| {
+//         ret.synthesis = synthesis;
+//     }
 
-    if (over.kerning) |kerning| {
-        ret.kerning = kerning;
-    }
+//     if (over.kerning) |kerning| {
+//         ret.kerning = kerning;
+//     }
 
-    return ret;
-}
+//     return ret;
+// }
 
 // TODO: Fetch the font and get the line height
-pub fn getLineHeightFactor(self: FontStyle) f32 {
-    return self.line_height_factor orelse 1;
-}
-
-pub fn getFont(self: FontStyle) dvui.Font {
-    return .{
-        .family = dvui.Font.array(self.font_family),
-        .weight = self.weight,
-        .style = self.style,
-    };
+pub fn getLineHeightFactor(self: FontStyle, family: []const u8) f32 {
+    _ = self;
+    _ = family;
+    return 1.2;
 }
 
 pub fn textHeight(self: FontStyle) f32 {
@@ -434,3 +548,153 @@ pub fn textSizeEx(self: FontStyle, text: []const u8, opts: TextSizeOptions) Size
     // convert size back from font units
     return s.scale(target_fraction, Size);
 }
+
+pub const FontSource = struct {
+    style: Style = .normal,
+    weight: Weight = .regular,
+    line_height_factor: f32 = 1.2,
+};
+
+pub const Database = struct {
+    backing: std.HashMapUnmanaged(
+        Key,
+        Value,
+        Context,
+        std.hash_map.default_max_load_percentage,
+    ) = .empty,
+
+    pub const Key = u64;
+    pub const Value = union(enum) {
+        variable: Entry,
+        // TODO: This is probably not the way...
+        family: *Family,
+
+        const Entry = struct {
+            line_height_factor: f32,
+            bytes: []const u8,
+        };
+
+        const Family = std.HashMapUnmanaged(
+            Key,
+            Entry,
+            Context,
+            std.hash_map.default_max_load_percentage,
+        );
+    };
+
+    const Context = struct {
+        pub fn hash(ctx: Context, key: Key) u64 {
+            _ = ctx;
+            return key;
+        }
+
+        pub fn eql(ctx: Context, a: Key, b: Key) bool {
+            _ = ctx;
+            return a == b;
+        }
+    };
+
+    const LookupKey = packed struct(u64) {
+        style: Style,
+        weight: Weight,
+        _: u22 = 0,
+    };
+
+    fn hashFamily(family: []const u8) u64 {
+        return std.hash.XxHash3.hash(0, family);
+    }
+
+    pub fn insert(
+        self: *Database,
+        gpa: std.mem.Allocator,
+        family: []const u8,
+        info: FontSource,
+        bytes: []const u8,
+        variable: bool,
+    ) !void {
+        const hash = hashFamily(family);
+
+        if (variable) return self.backing.put(gpa, hash, .{
+            .variable = .{
+                .line_height_factor = info.line_height_factor,
+                .bytes = bytes,
+            },
+        });
+
+        var family_map: *Value.Family = blk: {
+            if (self.backing.get(hash)) |val| {
+                if (val != .family)
+                    return dvui.log.err("Failed to insert font: '{s} {t} {t}'", .{ family, info.weight, info.style });
+
+                break :blk val.family;
+            }
+
+            const map = try gpa.create(Value.Family);
+            map.* = .empty;
+            break :blk map;
+        };
+
+        return family_map.put(
+            gpa,
+            @bitCast(LookupKey{ .style = info.style, .weight = info.weight }),
+            .{ .line_height_factor = info.line_height_factor, .bytes = bytes },
+        );
+    }
+
+    pub const GetReturnType = union(enum) {
+        variable: Value.Entry,
+        family: Value.Entry,
+    };
+
+    pub fn get(
+        self: *Database,
+        family: []const u8,
+        lookup: LookupKey,
+    ) ?GetReturnType {
+        const hash = hashFamily(family);
+        const entry = self.backing.get(hash) orelse return null;
+
+        switch (entry) {
+            .variable => |variable| return .{ .variable = variable },
+            .family => |family_map| {
+                const result = family_map.get(@bitCast(lookup)) orelse return null;
+                return .{ .family = result };
+            },
+        }
+    }
+};
+
+pub const Cache = struct {
+    // TODO: `Font.Cache.Entry` stores `name` for whatever reason, so we need a new type that doesn't
+    // this is all just poc
+    backing: dvui.TrackingAutoHashMap(u64, dvui.Font.Cache.Entry, .get_and_put, void) = .empty,
+    database: *Database = &.{},
+
+    fn createCacheHash(family: []const u8, lookup: Database.LookupKey) u64 {
+        var h = std.hash.XxHash3.init(0);
+        h.update(family);
+        h.update(std.mem.asBytes(&lookup));
+        return h.final();
+    }
+
+    pub fn getOrCreate(
+        self: *Cache,
+        gpa: std.mem.Allocator,
+        family: []const u8,
+        lookup: Database.LookupKey,
+    ) !*dvui.Font.Cache.Entry {
+        const entry = try self.backing.getOrPut(gpa, family, lookup);
+        if (entry.found_existing) return entry.value_ptr;
+
+        // TODO: Global fallbacks need to be implemented differently from status quo
+        const source = self.database.get(family, lookup) orelse return error.NoSource;
+
+        // TODO: Entry needs to be heavily modified looking at this...
+        entry.value_ptr.* = dvui.Font.CacheEntry.init(gpa, source.bytes, .{}) catch |err| {
+            dvui.log.err("Font {s} init got {any}, using fallback", .{ family, err });
+            self.backing.map.removeByPtr(entry.key_ptr);
+            return error.NoSource;
+        };
+        return entry.value_ptr;
+    }
+};

--- a/src/FontStyle.zig
+++ b/src/FontStyle.zig
@@ -16,6 +16,7 @@ size: f32 = 10,
 // The idea is for `scale` to be able to scale `x` and `y` individually using `size` as a base
 scale: ?dvui.Point = null,
 fill: dvui.Color = .white,
+select: dvui.Color = .{ .r = 0x32, .g = 0x60, .b = 0x98 },
 outline: ?Outline = null,
 shadow: ?Shadow = null,
 spacing: f32 = 0,
@@ -153,43 +154,41 @@ pub const Weight = enum(u10) {
     }
 };
 
-pub const Width = enum(f32) {
-    ultra_condensed = 0.5,
-    extra_condensed = 0.625,
-    condensed = 0.75,
-    semi_condensed = 0.875,
-    normal = 1,
-    semi_expanded = 1.125,
-    expanded = 1.25,
-    extra_expanded = 1.5,
-    ultra_expanded = 2,
+pub const Width = enum(u32) {
+    ultra_condensed = 500,
+    extra_condensed = 625,
+    condensed = 750,
+    semi_condensed = 875,
+    normal = 1000,
+    semi_expanded = 1125,
+    expanded = 1250,
+    extra_expanded = 1500,
+    ultra_expanded = 2000,
     _,
 
     /// Supported range is usually [0.5, 2]
     pub fn from(width: f32) Weight {
-        // This is probably unsafe...
-        return @bitCast(width);
+        return @enumFromInt(@as(u32, @intFromFloat(width * 1000)));
+    }
+
+    pub fn toFloat(self: Width) f32 {
+        return @as(f32, @floatFromInt(@intFromEnum(self))) / 1000;
     }
 
     /// Normalizes the enum into a known variant
     // The values here are very much arbitrary
     pub fn normalize(self: Weight) Weight {
-        return if (self < 0.6)
-            .ultra_condensed
-        else if (self < 0.72)
-            .extra_condensed
-        else if (self < 0.83)
-            .condensed
-        else if (self < 1.1)
-            .normal
-        else if (self < 1.225)
-            .semi_expanded
-        else if (self < 1.4)
-            .expanded
-        else if (self < 1.8)
-            .extra_expanded
-        else
-            .ultra_expanded;
+        return switch (self) {
+            0...524 => .ultra_condensed,
+            525...724 => .extra_condensed,
+            725...849 => .condensed,
+            850...949 => .semi_condensed,
+            950...1099 => .normal,
+            1100...1180 => .semi_expanded,
+            1178...1399 => .expanded,
+            1400...1849 => .extra_expanded,
+            else => .ultra_expanded,
+        };
     }
 };
 

--- a/src/FontStyle.zig
+++ b/src/FontStyle.zig
@@ -5,6 +5,12 @@ const dvui = @import("dvui.zig");
 // Perhaps `FontOptions` or something among those lines?
 const FontStyle = @This();
 
+// Ideally the user would be able to pass a list of font families so fallbacks can be provided
+// For example, fonts like `Noto Sans` do not include emojis so the user
+// needs to provide something like `Noto Color Emoji` as a fallback
+// Currently dvui provides no way for fallbacks as far as im aware
+// so i don't know how this should look like.
+font_family: []const u8,
 size: f32 = 10,
 // This might nto be the correct dvui builtin to use
 // The idea is for `scale` to be able to scale `x` and `y` individually using `size` as a base
@@ -16,7 +22,8 @@ spacing: f32 = 0,
 style: Style = .normal,
 weight: Weight = .normal,
 width: Width = .normal,
-line_height_factor: f32 = 1.2,
+/// This overrides the font's default line height
+line_height_factor: ?f32 = null,
 decorations: []Decoration = &.{},
 // Synthesis should probably be a list as well...
 // You might want to allow style and caps synthesis for example
@@ -245,7 +252,12 @@ pub fn override(self: *const FontStyle, over: Options) FontStyle {
     if (over.line_height_factor) |line_height_factor| {
         switch (line_height_factor) {
             .value => |val| ret.line_height_factor = val,
-            .larger => |val| ret.line_height_factor += val,
+            .larger => |val| {
+                if (ret.line_height_factor != null)
+                    ret.line_height_factor.? += val
+                else
+                    ret.line_height_factor = val;
+            },
         }
     }
 

--- a/src/FontStyle.zig
+++ b/src/FontStyle.zig
@@ -1,5 +1,8 @@
 const dvui = @import("dvui.zig");
 
+const Rect = dvui.Rect;
+const Size = dvui.Size;
+
 // Actually doing this made me realize that `Style`
 // might not be the best name for it.
 // Perhaps `FontOptions` or something among those lines?
@@ -12,16 +15,18 @@ const FontStyle = @This();
 // so i don't know how this should look like.
 font_family: []const u8,
 size: f32 = 10,
-// This might nto be the correct dvui builtin to use
+// This might not be the correct dvui builtin to use
 // The idea is for `scale` to be able to scale `x` and `y` individually using `size` as a base
 scale: ?dvui.Point = null,
 fill: dvui.Color = .white,
+hover: ?dvui.Color = null,
+press: ?dvui.Color = null,
 select: dvui.Color = .{ .r = 0x32, .g = 0x60, .b = 0x98 },
 outline: ?Outline = null,
 shadow: ?Shadow = null,
 spacing: f32 = 0,
 style: Style = .normal,
-weight: Weight = .normal,
+weight: Weight = .regular,
 width: Width = .normal,
 /// This overrides the font's default line height
 line_height_factor: ?f32 = null,
@@ -101,13 +106,22 @@ pub const Style = union(enum) {
     /// An angle between -90 and 90
     /// If `0` is passed, the default (14) will be used
     oblique: i8,
+
+    pub fn toString(self: Style) []const u8 {
+        return switch (self) {
+            // I have never seen a font with a distinct oblique face
+            // usually oblique means a normal font with synthesized inclination
+            .normal, .oblique => "",
+            .italic => " Italic",
+        };
+    }
 };
 
 pub const Weight = enum(u10) {
     thin = 100,
     extra_light = 200,
     light = 300,
-    normal = 400,
+    regular = 400,
     medium = 500,
     semi_bold = 600,
     bold = 700,
@@ -123,8 +137,8 @@ pub const Weight = enum(u10) {
 
     pub fn bolder(self: Weight) Weight {
         return switch (self) {
-            0...399 => .normal,
-            .normal...699 => .bold,
+            0...399 => .regular,
+            .regular...699 => .bold,
             else => .black,
         };
     }
@@ -139,17 +153,35 @@ pub const Weight = enum(u10) {
 
     /// Normalizes the enum into a known variant
     pub fn normalize(self: Weight) Weight {
-        return switch (self) {
+        return switch (@intFromEnum(self)) {
             0...149 => .thin,
             150...249 => .extra_light,
             250...349 => .light,
-            350...449 => .normal,
+            350...449 => .regular,
             450...549 => .medium,
             550...649 => .semi_bold,
             650...749 => .bold,
             750...849 => .extra_bold,
             850...949 => .black,
             else => .extra_black,
+        };
+    }
+
+    pub fn toString(self: Weight) []const u8 {
+        return switch (self.normalize()) {
+            .thin => " Thin",
+            .extra_light => " ExtraLight",
+            .light => " Light",
+            // Should we suffix it with `Regular`?
+            // After all we are looking for a specific font inside a family
+            .regular => "",
+            .medium => " Medium",
+            .semi_bold => " SemiBold",
+            .bold => " Bold",
+            .extra_bold => " ExtraBold",
+            .black => " Black",
+            .extra_black => " ExtraBlack",
+            else => unreachable,
         };
     }
 };
@@ -194,23 +226,23 @@ pub const Width = enum(u32) {
 
 // This needs a better name
 pub const Options = struct {
-    size: ?Size = null,
+    size: ?Apply = null,
     fill: ?Color = null,
     style: ?Style = null,
     weight: ?Weight = null,
     width: ?Width = null,
-    line_height_factor: ?Size = null,
-    decorations: ?[]Decoration = null,
+    line_height_factor: ?Apply = null,
+    // decorations: ?[]Decoration = null,
     synthesis: ?Synthesis = null,
     kerning: ?Kerning = null,
 
-    pub const Size = union(enum) {
+    pub const Apply = union(enum) {
         value: f32,
         larger: f32,
     };
 
     pub const Color = union(enum) {
-        value: dvui.Color,
+        value: ?dvui.Color,
         darker: void,
         lighter: void,
     };
@@ -230,7 +262,9 @@ pub fn override(self: *const FontStyle, over: Options) FontStyle {
 
     if (over.fill) |fill| {
         switch (fill) {
-            .value => |val| ret.fill = val,
+            .value => |val| {
+                if (val) |color| ret.fill = color;
+            },
             .darker => @panic("TODO"),
             .lighter => @panic("TODO"),
         }
@@ -263,7 +297,7 @@ pub fn override(self: *const FontStyle, over: Options) FontStyle {
     // What would be the best way to merge decorations?
     // Maybe they should be changed to a different api?
 
-    if (over.decorations) |_| {}
+    // if (over.decorations) |_| {}
 
     if (over.synthesis) |synthesis| {
         ret.synthesis = synthesis;
@@ -274,4 +308,129 @@ pub fn override(self: *const FontStyle, over: Options) FontStyle {
     }
 
     return ret;
+}
+
+// TODO: Fetch the font and get the line height
+pub fn getLineHeightFactor(self: FontStyle) f32 {
+    return self.line_height_factor orelse 1;
+}
+
+pub fn getFont(self: FontStyle) dvui.Font {
+    return .{
+        .family = dvui.Font.array(self.font_family),
+        .weight = self.weight,
+        .style = self.style,
+    };
+}
+
+pub fn textHeight(self: FontStyle) f32 {
+    return self.sizeM(1, 1).h;
+}
+
+pub fn lineHeight(self: FontStyle) f32 {
+    return self.textHeight() * self.getLineHeightFactor();
+}
+
+pub fn sizeM(self: FontStyle, wide: f32, tall: f32) Size {
+    const m_size: Size = self.textSize("M");
+    return .{ .w = m_size.w * wide, .h = m_size.h * tall };
+}
+
+/// handles multiple lines
+///
+/// Only valid between `Window.begin`and `Window.end`.
+pub fn textSize(self: FontStyle, text: []const u8) Size {
+    if (text.len == 0) {
+        // just want the normal text height
+        return .{ .w = 0, .h = self.textHeight() };
+    }
+
+    const line_height_factor = self.getLineHeightFactor();
+
+    var ret = Size{};
+
+    var line_height_adj: f32 = 0.0;
+    var end: usize = 0;
+    while (end < text.len) {
+        if (end > 0) {
+            ret.h += line_height_adj;
+        }
+
+        var end_idx: usize = undefined;
+        var s = self.textSizeEx(text[end..], .{ .end_idx = &end_idx, .end_metric = .before });
+        if (line_height_factor >= 1.0) {
+            line_height_adj = s.h * (line_height_factor - 1.0);
+        } else {
+            s.h *= line_height_factor;
+        }
+        ret.h += s.h;
+        ret.w = @max(ret.w, s.w);
+
+        end += end_idx;
+    }
+
+    return ret;
+}
+
+pub const TextSizeOptions = struct {
+    max_width: ?f32 = null,
+    end_idx: ?*usize = null,
+    end_metric: EndMetric = .before,
+    kerning: ?bool = null,
+    kern_in: ?[]u32 = null,
+    kern_out: ?[]u32 = null,
+    ascent_out: ?*f32 = null,
+
+    pub const EndMetric = enum {
+        before, // end_idx stops before text goes past max_width
+        nearest, // end_idx stops at start of character closest to max_width
+    };
+};
+
+/// textSizeEx always stops at a newline, use textSize to get multiline sizes
+///
+/// Only valid between `Window.begin`and `Window.end`.
+pub fn textSizeEx(self: FontStyle, text: []const u8, opts: TextSizeOptions) Size {
+    // ask for a font that matches the natural display pixels so we get a more
+    // accurate size
+    const ss = dvui.parentGet().screenRectScale(Rect{}).s;
+    const ask_size = self.size * ss;
+    const sized_style = self.override(.{ .size = .{ .value = ask_size } });
+
+    const cw = dvui.currentWindow();
+
+    if (opts.ascent_out) |ao| ao.* = 10;
+
+    // might give us a slightly smaller font
+    const fce = dvui.fontCacheGet(sized_style) catch return .{ .w = 10, .h = 10 };
+
+    // this must be synced with dvui.renderText()
+    const target_fraction = if (cw.snap_to_pixels) 1.0 / ss else self.size / fce.em_height;
+
+    var options = opts;
+    if (opts.max_width) |mwidth| {
+        // convert max_width into font units
+        options.max_width = mwidth / target_fraction;
+    }
+    options.kerning = opts.kerning orelse cw.kerning;
+
+    var s = fce.textSizeRaw(cw.gpa, text, options) catch return .{ .w = 10, .h = 10 };
+    const line_height_factor = self.getLineHeightFactor();
+
+    // do this check after calling textSizeRaw so that end_idx is set
+    if (ask_size == 0.0) {
+        if (opts.ascent_out) |ao| ao.* = 0;
+        return Size{};
+    }
+
+    if (opts.ascent_out) |ao| {
+        ao.* = fce.ascent;
+        if (line_height_factor < 1.0) {
+            ao.* = @round(ao.* * line_height_factor);
+        }
+        ao.* *= target_fraction;
+    }
+
+    // convert size back from font units
+    return s.scale(target_fraction, Size);
 }

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const dvui = @import("dvui.zig");
 
 const Color = dvui.Color;
-const Font = dvui.Font;
+const FontStyle = dvui.FontStyle;
 const Rect = dvui.Rect;
 const Size = dvui.Size;
 const Theme = dvui.Theme;
@@ -59,9 +59,6 @@ tab_index: ?u16 = null,
 color_fill: ?Color = null,
 color_fill_hover: ?Color = null,
 color_fill_press: ?Color = null,
-color_text: ?Color = null,
-color_text_hover: ?Color = null,
-color_text_press: ?Color = null,
 color_border: ?Color = null,
 
 ninepatch_fill: ?*const Ninepatch = null,
@@ -74,8 +71,7 @@ style: ?Theme.Style.Name = null,
 // If not null, source colors from here instead of the global theme.
 theme: ?*const Theme = null,
 
-// Use specified font
-font: ?Font = null,
+text_style: ?FontStyle.Options = null,
 
 // only used for icons/images, rotates around center, radians clockwise
 rotation: ?f32 = null,
@@ -223,14 +219,15 @@ pub const ColorAsk = enum {
 ///
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn color(self: *const Options, ask: ColorAsk) Color {
+    const text_style = self.fontStyleGet();
     return switch (ask) {
         .border => self.color_border,
         .fill => self.color_fill,
         .fill_hover => self.color_fill_hover orelse if (self.color_fill) |col| self.themeGet().adjustColorForState(col, ask) else null,
         .fill_press => self.color_fill_press orelse if (self.color_fill) |col| self.themeGet().adjustColorForState(col, ask) else null,
-        .text => self.color_text,
-        .text_hover => self.color_text_hover orelse self.color_text,
-        .text_press => self.color_text_press orelse self.color_text,
+        .text => text_style.fill,
+        .text_hover => text_style.hover orelse text_style.fill,
+        .text_press => text_style.press orelse text_style.fill,
     } orelse self.themeGet().color(self.styleGet(), ask);
 }
 
@@ -252,8 +249,10 @@ pub fn ninepatch(self: *const Options, ask: NinepatchAsk) ?*const Ninepatch {
     return self.themeGet().ninepatch(self.styleGet(), ask);
 }
 
-pub fn fontGet(self: *const Options) Font {
-    return self.font orelse self.themeGet().font_body;
+pub fn fontStyleGet(self: *const Options) FontStyle {
+    const body_style = self.themeGet().body_style;
+    const style_options = self.text_style orelse return body_style;
+    return body_style.override(style_options);
 }
 
 pub fn idExtra(self: *const Options) usize {
@@ -330,12 +329,9 @@ pub fn styleOnly(self: *const Options) Options {
         .color_fill = self.color_fill,
         .color_fill_hover = self.color_fill_hover,
         .color_fill_press = self.color_fill_press,
-        .color_text = self.color_text,
-        .color_text_hover = self.color_text_hover,
-        .color_text_press = self.color_text_press,
         .color_border = self.color_border,
 
-        .font = self.font,
+        .text_style = self.text_style,
     };
 }
 
@@ -394,12 +390,9 @@ pub fn strip(self: *const Options) Options {
         .color_fill = self.color_fill,
         .color_fill_hover = self.color_fill_hover,
         .color_fill_press = self.color_fill_press,
-        .color_text = self.color_text,
-        .color_text_hover = self.color_text_hover,
-        .color_text_press = self.color_text_press,
         .color_border = self.color_border,
 
-        .font = self.font,
+        .text_style = self.text_style,
 
         .rotation = self.rotation,
     };
@@ -436,11 +429,11 @@ pub fn themeOverride(self: *const Options, theme: ?*const Theme) Options {
 }
 
 pub fn min_sizeM(self: *const Options, wide: f32, tall: f32) Options {
-    return self.override(.{ .min_size_content = self.fontGet().sizeM(wide, tall) });
+    return self.override(.{ .min_size_content = self.fontStyleGet().sizeM(wide, tall) });
 }
 
 pub fn max_sizeM(self: *const Options, wide: f32, tall: f32) Options {
-    return self.override(.{ .max_size_content = .size(self.fontGet().sizeM(wide, tall)) });
+    return self.override(.{ .max_size_content = .size(self.fontStyleGet().sizeM(wide, tall)) });
 }
 
 pub fn padSize(self: *const Options, s: Size) Size {
@@ -475,12 +468,9 @@ pub fn hash(self: *const Options) u64 {
     if (self.color_fill) |col| hasher.update(asBytes(&col));
     if (self.color_fill_hover) |col| hasher.update(asBytes(&col));
     if (self.color_fill_press) |col| hasher.update(asBytes(&col));
-    if (self.color_text) |col| hasher.update(asBytes(&col));
-    if (self.color_text_hover) |col| hasher.update(asBytes(&col));
-    if (self.color_text_press) |col| hasher.update(asBytes(&col));
     if (self.color_border) |col| hasher.update(asBytes(&col));
 
-    const font = self.fontGet();
+    const font = self.fontStyleGet().getFont();
     hasher.update(asBytes(&font.hash()));
 
     if (self.tab_index) |ti| hasher.update(asBytes(&ti));

--- a/src/Theme.zig
+++ b/src/Theme.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 
 const Color = dvui.Color;
 const Font = dvui.Font;
+const FontStyle = dvui.FontStyle;
 const Options = dvui.Options;
 
 const Theme = @This();
@@ -42,9 +43,6 @@ dark: bool,
 /// used for focus highlighting
 focus: Color,
 
-/// color used to show selected text.  textLayout composites this color partially opaque under selected text.
-text_select: ?Color = null,
-
 /// fill for .content Style, fallback for any Style without fill.  Example is background of textLayout and textEntry.
 fill: Color,
 
@@ -62,15 +60,6 @@ ninepatch_hover: ?dvui.Ninepatch = null,
 
 /// ninepatch when pressed for .content Style, fallback for any Style without fill.
 ninepatch_press: ?dvui.Ninepatch = null,
-
-/// text color for .content Style, fallback for any Style without text.  Example is text in a textLayout or textEntry.  Also used as general foreground color like a checkmark or icon color.
-text: Color,
-
-/// text when hovered for .content Style.  Currently unused in dvui widgets.  If null, uses text.
-text_hover: ?Color = null,
-
-/// text when pressed for .content Style.  Currently unused in dvui widgets (but text_press in .control Style is).  If null, uses text.
-text_press: ?Color = null,
 
 /// border for .content Style, fallback for any Style without border.
 border: Color,
@@ -100,7 +89,7 @@ app3: Style = .{},
 /// Suggestions:
 /// - headings: bold, same size
 /// - captions: size 2-3 smaller, smaller line height factor like 1.1
-font_body: Font,
+body_style: FontStyle,
 
 /// Usually a bold version of font_body.
 /// dvui uses this by default for:
@@ -108,15 +97,15 @@ font_body: Font,
 /// * active tab name
 /// * grid headers
 /// * expanders
-font_heading: Font,
+heading_style: FontStyle,
 
 /// Usually a larger version of font_body.
 /// dvui uses this by default for:
 /// * plot titles
-font_title: Font,
+title_style: FontStyle,
 
 /// Font for monospaced body text.  dvui only uses this in examples.
-font_mono: Font,
+mono_style: FontStyle,
 
 /// Caps widget default corner_radius.  Can be overridden at widget call sites.
 max_default_corner_radius: ?f32 = null,
@@ -156,9 +145,9 @@ pub fn color(self: *const Theme, style_name: Style.Name, ask: Options.ColorAsk) 
             .fill => self.adjustColorForState(self.fill, ask),
             .fill_hover => self.fill_hover orelse continue :sw .fill,
             .fill_press => self.fill_press orelse continue :sw .fill,
-            .text => self.text,
-            .text_hover => self.text_hover orelse self.text,
-            .text_press => self.text_press orelse self.text,
+            .text => self.body_style.fill,
+            .text_hover => self.body_style.hover orelse self.body_style.fill,
+            .text_press => self.body_style.press orelse self.body_style.fill,
         },
         .control => self.control,
         .window => self.window,

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -329,10 +329,10 @@ pub fn native(self: *Self) Native {
 pub fn addFont(self: *Self, name: []const u8, ttf_bytes: []const u8, ttf_bytes_allocator: ?std.mem.Allocator) (std.mem.Allocator.Error || dvui.Font.Error)!void {
     try self.fonts.database.ensureUnusedCapacity(self.gpa, 1);
     // TODO: try to get this info from the ttf file, and also add override options
-    const font: dvui.Font = .find(.{ .family = name });
+    const font: dvui.Font = .{ .family = dvui.Font.array(name) };
     // Test if we can successfully open this font
     // TODO: Find some more elegant way of validating ttf files
-    var entry = try dvui.Font.Cache.Entry.init(self.gpa, ttf_bytes, font);
+    var entry = try dvui.Font.Cache.Entry.init(self.gpa, ttf_bytes, .{ .font_family = name });
     // Try and cache the entry since the work is already done
     self.fonts.cache.put(self.gpa, font.hash(), entry) catch entry.deinit(self.gpa, self.backend);
     self.fonts.database.appendAssumeCapacity(.{

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -562,9 +562,9 @@ pub fn addFont(name: []const u8, ttf_bytes: []const u8, ttf_bytes_allocator: ?st
 }
 
 // Get or load the underlying font at an integer size <= font.size (guaranteed to have a minimum pixel size of 1)
-pub fn fontCacheGet(font: Font) std.mem.Allocator.Error!*Font.Cache.Entry {
+pub fn fontCacheGet(style: FontStyle) std.mem.Allocator.Error!*Font.Cache.Entry {
     const cw = currentWindow();
-    return cw.fonts.getOrCreate(cw.gpa, font);
+    return cw.fonts.getOrCreate(cw.gpa, style);
 }
 
 /// Takes in svg bytes and returns a tvg bytes that can be used
@@ -2360,13 +2360,12 @@ pub fn windowHeader(str: []const u8, right_str: []const u8, openflag: ?*bool) Re
 
     dvui.labelNoFmt(@src(), str, .{ .align_x = 0.5 }, .{
         .expand = .horizontal,
-        .font = .theme(.heading),
         .padding = .{ .x = 6, .y = 6, .w = 6, .h = 4 },
         .label = .{ .for_id = dvui.subwindowCurrentId() },
     });
 
     if (openflag) |of| {
-        const opts: Options = .{ .font = .theme(.heading), .corner_radius = Rect.all(1000), .padding = Rect.all(2), .margin = Rect.all(2), .gravity_y = 0.5, .expand = .ratio };
+        const opts: Options = .{ .corner_radius = Rect.all(1000), .padding = Rect.all(2), .margin = Rect.all(2), .gravity_y = 0.5, .expand = .ratio };
         if (dvui.buttonIcon(
             @src(),
             "close",
@@ -2789,7 +2788,7 @@ pub fn dropdown(src: std.builtin.SourceLocation, entries: []const []const u8, ch
             defer mi.deinit();
             dvui.labelNoFmt(@src(), init_opts.placeholder orelse dropdown_placeholder_default, .{}, opts.strip().override(.{
                 .gravity_y = 0.5,
-                .color_text = opts.color(.text).opacity(0.65),
+                .text_style = .{ .fill = .{ .value = opts.color(.text).opacity(0.65) } },
             }));
             if (mi.activeRect()) |_| {
                 dd.close();
@@ -2851,7 +2850,7 @@ pub fn dropdownEnum(src: std.builtin.SourceLocation, T: type, choice: DropdownCh
             defer mi.deinit();
             dvui.labelNoFmt(@src(), init_opts.placeholder orelse dropdown_placeholder_default, .{}, opts.strip().override(.{
                 .gravity_y = 0.5,
-                .color_text = opts.color(.text).opacity(0.65),
+                .text_style = .{ .fill = .{ .value = opts.color(.text).opacity(0.65) } },
             }));
             if (mi.activeRect()) |_| {
                 dd.close();
@@ -3051,7 +3050,7 @@ pub const ExpanderOptions = struct {
 ///
 /// Only valid between `Window.begin`and `Window.end`.
 pub fn expander(src: std.builtin.SourceLocation, label_str: []const u8, init_opts: ExpanderOptions, opts: Options) bool {
-    const options = expander_defaults.override(.{ .font = opts.themeGet().font_heading }).override(opts);
+    const options = expander_defaults.override(opts);
 
     var b = box(src, .{ .dir = .horizontal }, options);
     defer b.deinit();
@@ -3115,7 +3114,7 @@ pub fn groupBox(src: std.builtin.SourceLocation, label_str: []const u8, opts: Op
         .label = .{ .text = label_str },
     }).override(opts);
 
-    const text_size = options.fontGet().textSize(label_str);
+    const text_size = options.fontStyleGet().textSize(label_str);
 
     // Offset top margin and padding to account for label
     options.margin.?.y += @max(text_size.h / 2 - options.borderGet().y / 2, 0);
@@ -3707,7 +3706,12 @@ pub fn menuItemIcon(src: std.builtin.SourceLocation, name: []const u8, tvg_bytes
 
     // pass min_size_content through to the icon so that it will figure out the
     // min width based on the height
-    var iconopts = opts.strip().override(.{ .gravity_x = 0.5, .gravity_y = 0.5, .min_size_content = opts.min_size_content, .expand = .ratio, .color_text = opts.color_text });
+    var iconopts = opts.strip().override(.{
+        .gravity_x = 0.5,
+        .gravity_y = 0.5,
+        .min_size_content = opts.min_size_content,
+        .expand = .ratio,
+    });
 
     var ret: ?Rect.Natural = null;
     if (mi.activeRect()) |r| {
@@ -3743,7 +3747,7 @@ pub const LinkOptions = struct {
 
 /// A label that calls `openURL` when clicked.
 pub fn link(src: std.builtin.SourceLocation, init_opts: LinkOptions, opts: Options) void {
-    const defaults: Options = .{ .color_text = dvui.themeGet().focus };
+    const defaults: Options = .{ .text_style = .{ .fill = .{ .value = dvui.themeGet().focus } } };
     var click_event: dvui.Event.EventTypes = undefined;
     if (dvui.labelClick(src, "{s}", .{init_opts.label orelse init_opts.url}, .{ .click_event = &click_event }, defaults.override(opts))) {
         const new_window = (click_event == .mouse and (click_event.mouse.button == .middle or click_event.mouse.mod.matchBind("ctrl/cmd")));
@@ -4025,7 +4029,13 @@ pub fn buttonIcon(src: std.builtin.SourceLocation, name: []const u8, tvg_bytes: 
         name,
         tvg_bytes,
         icon_opts,
-        opts.strip().override(bw.style()).override(.{ .gravity_x = 0.5, .gravity_y = 0.5, .min_size_content = opts.min_size_content, .expand = .ratio, .color_text = opts.color_text, .role = .none }),
+        opts.strip().override(bw.style()).override(.{
+            .gravity_x = 0.5,
+            .gravity_y = 0.5,
+            .min_size_content = opts.min_size_content,
+            .expand = .ratio,
+            .role = .none,
+        }),
     );
 
     const click = bw.clicked();
@@ -4057,7 +4067,13 @@ pub fn buttonLabelAndIcon(src: std.builtin.SourceLocation, combined_opts: Button
     {
         var outer_hbox = box(src, .{ .dir = .horizontal }, .{ .expand = .horizontal });
         defer outer_hbox.deinit();
-        icon(@src(), combined_opts.icon_label orelse combined_opts.label, combined_opts.tvg_bytes, .{}, options.strip().override(.{ .gravity_x = if (combined_opts.icon_first) 0.0 else 1.0, .color_text = opts.color_text }));
+        icon(
+            @src(),
+            combined_opts.icon_label orelse combined_opts.label,
+            combined_opts.tvg_bytes,
+            .{},
+            options.strip().override(.{ .gravity_x = if (combined_opts.icon_first) 0.0 else 1.0 }),
+        );
         labelEx(@src(), "{s}", .{combined_opts.label}, .{ .align_x = 0.5 }, options.strip().override(.{ .expand = .both }));
     }
 
@@ -4773,7 +4789,7 @@ pub fn checkboxEx(src: std.builtin.SourceLocation, target: *bool, label_str: ?[]
         AccessKit.nodeSetToggled(ak_node, if (target.*) AccessKit.Toggled.ak_true else AccessKit.Toggled.ak_false);
     }
 
-    const check_size = options.fontGet().textHeight();
+    const check_size = options.fontStyleGet().textHeight();
     const s = spacer(@src(), .{ .min_size_content = Size.all(check_size), .gravity_y = 0.5 });
 
     const rs = s.borderRectScale();
@@ -4863,7 +4879,7 @@ pub fn radio(src: std.builtin.SourceLocation, active: bool, label_str: ?[]const 
         AccessKit.nodeSetToggled(ak_node, if (active) AccessKit.Toggled.ak_true else AccessKit.Toggled.ak_false);
     }
 
-    const radio_size = options.fontGet().textHeight();
+    const radio_size = options.fontStyleGet().textHeight();
     const s = spacer(@src(), .{ .min_size_content = Size.all(radio_size), .gravity_y = 0.5 });
 
     const rs = s.borderRectScale();
@@ -5195,7 +5211,7 @@ pub fn textEntryColor(src: std.builtin.SourceLocation, init_opts: TextEntryColor
 
     var options = defaults.override(opts);
     if (options.min_size_content == null) {
-        options = options.override(.{ .min_size_content = opts.fontGet().textSize(if (init_opts.allow_alpha) "#DDDDDDDD" else "#DDDDDD") });
+        options = options.override(.{ .min_size_content = opts.fontStyleGet().textSize(if (init_opts.allow_alpha) "#DDDDDDDD" else "#DDDDDD") });
     }
 
     const id = dvui.parentGet().extendId(src, opts.idExtra());

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -51,6 +51,7 @@ pub const Examples = @import("Examples.zig");
 pub const Color = @import("Color.zig");
 pub const Event = @import("Event.zig");
 pub const Font = @import("Font.zig");
+pub const FontStyle = @import("FontStyle.zig");
 pub const Options = @import("Options.zig");
 pub const Point = @import("Point.zig").Point;
 pub const Path = @import("Path.zig");

--- a/src/render.zig
+++ b/src/render.zig
@@ -101,14 +101,13 @@ pub fn renderTriangles(triangles: Triangles, tex: ?Texture) Backend.GenericError
 }
 
 pub const TextOptions = struct {
-    font: Font,
     text: []const u8,
+    text_style: dvui.FontStyle,
     rs: RectScale,
 
     /// Draw text starting here (top left corner of start of text).  If null,
     /// use rs.r.topLeft().
     p: ?Point.Physical = null,
-    color: Color,
     background_color: ?Color = null,
 
     /// radians clockwise, rotates around top-left corner (rs.x/rs.y)
@@ -116,7 +115,6 @@ pub const TextOptions = struct {
     rotation: f32 = 0.0,
     sel_start: ?usize = null,
     sel_end: ?usize = null,
-    sel_color: ?Color = null,
     debug: bool = false,
     kerning: ?bool = null,
     kern_in: ?[]u32 = null,
@@ -152,18 +150,19 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
         return;
     }
 
-    const target_size = opts.font.size * opts.rs.s;
-    const sized_font = opts.font.withSize(target_size);
+    const sized_style = opts.text_style.override(.{ .size = .{ .value = opts.text_style.size * opts.rs.s } });
+    const line_height_factor = opts.text_style.getLineHeightFactor();
 
     // might get a slightly smaller font
-    var fce = try cw.fonts.getOrCreate(cw.gpa, sized_font);
+    var fce = try cw.fonts.getOrCreate(cw.gpa, sized_style);
     var fce_ascent = fce.ascent;
-    if (opts.font.line_height_factor < 1.0) {
-        fce_ascent = @round(fce_ascent * opts.font.line_height_factor);
+    if (line_height_factor < 1.0) {
+        fce_ascent = @round(fce_ascent * line_height_factor);
     }
 
+    const font = sized_style.getFont();
     // this must be synced with Font.textSizeEx()
-    const target_fraction = if (cw.snap_to_pixels) 1.0 else target_size / fce.em_height;
+    const target_fraction = if (cw.snap_to_pixels) 1.0 else sized_style.size / fce.em_height;
 
     // make sure the cache has all the glyphs we need
     if (opts.kern_in == null) {
@@ -178,7 +177,7 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
     const texture_atlas = fce.getTextureAtlas(cw.gpa, cw.backend) catch |err| switch (err) {
         error.OutOfMemory => |e| return e,
         else => {
-            const fname = opts.font.name(cw.arena());
+            const fname = font.name(cw.arena());
             defer cw.arena().free(fname);
             dvui.log.err("Could not get texture atlas for font {s}, text area marked in magenta, to display '{s}'", .{ fname, opts.text });
             opts.rs.r.fill(.{}, .{ .color = .magenta });
@@ -190,7 +189,7 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
     var builder = try dvui.Triangles.Builder.init(cw.lifo(), 4 * utf8_text.len, 6 * utf8_text.len);
     defer builder.deinit(cw.lifo());
 
-    const color = opts.color.opacity(cw.alpha);
+    const color = opts.text_style.fill.opacity(cw.alpha);
     const col: Color.PMA = .fromColor(color);
 
     var start = opts.p orelse opts.rs.r.topLeft();
@@ -347,7 +346,7 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
     if (opts.background_color) |bgcol| {
         opts.rs.r.toPoint(.{
             .x = max_x,
-            .y = @max(sel_max_y, opts.rs.r.y + fce.height * target_fraction * opts.font.line_height_factor),
+            .y = @max(sel_max_y, opts.rs.r.y + fce.height * target_fraction * line_height_factor),
         }).fill(.{}, .{ .color = bgcol, .fade = 0 });
     }
 
@@ -355,39 +354,41 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
         Rect.Physical.fromPoint(.{ .x = sel_start_x, .y = opts.rs.r.y })
             .toPoint(.{
                 .x = sel_end_x,
-                .y = @max(sel_max_y, opts.rs.r.y + fce.height * target_fraction * opts.font.line_height_factor),
+                .y = @max(sel_max_y, opts.rs.r.y + fce.height * target_fraction * line_height_factor),
             })
-            .fill(.{}, .{ .color = opts.sel_color orelse dvui.themeGet().focus, .fade = 0 });
+            .fill(.{}, .{ .color = opts.text_style.select, .fade = 0 });
     }
 
-    if (opts.font.underline) |u| {
-        if (u.thick > 0) {
-            var topleft: dvui.Point.Physical = .{ .x = start.x, .y = start.y + fce_ascent + (fce.em_height * 0.2) };
-            if (cw.snap_to_pixels) {
-                // x should already be snapped
-                topleft.y = @round(topleft.y);
-            }
+    // TODO: Look into the `Decoration`s api
 
-            const botright: dvui.Point.Physical = .{ .x = max_x, .y = topleft.y + @max(1.0 * opts.rs.s, fce.em_height * u.thick) };
+    // if (opts.font.underline) |u| {
+    //     if (u.thick > 0) {
+    //         var topleft: dvui.Point.Physical = .{ .x = start.x, .y = start.y + fce_ascent + (fce.em_height * 0.2) };
+    //         if (cw.snap_to_pixels) {
+    //             // x should already be snapped
+    //             topleft.y = @round(topleft.y);
+    //         }
 
-            Rect.Physical.fromPoint(topleft).toPoint(botright).fill(.{}, .{ .color = color, .fade = 0 });
-        }
-    }
+    //         const botright: dvui.Point.Physical = .{ .x = max_x, .y = topleft.y + @max(1.0 * opts.rs.s, fce.em_height * u.thick) };
 
-    if (opts.font.strike) |s| {
-        if (s.thick > 0) {
-            const thick = @max(1.0 * opts.rs.s, fce.em_height * s.thick);
-            var topleft: dvui.Point.Physical = .{ .x = start.x, .y = start.y + fce_ascent - (fce.em_height * 0.5) - thick * 0.5 };
-            if (cw.snap_to_pixels) {
-                // x should already be snapped
-                topleft.y = @round(topleft.y);
-            }
+    //         Rect.Physical.fromPoint(topleft).toPoint(botright).fill(.{}, .{ .color = color, .fade = 0 });
+    //     }
+    // }
 
-            const botright: dvui.Point.Physical = .{ .x = max_x, .y = topleft.y + thick };
+    // if (opts.font.strike) |s| {
+    //     if (s.thick > 0) {
+    //         const thick = @max(1.0 * opts.rs.s, fce.em_height * s.thick);
+    //         var topleft: dvui.Point.Physical = .{ .x = start.x, .y = start.y + fce_ascent - (fce.em_height * 0.5) - thick * 0.5 };
+    //         if (cw.snap_to_pixels) {
+    //             // x should already be snapped
+    //             topleft.y = @round(topleft.y);
+    //         }
 
-            Rect.Physical.fromPoint(topleft).toPoint(botright).fill(.{}, .{ .color = color, .fade = 0 });
-        }
-    }
+    //         const botright: dvui.Point.Physical = .{ .x = max_x, .y = topleft.y + thick };
+
+    //         Rect.Physical.fromPoint(topleft).toPoint(botright).fill(.{}, .{ .color = color, .fade = 0 });
+    //     }
+    // }
 
     var tri = builder.build();
     defer tri.deinit(cw.lifo());

--- a/src/themes/Adwaita.zig
+++ b/src/themes/Adwaita.zig
@@ -82,18 +82,37 @@ pub const light = light: {
 
         .embedded_fonts = fonts,
 
-        .font_body = .find(.{ .family = "Vera Sans" }),
-        .font_heading = .find(.{ .family = "Vera Sans", .weight = .bold }),
-        .font_title = .find(.{ .family = "Vera Sans", .size = dvui.Font.DefaultSize + 2 }),
-        .font_mono = .find(.{ .family = "Vera Sans Mono" }),
+        .body_style = .{
+            .font_family = "Vera Sans",
+            .fill = .black,
+            .select = .{ .r = 0x91, .g = 0xbc, .b = 0xf0 },
+        },
+
+        .heading_style = .{
+            .font_family = "Vera Sans",
+            .weight = .bold,
+            .fill = .black,
+            .select = .{ .r = 0x91, .g = 0xbc, .b = 0xf0 },
+        },
+
+        .title_style = .{
+            .font_family = "Vera Sans",
+            .size = 12,
+            .fill = .black,
+            .select = .{ .r = 0x91, .g = 0xbc, .b = 0xf0 },
+        },
+
+        .mono_style = .{
+            .font_family = "Vera Sans Mono",
+            .fill = .black,
+            .select = .{ .r = 0x91, .g = 0xbc, .b = 0xf0 },
+        },
 
         .focus = accent,
 
         .fill = Color.white,
         .fill_hover = (Color.HSLuv{ .s = 0, .l = 82 }).color(),
         .fill_press = (Color.HSLuv{ .s = 0, .l = 72 }).color(),
-        .text = Color.black,
-        .text_select = .{ .r = 0x91, .g = 0xbc, .b = 0xf0 },
         .border = (Color.HSLuv{ .s = 0, .l = 63 }).color(),
 
         .control = .{
@@ -146,18 +165,29 @@ pub const dark = dark: {
 
         .embedded_fonts = fonts,
 
-        .font_body = .find(.{ .family = "Vera Sans" }),
-        .font_heading = .find(.{ .family = "Vera Sans", .weight = .bold }),
-        .font_title = .find(.{ .family = "Vera Sans", .size = dvui.Font.DefaultSize + 2 }),
-        .font_mono = .find(.{ .family = "Vera Sans Mono" }),
+        .body_style = .{
+            .font_family = "Vera Sans",
+        },
+
+        .heading_style = .{
+            .font_family = "Vera Sans",
+            .weight = .bold,
+        },
+
+        .title_style = .{
+            .font_family = "Vera Sans",
+            .size = 12,
+        },
+
+        .mono_style = .{
+            .font_family = "Vera Sans Mono",
+        },
 
         .focus = accent,
 
         .fill = dark_fill,
         .fill_hover = dark_fill_hsl.lighten(21).color(),
         .fill_press = dark_fill_hsl.lighten(30).color(),
-        .text = Color.white,
-        .text_select = .{ .r = 0x32, .g = 0x60, .b = 0x98 },
         .border = dark_fill_hsl.lighten(39).color(),
 
         .control = .{

--- a/src/themes/Dracula.zig
+++ b/src/themes/Dracula.zig
@@ -24,14 +24,30 @@ pub const theme: dvui.Theme = blk: {
 
         .embedded_fonts = fonts,
 
-        .font_body = .find(.{ .family = "Pixelify Sans" }),
-        .font_heading = .find(.{ .family = "Pixelify Sans", .weight = .bold }),
-        .font_title = .find(.{ .family = "Pixelify Sans", .size = dvui.Font.DefaultSize + 2 }),
-        .font_mono = .find(.{ .family = "None" }),
+        .body_style = .{
+            .font_family = "Pixelify Sans",
+            .fill = text,
+        },
+
+        .heading_style = .{
+            .font_family = "Pixelify Sans",
+            .weight = .bold,
+            .fill = text,
+        },
+
+        .title_style = .{
+            .font_family = "Pixelify Sans",
+            .size = 12,
+            .fill = text,
+        },
+
+        .mono_style = .{
+            .font_family = "None",
+            .fill = text,
+        },
 
         .focus = .fromHex("#ff79c6"),
         .fill = fill,
-        .text = text,
         .border = border,
 
         .control = .{

--- a/src/themes/Gruvbox.zig
+++ b/src/themes/Gruvbox.zig
@@ -36,15 +36,31 @@ pub const theme: dvui.Theme = blk: {
 
         .embedded_fonts = fonts,
 
-        .font_body = .find(.{ .family = "Aleo" }),
-        .font_heading = .find(.{ .family = "Aleo", .weight = .bold }),
-        .font_title = .find(.{ .family = "Aleo", .size = dvui.Font.DefaultSize + 2 }),
-        .font_mono = .find(.{ .family = "None" }),
+        .body_style = .{
+            .font_family = "Aleo",
+            .fill = text,
+        },
+
+        .heading_style = .{
+            .font_family = "Aleo",
+            .weight = .bold,
+            .fill = text,
+        },
+
+        .title_style = .{
+            .font_family = "Aleo",
+            .size = 12,
+            .fill = text,
+        },
+
+        .mono_style = .{
+            .font_family = "None",
+            .fill = text,
+        },
 
         .focus = .fromHex("#fe8019"),
         .fill = fill,
         .fill_press = fill_press,
-        .text = text,
         .border = border,
 
         .control = .{

--- a/src/themes/Jungle.zig
+++ b/src/themes/Jungle.zig
@@ -24,14 +24,30 @@ pub const theme: dvui.Theme = blk: {
 
         .embedded_fonts = fonts,
 
-        .font_body = .find(.{ .family = "Pixelify Sans" }),
-        .font_heading = .find(.{ .family = "Pixelify Sans", .weight = .bold }),
-        .font_title = .find(.{ .family = "Pixelify Sans", .size = dvui.Font.DefaultSize + 2 }),
-        .font_mono = .find(.{ .family = "None" }),
+        .body_style = .{
+            .font_family = "Pixelify Sans",
+            .fill = text,
+        },
+
+        .heading_style = .{
+            .font_family = "Pixelify Sans",
+            .weight = .bold,
+            .fill = text,
+        },
+
+        .title_style = .{
+            .font_family = "Pixelify Sans",
+            .size = 12,
+            .fill = text,
+        },
+
+        .mono_style = .{
+            .font_family = "None",
+            .fill = text,
+        },
 
         .focus = .fromHex("#638465"),
         .fill = fill,
-        .text = text,
         .border = border,
 
         .control = .{

--- a/src/themes/OpenDyslexic.zig
+++ b/src/themes/OpenDyslexic.zig
@@ -35,14 +35,32 @@ pub const theme: dvui.Theme = blk: {
 
         .embedded_fonts = fonts,
 
-        .font_body = .find(.{ .family = "OpenDyslexic", .size = 9 }),
-        .font_heading = .find(.{ .family = "OpenDyslexic", .size = 9, .weight = .bold }),
-        .font_title = .find(.{ .family = "OpenDyslexic", .size = 11 }),
-        .font_mono = .find(.{ .family = "None" }),
+        .body_style = .{
+            .font_family = "OpenDyslexic",
+            .size = 9,
+            .fill = text,
+        },
+
+        .heading_style = .{
+            .font_family = "OpenDyslexic",
+            .size = 9,
+            .weight = .bold,
+            .fill = text,
+        },
+
+        .title_style = .{
+            .font_family = "OpenDyslexic",
+            .size = 11,
+            .fill = text,
+        },
+
+        .mono_style = .{
+            .font_family = "None",
+            .fill = text,
+        },
 
         .focus = .fromHex("#3584e4"),
         .fill = fill,
-        .text = text,
         .border = border,
 
         .control = .{

--- a/src/themes/win98.zig
+++ b/src/themes/win98.zig
@@ -78,16 +78,35 @@ pub const light = light: {
 
         .embedded_fonts = fonts,
 
-        .font_body = .find(.{ .family = "Aleo" }),
-        .font_heading = .find(.{ .family = "Aleo", .weight = .bold }),
-        .font_title = .find(.{ .family = "Aleo", .size = dvui.Font.DefaultSize + 2 }),
-        .font_mono = .find(.{ .family = "None" }),
+        .body_style = .{
+            .font_family = "Aleo",
+            .fill = text_color,
+            .select = dialog_blue_light,
+        },
 
-        .text_select = dialog_blue_light,
+        .heading_style = .{
+            .font_family = "Aleo",
+            .weight = .bold,
+            .fill = text_color,
+            .select = dialog_blue_light,
+        },
+
+        .title_style = .{
+            .font_family = "Aleo",
+            .size = 12,
+            .fill = text_color,
+            .select = dialog_blue_light,
+        },
+
+        .mono_style = .{
+            .font_family = "None",
+            .fill = text_color,
+            .select = dialog_blue_light,
+        },
+
         .focus = dialog_blue_light,
 
         .fill = surface,
-        .text = text_color,
         .border = .white,
 
         .max_default_corner_radius = 0.0,

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -50,7 +50,9 @@ click: bool = false,
 pub fn init(self: *ButtonWidget, src: std.builtin.SourceLocation, init_options: InitOptions, opts: Options) void {
     var options = defaults.themeOverride(opts.theme).override(opts);
     if (init_options.grayed) {
-        options.color_text = dvui.Color.average(options.color(.text), options.color(.fill));
+        const average_color = dvui.Color.average(options.color(.text), options.color(.fill));
+        if (options.text_style != null) options.text_style.?.fill = .{ .value = average_color };
+        options.text_style = .{ .fill = .{ .value = average_color } };
     }
     self.* = .{
         .wd = .init(src, .{}, options),
@@ -100,10 +102,8 @@ pub fn style(self: *ButtonWidget) Options {
     var opts = self.data().options.styleOnly();
     if (dvui.captured(self.data().id)) {
         opts.color_fill = self.data().options.color(.fill_press);
-        opts.color_text = self.data().options.color(.text_press);
     } else if (self.hover) {
         opts.color_fill = self.data().options.color(.fill_hover);
-        opts.color_text = self.data().options.color(.text_hover);
     }
     return opts;
 }

--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -90,7 +90,10 @@ pub fn init(self: *DropdownWidget, src: std.builtin.SourceLocation, init_opts: I
         var lw: LabelWidget = undefined;
         lw.initNoFmt(@src(), ll, .{}, self.options.strip().override(.{
             .gravity_y = 0.5,
-            .color_text = if (self.init_options.selected_index == null and self.init_options.placeholder != null) self.data().options.color(.text).opacity(0.65) else null,
+            .text_style = if (self.init_options.selected_index == null and self.init_options.placeholder != null)
+                .{ .fill = .{ .value = self.data().options.color(.text).opacity(0.65) } }
+            else
+                null,
         }));
         lw.draw();
         lw.deinit();

--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -22,7 +22,7 @@ pub fn init(self: *IconWidget, src: std.builtin.SourceLocation, name: []const u8
         size.w = @max(size.w, dvui.iconWidth(name, tvg_bytes, size.h) catch size.w);
     } else {
         // user didn't give us one, make it the height of text
-        const h = opts.fontGet().textHeight();
+        const h = opts.fontStyleGet().textHeight();
         size = Size{ .w = dvui.iconWidth(name, tvg_bytes, h) catch h, .h = h };
     }
 
@@ -52,17 +52,19 @@ pub fn draw(self: *IconWidget) void {
     var texOpts: dvui.RenderTextureOptions = .{ .rotation = self.data().options.rotationGet() };
 
     const white: ?dvui.Color = .white;
+    const opts = self.data().options;
+    const text_style = opts.fontStyleGet();
     const as_bytes = std.mem.asBytes;
     if (std.mem.eql(u8, as_bytes(&self.icon_opts.fill_color), as_bytes(&white)) and
         std.mem.eql(u8, as_bytes(&self.icon_opts.stroke_color), as_bytes(&white)))
     {
         // user is rasterizing icon with defaults (white), so always use
         // colormod (so icons default to text color)
-        texOpts.colormod = self.data().options.color(.text);
-    } else if (self.data().options.color_text) |ct| {
+        texOpts.colormod = opts.color(.text);
+    } else {
         // user is customizing icon rasterization, only colormod if they passed
         // a text color
-        texOpts.colormod = ct;
+        texOpts.colormod = text_style.fill;
     }
 
     dvui.renderIcon(

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -85,7 +85,7 @@ pub fn initNoFmt(self: *LabelWidget, src: std.builtin.SourceLocation, label_str:
 /// It's expected to call this when `self` is `undefined`
 pub fn initNoFmtAllocator(self: *LabelWidget, src: std.builtin.SourceLocation, label_str: []const u8, allocator: ?std.mem.Allocator, init_opts: InitOptions, opts: Options) void {
     const options = defaults.override(opts);
-    const lsize = options.fontGet().textSize(label_str);
+    const lsize = options.fontStyleGet().textSize(label_str);
     var size = lsize;
     if (opts.rotationGet() != 0.0) {
         var t: dvui.Triangles = .{ .vertexes = &.{}, .indices = &.{}, .bounds = .{ .w = size.w, .h = size.h } };
@@ -125,6 +125,7 @@ pub fn draw(self: *LabelWidget) void {
     const rect = dvui.placeIn(self.data().contentRect(), self.data().options.min_size_contentGet(), .none, label_gravity);
     const rs = self.data().parent.screenRectScale(rect);
     const oldclip = if (rot == 0.0) dvui.clip(rs.r) else dvui.clipGet();
+    const text_style = self.data().options.fontStyleGet();
     var iter = std.mem.splitScalar(u8, self.label_str, '\n');
     var line_height_adj: ?f32 = null;
     var first: bool = true;
@@ -135,13 +136,13 @@ pub fn draw(self: *LabelWidget) void {
             first = false;
         } else {
             if (line_height_adj == null) {
-                line_height_adj = self.data().options.fontGet().textHeight() * (self.data().options.fontGet().line_height_factor - 1.0);
+                line_height_adj = text_style.textHeight() * (text_style.getLineHeightFactor() - 1.0);
             }
             r.y += rs.s * line_height_adj.?;
         }
 
         var line = line_slice;
-        var tsize = if (line.len == self.label_str.len) self.label_size else self.data().options.fontGet().textSize(line);
+        var tsize = if (line.len == self.label_str.len) self.label_size else text_style.textSize(line);
 
         // this is only about horizontal direction
         var lineRect = dvui.placeIn(self.data().contentRect(), tsize, .none, label_gravity);
@@ -151,9 +152,9 @@ pub fn draw(self: *LabelWidget) void {
         // - a lot of times the content Rect is sized based on the text width
         if (rot == 0.0 and self.init_options.ellipsize and tsize.w > (self.data().contentRect().w + 0.001)) {
             self.ellipsized = true;
-            const esize = self.data().options.fontGet().textSize(ellip);
+            const esize = text_style.textSize(ellip);
             var endi: usize = 0;
-            tsize = self.data().options.fontGet().textSizeEx(line, .{ .max_width = self.data().contentRect().w - esize.w, .end_idx = &endi });
+            tsize = text_style.textSizeEx(line, .{ .max_width = self.data().contentRect().w - esize.w, .end_idx = &endi });
             line = line[0..endi];
             lineRect = dvui.placeIn(self.data().contentRect(), tsize, .none, .{ .x = 0, .y = 0 });
         }
@@ -191,11 +192,10 @@ pub fn draw(self: *LabelWidget) void {
         }
 
         dvui.renderText(.{
-            .font = self.data().options.fontGet(),
             .text = line,
+            .text_style = text_style,
             .p = render_p,
             .rs = rs,
-            .color = self.data().options.color(.text),
             .rotation = rot,
         }) catch |err| {
             dvui.logError(@src(), err, "Failed to render text: {s}", .{line});
@@ -204,10 +204,9 @@ pub fn draw(self: *LabelWidget) void {
         if (self.ellipsized) {
             r.x += liners.r.w;
             dvui.renderText(.{
-                .font = self.data().options.fontGet(),
                 .text = ellip,
+                .text_style = text_style,
                 .rs = .{ .r = r, .s = rs.s },
-                .color = self.data().options.color(.text),
             }) catch |err| {
                 dvui.logError(@src(), err, "Failed to render ellipses after text: {s}", .{line});
             };

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -113,11 +113,11 @@ pub fn style(self: *MenuItemWidget) Options {
     if (self.show_active and !self.init_opts.focus_as_outline) {
         opts.style = .highlight;
         opts.color_fill = opts.color_fill_hover orelse opts.color(.fill);
-        opts.color_text = opts.color_text_hover orelse opts.color(.text_hover);
+        // opts.color_text = opts.color_text_hover orelse opts.color(.text_hover);
     } else if (self.highlight) {
         // mouse is over us
         opts.color_fill = opts.color_fill_hover orelse opts.color(.fill_hover);
-        opts.color_text = opts.color_text_hover orelse opts.color(.text_hover);
+        // opts.color_text = opts.color_text_hover orelse opts.color(.text_hover);
     }
 
     return opts;

--- a/src/widgets/PlotWidget.zig
+++ b/src/widgets/PlotWidget.zig
@@ -407,10 +407,11 @@ pub fn init(self: *PlotWidget, src: std.builtin.SourceLocation, init_opts: InitO
     self.box.drawBackground();
 
     if (self.init_options.title) |title| {
-        dvui.label(@src(), "{s}", .{title}, .{ .gravity_x = 0.5, .font = opts.themeGet().font_title });
+        dvui.label(@src(), "{s}", .{title}, .{ .gravity_x = 0.5 });
     }
 
-    const tick_font = opts.themeGet().font_body.larger(-3);
+    var thin_style = opts.themeGet().body_style;
+    thin_style.size -= 3;
 
     var yticks = self.y_axis.getTicks(dvui.currentWindow().lifo()) catch Axis.Ticks.empty;
     defer yticks.deinit(dvui.currentWindow().lifo());
@@ -425,7 +426,7 @@ pub fn init(self: *PlotWidget, src: std.builtin.SourceLocation, init_opts: InitO
         for (yticks.values) |ytick| {
             const tick_str = self.y_axis.formatTick(dvui.currentWindow().lifo(), ytick) catch "";
             defer dvui.currentWindow().lifo().free(tick_str);
-            max_width = @max(max_width, tick_font.textSize(tick_str).w);
+            max_width = @max(max_width, thin_style.textSize(tick_str).w);
         }
 
         break :blk max_width;
@@ -439,7 +440,7 @@ pub fn init(self: *PlotWidget, src: std.builtin.SourceLocation, init_opts: InitO
         ) catch "";
         defer dvui.currentWindow().lifo().free(str);
 
-        break :blk tick_font.sizeM(@as(f32, @floatFromInt(str.len)), 1).w;
+        break :blk thin_style.sizeM(@as(f32, @floatFromInt(str.len)), 1).w;
     };
 
     var hbox1 = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .both });
@@ -513,7 +514,7 @@ pub fn init(self: *PlotWidget, src: std.builtin.SourceLocation, init_opts: InitO
     var x_tick_height: f32 = 0;
     if (self.x_axis.name) |_| {
         if (self.x_axis.min != null or self.x_axis.max != null) {
-            x_tick_height = tick_font.sizeM(1, 1).h;
+            x_tick_height = thin_style.sizeM(1, 1).h;
         }
     }
 
@@ -546,7 +547,7 @@ pub fn init(self: *PlotWidget, src: std.builtin.SourceLocation, init_opts: InitO
             const tick: Data = .{ .x = self.x_axis.min orelse 0, .y = ytick };
             const tick_str = self.y_axis.formatTick(dvui.currentWindow().lifo(), ytick) catch "";
             defer dvui.currentWindow().lifo().free(tick_str);
-            const tick_str_size = tick_font.textSize(tick_str).scale(self.data_rs.s, Size.Physical);
+            const tick_str_size = thin_style.textSize(tick_str).scale(self.data_rs.s, Size.Physical);
 
             const tick_p = self.dataToScreen(tick);
             self.drawTickline(
@@ -564,10 +565,9 @@ pub fn init(self: *PlotWidget, src: std.builtin.SourceLocation, init_opts: InitO
             const tick_rs: RectScale = .{ .r = Rect.Physical.fromPoint(tick_label_p).toSize(tick_str_size), .s = self.data_rs.s };
 
             dvui.renderText(.{
-                .font = tick_font,
+                .text_style = thin_style,
                 .text = tick_str,
                 .rs = tick_rs,
-                .color = self.box.data().options.color(.text),
             }) catch |err| {
                 dvui.logError(@src(), err, "y axis tick text for {d}", .{ytick});
             };
@@ -593,7 +593,7 @@ pub fn init(self: *PlotWidget, src: std.builtin.SourceLocation, init_opts: InitO
             const tick: Data = .{ .x = xtick, .y = self.y_axis.min orelse 0 };
             const tick_str = self.x_axis.formatTick(dvui.currentWindow().lifo(), xtick) catch "";
             defer dvui.currentWindow().lifo().free(tick_str);
-            const tick_str_size = tick_font.textSize(tick_str).scale(self.data_rs.s, Size.Physical);
+            const tick_str_size = thin_style.textSize(tick_str).scale(self.data_rs.s, Size.Physical);
 
             const tick_p = self.dataToScreen(tick);
             self.drawTickline(
@@ -611,10 +611,9 @@ pub fn init(self: *PlotWidget, src: std.builtin.SourceLocation, init_opts: InitO
             const tick_rs: RectScale = .{ .r = Rect.Physical.fromPoint(tick_label_p).toSize(tick_str_size), .s = self.data_rs.s };
 
             dvui.renderText(.{
-                .font = tick_font,
+                .text_style = thin_style,
                 .text = tick_str,
                 .rs = tick_rs,
-                .color = self.box.data().options.color(.text),
             }) catch |err| {
                 dvui.logError(@src(), err, "x axis tick text for {d}", .{xtick});
             };
@@ -865,7 +864,7 @@ fn hoverLabel(self: *@This(), comptime fmt: []const u8, args: anytype) void {
     const str = std.fmt.allocPrint(dvui.currentWindow().lifo(), fmt, args) catch "";
     // NOTE: Always calling free is safe because fallback is a 0 len slice, which is ignored
     defer dvui.currentWindow().lifo().free(str);
-    const size: Size = (dvui.Options{}).fontGet().textSize(str);
+    const size: Size = (dvui.Options{}).fontStyleGet().textSize(str);
     p.x -= size.w / 2;
     const padding = dvui.LabelWidget.defaults.paddingGet();
     p.y -= size.h + padding.y + padding.h + 8;

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -79,7 +79,8 @@ pub fn addTabLabel(self: *TabsWidget, selected: bool, text: []const u8, opts: Op
 
     var label_opts = tab.data().options.strip();
     if (dvui.captured(tab.data().id)) {
-        label_opts.color_text = label_opts.color(.text_press);
+        if (label_opts.text_style != null) label_opts.text_style.?.fill = .{ .value = label_opts.color(.text_press) };
+        label_opts.text_style = .{ .fill = .{ .value = label_opts.color(.text_press) } };
     }
 
     dvui.labelNoFmt(@src(), text, .{}, label_opts);
@@ -98,7 +99,7 @@ pub fn addTab(self: *TabsWidget, selected: bool, opts: Options) *ButtonWidget {
 
     if (selected) {
         tab_defaults.style = .window;
-        tab_defaults.font = opts.fontGet().withWeight(.bold);
+        tab_defaults.text_style = .{ .weight = .bold };
         tab_defaults.border = switch (self.init_options.dir) {
             .horizontal => .{ .x = 1, .y = 1, .w = 1 },
             .vertical => .{ .x = 1, .y = 1, .h = 1 },

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -423,7 +423,7 @@ pub fn draw(self: *TextEntryWidget) void {
                 // prevent textLayout from making a text run for the placeholder text
                 dvui.currentWindow().accesskit.text_run_parent = null;
             }
-            self.textLayout.addText(placeholder, .{ .color_text = self.textLayout.data().options.color(.text).opacity(0.65) });
+            self.textLayout.addText(placeholder, .{ .text_style = .{ .fill = .{ .value = self.textLayout.data().options.color(.text).opacity(0.65) } } });
         }
     }
 
@@ -1204,7 +1204,7 @@ pub fn processEvent(self: *TextEntryWidget, e: *Event) void {
 
                             self.textChangedRemoved(sel.cursor, sel.cursor + i);
                             const remaining = self.len - (sel.cursor + i);
-                            @memmove(self.text[sel.cursor..][0..remaining], self.text[sel.cursor + i..][0..remaining]);
+                            @memmove(self.text[sel.cursor..][0..remaining], self.text[sel.cursor + i ..][0..remaining]);
                             self.setLen(self.len - i);
                             self.textLayout.scroll_to_cursor = true;
                         }

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -583,7 +583,12 @@ fn findPoint(self: *TextLayoutWidget, p: Point, r: Rect, bytes_seen: usize, txt:
         // found it - p is in this rect
         const how_far = p.x - r.x;
         var pt_end: usize = undefined;
-        _ = options.fontGet().textSizeEx(txt, .{ .kerning = self.kerning, .max_width = how_far, .end_idx = &pt_end, .end_metric = .nearest });
+        _ = options.fontStyleGet().textSizeEx(txt, .{
+            .kerning = self.kerning,
+            .max_width = how_far,
+            .end_idx = &pt_end,
+            .end_metric = .nearest,
+        });
         return .{ .byte = bytes_seen + pt_end, .affinity = if (pt_end == txt.len) .before else .after };
     }
 
@@ -1256,9 +1261,9 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
     }
 
     const options = self.data().options.override(opts);
-    const font = options.fontGet();
-    const msize = font.sizeM(1, 1);
-    const line_height = font.lineHeight();
+    const text_style = self.data().options.fontStyleGet();
+    const m_size = text_style.sizeM(1, 1);
+    const line_height = text_style.lineHeight();
 
     var container_width = self.data().contentRect().w;
     if (container_width == 0) {
@@ -1293,7 +1298,7 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
         var width_after: f32 = 0;
         for (self.corners, 0..) |corner, i| {
             if (corner) |cor| {
-                if (@max(cor.y, self.insert_pt.y) < @min(cor.y + cor.h, self.insert_pt.y + msize.h)) {
+                if (@max(cor.y, self.insert_pt.y) < @min(cor.y + cor.h, self.insert_pt.y + m_size.h)) {
                     linewidth -= cor.w;
                     if (linestart == cor.x) {
                         // used below - if we moved over for a widget, we
@@ -1322,7 +1327,7 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
 
         // get slice of text that fits within width or ends with newline
         var ascent: f32 = undefined;
-        var s = font.textSizeEx(txt, .{
+        var s = text_style.textSizeEx(txt, .{
             .kerning = self.kerning,
             .max_width = if (self.break_lines) width else null,
             .end_idx = &end,
@@ -1333,7 +1338,7 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
         // ensure we always get at least 1 codepoint so we make progress
         if (end == 0) {
             end = std.unicode.utf8ByteSequenceLength(txt[0]) catch 1;
-            s = font.textSizeEx(txt[0..end], .{ .kerning = self.kerning });
+            s = text_style.textSizeEx(txt[0..end], .{ .kerning = self.kerning });
         }
 
         self.newline = (txt[end - 1] == '\n');
@@ -1345,13 +1350,13 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
             // try to break on space if:
             // - slice ended due to width (not newline)
             // - linewidth is long enough (otherwise too narrow to break on space)
-            if (end < txt.len and !self.newline and linewidth > (10 * msize.w)) {
+            if (end < txt.len and !self.newline and linewidth > (10 * m_size.w)) {
                 // now we are under the length limit but might be in the middle of a word
                 // look one char further because we might be right at the end of a word
                 const spaceIdx = std.mem.findLastLinear(u8, txt[0 .. end + 1], " ");
                 if (spaceIdx) |si| {
                     end = si + 1;
-                    s = font.textSizeEx(txt[0..end], .{ .kerning = self.kerning, .kern_in = &kern_buf });
+                    s = text_style.textSizeEx(txt[0..end], .{ .kerning = self.kerning, .kern_in = &kern_buf });
                     break :blk; // this part will fit
                 }
 
@@ -1458,7 +1463,7 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
                         // point is in this text
                         const how_far = p.x - rs.x;
                         var pt_end: usize = undefined;
-                        _ = font.textSizeEx(txt, .{ .kerning = self.kerning, .max_width = how_far, .end_idx = &pt_end, .end_metric = .nearest });
+                        _ = text_style.textSizeEx(txt, .{ .kerning = self.kerning, .max_width = how_far, .end_idx = &pt_end, .end_metric = .nearest });
                         sel_bytes[i] = self.bytes_seen + pt_end;
                         self.sel_pts[i] = null;
                     } else {
@@ -1492,12 +1497,12 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
         // record screen position of selection for touch editing (use s for
         // height in case we are calling textSize with an empty slice)
         if (self.selection.start >= self.bytes_seen and self.selection.start <= self.bytes_seen + end) {
-            const start_off = font.textSize(txt[0..self.selection.start -| self.bytes_seen]);
+            const start_off = text_style.textSize(txt[0..self.selection.start -| self.bytes_seen]);
             self.sel_start_r_new = .{ .x = self.insert_pt.x + start_off.w, .y = self.insert_pt.y, .w = 1, .h = s.h };
         }
 
         if (self.selection.end >= self.bytes_seen and self.selection.end <= self.bytes_seen + end) {
-            const end_off = font.textSize(txt[0..self.selection.end -| self.bytes_seen]);
+            const end_off = text_style.textSize(txt[0..self.selection.end -| self.bytes_seen]);
             self.sel_end_r_new = .{ .x = self.insert_pt.x + end_off.w, .y = self.insert_pt.y, .w = 1, .h = s.h };
         }
 
@@ -1505,7 +1510,7 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
             std.debug.assert(self.selection.cursor >= self.bytes_seen);
             const cursor_offset = self.selection.cursor - self.bytes_seen;
             const text_to_cursor = txt[0..cursor_offset];
-            const size = font.textSize(text_to_cursor);
+            const size = text_style.textSize(text_to_cursor);
             self.cursor_rect = Rect{ .x = self.insert_pt.x + size.w, .y = self.insert_pt.y, .w = 1, .h = s.h };
 
             self.selMoveText(text_to_cursor, self.bytes_seen);
@@ -1561,15 +1566,13 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
             };
 
             dvui.renderText(.{
-                .font = font,
                 .text = rtxt,
+                .text_style = text_style,
                 .rs = rs,
-                .color = options.color(.text),
                 // TODO: Should this take `options.background` into account?
                 .background_color = options.color_fill,
                 .sel_start = self.selection.start -| self.bytes_seen,
                 .sel_end = self.selection.end -| self.bytes_seen,
-                .sel_color = (dvui.themeGet().text_select orelse dvui.themeGet().color(.highlight, .fill)).opacity(0.75),
                 .kerning = self.kerning,
                 .kern_in = &kern_buf,
                 .ak_opts = textrun_info,
@@ -1799,7 +1802,8 @@ pub fn addTextDone(self: *TextLayoutWidget, opts: Options) void {
     self.selection.end = @min(self.selection.end, self.bytes_seen);
 
     const options = self.data().options.override(opts);
-    const text_height = if (self.current_line_height > 0) self.current_line_height else options.fontGet().textHeight();
+    const text_style = options.fontStyleGet();
+    const text_height = if (self.current_line_height > 0) self.current_line_height else text_style.textHeight();
 
     if (!self.cursor_seen) {
         self.cursor_rect = Rect{ .x = self.insert_pt.x, .y = self.insert_pt.y, .w = 1, .h = text_height };


### PR DESCRIPTION
Initial draft for #849

There are naming issues, `Style` ended up not being the best of ideas, going with `FontStyle` for now but perhaps something like `TextStyle` would be more ideal.

As of opening the draft it only includes a rough idea of what `FontStyle` is aiming to be, a way to unify font style in a place independent from the font itself.