### PR TITLE
texture: uv wrap modes .clamp and .repeat

### DIFF
--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -85,8 +85,8 @@ pub fn drawClippedTriangles(self: Backend, texture: ?dvui.Texture, vtx: []const 
 
 /// Create a `dvui.Texture` from premultiplied alpha `pixels` in RGBA.  The
 /// returned pointer is what will later be passed to `drawClippedTriangles`.
-pub fn textureCreate(self: Backend, pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) TextureError!dvui.Texture {
-    return self.renderer().textureCreate(pixels, width, height, interpolation, format);
+pub fn textureCreate(self: Backend, pixels: [*]const u8, options: dvui.Texture.CreateOptions) TextureError!dvui.Texture {
+    return self.renderer().textureCreate(pixels, options);
 }
 
 /// Update a `dvui.Texture` from premultiplied alpha `pixels` in RGBA.  The
@@ -118,8 +118,8 @@ pub fn textureDestroy(self: Backend, texture: dvui.Texture) void {
 
 /// Create a `dvui.Texture` that can be rendered to with `renderTarget`.  The
 /// returned pointer is what will later be passed to `drawClippedTriangles`.
-pub fn textureCreateTarget(self: Backend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) TextureError!dvui.TextureTarget {
-    return self.renderer().textureCreateTarget(width, height, interpolation, format);
+pub fn textureCreateTarget(self: Backend, options: dvui.Texture.CreateOptions) TextureError!dvui.TextureTarget {
+    return self.renderer().textureCreateTarget(options);
 }
 
 /// Read pixel data (RGBA) from `texture` into `pixels_out`.

--- a/src/Examples/applets.zig
+++ b/src/Examples/applets.zig
@@ -412,25 +412,52 @@ pub fn textureSubRect() void {
 }
 
 pub fn uvRect() void {
-    dvui.label(@src(), "Slide a window over a texture", .{}, .{});
     const uniqueId = dvui.parentGet().extendId(@src(), 0);
-    const fracx = dvui.dataGetPtrDefault(null, uniqueId, "shiftx", f32, 0);
-    const fracy = dvui.dataGetPtrDefault(null, uniqueId, "shifty", f32, 0);
+    const wrapu = dvui.dataGetPtrDefault(null, uniqueId, "wrapu", dvui.enums.TextureWrap, .clamp);
+    const wrapv = dvui.dataGetPtrDefault(null, uniqueId, "wrapv", dvui.enums.TextureWrap, .clamp);
+
+    {
+        var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+        defer hbox.deinit();
+
+        dvui.label(@src(), "Slide a window over a texture", .{}, .{ .gravity_y = 0.5 });
+
+        _ = dvui.spacer(@src(), .{ .min_size_content = .width(10) });
+
+        dvui.label(@src(), "Wrap U", .{}, .{ .gravity_y = 0.5 });
+        _ = dvui.dropdownEnum(@src(), dvui.enums.TextureWrap, .{ .choice = wrapu }, .{}, .{});
+
+        _ = dvui.spacer(@src(), .{ .min_size_content = .width(10) });
+
+        dvui.label(@src(), "Wrap V", .{}, .{ .gravity_y = 0.5 });
+        _ = dvui.dropdownEnum(@src(), dvui.enums.TextureWrap, .{ .choice = wrapv }, .{}, .{});
+    }
+
+    const fracx = dvui.dataGetPtrDefault(null, uniqueId, "shiftx", f32, 0.4);
+    const fracy = dvui.dataGetPtrDefault(null, uniqueId, "shifty", f32, 0.4);
 
     const pixels = dvui.dataGetPtrDefault(null, uniqueId, "pixels", [4]dvui.Color.PMA, .{ .yellow, .cyan, .red, .magenta });
-    const tex = dvui.dataGet(null, uniqueId, "texture", dvui.Texture) orelse blk: {
+    const tex = dvui.dataGetPtr(null, uniqueId, "texture", dvui.Texture) orelse blk: {
         const t = dvui.Texture.create(pixels, 2, 2, .nearest, .rgba_32) catch @panic("couldn't make texture");
         dvui.dataSet(null, uniqueId, "texture", t);
-        break :blk dvui.dataGet(null, uniqueId, "texture", dvui.Texture).?;
+        break :blk dvui.dataGetPtr(null, uniqueId, "texture", dvui.Texture).?;
     };
 
-    // texture is logically this big
+    tex.wrap_u = wrapu.*;
+    tex.wrap_v = wrapv.*;
+
     var texBox = dvui.box(@src(), .{}, .{ .expand = .both });
     defer texBox.deinit();
 
+    // texture is logically this big, inset for wrapping
+    const tRect = texBox.data().contentRectScale().r.insetAll(100);
+    tRect.stroke(.{}, .{ .thickness = 1 * texBox.data().rectScale().s, .color = .gray });
+
     // render texture faded in background
     const a = dvui.alpha(0.3);
-    dvui.renderTexture(tex, texBox.data().contentRectScale(), .{}) catch @panic("couldn't render texture");
+    dvui.renderTexture(tex.*, texBox.data().contentRectScale(), .{
+        .uv_rect = tRect,
+    }) catch @panic("couldn't render texture");
     dvui.alphaSet(a);
 
     // we are going to only show this part
@@ -445,11 +472,11 @@ pub fn uvRect() void {
     defer windowBox.deinit();
 
     dvui.renderTexture(
-        tex,
+        tex.*,
         windowBox.data().contentRectScale(),
         .{
             .corner_radius = windowBox.data().options.corner_radiusGet(),
-            .uv_rect = texBox.data().contentRectScale().r,
+            .uv_rect = tRect,
         },
     ) catch @panic("couldn't render texture");
 
@@ -477,6 +504,9 @@ pub fn uvRect() void {
                         if (dvui.captured(texBox.data().id)) {
                             dvui.captureMouse(null, e.num);
                         }
+                    },
+                    .position => {
+                        dvui.cursorSet(.hand);
                     },
                     else => {},
                 }

--- a/src/Examples/applets.zig
+++ b/src/Examples/applets.zig
@@ -283,7 +283,7 @@ pub fn texture() void {
     defer hbox.deinit();
 
     const tex: dvui.Texture.Target = dvui.dataGet(null, hbox.data().id, "tex", dvui.Texture.Target) orelse blk: {
-        const t = dvui.Texture.Target.create(.{ .width = @trunc(scale * size), .height = @trunc(scale * size)}) catch {
+        const t = dvui.Texture.Target.create(.{ .width = @trunc(scale * size), .height = @trunc(scale * size) }) catch {
             dvui.log.debug("Can't create target texture", .{});
             return;
         };

--- a/src/Examples/applets.zig
+++ b/src/Examples/applets.zig
@@ -283,7 +283,7 @@ pub fn texture() void {
     defer hbox.deinit();
 
     const tex: dvui.Texture.Target = dvui.dataGet(null, hbox.data().id, "tex", dvui.Texture.Target) orelse blk: {
-        const t = dvui.Texture.Target.create(@trunc(scale * size), @trunc(scale * size), .linear, .rgba_32) catch {
+        const t = dvui.Texture.Target.create(.{ .width = @trunc(scale * size), .height = @trunc(scale * size)}) catch {
             dvui.log.debug("Can't create target texture", .{});
             return;
         };
@@ -374,7 +374,7 @@ pub fn textureSubRect() void {
         for (pixels) |*p| {
             p.* = .black;
         }
-        const t = dvui.Texture.create(pixels, @trunc(scale * size), @trunc(scale * size), .linear, .rgba_32) catch {
+        const t = dvui.Texture.create(pixels, .{ .width = @trunc(scale * size), .height = @trunc(scale * size) }) catch {
             dvui.log.debug("Can't create texture", .{});
             return;
         };
@@ -413,6 +413,7 @@ pub fn textureSubRect() void {
 
 pub fn uvRect() void {
     const uniqueId = dvui.parentGet().extendId(@src(), 0);
+    const tex_size = dvui.dataGetPtrDefault(null, uniqueId, "tex_size", f32, 300);
     const wrapu = dvui.dataGetPtrDefault(null, uniqueId, "wrapu", dvui.enums.TextureWrap, .clamp);
     const wrapv = dvui.dataGetPtrDefault(null, uniqueId, "wrapv", dvui.enums.TextureWrap, .clamp);
 
@@ -420,9 +421,16 @@ pub fn uvRect() void {
         var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
         defer hbox.deinit();
 
-        dvui.label(@src(), "Slide a window over a texture", .{}, .{ .gravity_y = 0.5 });
+        dvui.label(@src(), "Window over texture", .{}, .{ .gravity_y = 0.5 });
 
         _ = dvui.spacer(@src(), .{ .min_size_content = .width(10) });
+
+        _ = dvui.sliderEntry(@src(), "Size {d:0.0}", .{ .value = tex_size, .min = 8, .max = 600, .interval = 1 }, .{ .gravity_y = 0.5 });
+    }
+
+    {
+        var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+        defer hbox.deinit();
 
         dvui.label(@src(), "Wrap U", .{}, .{ .gravity_y = 0.5 });
         _ = dvui.dropdownEnum(@src(), dvui.enums.TextureWrap, .{ .choice = wrapu }, .{}, .{});
@@ -438,20 +446,24 @@ pub fn uvRect() void {
 
     const pixels = dvui.dataGetPtrDefault(null, uniqueId, "pixels", [4]dvui.Color.PMA, .{ .yellow, .cyan, .red, .magenta });
     const tex = dvui.dataGetPtr(null, uniqueId, "texture", dvui.Texture) orelse blk: {
-        const t = dvui.Texture.create(pixels, 2, 2, .nearest, .rgba_32) catch @panic("couldn't make texture");
+        const t = dvui.Texture.create(pixels, .{ .width = 2, .height = 2, .interpolation = .nearest, .wrap_u = wrapu.*, .wrap_v = wrapv.* }) catch @panic("couldn't make texture");
         dvui.dataSet(null, uniqueId, "texture", t);
         break :blk dvui.dataGetPtr(null, uniqueId, "texture", dvui.Texture).?;
     };
 
-    tex.wrap_u = wrapu.*;
-    tex.wrap_v = wrapv.*;
+    if (wrapu.* != tex.wrap_u or wrapv.* != tex.wrap_v) {
+        dvui.Texture.destroyLater(tex.*);
+        tex.* = dvui.Texture.create(pixels, .{ .width = 2, .height = 2, .interpolation = .nearest, .wrap_u = wrapu.*, .wrap_v = wrapv.* }) catch @panic("couldn't make texture");
+    }
 
     var texBox = dvui.box(@src(), .{}, .{ .expand = .both });
     defer texBox.deinit();
 
-    // texture is logically this big, inset for wrapping
-    const tRect = texBox.data().contentRectScale().r.insetAll(100);
-    tRect.stroke(.{}, .{ .thickness = 1 * texBox.data().rectScale().s, .color = .gray });
+    // texture is logically this big
+    const tRectLogical = dvui.placeIn(texBox.data().contentRect().justSize(), .all(tex_size.*), .none, .{ .x = 0.5, .y = 0.5 });
+    const rs = texBox.data().contentRectScale();
+    const tRect = rs.rectToPhysical(tRectLogical);
+    tRect.stroke(.{}, .{ .thickness = 1 * rs.s, .color = .gray });
 
     // render texture faded in background
     const a = dvui.alpha(0.3);

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -727,7 +727,7 @@ pub const Cache = struct {
                 }
             }
 
-            self.texture_atlas_cache = try backend.textureCreate(@ptrCast(pixels.ptr), @as(u32, @trunc(s.w)), @as(u32, @trunc(s.h)), .linear, .rgba_32);
+            self.texture_atlas_cache = try backend.textureCreate(@ptrCast(pixels.ptr), .{ .width = @trunc(s.w), .height = @trunc(s.h) });
             return self.texture_atlas_cache.?;
         }
 

--- a/src/Texture.zig
+++ b/src/Texture.zig
@@ -4,10 +4,20 @@ ptr: *anyopaque,
 width: u32,
 height: u32,
 format: TexturePixelFormat,
-wrap_u: dvui.enums.TextureWrap = .clamp,
-wrap_v: dvui.enums.TextureWrap = .clamp,
+interpolation: TextureInterpolation,
+wrap_u: dvui.enums.TextureWrap,
+wrap_v: dvui.enums.TextureWrap,
 
 const Texture = @This();
+
+pub const CreateOptions = struct {
+    width: u32,
+    height: u32,
+    format: TexturePixelFormat = .rgba_32,
+    interpolation: TextureInterpolation = .linear,
+    wrap_u: dvui.enums.TextureWrap = .clamp,
+    wrap_v: dvui.enums.TextureWrap = .clamp,
+};
 
 /// A texture held by the backend that can be drawn onto.  See `dvui.Picture`.
 pub const Target = struct {
@@ -15,6 +25,9 @@ pub const Target = struct {
     width: u32,
     height: u32,
     format: TexturePixelFormat,
+    interpolation: TextureInterpolation,
+    wrap_u: dvui.enums.TextureWrap,
+    wrap_v: dvui.enums.TextureWrap,
 
     /// Create a texture that can be rendered with `renderTexture` and drawn to
     /// with `renderTarget`.  Starts transparent (all zero).
@@ -22,8 +35,8 @@ pub const Target = struct {
     /// Remember to destroy the texture at some point, see `destroyLater`.
     ///
     /// Only valid between `Window.begin`and `Window.end`.
-    pub fn create(width: u32, height: u32, interpolation: TextureInterpolation, format: TexturePixelFormat) TextureError!Target {
-        return try dvui.currentWindow().backend.textureCreateTarget(width, height, interpolation, format);
+    pub fn create(options: CreateOptions) TextureError!Target {
+        return try dvui.currentWindow().backend.textureCreateTarget(options);
     }
 
     /// Destroy target from `Target.create` at the end of the frame.
@@ -45,6 +58,10 @@ pub const Target = struct {
     /// Only valid between `Window.begin`and `Window.end`.
     pub fn clear(self: Target) void {
         dvui.currentWindow().backend.textureClearTarget(self);
+    }
+
+    pub fn cast(t: Texture) Target {
+        return .{ .ptr = t.ptr, .width = t.width, .height = t.height, .format = t.format, .interpolation = t.interpolation, .wrap_u = t.wrap_u, .wrap_v = t.wrap_v };
     }
 };
 
@@ -314,16 +331,16 @@ pub fn updateImageSource(self: *Texture, src: ImageSource) !void {
         .imageFile => |f| {
             const img = try Color.PMAImage.fromImageFile(f.name, dvui.currentWindow().arena(), f.bytes);
             defer dvui.currentWindow().arena().free(img.pma);
-            try update(self, img.pma, f.interpolation);
+            try update(self, img.pma);
         },
         .pixels => |px| {
             const copy = try dvui.currentWindow().arena().dupe(u8, px.rgba);
             defer dvui.currentWindow().arena().free(copy);
             const pma = Color.PMA.sliceFromRGBA(copy);
-            try update(self, pma, px.interpolation);
+            try update(self, pma);
         },
         .pixelsPMA => |px| {
-            try update(self, px.rgba, px.interpolation);
+            try update(self, px.rgba);
         },
         .texture => @panic("this is not supported currently"),
     }
@@ -351,11 +368,11 @@ pub fn fromImageSource(source: ImageSource) !Texture {
 pub fn fromImageFile(name: []const u8, image_bytes: []const u8, interpolation: TextureInterpolation) (TextureError || StbImageError)!Texture {
     const img = Color.PMAImage.fromImageFile(name, dvui.currentWindow().arena(), image_bytes) catch return StbImageError.stbImageError;
     defer dvui.currentWindow().arena().free(img.pma);
-    return try create(img.pma, img.width, img.height, interpolation, .rgba_32);
+    return try create(img.pma, .{ .width = img.width, .height = img.height, .interpolation = interpolation });
 }
 
 pub fn fromPixelsPMA(pma: []const Color.PMA, width: u32, height: u32, interpolation: TextureInterpolation) TextureError!Texture {
-    return try dvui.textureCreate(pma, width, height, interpolation, .rgba_32);
+    return try dvui.textureCreate(pma, .{ .width = width, .height = height, .interpolation = interpolation });
 }
 
 /// Render `tvg_bytes` at `height` into a `Texture`.  Name is for debugging.
@@ -365,7 +382,7 @@ pub fn fromTvgFile(name: []const u8, tvg_bytes: []const u8, height: u32, icon_op
     const cw = dvui.currentWindow();
     const img = Color.PMAImage.fromTvgFile(name, cw.lifo(), cw.arena(), tvg_bytes, height, icon_opts) catch return TvgError.tvgError;
     defer cw.lifo().free(img.pma);
-    return try create(img.pma, img.width, img.height, .linear, .rgba_32);
+    return try create(img.pma, .{ .width = img.width, .height = img.height });
 }
 
 /// Create a texture that can be rendered with `renderTexture`.
@@ -373,11 +390,15 @@ pub fn fromTvgFile(name: []const u8, tvg_bytes: []const u8, height: u32, icon_op
 /// Remember to destroy the texture at some point, see `destroyLater`.
 ///
 /// Only valid between `Window.begin` and `Window.end`.
-pub fn create(pixels: []const Color.PMA, width: u32, height: u32, interpolation: TextureInterpolation, format: TexturePixelFormat) TextureError!Texture {
-    if (pixels.len != width * height) {
-        dvui.log.err("Texture was created with an incorrect amount of pixels, expected {d} but got {d} (w: {d}, h: {d})", .{ pixels.len, width * height, width, height });
+pub fn create(pixels: []const Color.PMA, options: CreateOptions) TextureError!Texture {
+    if (pixels.len != options.width * options.height) {
+        dvui.log.err("Texture was created with an incorrect amount of pixels, expected {d} but got {d} (w: {d}, h: {d})", .{ pixels.len, options.width * options.height, options.width, options.height });
     }
-    return dvui.currentWindow().backend.textureCreate(@ptrCast(pixels.ptr), width, height, interpolation, format);
+    return dvui.currentWindow().backend.textureCreate(@ptrCast(pixels.ptr), options);
+}
+
+pub fn cast(t: Target) Texture {
+    return .{ .ptr = t.ptr, .width = t.width, .height = t.height, .format = t.format, .interpolation = t.interpolation, .wrap_u = t.wrap_u, .wrap_v = t.wrap_v };
 }
 
 /// Update a texture that was created with `textureCreate`.
@@ -386,12 +407,12 @@ pub fn create(pixels: []const Color.PMA, width: u32, height: u32, interpolation:
 /// recreated, changing the pointer inside tex.
 ///
 /// Only valid between `Window.begin` and `Window.end`.
-pub fn update(tex: *Texture, pma: []const Color.PMA, interpolation: TextureInterpolation) !void {
+pub fn update(tex: *Texture, pma: []const Color.PMA) !void {
     if (pma.len != tex.width * tex.height) @panic("Texture size and supplied Content did not match");
     dvui.currentWindow().backend.textureUpdate(tex.*, @ptrCast(pma.ptr)) catch |err| {
         // texture update not supported by backend, destroy and create texture
         if (err == TextureError.NotImplemented) {
-            const new_tex = try create(pma, tex.width, tex.height, interpolation, tex.format);
+            const new_tex = try create(pma, .{ .width = tex.width, .height = tex.height, .interpolation = tex.interpolation, .format = tex.format, .wrap_u = tex.wrap_u, .wrap_v = tex.wrap_v });
             destroyLater(tex.*);
             tex.* = new_tex;
         } else {
@@ -413,7 +434,7 @@ pub fn updateSubRect(tex: *Texture, pma: [*]const u8, x: u32, y: u32, w: u32, h:
         if (err == TextureError.NotImplemented) {
             const full_len = tex.width * tex.height;
             const full: []const Color.PMA = @as([*]const Color.PMA, @ptrCast(@alignCast(pma)))[0..full_len];
-            try update(tex, full, .nearest);
+            try update(tex, full);
         } else {
             return err;
         }

--- a/src/Texture.zig
+++ b/src/Texture.zig
@@ -4,6 +4,8 @@ ptr: *anyopaque,
 width: u32,
 height: u32,
 format: TexturePixelFormat,
+wrap_u: dvui.enums.TextureWrap = .clamp,
+wrap_v: dvui.enums.TextureWrap = .clamp,
 
 const Texture = @This();
 

--- a/src/Triangles.zig
+++ b/src/Triangles.zig
@@ -114,16 +114,13 @@ pub fn color(self: *Triangles, col: Color) void {
 
 /// Set uv coords of vertexes according to position in r (with r_uv coords
 /// at corners).
-pub fn uvFromRectuv(self: *Triangles, r: Rect.Physical, r_uv: Rect, clamp_u: bool, clamp_v: bool) void {
+pub fn uvFromRectuv(self: *Triangles, r: Rect.Physical, r_uv: Rect) void {
     for (self.vertexes) |*v| {
         const xfrac = (v.pos.x - r.x) / r.w;
         v.uv[0] = r_uv.x + xfrac * r_uv.w;
 
         const yfrac = (v.pos.y - r.y) / r.h;
         v.uv[1] = r_uv.y + yfrac * r_uv.h;
-
-        if (clamp_u) v.uv[0] = std.math.clamp(v.uv[0], 0, 1);
-        if (clamp_v) v.uv[1] = std.math.clamp(v.uv[1], 0, 1);
     }
 }
 

--- a/src/Triangles.zig
+++ b/src/Triangles.zig
@@ -114,13 +114,16 @@ pub fn color(self: *Triangles, col: Color) void {
 
 /// Set uv coords of vertexes according to position in r (with r_uv coords
 /// at corners).
-pub fn uvFromRectuv(self: *Triangles, r: Rect.Physical, r_uv: Rect) void {
+pub fn uvFromRectuv(self: *Triangles, r: Rect.Physical, r_uv: Rect, clamp_u: bool, clamp_v: bool) void {
     for (self.vertexes) |*v| {
         const xfrac = (v.pos.x - r.x) / r.w;
         v.uv[0] = r_uv.x + xfrac * r_uv.w;
 
         const yfrac = (v.pos.y - r.y) / r.h;
         v.uv[1] = r_uv.y + yfrac * r_uv.h;
+
+        if (clamp_u) v.uv[0] = std.math.clamp(v.uv[0], 0, 1);
+        if (clamp_v) v.uv[1] = std.math.clamp(v.uv[1], 0, 1);
     }
 }
 

--- a/src/Triangles.zig
+++ b/src/Triangles.zig
@@ -113,14 +113,14 @@ pub fn color(self: *Triangles, col: Color) void {
 }
 
 /// Set uv coords of vertexes according to position in r (with r_uv coords
-/// at corners), clamped to 0-1.
+/// at corners).
 pub fn uvFromRectuv(self: *Triangles, r: Rect.Physical, r_uv: Rect) void {
     for (self.vertexes) |*v| {
         const xfrac = (v.pos.x - r.x) / r.w;
-        v.uv[0] = std.math.clamp(r_uv.x + xfrac * r_uv.w, 0, 1);
+        v.uv[0] = r_uv.x + xfrac * r_uv.w;
 
         const yfrac = (v.pos.y - r.y) / r.h;
-        v.uv[1] = std.math.clamp(r_uv.y + yfrac * r_uv.h, 0, 1);
+        v.uv[1] = r_uv.y + yfrac * r_uv.h;
     }
 }
 

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -19,8 +19,6 @@ pub const WindowState = struct {
     last_window_size: dvui.Size.Natural = .{ .w = 800, .h = 600 },
     cursor_last: dvui.enums.Cursor = .arrow,
 
-    texture_interpolation: std.AutoHashMapUnmanaged(*anyopaque, dvui.enums.TextureInterpolation) = .empty,
-
     device: *win32.ID3D11Device,
     device_context: *win32.ID3D11DeviceContext,
     swap_chain: *win32.IDXGISwapChain,
@@ -42,9 +40,7 @@ pub const WindowState = struct {
     arena: std.mem.Allocator = undefined,
 
     pub fn deinit(state: *WindowState) void {
-        const gpa = state.dvui_window.gpa;
         state.dvui_window.deinit();
-        state.texture_interpolation.deinit(gpa);
         if (state.render_target) |rt| {
             _ = rt.IUnknown.Release();
         }
@@ -650,8 +646,8 @@ fn createBuffer(state: *WindowState, bind_type: anytype, comptime InitialType: t
 }
 
 // ############ Satisfy DVUI interfaces ############
-pub fn textureCreate(self: Context, pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.Texture {
-    if (format != .rgba_32) {
+pub fn textureCreate(self: Context, pixels: [*]const u8, options: dvui.Texture.CreateOptions) !dvui.Texture {
+    if (options.format != .rgba_32) {
         log.err("textureCreate currently only supports pixel format .rgba_32", .{});
         return dvui.Backend.TextureError.TextureCreate;
     }
@@ -660,8 +656,8 @@ pub fn textureCreate(self: Context, pixels: [*]const u8, width: u32, height: u32
 
     var texture: *win32.ID3D11Texture2D = undefined;
     var tex_desc = win32.D3D11_TEXTURE2D_DESC{
-        .Width = width,
-        .Height = height,
+        .Width = options.width,
+        .Height = options.height,
         .MipLevels = 1,
         .ArraySize = 1,
         .Format = win32.DXGI_FORMAT.R8G8B8A8_UNORM,
@@ -677,7 +673,7 @@ pub fn textureCreate(self: Context, pixels: [*]const u8, width: u32, height: u32
 
     var resource_data = std.mem.zeroes(win32.D3D11_SUBRESOURCE_DATA);
     resource_data.pSysMem = pixels;
-    resource_data.SysMemPitch = width * 4; // 4 byte per pixel (RGBA)
+    resource_data.SysMemPitch = options.width * 4; // 4 byte per pixel (RGBA)
 
     resToErr(
         state.device.CreateTexture2D(&tex_desc, &resource_data, &texture),
@@ -685,11 +681,17 @@ pub fn textureCreate(self: Context, pixels: [*]const u8, width: u32, height: u32
     ) catch return dvui.Backend.TextureError.TextureCreate;
     errdefer _ = texture.IUnknown.Release();
 
-    try state.texture_interpolation.put(state.dvui_window.gpa, texture, interpolation);
-
     log.debug("created texture @0x{x}", .{@intFromPtr(texture)});
 
-    return dvui.Texture{ .ptr = texture, .width = width, .height = height, .format = .rgba_32 };
+    return dvui.Texture{
+        .ptr = texture,
+        .width = options.width,
+        .height = options.height,
+        .format = options.format,
+        .interpolation = options.interpolation,
+        .wrap_u = options.wrap_u,
+        .wrap_v = options.wrap_v,
+    };
 }
 
 pub fn textureUpdate(
@@ -711,8 +713,8 @@ pub fn textureUpdate(
     );
 }
 
-pub fn textureCreateTarget(self: Context, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.TextureTarget {
-    if (format != .rgba_32) {
+pub fn textureCreateTarget(self: Context, options: dvui.Texture.CreateOptions) !dvui.TextureTarget {
+    if (options.format != .rgba_32) {
         log.err("textureCreateTarget currently only supports pixel format .rgba_32", .{});
         return dvui.Backend.TextureError.TextureCreate;
     }
@@ -720,8 +722,8 @@ pub fn textureCreateTarget(self: Context, width: u32, height: u32, interpolation
     const state = stateFromHwnd(hwndFromContext(self));
 
     const texture_desc = win32.D3D11_TEXTURE2D_DESC{
-        .Height = height,
-        .Width = width,
+        .Height = options.height,
+        .Width = options.width,
         .MipLevels = 1,
         .ArraySize = 1,
         .Format = win32.DXGI_FORMAT.R8G8B8A8_UNORM,
@@ -741,8 +743,15 @@ pub fn textureCreateTarget(self: Context, width: u32, height: u32, interpolation
     ) catch return dvui.Backend.TextureError.TextureCreate;
     errdefer _ = texture.IUnknown.Release();
 
-    try state.texture_interpolation.put(state.dvui_window.gpa, texture, interpolation);
-    return .{ .ptr = @ptrCast(texture), .width = width, .height = height, .format = .rgba_32 };
+    return dvui.TextureTarget{
+        .ptr = @ptrCast(texture),
+        .width = options.width,
+        .height = options.height,
+        .format = options.format,
+        .interpolation = options.interpolation,
+        .wrap_u = options.wrap_u,
+        .wrap_v = options.wrap_v,
+    };
 }
 
 pub fn textureClearTarget(_: Context, _: dvui.TextureTarget) void {
@@ -795,25 +804,14 @@ pub fn textureReadTarget(self: Context, texture: dvui.TextureTarget, pixels_out:
     }
 }
 
-pub fn textureDestroy(self: Context, texture: dvui.Texture) void {
+pub fn textureDestroy(_: Context, texture: dvui.Texture) void {
     log.debug("Destroying texture @0x{x}", .{@intFromPtr(texture.ptr)});
-    const state = stateFromHwnd(hwndFromContext(self));
     const tex: *win32.ID3D11Texture2D = @ptrCast(@alignCast(texture.ptr));
-    if (!state.texture_interpolation.remove(texture.ptr)) {
-        log.err(
-            "Destroyed texture @0x{x} that did not have a stored interpolation",
-            .{@intFromPtr(texture.ptr)},
-        );
-    }
     _ = tex.IUnknown.Release();
 }
 
-pub fn textureDestroyTarget(self: Context, texture: dvui.Texture.Target) void {
-    const state = stateFromHwnd(hwndFromContext(self));
+pub fn textureDestroyTarget(_: Context, texture: dvui.Texture.Target) void {
     const tex: *win32.ID3D11Texture2D = @ptrCast(@alignCast(texture.ptr));
-    if (!state.texture_interpolation.remove(texture.ptr)) {
-        log.err("Destroyed texture that did not have a stored interpolation", .{});
-    }
     _ = tex.IUnknown.Release();
 }
 
@@ -828,14 +826,7 @@ pub fn textureFromTarget(self: Context, texture: dvui.TextureTarget) !dvui.Textu
     defer state.arena.free(pixels);
 
     log.debug("Destroying texture @0x{x}", .{@intFromPtr(texture.ptr)});
-    const interpolation = if (state.texture_interpolation.fetchRemove(texture.ptr)) |kv| kv.value else blk: {
-        log.err(
-            "Destroyed texture @0x{x} that did not have a stored interpolation",
-            .{@intFromPtr(texture.ptr)},
-        );
-        break :blk .linear;
-    };
-    const newTex = try self.textureCreate(pixels.ptr, texture.width, texture.height, interpolation, .rgba_32);
+    const newTex = try self.textureCreate(pixels.ptr, .{ .width = texture.width, .height = texture.height, .interpolation = texture.interpolation, .wrap_u = texture.wrap_u, .wrap_v = texture.wrap_v });
 
     // copy
     const tex_new: *win32.ID3D11Texture2D = @ptrCast(@alignCast(newTex.ptr));
@@ -848,13 +839,9 @@ pub fn textureFromTargetTemp(self: Context, texture: dvui.TextureTarget) !dvui.T
     const state = stateFromHwnd(hwndFromContext(self));
 
     // DX11 can't draw target textures, so copy to a new texture
-    const interpolation = state.texture_interpolation.get(texture.ptr) orelse blk: {
-        log.err("Target texture did not have a stored interpolation", .{});
-        break :blk .linear;
-    };
     const pixels = try state.arena.alloc(u8, texture.width * texture.height * 4);
     defer state.arena.free(pixels);
-    const newTex = try self.textureCreate(pixels.ptr, texture.width, texture.height, interpolation, .rgba_32);
+    const newTex = try self.textureCreate(pixels.ptr, .{ .width = texture.width, .height = texture.height, .interpolation = texture.interpolation, .wrap_u = texture.wrap_u, .wrap_v = texture.wrap_v });
 
     // copy
     const tex_old: *win32.ID3D11Texture2D = @ptrCast(@alignCast(texture.ptr));
@@ -929,7 +916,6 @@ pub fn drawClippedTriangles(
     setViewport(state, @floatFromInt(client_size.cx), @floatFromInt(client_size.cy));
 
     if (texture) |tex| try recreateShaderView(state, tex.ptr);
-    const interpolation = if (texture) |tex| state.texture_interpolation.get(tex.ptr) orelse .linear else .linear;
 
     var scissor_rect: ?win32.RECT = std.mem.zeroes(win32.RECT);
     var nums: u32 = 1;
@@ -956,7 +942,7 @@ pub fn drawClippedTriangles(
     state.device_context.PSSetShader(state.dx_options.pixel_shader, null, 0);
 
     state.device_context.PSSetShaderResources(0, 1, @ptrCast(&state.dx_options.texture_view));
-    state.device_context.PSSetSamplers(0, 1, switch (interpolation) {
+    state.device_context.PSSetSamplers(0, 1, switch (if (texture) |tex| tex.interpolation else .linear) {
         .linear => @ptrCast(&state.dx_options.sampler_linear),
         .nearest => @ptrCast(&state.dx_options.sampler_nearest),
     });

--- a/src/backends/raylib-c.zig
+++ b/src/backends/raylib-c.zig
@@ -307,16 +307,16 @@ pub fn drawClippedTriangles(self: *RaylibBackend, texture: ?dvui.Texture, vtx: [
     }
 }
 
-pub fn textureCreate(_: *RaylibBackend, pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.Texture {
-    if (format != .rgba_32) {
+pub fn textureCreate(_: *RaylibBackend, pixels: [*]const u8, options: dvui.Texture.CreateOptions) !dvui.Texture {
+    if (options.format != .rgba_32) {
         log.err("textureCreate currently only supports pixel format .rgba_32", .{});
         return dvui.Backend.TextureError.TextureCreate;
     }
 
-    const texid = c.rlLoadTexture(pixels, @intCast(width), @intCast(height), c.PIXELFORMAT_UNCOMPRESSED_R8G8B8A8, 1);
+    const texid = c.rlLoadTexture(pixels, @intCast(options.width), @intCast(options.height), c.PIXELFORMAT_UNCOMPRESSED_R8G8B8A8, 1);
     if (texid <= 0) return dvui.Backend.TextureError.TextureCreate;
 
-    switch (interpolation) {
+    switch (options.interpolation) {
         .nearest => {
             c.rlTextureParameters(texid, c.RL_TEXTURE_MIN_FILTER, c.RL_TEXTURE_FILTER_NEAREST);
             c.rlTextureParameters(texid, c.RL_TEXTURE_MAG_FILTER, c.RL_TEXTURE_FILTER_NEAREST);
@@ -327,14 +327,20 @@ pub fn textureCreate(_: *RaylibBackend, pixels: [*]const u8, width: u32, height:
         },
     }
 
-    c.rlTextureParameters(texid, c.RL_TEXTURE_WRAP_S, c.RL_TEXTURE_WRAP_CLAMP);
-    c.rlTextureParameters(texid, c.RL_TEXTURE_WRAP_T, c.RL_TEXTURE_WRAP_CLAMP);
+    switch (options.wrap_u) {
+        .clamp => c.rlTextureParameters(texid, c.RL_TEXTURE_WRAP_S, c.RL_TEXTURE_WRAP_CLAMP),
+        .repeat => c.rlTextureParameters(texid, c.RL_TEXTURE_WRAP_S, c.RL_TEXTURE_WRAP_REPEAT),
+    }
+    switch (options.wrap_v) {
+        .clamp => c.rlTextureParameters(texid, c.RL_TEXTURE_WRAP_T, c.RL_TEXTURE_WRAP_CLAMP),
+        .repeat => c.rlTextureParameters(texid, c.RL_TEXTURE_WRAP_T, c.RL_TEXTURE_WRAP_REPEAT),
+    }
 
-    return dvui.Texture{ .ptr = @ptrFromInt(texid), .width = width, .height = height, .format = format };
+    return dvui.Texture{ .ptr = @ptrFromInt(texid), .width = options.width, .height = options.height, .format = options.format, .interpolation = options.interpolation, .wrap_u = options.wrap_u, .wrap_v = options.wrap_v };
 }
 
-pub fn textureCreateTarget(self: *RaylibBackend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.TextureTarget {
-    if (format != .rgba_32) {
+pub fn textureCreateTarget(self: *RaylibBackend, options: dvui.Texture.CreateOptions) !dvui.TextureTarget {
+    if (options.format != .rgba_32) {
         log.err("textureCreateTarget currently only supports pixel format .rgba_32", .{});
         return dvui.Backend.TextureError.TextureCreate;
     }
@@ -349,9 +355,9 @@ pub fn textureCreateTarget(self: *RaylibBackend, width: u32, height: u32, interp
     defer c.rlDisableFramebuffer();
 
     // Create color texture (default to RGBA)
-    const texid = c.rlLoadTexture(null, @intCast(width), @intCast(height), c.PIXELFORMAT_UNCOMPRESSED_R8G8B8A8, 1);
+    const texid = c.rlLoadTexture(null, @intCast(options.width), @intCast(options.height), c.PIXELFORMAT_UNCOMPRESSED_R8G8B8A8, 1);
     if (texid <= 0) return dvui.Backend.TextureError.TextureCreate;
-    switch (interpolation) {
+    switch (options.interpolation) {
         .nearest => {
             c.rlTextureParameters(texid, c.RL_TEXTURE_MIN_FILTER, c.RL_TEXTURE_FILTER_NEAREST);
             c.rlTextureParameters(texid, c.RL_TEXTURE_MAG_FILTER, c.RL_TEXTURE_FILTER_NEAREST);
@@ -362,8 +368,14 @@ pub fn textureCreateTarget(self: *RaylibBackend, width: u32, height: u32, interp
         },
     }
 
-    c.rlTextureParameters(texid, c.RL_TEXTURE_WRAP_S, c.RL_TEXTURE_WRAP_CLAMP);
-    c.rlTextureParameters(texid, c.RL_TEXTURE_WRAP_T, c.RL_TEXTURE_WRAP_CLAMP);
+    switch (options.wrap_u) {
+        .clamp => c.rlTextureParameters(texid, c.RL_TEXTURE_WRAP_S, c.RL_TEXTURE_WRAP_CLAMP),
+        .repeat => c.rlTextureParameters(texid, c.RL_TEXTURE_WRAP_S, c.RL_TEXTURE_WRAP_REPEAT),
+    }
+    switch (options.wrap_v) {
+        .clamp => c.rlTextureParameters(texid, c.RL_TEXTURE_WRAP_T, c.RL_TEXTURE_WRAP_CLAMP),
+        .repeat => c.rlTextureParameters(texid, c.RL_TEXTURE_WRAP_T, c.RL_TEXTURE_WRAP_REPEAT),
+    }
 
     c.rlFramebufferAttach(id, texid, c.RL_ATTACHMENT_COLOR_CHANNEL0, c.RL_ATTACHMENT_TEXTURE2D, 0);
 
@@ -375,7 +387,7 @@ pub fn textureCreateTarget(self: *RaylibBackend, width: u32, height: u32, interp
 
     try self.frame_buffers.put(self.gpa, texid, id);
 
-    const ret = dvui.TextureTarget{ .ptr = @ptrFromInt(texid), .width = width, .height = height, .format = format };
+    const ret = dvui.TextureTarget{ .ptr = @ptrFromInt(texid), .width = options.width, .height = options.height, .format = options.format, .interpolation = options.interpolation, .wrap_u = options.wrap_u, .wrap_v = options.wrap_v };
     self.textureClearTarget(ret);
     return ret;
 }
@@ -390,11 +402,11 @@ pub fn textureClearTarget(self: *RaylibBackend, texture: dvui.TextureTarget) voi
 }
 
 pub fn textureFromTarget(_: *RaylibBackend, texture: dvui.TextureTarget) dvui.Texture {
-    return .{ .ptr = texture.ptr, .width = texture.width, .height = texture.height, .format = texture.format };
+    return .cast(texture);
 }
 
 pub fn textureFromTargetTemp(_: *RaylibBackend, texture: dvui.TextureTarget) dvui.Texture {
-    return .{ .ptr = texture.ptr, .width = texture.width, .height = texture.height, .format = texture.format };
+    return .cast(texture);
 }
 
 /// Render future drawClippedTriangles() to the passed texture (or screen

--- a/src/backends/raylib-zig.zig
+++ b/src/backends/raylib-zig.zig
@@ -309,16 +309,16 @@ pub fn drawClippedTriangles(self: *RaylibBackend, texture: ?dvui.Texture, vtx: [
     }
 }
 
-pub fn textureCreate(_: *RaylibBackend, pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.Texture {
-    if (format != .rgba_32) {
+pub fn textureCreate(_: *RaylibBackend, pixels: [*]const u8, options: dvui.Texture.CreateOptions) !dvui.Texture {
+    if (options.format != .rgba_32) {
         log.err("textureCreate currently only supports pixel format .rgba_32", .{});
         return dvui.Backend.TextureError.TextureCreate;
     }
 
-    const texid = raylib.gl.rlLoadTexture(pixels, @intCast(width), @intCast(height), @intFromEnum(raylib.PixelFormat.uncompressed_r8g8b8a8), 1);
+    const texid = raylib.gl.rlLoadTexture(pixels, @intCast(options.width), @intCast(options.height), @intFromEnum(raylib.PixelFormat.uncompressed_r8g8b8a8), 1);
     if (texid <= 0) return dvui.Backend.TextureError.TextureCreate;
 
-    switch (interpolation) {
+    switch (options.interpolation) {
         .nearest => {
             raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_min_filter, raylib.gl.rl_texture_filter_nearest);
             raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_mag_filter, raylib.gl.rl_texture_filter_nearest);
@@ -329,14 +329,20 @@ pub fn textureCreate(_: *RaylibBackend, pixels: [*]const u8, width: u32, height:
         },
     }
 
-    raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_wrap_s, raylib.gl.rl_texture_wrap_clamp);
-    raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_wrap_t, raylib.gl.rl_texture_wrap_clamp);
+    switch (options.wrap_u) {
+        .clamp => raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_wrap_s, raylib.gl.rl_texture_wrap_clamp),
+        .repeat => raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_wrap_s, raylib.gl.rl_texture_wrap_repeat),
+    }
+    switch (options.wrap_v) {
+        .clamp => raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_wrap_t, raylib.gl.rl_texture_wrap_clamp),
+        .repeat => raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_wrap_t, raylib.gl.rl_texture_wrap_repeat),
+    }
 
-    return dvui.Texture{ .ptr = @ptrFromInt(texid), .width = width, .height = height, .format = format };
+    return dvui.Texture{ .ptr = @ptrFromInt(texid), .width = options.width, .height = options.height, .format = options.format, .interpolation = options.interpolation, .wrap_u = options.wrap_u, .wrap_v = options.wrap_v };
 }
 
-pub fn textureCreateTarget(self: *RaylibBackend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.TextureTarget {
-    if (format != .rgba_32) {
+pub fn textureCreateTarget(self: *RaylibBackend, options: dvui.Texture.CreateOptions) !dvui.TextureTarget {
+    if (options.format != .rgba_32) {
         log.err("textureCreateTarget currently only supports pixel format .rgba_32", .{});
         return dvui.Backend.TextureError.TextureCreate;
     }
@@ -351,9 +357,9 @@ pub fn textureCreateTarget(self: *RaylibBackend, width: u32, height: u32, interp
     defer raylib.gl.rlDisableFramebuffer();
 
     // Create color texture (default to RGBA)
-    const texid = raylib.gl.rlLoadTexture(null, @intCast(width), @intCast(height), @intFromEnum(raylib.PixelFormat.uncompressed_r8g8b8a8), 1);
+    const texid = raylib.gl.rlLoadTexture(null, @intCast(options.width), @intCast(options.height), @intFromEnum(raylib.PixelFormat.uncompressed_r8g8b8a8), 1);
     if (texid <= 0) return dvui.Backend.TextureError.TextureCreate;
-    switch (interpolation) {
+    switch (options.interpolation) {
         .nearest => {
             raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_min_filter, raylib.gl.rl_texture_filter_nearest);
             raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_mag_filter, raylib.gl.rl_texture_filter_nearest);
@@ -364,8 +370,14 @@ pub fn textureCreateTarget(self: *RaylibBackend, width: u32, height: u32, interp
         },
     }
 
-    raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_wrap_s, raylib.gl.rl_texture_wrap_clamp);
-    raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_wrap_t, raylib.gl.rl_texture_wrap_clamp);
+    switch (options.wrap_u) {
+        .clamp => raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_wrap_s, raylib.gl.rl_texture_wrap_clamp),
+        .repeat => raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_wrap_s, raylib.gl.rl_texture_wrap_repeat),
+    }
+    switch (options.wrap_v) {
+        .clamp => raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_wrap_t, raylib.gl.rl_texture_wrap_clamp),
+        .repeat => raylib.gl.rlTextureParameters(texid, raylib.gl.rl_texture_wrap_t, raylib.gl.rl_texture_wrap_repeat),
+    }
 
     raylib.gl.rlFramebufferAttach(id, texid, @intFromEnum(raylib.gl.rlFramebufferAttachType.rl_attachment_color_channel0), @intFromEnum(raylib.gl.rlFramebufferAttachTextureType.rl_attachment_texture2d), 0);
 
@@ -376,7 +388,7 @@ pub fn textureCreateTarget(self: *RaylibBackend, width: u32, height: u32, interp
 
     try self.frame_buffers.put(self.gpa, texid, id);
 
-    const ret = dvui.TextureTarget{ .ptr = @ptrFromInt(texid), .width = width, .height = height, .format = format };
+    const ret = dvui.TextureTarget{ .ptr = @ptrFromInt(texid), .width = options.width, .height = options.height, .format = options.format, .interpolation = options.interpolation, .wrap_u = options.wrap_u, .wrap_v = options.wrap_v };
     self.textureClearTarget(ret);
     return ret;
 }
@@ -391,11 +403,11 @@ pub fn textureClearTarget(self: *RaylibBackend, texture: dvui.TextureTarget) voi
 }
 
 pub fn textureFromTarget(_: *RaylibBackend, texture: dvui.TextureTarget) dvui.Texture {
-    return .{ .ptr = texture.ptr, .width = texture.width, .height = texture.height, .format = texture.format };
+    return .cast(texture);
 }
 
 pub fn textureFromTargetTemp(_: *RaylibBackend, texture: dvui.TextureTarget) dvui.Texture {
-    return .{ .ptr = texture.ptr, .width = texture.width, .height = texture.height, .format = texture.format };
+    return .cast(texture);
 }
 
 /// Render future drawClippedTriangles() to the passed texture (or screen

--- a/src/backends/render/opengl.zig
+++ b/src/backends/render/opengl.zig
@@ -231,7 +231,7 @@ pub fn textureDestroy(self: *@This(), texture: dvui.Texture) void {
     }
 }
 
-pub fn textureCreateTarget(self: *@This(),  options: dvui.Texture.CreateOptions) !dvui.TextureTarget {
+pub fn textureCreateTarget(self: *@This(), options: dvui.Texture.CreateOptions) !dvui.TextureTarget {
     const texture = try createTexture(null, options);
     errdefer gl.deleteTextures(1, &texture);
 

--- a/src/backends/render/opengl.zig
+++ b/src/backends/render/opengl.zig
@@ -214,8 +214,8 @@ pub fn drawClippedTriangles(self: *@This(), physical_size: dvui.Size.Physical, m
     }
 }
 
-pub fn textureCreate(_: *@This(), pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.Texture {
-    return .{ .ptr = @ptrFromInt(try createTexture(pixels, width, height, interpolation, format)), .width = width, .height = height, .format = format };
+pub fn textureCreate(_: *@This(), pixels: [*]const u8, options: dvui.Texture.CreateOptions) !dvui.Texture {
+    return .{ .ptr = @ptrFromInt(try createTexture(pixels, options)), .width = options.width, .height = options.height, .format = options.format, .interpolation = options.interpolation, .wrap_u = options.wrap_u, .wrap_v = options.wrap_v };
 }
 
 pub fn textureUpdate(_: *@This(), texture: dvui.Texture, pixels: [*]const u8) !void {
@@ -231,8 +231,8 @@ pub fn textureDestroy(self: *@This(), texture: dvui.Texture) void {
     }
 }
 
-pub fn textureCreateTarget(self: *@This(), width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.TextureTarget {
-    const texture = try createTexture(null, width, height, interpolation, format);
+pub fn textureCreateTarget(self: *@This(),  options: dvui.Texture.CreateOptions) !dvui.TextureTarget {
+    const texture = try createTexture(null, options);
     errdefer gl.deleteTextures(1, &texture);
 
     var framebuffer: u32 = undefined;
@@ -247,7 +247,7 @@ pub fn textureCreateTarget(self: *@This(), width: u32, height: u32, interpolatio
     gl.clear(gl.COLOR_BUFFER_BIT);
     gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, 0);
 
-    return .{ .ptr = @ptrFromInt(texture), .width = width, .height = height, .format = format };
+    return .{ .ptr = @ptrFromInt(texture), .width = options.width, .height = options.height, .format = options.format, .interpolation = options.interpolation, .wrap_u = options.wrap_u, .wrap_v = options.wrap_v };
 }
 
 pub fn textureReadTarget(_: *@This(), texture: dvui.TextureTarget, pixels_out: [*]u8) !void {
@@ -271,11 +271,11 @@ pub fn textureDestroyTarget(self: *@This(), texture: dvui.Texture.Target) void {
 }
 
 pub fn textureFromTarget(_: *@This(), target: dvui.TextureTarget) !dvui.Texture {
-    return .{ .ptr = target.ptr, .height = target.height, .width = target.width, .format = target.format };
+    return .cast(target);
 }
 
-pub fn textureFromTargetTemp(self: *@This(), target: dvui.TextureTarget) !dvui.Texture {
-    return self.textureFromTarget(target);
+pub fn textureFromTargetTemp(_: *@This(), target: dvui.TextureTarget) !dvui.Texture {
+    return .cast(target);
 }
 
 pub fn renderTarget(self: *@This(), maybe_texture: ?dvui.TextureTarget) !void {
@@ -289,8 +289,8 @@ pub fn renderTarget(self: *@This(), maybe_texture: ?dvui.TextureTarget) !void {
     }
 }
 
-fn createTexture(pixels: ?[*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !u32 {
-    if (format != .rgba_32) {
+fn createTexture(pixels: ?[*]const u8, options: dvui.Texture.CreateOptions) !u32 {
+    if (options.format != .rgba_32) {
         log.err("unsupported texture format", .{});
         return dvui.Backend.TextureError.TextureCreate;
     }
@@ -298,12 +298,18 @@ fn createTexture(pixels: ?[*]const u8, width: u32, height: u32, interpolation: d
     var texture: u32 = undefined;
     gl.genTextures(1, &texture);
     gl.bindTexture(gl.TEXTURE_2D, texture);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, @bitCast(width), @bitCast(height), 0, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, @bitCast(options.width), @bitCast(options.height), 0, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
 
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    switch (options.wrap_u) {
+        .clamp => gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE),
+        .repeat => gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT),
+    }
+    switch (options.wrap_v) {
+        .clamp => gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE),
+        .repeat => gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT),
+    }
 
-    switch (interpolation) {
+    switch (options.interpolation) {
         .linear => {
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -789,13 +789,16 @@ pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []co
         defer if (clamped) |cld| self.arena.free(cld);
 
         if (texture) |t| {
-            if (t.wrap_u != .clamp or t.wrap_v != .clamp) {
-                log.err("sdl2: wrap_u/wrap_v .repeat not supported", .{});
-                clamped = try self.arena.alloc(f32, vtx.len * 2);
-                for (vtx, 0..) |v, i| {
-                    clamped.?[i * 2] = std.math.clamp(v.uv[0], 0, 1);
-                    clamped.?[i * 2 + 1] = std.math.clamp(v.uv[1], 0, 1);
-                }
+            var out_of_bounds = false;
+            clamped = try self.arena.alloc(f32, vtx.len * 2);
+            for (vtx, 0..) |v, i| {
+                if (v.uv[0] < 0 or v.uv[0] > 1 or v.uv[1] < 0 or v.uv[1] > 1) out_of_bounds = true;
+                clamped.?[i * 2] = std.math.clamp(v.uv[0], 0, 1);
+                clamped.?[i * 2 + 1] = std.math.clamp(v.uv[1], 0, 1);
+            }
+
+            if (out_of_bounds and (t.wrap_u != .clamp or t.wrap_v != .clamp)) {
+                log.err("sdl2: uv coords clamped, .repeat not supported", .{});
             }
         }
 

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -844,32 +844,32 @@ pub fn pixelFormatToSdl(format: dvui.enums.TexturePixelFormat) ?u32 {
     };
 }
 
-pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.Texture {
-    if (!sdl3) switch (interpolation) {
+pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, options: dvui.Texture.CreateOptions) !dvui.Texture {
+    if (!sdl3) switch (options.interpolation) {
         .nearest => _ = c.SDL_SetHint(c.SDL_HINT_RENDER_SCALE_QUALITY, "nearest"),
         .linear => _ = c.SDL_SetHint(c.SDL_HINT_RENDER_SCALE_QUALITY, "linear"),
     };
 
-    const sdl_format = pixelFormatToSdl(format) orelse {
-        log.err("pixel format {} not supported", .{format});
+    const sdl_format = pixelFormatToSdl(options.format) orelse {
+        log.err("pixel format {} not supported", .{options.format});
         return dvui.Backend.TextureError.NotImplemented;
     };
 
     const surface = if (sdl3)
         c.SDL_CreateSurfaceFrom(
-            @as(c_int, @intCast(width)),
-            @as(c_int, @intCast(height)),
+            @as(c_int, @intCast(options.width)),
+            @as(c_int, @intCast(options.height)),
             @as(c.SDL_PixelFormat, @intCast(sdl_format)),
             @constCast(pixels),
-            @as(c_int, @intCast(width * format.pitchFactor())),
+            @as(c_int, @intCast(options.width * options.format.pitchFactor())),
         ) orelse return logErr("SDL_CreateSurfaceFrom in textureCreate")
     else
         c.SDL_CreateRGBSurfaceWithFormatFrom(
             @constCast(pixels),
-            @as(c_int, @intCast(width)),
-            @as(c_int, @intCast(height)),
+            @as(c_int, @intCast(options.width)),
+            @as(c_int, @intCast(options.height)),
             32,
-            @as(c_int, @intCast(width * format.pitchFactor())),
+            @as(c_int, @intCast(options.width * options.format.pitchFactor())),
             sdl_format,
         ) orelse return logErr("SDL_CreateRGBSurfaceWithFormatFrom in textureCreate");
 
@@ -878,14 +878,14 @@ pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, width: u32, height:
     const texture = c.SDL_CreateTextureFromSurface(self.renderer, surface) orelse return logErr("SDL_CreateTextureFromSurface in textureCreate");
     errdefer c.SDL_DestroyTexture(texture);
 
-    if (sdl3) try toErr(switch (interpolation) {
+    if (sdl3) try toErr(switch (options.interpolation) {
         .nearest => c.SDL_SetTextureScaleMode(texture, c.SDL_SCALEMODE_NEAREST),
         .linear => c.SDL_SetTextureScaleMode(texture, c.SDL_SCALEMODE_LINEAR),
     }, "SDL_SetTextureScaleMode in textureCreates");
 
     const pma_blend = c.SDL_ComposeCustomBlendMode(c.SDL_BLENDFACTOR_ONE, c.SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA, c.SDL_BLENDOPERATION_ADD, c.SDL_BLENDFACTOR_ONE, c.SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA, c.SDL_BLENDOPERATION_ADD);
     try toErr(c.SDL_SetTextureBlendMode(texture, pma_blend), "SDL_SetTextureBlendMode in textureCreate");
-    return dvui.Texture{ .ptr = texture, .width = width, .height = height, .format = format };
+    return dvui.Texture{ .ptr = texture, .width = options.width, .height = options.height, .format = options.format, .interpolation = options.interpolation, .wrap_u = options.wrap_u, .wrap_v = options.wrap_v };
 }
 
 pub fn textureUpdate(_: *SDLBackend, texture: dvui.Texture, pixels: [*]const u8) !void {
@@ -910,14 +910,14 @@ pub fn textureUpdateSubRect(_: *SDLBackend, texture: dvui.Texture, pixels: [*]co
     }
 }
 
-pub fn textureCreateTarget(self: *SDLBackend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.TextureTarget {
-    if (!sdl3) switch (interpolation) {
+pub fn textureCreateTarget(self: *SDLBackend, options: dvui.Texture.CreateOptions) !dvui.TextureTarget {
+    if (!sdl3) switch (options.interpolation) {
         .nearest => _ = c.SDL_SetHint(c.SDL_HINT_RENDER_SCALE_QUALITY, "nearest"),
         .linear => _ = c.SDL_SetHint(c.SDL_HINT_RENDER_SCALE_QUALITY, "linear"),
     };
 
-    const sdl_format = pixelFormatToSdl(format) orelse {
-        log.err("pixel format {} not supported", .{format});
+    const sdl_format = pixelFormatToSdl(options.format) orelse {
+        log.err("pixel format {} not supported", .{options.format});
         return dvui.Backend.TextureError.NotImplemented;
     };
 
@@ -925,12 +925,12 @@ pub fn textureCreateTarget(self: *SDLBackend, width: u32, height: u32, interpola
         self.renderer,
         if (comptime sdl3) @as(c.SDL_PixelFormat, @intCast(sdl_format)) else sdl_format,
         c.SDL_TEXTUREACCESS_TARGET,
-        @intCast(width),
-        @intCast(height),
+        @intCast(options.width),
+        @intCast(options.height),
     ) orelse return logErr("SDL_CreateTexture in textureCreateTarget");
     errdefer c.SDL_DestroyTexture(texture);
 
-    if (sdl3) try toErr(switch (interpolation) {
+    if (sdl3) try toErr(switch (options.interpolation) {
         .nearest => c.SDL_SetTextureScaleMode(texture, c.SDL_SCALEMODE_NEAREST),
         .linear => c.SDL_SetTextureScaleMode(texture, c.SDL_SCALEMODE_LINEAR),
     }, "SDL_SetTextureScaleMode in textureCreates");
@@ -942,7 +942,7 @@ pub fn textureCreateTarget(self: *SDLBackend, width: u32, height: u32, interpola
     );
     //try toErr(c.SDL_SetTextureBlendMode(texture, c.SDL_BLENDMODE_BLEND), "SDL_SetTextureBlendMode in textureCreateTarget",);
 
-    const tex = dvui.TextureTarget{ .ptr = texture, .width = width, .height = height, .format = format };
+    const tex = dvui.TextureTarget{ .ptr = texture, .width = options.width, .height = options.height, .format = options.format, .interpolation = options.interpolation, .wrap_u = .clamp, .wrap_v = .clamp };
     self.textureClearTarget(tex);
     return tex;
 }
@@ -1063,12 +1063,12 @@ pub fn textureDestroyTarget(_: *SDLBackend, texture: dvui.Texture.Target) void {
 // as if we are destroying target and creating a new texture
 pub fn textureFromTarget(_: *SDLBackend, target: dvui.TextureTarget) !dvui.Texture {
     // SDL can't read from non-target textures, but we are enforcing that through zig types
-    return .{ .ptr = target.ptr, .width = target.width, .height = target.height, .format = target.format };
+    return .cast(target);
 }
 
 // return is temporary, will not be destroyed
 pub fn textureFromTargetTemp(_: *SDLBackend, target: dvui.TextureTarget) !dvui.Texture {
-    return .{ .ptr = target.ptr, .width = target.width, .height = target.height, .format = target.format };
+    return .cast(target);
 }
 
 pub fn renderTarget(self: *SDLBackend, texture: ?dvui.TextureTarget) !void {

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -785,6 +785,20 @@ pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []co
             @sizeOf(dvui.Vertex.Index),
         ), "SDL_RenderGeometryRaw, in drawClippedTriangles");
     } else {
+        var clamped: ?[]f32 = null;
+        defer if (clamped) |cld| self.arena.free(cld);
+
+        if (texture) |t| {
+            if (t.wrap_u != .clamp or t.wrap_v != .clamp) {
+                log.err("sdl2: wrap_u/wrap_v .repeat not supported", .{});
+                clamped = try self.arena.alloc(f32, vtx.len * 2);
+                for (vtx, 0..) |v, i| {
+                    clamped.?[i * 2] = std.math.clamp(v.uv[0], 0, 1);
+                    clamped.?[i * 2 + 1] = std.math.clamp(v.uv[1], 0, 1);
+                }
+            }
+        }
+
         try toErr(c.SDL_RenderGeometryRaw(
             self.renderer,
             tex,
@@ -792,8 +806,8 @@ pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []co
             @sizeOf(dvui.Vertex),
             @as(*const c.SDL_Color, @ptrCast(@alignCast(&vtx[0].col))),
             @sizeOf(dvui.Vertex),
-            @as(*const f32, @ptrCast(&vtx[0].uv)),
-            @sizeOf(dvui.Vertex),
+            if (clamped) |cld| cld.ptr else @ptrCast(&vtx[0].uv),
+            if (clamped) |_| 2 * @sizeOf(f32) else @sizeOf(dvui.Vertex),
             @as(c_int, @intCast(vtx.len)),
             idx.ptr,
             @as(c_int, @intCast(idx.len)),

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -674,6 +674,11 @@ pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []co
     var tex: ?*c.SDL_Texture = null;
     if (texture) |t| {
         tex = @ptrCast(@alignCast(t.ptr));
+        _ = c.SDL_SetRenderTextureAddressMode(
+            self.renderer,
+            if (t.wrap_u == .clamp) c.SDL_TEXTURE_ADDRESS_CLAMP else c.SDL_TEXTURE_ADDRESS_WRAP,
+            if (t.wrap_v == .clamp) c.SDL_TEXTURE_ADDRESS_CLAMP else c.SDL_TEXTURE_ADDRESS_WRAP,
+        );
     }
 
     if (sdl3) {

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -749,11 +749,13 @@ pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []co
     var tex: ?*c.SDL_Texture = null;
     if (texture) |t| {
         tex = @ptrCast(@alignCast(t.ptr));
-        _ = c.SDL_SetRenderTextureAddressMode(
-            self.renderer,
-            if (t.wrap_u == .clamp) c.SDL_TEXTURE_ADDRESS_CLAMP else c.SDL_TEXTURE_ADDRESS_WRAP,
-            if (t.wrap_v == .clamp) c.SDL_TEXTURE_ADDRESS_CLAMP else c.SDL_TEXTURE_ADDRESS_WRAP,
-        );
+        if (sdl3) {
+            _ = c.SDL_SetRenderTextureAddressMode(
+                self.renderer,
+                if (t.wrap_u == .clamp) c.SDL_TEXTURE_ADDRESS_CLAMP else c.SDL_TEXTURE_ADDRESS_WRAP,
+                if (t.wrap_v == .clamp) c.SDL_TEXTURE_ADDRESS_CLAMP else c.SDL_TEXTURE_ADDRESS_WRAP,
+            );
+        }
     }
 
     if (sdl3) {

--- a/src/backends/sdl3gpu.zig
+++ b/src/backends/sdl3gpu.zig
@@ -356,8 +356,14 @@ current_render_pass: ?*c.SDL_GPURenderPass = null,
 white_texture: *BackendTexture = undefined,
 
 // Shared samplers for all textures
-linear_sampler: *c.SDL_GPUSampler = undefined,
-nearest_sampler: *c.SDL_GPUSampler = undefined,
+linear_clamp_clamp: *c.SDL_GPUSampler = undefined,
+linear_repeat_clamp: *c.SDL_GPUSampler = undefined,
+linear_clamp_repeat: *c.SDL_GPUSampler = undefined,
+linear_repeat_repeat: *c.SDL_GPUSampler = undefined,
+nearest_clamp_clamp: *c.SDL_GPUSampler = undefined,
+nearest_repeat_clamp: *c.SDL_GPUSampler = undefined,
+nearest_clamp_repeat: *c.SDL_GPUSampler = undefined,
+nearest_repeat_repeat: *c.SDL_GPUSampler = undefined,
 
 // list of linearly allocated buffers for transfers
 texture_transfer_buffer: *c.SDL_GPUTransferBuffer = undefined,
@@ -574,7 +580,7 @@ pub fn init(io: std.Io, window: *c.SDL_Window, device: *c.SDL_GPUDevice, allocat
 }
 
 fn createWhiteTexture(self: *SDLBackend) !void {
-    self.white_texture = @ptrCast(@alignCast((self.textureCreate(&.{ 255, 255, 255, 255 }, 1, 1, .linear, .rgba_32) catch return error.BackendError).ptr));
+    self.white_texture = @ptrCast(@alignCast((self.textureCreate(&.{ 255, 255, 255, 255 }, .{ .width = 1, .height = 1 }) catch return error.BackendError).ptr));
 }
 
 fn detectShaderFormat(self: *SDLBackend) void {
@@ -741,7 +747,7 @@ pub fn createPipeline(self: *SDLBackend) !void {
 
 pub fn createSamplers(self: *SDLBackend) !void {
     // Create linear sampler
-    const linear_sampler_info = c.SDL_GPUSamplerCreateInfo{
+    var linear_sampler_info = c.SDL_GPUSamplerCreateInfo{
         .min_filter = c.SDL_GPU_FILTER_LINEAR,
         .mag_filter = c.SDL_GPU_FILTER_LINEAR,
         .mipmap_mode = c.SDL_GPU_SAMPLERMIPMAPMODE_LINEAR,
@@ -758,13 +764,33 @@ pub fn createSamplers(self: *SDLBackend) !void {
         .props = 0,
     };
 
-    self.linear_sampler = c.SDL_CreateGPUSampler(self.device, &linear_sampler_info) orelse {
+    self.linear_clamp_clamp = c.SDL_CreateGPUSampler(self.device, &linear_sampler_info) orelse {
+        log.err("Failed to create linear sampler: {s}", .{c.SDL_GetError()});
+        return error.SamplerCreationFailed;
+    };
+
+    linear_sampler_info.address_mode_u = c.SDL_GPU_SAMPLERADDRESSMODE_REPEAT;
+    self.linear_repeat_clamp = c.SDL_CreateGPUSampler(self.device, &linear_sampler_info) orelse {
+        log.err("Failed to create linear sampler: {s}", .{c.SDL_GetError()});
+        return error.SamplerCreationFailed;
+    };
+
+    linear_sampler_info.address_mode_u = c.SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+    linear_sampler_info.address_mode_v = c.SDL_GPU_SAMPLERADDRESSMODE_REPEAT;
+    self.linear_clamp_repeat = c.SDL_CreateGPUSampler(self.device, &linear_sampler_info) orelse {
+        log.err("Failed to create linear sampler: {s}", .{c.SDL_GetError()});
+        return error.SamplerCreationFailed;
+    };
+
+    linear_sampler_info.address_mode_u = c.SDL_GPU_SAMPLERADDRESSMODE_REPEAT;
+    linear_sampler_info.address_mode_v = c.SDL_GPU_SAMPLERADDRESSMODE_REPEAT;
+    self.linear_repeat_repeat = c.SDL_CreateGPUSampler(self.device, &linear_sampler_info) orelse {
         log.err("Failed to create linear sampler: {s}", .{c.SDL_GetError()});
         return error.SamplerCreationFailed;
     };
 
     // Create nearest sampler
-    const nearest_sampler_info = c.SDL_GPUSamplerCreateInfo{
+    var nearest_sampler_info = c.SDL_GPUSamplerCreateInfo{
         .min_filter = c.SDL_GPU_FILTER_NEAREST,
         .mag_filter = c.SDL_GPU_FILTER_NEAREST,
         .mipmap_mode = c.SDL_GPU_SAMPLERMIPMAPMODE_NEAREST,
@@ -781,7 +807,27 @@ pub fn createSamplers(self: *SDLBackend) !void {
         .props = 0,
     };
 
-    self.nearest_sampler = c.SDL_CreateGPUSampler(self.device, &nearest_sampler_info) orelse {
+    self.nearest_clamp_clamp = c.SDL_CreateGPUSampler(self.device, &nearest_sampler_info) orelse {
+        log.err("Failed to create nearest sampler: {s}", .{c.SDL_GetError()});
+        return error.SamplerCreationFailed;
+    };
+
+    nearest_sampler_info.address_mode_u = c.SDL_GPU_SAMPLERADDRESSMODE_REPEAT;
+    self.nearest_repeat_clamp = c.SDL_CreateGPUSampler(self.device, &nearest_sampler_info) orelse {
+        log.err("Failed to create nearest sampler: {s}", .{c.SDL_GetError()});
+        return error.SamplerCreationFailed;
+    };
+
+    nearest_sampler_info.address_mode_u = c.SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+    nearest_sampler_info.address_mode_v = c.SDL_GPU_SAMPLERADDRESSMODE_REPEAT;
+    self.nearest_clamp_repeat = c.SDL_CreateGPUSampler(self.device, &nearest_sampler_info) orelse {
+        log.err("Failed to create nearest sampler: {s}", .{c.SDL_GetError()});
+        return error.SamplerCreationFailed;
+    };
+
+    nearest_sampler_info.address_mode_u = c.SDL_GPU_SAMPLERADDRESSMODE_REPEAT;
+    nearest_sampler_info.address_mode_v = c.SDL_GPU_SAMPLERADDRESSMODE_REPEAT;
+    self.nearest_repeat_repeat = c.SDL_CreateGPUSampler(self.device, &nearest_sampler_info) orelse {
         log.err("Failed to create nearest sampler: {s}", .{c.SDL_GetError()});
         return error.SamplerCreationFailed;
     };
@@ -999,8 +1045,14 @@ pub fn deinit(self: *SDLBackend) void {
     self.frame_uploads.deinit(self.device);
 
     c.SDL_ReleaseGPUTexture(self.device, self.white_texture.texture);
-    c.SDL_ReleaseGPUSampler(self.device, self.linear_sampler);
-    c.SDL_ReleaseGPUSampler(self.device, self.nearest_sampler);
+    c.SDL_ReleaseGPUSampler(self.device, self.linear_clamp_clamp);
+    c.SDL_ReleaseGPUSampler(self.device, self.linear_repeat_clamp);
+    c.SDL_ReleaseGPUSampler(self.device, self.linear_clamp_repeat);
+    c.SDL_ReleaseGPUSampler(self.device, self.linear_repeat_repeat);
+    c.SDL_ReleaseGPUSampler(self.device, self.nearest_clamp_clamp);
+    c.SDL_ReleaseGPUSampler(self.device, self.nearest_repeat_clamp);
+    c.SDL_ReleaseGPUSampler(self.device, self.nearest_clamp_repeat);
+    c.SDL_ReleaseGPUSampler(self.device, self.nearest_repeat_repeat);
 
     c.SDL_ReleaseGPUTransferBuffer(self.device, self.texture_transfer_buffer);
 
@@ -1254,8 +1306,8 @@ pub fn createTextureTransferBuffer(self: *SDLBackend) !void {
     log.info("Transfer buffer created: {} bytes", .{self.texture_transfer_buffer_size});
 }
 
-pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.Texture {
-    if (format != .rgba_32) {
+pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, options: dvui.Texture.CreateOptions) !dvui.Texture {
+    if (options.format != .rgba_32) {
         log.err("textureCreate currently only supports pixel format .rgba_32", .{});
         return dvui.Backend.TextureError.TextureCreate;
     }
@@ -1267,8 +1319,8 @@ pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, width: u32, height:
             .type = c.SDL_GPU_TEXTURETYPE_2D,
             .format = c.SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM,
             .usage = c.SDL_GPU_TEXTUREUSAGE_SAMPLER,
-            .width = width,
-            .height = height,
+            .width = options.width,
+            .height = options.height,
             .layer_count_or_depth = 1,
             .num_levels = 1,
             .sample_count = c.SDL_GPU_SAMPLECOUNT_1,
@@ -1291,8 +1343,8 @@ pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, width: u32, height:
     };
 
     @memcpy(
-        @as([*]u8, @ptrCast(mapped))[0 .. width * height * 4],
-        pixels[0 .. width * height * 4],
+        @as([*]u8, @ptrCast(mapped))[0 .. options.width * options.height * 4],
+        pixels[0 .. options.width * options.height * 4],
     );
     c.SDL_UnmapGPUTransferBuffer(self.device, self.texture_transfer_buffer);
 
@@ -1312,8 +1364,8 @@ pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, width: u32, height:
         &c.SDL_GPUTextureTransferInfo{
             .transfer_buffer = self.texture_transfer_buffer,
             .offset = 0,
-            .pixels_per_row = width,
-            .rows_per_layer = height,
+            .pixels_per_row = options.width,
+            .rows_per_layer = options.height,
         },
         &c.SDL_GPUTextureRegion{
             .texture = texture,
@@ -1322,8 +1374,8 @@ pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, width: u32, height:
             .x = 0,
             .y = 0,
             .z = 0,
-            .w = width,
-            .h = height,
+            .w = options.width,
+            .h = options.height,
             .d = 1,
         },
         false,
@@ -1345,9 +1397,27 @@ pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, width: u32, height:
 
     backendTexture.* = .{
         .texture = texture,
-        .sampler = switch (interpolation) {
-            .linear => self.linear_sampler,
-            .nearest => self.nearest_sampler,
+        .sampler = switch (options.interpolation) {
+            .linear => switch (options.wrap_u) {
+                .clamp => switch (options.wrap_v) {
+                    .clamp => self.linear_clamp_clamp,
+                    .repeat => self.linear_clamp_repeat,
+                },
+                .repeat => switch (options.wrap_v) {
+                    .clamp => self.linear_repeat_clamp,
+                    .repeat => self.linear_repeat_repeat,
+                },
+            },
+            .nearest => switch (options.wrap_u) {
+                .clamp => switch (options.wrap_v) {
+                    .clamp => self.nearest_clamp_clamp,
+                    .repeat => self.nearest_clamp_repeat,
+                },
+                .repeat => switch (options.wrap_v) {
+                    .clamp => self.nearest_repeat_clamp,
+                    .repeat => self.nearest_repeat_repeat,
+                },
+            },
         },
     };
 
@@ -1355,9 +1425,12 @@ pub fn textureCreate(self: *SDLBackend, pixels: [*]const u8, width: u32, height:
 
     return dvui.Texture{
         .ptr = backendTexture,
-        .width = width,
-        .height = height,
-        .format = format,
+        .width = options.width,
+        .height = options.height,
+        .format = options.format,
+        .interpolation = options.interpolation,
+        .wrap_u = options.wrap_u,
+        .wrap_v = options.wrap_v,
     };
 }
 
@@ -1367,8 +1440,8 @@ const BackendTextureTarget = struct {
     sampler: *c.SDL_GPUSampler, // points to either linear_sampler or nearest_sampler
 };
 
-pub fn textureCreateTarget(self: *SDLBackend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.TextureTarget {
-    if (format != .rgba_32) {
+pub fn textureCreateTarget(self: *SDLBackend, options: dvui.Texture.CreateOptions) !dvui.TextureTarget {
+    if (options.format != .rgba_32) {
         log.err("textureCreateTarget currently only supports pixel format .rgba_32", .{});
         return dvui.Backend.TextureError.TextureCreate;
     }
@@ -1380,8 +1453,8 @@ pub fn textureCreateTarget(self: *SDLBackend, width: u32, height: u32, interpola
             .type = c.SDL_GPU_TEXTURETYPE_2D,
             .format = c.SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM,
             .usage = c.SDL_GPU_TEXTUREUSAGE_SAMPLER | c.SDL_GPU_TEXTUREUSAGE_COLOR_TARGET,
-            .width = width,
-            .height = height,
+            .width = options.width,
+            .height = options.height,
             .layer_count_or_depth = 1,
             .num_levels = 1,
             .sample_count = c.SDL_GPU_SAMPLECOUNT_1,
@@ -1398,17 +1471,38 @@ pub fn textureCreateTarget(self: *SDLBackend, width: u32, height: u32, interpola
 
     backendTexture.* = .{
         .texture = texture,
-        .sampler = switch (interpolation) {
-            .linear => self.linear_sampler,
-            .nearest => self.nearest_sampler,
+        .sampler = switch (options.interpolation) {
+            .linear => switch (options.wrap_u) {
+                .clamp => switch (options.wrap_v) {
+                    .clamp => self.linear_clamp_clamp,
+                    .repeat => self.linear_clamp_repeat,
+                },
+                .repeat => switch (options.wrap_v) {
+                    .clamp => self.linear_repeat_clamp,
+                    .repeat => self.linear_repeat_repeat,
+                },
+            },
+            .nearest => switch (options.wrap_u) {
+                .clamp => switch (options.wrap_v) {
+                    .clamp => self.nearest_clamp_clamp,
+                    .repeat => self.nearest_clamp_repeat,
+                },
+                .repeat => switch (options.wrap_v) {
+                    .clamp => self.nearest_repeat_clamp,
+                    .repeat => self.nearest_repeat_repeat,
+                },
+            },
         },
     };
 
     return dvui.TextureTarget{
         .ptr = backendTexture,
-        .width = width,
-        .height = height,
-        .format = format,
+        .width = options.width,
+        .height = options.height,
+        .format = options.format,
+        .interpolation = options.interpolation,
+        .wrap_u = options.wrap_u,
+        .wrap_v = options.wrap_v,
     };
 }
 
@@ -1466,12 +1560,12 @@ pub fn textureDestroyTarget(self: *SDLBackend, target: dvui.Texture.Target) void
 // as if we are destroying target and creating a new texture
 pub fn textureFromTarget(_: *SDLBackend, target: dvui.TextureTarget) !dvui.Texture {
     // SDL can't read from non-target textures, but we are enforcing that through zig types
-    return .{ .ptr = target.ptr, .width = target.width, .height = target.height, .format = target.format };
+    return .cast(target);
 }
 
 // return is temporary, will not be destroyed
 pub fn textureFromTargetTemp(_: *SDLBackend, target: dvui.TextureTarget) !dvui.Texture {
-    return .{ .ptr = target.ptr, .width = target.width, .height = target.height, .format = target.format };
+    return .cast(target);
 }
 
 pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool {

--- a/src/backends/testing.zig
+++ b/src/backends/testing.zig
@@ -85,19 +85,22 @@ pub fn drawClippedTriangles(_: *TestingBackend, _: ?dvui.Texture, _: []const dvu
 
 /// Create a texture from the given pixels in RGBA.  The returned
 /// pointer is what will later be passed to drawClippedTriangles.
-pub fn textureCreate(self: *TestingBackend, pixels: [*]const u8, width: u32, height: u32, _: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.Texture {
-    const new_pixels = self.allocator.dupe(u8, pixels[0 .. width * height * 4]) catch @panic("Couldn't create texture: OOM");
+pub fn textureCreate(self: *TestingBackend, pixels: [*]const u8, options: dvui.Texture.CreateOptions) !dvui.Texture {
+    const new_pixels = self.allocator.dupe(u8, pixels[0 .. options.width * options.height * 4]) catch @panic("Couldn't create texture: OOM");
     return .{
-        .width = width,
-        .height = height,
+        .width = options.width,
+        .height = options.height,
         .ptr = new_pixels.ptr,
-        .format = format,
+        .format = options.format,
+        .interpolation = options.interpolation,
+        .wrap_u = options.wrap_u,
+        .wrap_v = options.wrap_v,
     };
 }
 
 /// Create a texture that can be rendered to with renderTarget().  The
 /// returned pointer is what will later be passed to drawClippedTriangles.
-pub fn textureCreateTarget(_: *TestingBackend, _: u32, _: u32, _: dvui.enums.TextureInterpolation, _: dvui.enums.TexturePixelFormat) !dvui.TextureTarget {
+pub fn textureCreateTarget(_: *TestingBackend, _: dvui.Texture.CreateOptions) !dvui.TextureTarget {
     return error.TextureCreate;
 }
 
@@ -120,11 +123,11 @@ pub fn textureDestroy(self: *TestingBackend, texture: dvui.Texture) void {
 pub fn textureDestroyTarget(_: *TestingBackend, _: dvui.Texture.Target) void {}
 
 pub fn textureFromTarget(_: *TestingBackend, texture: dvui.TextureTarget) !dvui.Texture {
-    return .{ .ptr = texture.ptr, .width = texture.width, .height = texture.height, .format = texture.format };
+    return .cast(texture);
 }
 
 pub fn textureFromTargetTemp(_: *TestingBackend, texture: dvui.TextureTarget) !dvui.Texture {
-    return .{ .ptr = texture.ptr, .width = texture.width, .height = texture.height, .format = texture.format };
+    return .cast(texture);
 }
 
 /// Render future drawClippedTriangles() to the passed texture (or screen

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -430,7 +430,7 @@ export class Dvui {
             wasm_canvas_height: () => {
                 return this.gl.canvas.clientHeight;
             },
-            wasm_textureCreate: (pixels, width, height, interp) => {
+            wasm_textureCreate: (pixels, width, height, interp, wrap_u, wrap_v) => {
                 const pixelData = this.bytesFromPointer(pixels, width * height * 4);
 
                 const texture = this.gl.createTexture();
@@ -480,22 +480,22 @@ export class Dvui {
                         this.gl.LINEAR,
                     );
                 }
-                this.gl.texParameteri(
-                    this.gl.TEXTURE_2D,
-                    this.gl.TEXTURE_WRAP_S,
-                    this.gl.CLAMP_TO_EDGE,
-                );
-                this.gl.texParameteri(
-                    this.gl.TEXTURE_2D,
-                    this.gl.TEXTURE_WRAP_T,
-                    this.gl.CLAMP_TO_EDGE,
-                );
+                if (wrap_u === 1) {
+                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.REPEAT);
+                } else {
+                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
+                }
+                if (wrap_v === 1) {
+                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.REPEAT);
+                } else {
+                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
+                }
 
                 this.gl.bindTexture(this.gl.TEXTURE_2D, null);
 
                 return id;
             },
-            wasm_textureCreateTarget: (width, height, interp) => {
+            wasm_textureCreateTarget: (width, height, interp, wrap_u, wrap_v) => {
                 const texture = this.gl.createTexture();
                 const id = this.newTextureId;
                 //console.log("creating texture " + id);
@@ -539,16 +539,16 @@ export class Dvui {
                         this.gl.LINEAR,
                     );
                 }
-                this.gl.texParameteri(
-                    this.gl.TEXTURE_2D,
-                    this.gl.TEXTURE_WRAP_S,
-                    this.gl.CLAMP_TO_EDGE,
-                );
-                this.gl.texParameteri(
-                    this.gl.TEXTURE_2D,
-                    this.gl.TEXTURE_WRAP_T,
-                    this.gl.CLAMP_TO_EDGE,
-                );
+                if (wrap_u === 1) {
+                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.REPEAT);
+                } else {
+                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
+                }
+                if (wrap_v === 1) {
+                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.REPEAT);
+                } else {
+                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
+                }
 
                 this.gl.bindTexture(this.gl.TEXTURE_2D, null);
 

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -45,8 +45,8 @@ pub const wasm = if (!builtin.is_test) struct {
     pub extern "dvui" fn wasm_canvas_height() f32;
 
     pub extern "dvui" fn wasm_frame_buffer() u8;
-    pub extern "dvui" fn wasm_textureCreate(pixels: [*]const u8, width: u32, height: u32, interp: u8) u32;
-    pub extern "dvui" fn wasm_textureCreateTarget(width: u32, height: u32, interp: u8) u32;
+    pub extern "dvui" fn wasm_textureCreate(pixels: [*]const u8, width: u32, height: u32, interp: u8, wrap_u: u8, wrap_v: u8) u32;
+    pub extern "dvui" fn wasm_textureCreateTarget(width: u32, height: u32, interp: u8, wrap_u: u8, wrap_v: u8) u32;
     pub extern "dvui" fn wasm_textureClearTarget(u32) void;
     pub extern "dvui" fn wasm_textureRead(texture: u32, pixels_out: [*]u8, width: u32, height: u32) void;
     pub extern "dvui" fn wasm_renderTarget(u32) void;
@@ -100,10 +100,10 @@ pub const wasm = if (!builtin.is_test) struct {
     pub fn wasm_frame_buffer() u8 {
         return undefined;
     }
-    pub fn wasm_textureCreate(_: [*]const u8, _: u32, _: u32, _: u8) u32 {
+    pub fn wasm_textureCreate(_: [*]const u8, _: u32, _: u32, _: u8, _: u8, _: u8) u32 {
         return undefined;
     }
-    pub fn wasm_textureCreateTarget(_: u32, _: u32, _: u8) u32 {
+    pub fn wasm_textureCreateTarget(_: u32, _: u32, _: u8, _: u8, _: u8) u32 {
         return undefined;
     }
     pub fn wasm_textureClearTarget(_: u32) void {}
@@ -618,34 +618,68 @@ pub fn drawClippedTriangles(_: *WebBackend, texture: ?dvui.Texture, vtx: []const
     );
 }
 
-pub fn textureCreate(_: *WebBackend, pixels: [*]const u8, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.Texture {
-    if (format != .rgba_32) {
+pub fn textureCreate(_: *WebBackend, pixels: [*]const u8, options: dvui.Texture.CreateOptions) !dvui.Texture {
+    if (options.format != .rgba_32) {
         log.err("textureCreate currently only supports pixel format .rgba_32", .{});
         return dvui.Backend.TextureError.TextureCreate;
     }
 
-    const wasm_interp: u8 = switch (interpolation) {
+    const wasm_interp: u8 = switch (options.interpolation) {
         .nearest => 0,
         .linear => 1,
     };
 
-    const id = wasm.wasm_textureCreate(pixels, width, height, wasm_interp);
-    return dvui.Texture{ .ptr = @ptrFromInt(id), .width = width, .height = height, .format = format };
+    const wasm_wrap_u: u8 = switch (options.wrap_u) {
+        .clamp => 0,
+        .repeat => 1,
+    };
+    const wasm_wrap_v: u8 = switch (options.wrap_v) {
+        .clamp => 0,
+        .repeat => 1,
+    };
+
+    const id = wasm.wasm_textureCreate(pixels, options.width, options.height, wasm_interp, wasm_wrap_u, wasm_wrap_v);
+    return dvui.Texture{
+        .ptr = @ptrFromInt(id),
+        .width = options.width,
+        .height = options.height,
+        .format = options.format,
+        .interpolation = options.interpolation,
+        .wrap_u = options.wrap_u,
+        .wrap_v = options.wrap_v,
+    };
 }
 
-pub fn textureCreateTarget(_: *WebBackend, width: u32, height: u32, interpolation: dvui.enums.TextureInterpolation, format: dvui.enums.TexturePixelFormat) !dvui.TextureTarget {
-    if (format != .rgba_32) {
+pub fn textureCreateTarget(_: *WebBackend, options: dvui.Texture.CreateOptions) !dvui.TextureTarget {
+    if (options.format != .rgba_32) {
         log.err("textureCreateTarget currently only supports pixel format .rgba_32", .{});
         return dvui.Backend.TextureError.TextureCreate;
     }
 
-    const wasm_interp: u8 = switch (interpolation) {
+    const wasm_interp: u8 = switch (options.interpolation) {
         .nearest => 0,
         .linear => 1,
     };
 
-    const id = wasm.wasm_textureCreateTarget(width, height, wasm_interp);
-    return dvui.TextureTarget{ .ptr = @ptrFromInt(id), .width = width, .height = height, .format = format };
+    const wasm_wrap_u: u8 = switch (options.wrap_u) {
+        .clamp => 0,
+        .repeat => 1,
+    };
+    const wasm_wrap_v: u8 = switch (options.wrap_v) {
+        .clamp => 0,
+        .repeat => 1,
+    };
+
+    const id = wasm.wasm_textureCreateTarget(options.width, options.height, wasm_interp, wasm_wrap_u, wasm_wrap_v);
+    return dvui.TextureTarget{
+        .ptr = @ptrFromInt(id),
+        .width = options.width,
+        .height = options.height,
+        .format = options.format,
+        .interpolation = options.interpolation,
+        .wrap_u = options.wrap_u,
+        .wrap_v = options.wrap_v,
+    };
 }
 
 pub fn textureClearTarget(_: *WebBackend, tex: dvui.TextureTarget) void {
@@ -653,11 +687,11 @@ pub fn textureClearTarget(_: *WebBackend, tex: dvui.TextureTarget) void {
 }
 
 pub fn textureFromTarget(_: *WebBackend, texture: dvui.TextureTarget) !dvui.Texture {
-    return .{ .ptr = texture.ptr, .width = texture.width, .height = texture.height, .format = texture.format };
+    return .cast(texture);
 }
 
 pub fn textureFromTargetTemp(_: *WebBackend, texture: dvui.TextureTarget) !dvui.Texture {
-    return .{ .ptr = texture.ptr, .width = texture.width, .height = texture.height, .format = texture.format };
+    return .cast(texture);
 }
 
 pub fn renderTarget(_: *WebBackend, texture: ?dvui.TextureTarget) !void {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5463,7 +5463,7 @@ pub const Picture = struct {
         r.y = y_start;
         r.h = @round(y_end - y_start);
 
-        const texture = dvui.textureCreateTarget(@trunc(r.w), @trunc(r.h), .linear, .rgba_32) catch return null;
+        const texture = dvui.textureCreateTarget(.{ .width = @trunc(r.w), .height = @trunc(r.h) }) catch return null;
         const target = dvui.renderTarget(.{ .texture = texture, .offset = r.topLeft() });
 
         return .{

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -40,6 +40,11 @@ pub const TextureInterpolation = enum {
     linear,
 };
 
+pub const TextureWrap = enum {
+    clamp,
+    repeat,
+};
+
 pub const TexturePixelFormat = enum {
     /// This is the native format of Color.PMA.  On little endian this is the
     /// same as abgr_8_8_8_8, on big endian it is rgba_8_8_8_8.

--- a/src/render.zig
+++ b/src/render.zig
@@ -442,7 +442,7 @@ pub fn renderTexture(tex: Texture, rs: RectScale, opts: TextureOptions) Backend.
     defer triangles.deinit(cw.lifo());
 
     const uvRect = opts.uv_rect orelse rect;
-    triangles.uvFromRectuv(uvRect, opts.uv, tex.wrap_u == .clamp, tex.wrap_v == .clamp);
+    triangles.uvFromRectuv(uvRect, opts.uv);
     triangles.rotate(rect.center(), opts.rotation);
 
     if (opts.background_color) |bg_col| {

--- a/src/render.zig
+++ b/src/render.zig
@@ -442,7 +442,7 @@ pub fn renderTexture(tex: Texture, rs: RectScale, opts: TextureOptions) Backend.
     defer triangles.deinit(cw.lifo());
 
     const uvRect = opts.uv_rect orelse rect;
-    triangles.uvFromRectuv(uvRect, opts.uv);
+    triangles.uvFromRectuv(uvRect, opts.uv, tex.wrap_u == .clamp, tex.wrap_v == .clamp);
     triangles.rotate(rect.center(), opts.rotation);
 
     if (opts.background_color) |bg_col| {

--- a/src/widgets/CacheWidget.zig
+++ b/src/widgets/CacheWidget.zig
@@ -81,7 +81,7 @@ pub fn init(self: *CacheWidget, src: std.builtin.SourceLocation, init_opts: Init
             const h: u32 = @ceil(rs.r.h);
             self.tex_uv = .{ .w = rs.r.w / @ceil(rs.r.w), .h = rs.r.h / @ceil(rs.r.h) };
 
-            self.caching_tex = dvui.textureCreateTarget(w, h, .linear, .rgba_32) catch |err| blk: switch (err) {
+            self.caching_tex = dvui.textureCreateTarget(.{ .width = w, .height = h }) catch |err| blk: switch (err) {
                 error.TextureCreate => {
                     self.state = .texture_create_error;
                     if (dvui.dataGet(null, self.data().id, "_texture_create_error", bool) orelse false) {

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -352,7 +352,7 @@ pub fn getHueSelectorTexture(dir: dvui.enums.Direction) dvui.Backend.TextureErro
             .horizontal => .{ hue_selector_colors.len, 1 },
             .vertical => .{ 1, hue_selector_colors.len },
         };
-        const texture = try dvui.textureCreate(&hue_selector_colors, width, height, .linear, .rgba_32);
+        const texture = try dvui.textureCreate(&hue_selector_colors, .{ .width = width, .height = height });
         dvui.textureAddToCache(id, texture);
         return texture;
     }
@@ -366,7 +366,7 @@ pub fn getValueSaturationTexture(hue: f32) dvui.Backend.TextureError!dvui.Textur
     if (dvui.textureGetCached(id)) |cached| return cached else {
         var pixels: [4]Color.PMA = .{ .white, .cast(Color.HSV.toColor(.{ .h = hue })), .black, .black };
         // set top right corner to the max value of that hue
-        const texture = try dvui.textureCreate(&pixels, 2, 2, .linear, .rgba_32);
+        const texture = try dvui.textureCreate(&pixels, .{ .width = 2, .height = 2 });
         dvui.textureAddToCache(id, texture);
         return texture;
     }


### PR DESCRIPTION
fixes #303

demo: uvRect applet gains dropdowns for switching the uv wrap modes

Going to take this opportunity to change the Texture.create() api to take an options struct.

All backends run, but sdl3gpu and dx11 don't yet work correctly.  I will file followup issues for them.