### PR TITLE
Make suggestions close on loss of focus

### DIFF
--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2973,15 +2973,18 @@ pub fn suggestion(te: *TextEntryWidget, init_opts: SuggestionInitOptions) *Sugge
         sug.open();
     }
 
+    const focused_now = dvui.focusedWidgetIdInCurrentSubwindow() == te.data().id;
     if (init_opts.open_on_focus) {
         const focused_last_frame = dvui.dataGet(null, te.data().id, "_focused_last_frame", bool) orelse false;
-        const focused_now = dvui.focusedWidgetIdInCurrentSubwindow() == te.data().id;
 
         if (!focused_last_frame and focused_now) {
             sug.open();
         }
 
         dvui.dataSet(null, te.data().id, "_focused_last_frame", focused_now);
+    }
+    if (!focused_now) {
+        sug.close();
     }
 
     return sug;


### PR DESCRIPTION
Makes it so that suggestion dropdowns on textboxes close on loss of focus. We might want to make this an option, but it's in my opinion the obvious default since there is no other way to close the dropdown with your mouse at present, without choosing an option from the dropdown.