### PR TITLE
Backends: Fix SDL builds

### DIFF
--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1954,10 +1954,10 @@ fn appIterate(_: ?*anyopaque) callconv(.c) c.SDL_AppResult {
         return c.SDL_APP_FAILURE;
     };
 
-    appState.back.setCursor(appState.win.cursorRequested()) catch return c.SDL_APP_FAILURE;
-    appState.back.textInputRect(appState.win.textInputRequested()) catch return c.SDL_APP_FAILURE;
+    appState.back.setCursor(appState.win.cursorRequested());
+    appState.back.textInputRect(appState.win.textInputRequested());
 
-    appState.back.renderPresent() catch return c.SDL_APP_FAILURE;
+    appState.back.renderPresent();
 
     if (res != .ok) return c.SDL_APP_SUCCESS;
 


### PR DESCRIPTION
Awesome library. It's great to use. 😄

I ran into this error when trying to build a project with the latest version using an SDL backend. I was able to recreate it too by cloning the repo and running `zig build`.

When building a project with an SDL backend, these errors are thrown.

src/backends/sdl.zig:1957:61: error: expected error union type, found 'void'
    appState.back.setCursor(appState.win.cursorRequested()) catch return c.SDL_APP_FAILURE;

This patch fixes this error by removing the `catch` block since there are no union errors.