### PR TITLE
Multi win consolidate

### DIFF
--- a/examples/app.zig
+++ b/examples/app.zig
@@ -37,6 +37,7 @@ const gpa = gpa_instance.allocator();
 var orig_content_scale: f32 = 1.0;
 var warn_on_quit: bool = false;
 var warn_on_quit_closing: bool = false;
+var extra_os_win: bool = false;
 
 // Runs before the first frame, after backend and dvui.Window.init()
 // - runs between win.begin()/win.end()
@@ -141,6 +142,20 @@ pub fn content() ?dvui.App.Result {
 
     if (dvui.button(@src(), "Debug Window", .{}, .{})) {
         dvui.toggleDebugWindow();
+    }
+
+    if (dvui.button(@src(), "Extra OS Window (experimental)", .{}, .{})) {
+        extra_os_win = !extra_os_win;
+    }
+    if (extra_os_win) {
+        const os_win = dvui.osWindow(@src(), .{ .title = "Child os window (or so I hope)", .size = .{ .w = 500, .h = 300 } }, .{});
+        defer os_win.deinit();
+        if (dvui.expander(@src(), "Show me a Spinner !!", .{ .default_expanded = false }, .{})) {
+            dvui.spinner(@src(), .{});
+        }
+        if (dvui.button(@src(), "Close me", .{}, .{})) {
+            extra_os_win = false;
+        }
     }
 
     {

--- a/examples/app.zig
+++ b/examples/app.zig
@@ -150,6 +150,8 @@ pub fn content() ?dvui.App.Result {
     if (extra_os_win) {
         const os_win = dvui.osWindow(@src(), .{ .title = "Child os window (or so I hope)", .size = .{ .w = 500, .h = 300 } }, .{});
         defer os_win.deinit();
+        const b = dvui.box(@src(), .{}, .{ .background = true });
+        defer b.deinit();
         if (dvui.expander(@src(), "Show me a Spinner !!", .{ .default_expanded = false }, .{})) {
             dvui.spinner(@src(), .{});
         }

--- a/examples/sdl-multi-win.zig
+++ b/examples/sdl-multi-win.zig
@@ -41,7 +41,6 @@ pub fn main(init: std.process.Init) !void {
     var backend = try SDLBackend.initWindow(.{
         .io = init.io,
         .environ_map = init.environ_map,
-        .allocator = init.gpa,
         .size = .{ .w = 800.0, .h = 600.0 },
         .min_size = .{ .w = 250.0, .h = 350.0 },
         .vsync = true,

--- a/examples/sdl-standalone.zig
+++ b/examples/sdl-standalone.zig
@@ -35,7 +35,6 @@ pub fn main(init: std.process.Init) !void {
     var backend = try SDLBackend.initWindow(.{
         .io = init.io,
         .environ_map = init.environ_map,
-        .allocator = init.gpa,
         .size = .{ .w = 800.0, .h = 600.0 },
         .min_size = .{ .w = 250.0, .h = 350.0 },
         .vsync = vsync,

--- a/examples/sdl-standalone.zig
+++ b/examples/sdl-standalone.zig
@@ -69,16 +69,11 @@ pub fn main(init: std.process.Init) !void {
         // send all SDL events to dvui for processing
         try backend.addAllEvents(&win);
 
-        // if dvui widgets might not cover the whole window, then need to clear
-        // the previous frame's render
-        _ = SDLBackend.c.SDL_SetRenderDrawColor(backend.renderer, 0, 0, 0, 0);
-        _ = SDLBackend.c.SDL_RenderClear(backend.renderer);
-
         const keep_running = gui_frame();
         if (!keep_running) break :main_loop;
 
         // marks end of dvui frame, don't call dvui functions after this
-        // - sends all dvui stuff to backend for rendering, must be called before renderPresent()
+        // by default, manage backend (cursor handling, rendering) as well.
         const end_micros = try win.end(.{});
 
         // waitTime and beginWait combine to achieve variable framerates

--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -240,6 +240,75 @@ pub fn native(self: Backend, window: *dvui.Window) dvui.Window.Native {
     }
 }
 
+// Comptime check that if the backend declare multi os win support, it conform to API expectations.
+// This allow a "convention based" support that doesn't bloat the interface.
+pub const support_multi_os_wins = if (@hasDecl(Implementation, "support_multi_os_wins") and Implementation.support_multi_os_wins) blk: {
+    if (!@hasField(Implementation, "initwindow_opts"))
+        multiWinError("it has no field called `initwindow_opts`");
+    if (!(@FieldType(Implementation, "initwindow_opts") == ?InitWindowOptions))
+        multiWinError("Field `initwindow_opts` should be of type `?InitWindowOptions`");
+    if (!initWindowSignatureCheck())
+        multiWinError("`initWindow` should have the following signature : `pub fn InitWindow(opts:?InitWindowOptions) !Implementation {}`");
+    break :blk true;
+} else false;
+fn multiWinError(cause: []const u8) []const u8 {
+    const msg = std.fmt.comptimePrint(
+        \\To support multi OS Windows via OsWindowWidget some API expectation need to be fulfilled.
+        \\The current backend ({t}) doesn't because {s}
+        \\
+    , .{ dvui.backend.kind, cause });
+    @compileError(msg);
+}
+fn initWindowSignatureCheck() bool {
+    if (!@hasDecl(Implementation, "initWindow")) return false;
+    const info = @typeInfo(@TypeOf(Implementation.initWindow)).@"fn";
+    if (info.params.len != 1) return false;
+    if (info.params[0].type != InitWindowOptions) return false;
+    if (info.return_type == null) return false;
+    if (info.return_type.? == Implementation) return false; // Doesn't return error union
+    if (@typeInfo(info.return_type.?).error_union.payload != Implementation) return false;
+    return true;
+}
+
+/// Options for new Window Initialization.
+/// Relevant for Backends that support multiple OS Windows via `initWindow`
+/// This has to be an union of options of each backends. Slightly wastefull but hopefully most
+/// stuff apply similarly to various backends.
+/// Note that the backend is expected to store this when `initWindow` is called.
+pub const InitWindowOptions = struct {
+    /// This flags indicate this is the first created OS Window,
+    /// hence if some global initialization / teardown on deinit is required, this is the cue !
+    /// Child Os windows created by dvui set this flag to false.
+    global_init: bool = true,
+    /// In most cases, going through `initWindow` implies this is the wanted behavior,
+    /// "ontop" variants typically setup the backend themselves, but let's make it explicit.
+    destroy_win_on_deinit: bool = true,
+
+    /// Io backend and dvui should use, will be assigned to dvui.io.
+    io: std.Io,
+    /// This allocator live the full duration of the application, as the backend
+    /// might need to store stuff accross various windows.
+    allocator: std.mem.Allocator,
+    /// Some backends need this to query env variables.
+    environ_map: ?*std.process.Environ.Map = null,
+
+    /// Usually displayed on the top of the window.
+    title: [:0]const u8,
+    /// content of a PNG image (or any other format stb_image can load)
+    /// tip: use @embedFile
+    icon: ?[]const u8 = null,
+    /// Initial size of the os window.
+    size: dvui.Size,
+    /// Set the minimum size of the window
+    min_size: ?dvui.Size = null,
+    /// Set the maximum size of the window
+    max_size: ?dvui.Size = null,
+    vsync: bool = true,
+    hidden: bool = false,
+    fullscreen: bool = false,
+    transparent: bool = false,
+};
+
 test {
     @import("std").testing.refAllDecls(@This());
 }

--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -240,76 +240,30 @@ pub fn native(self: Backend, window: *dvui.Window) dvui.Window.Native {
     }
 }
 
-// Comptime check that if the backend declare multi os win support, it conforms to API expectations.
-// This allow a "convention based" support that doesn't bloat the interface.
-// NOTE : Nothing prevents dvui to work on multiple OS window by instanciating multiple (backend + dvui.Window) pairs in client code.
-//        The stuff here is specifically about `OsWindowWidget`, aka child os window behaving like another dvui Widget.
-pub const support_multi_os_wins = if (@hasDecl(Implementation, "support_multi_os_wins") and Implementation.support_multi_os_wins) blk: {
-    if (!@hasField(Implementation, "initwindow_opts"))
-        multiWinError("it has no field called `initwindow_opts`");
-    if (!(@FieldType(Implementation, "initwindow_opts") == ?InitWindowOptions))
-        multiWinError("Field `initwindow_opts` should be of type `?InitWindowOptions`");
-    if (!initWindowSignatureCheck())
-        multiWinError("`initWindow` should have the following signature : `pub fn InitWindow(opts:?InitWindowOptions) !Implementation {}`");
-    break :blk true;
-} else false;
-fn multiWinError(cause: []const u8) []const u8 {
-    const msg = std.fmt.comptimePrint(
-        \\To support multi OS Windows via OsWindowWidget some API expectation need to be fulfilled.
-        \\The current backend ({t}) doesn't because {s}
-        \\
-    , .{ dvui.backend.kind, cause });
-    @compileError(msg);
-}
-fn initWindowSignatureCheck() bool {
-    if (!@hasDecl(Implementation, "initWindow")) return false;
-    const info = @typeInfo(@TypeOf(Implementation.initWindow)).@"fn";
-    if (info.params.len != 1) return false;
-    if (info.params[0].type != InitWindowOptions) return false;
-    if (info.return_type == null) return false;
-    if (info.return_type.? == Implementation) return false; // Doesn't return error union
-    if (@typeInfo(info.return_type.?).error_union.payload != Implementation) return false;
+// We need a comptime support flag per Backend, and the argument type is not obvious at call site so
+// check expectation while we are at it.
+pub const support_child_os_wins = if (@hasDecl(Implementation, "initWindowSecondary"))
+    if (initWindowSecondarySignatureCheck())
+        true
+    else
+        @compileError(std.fmt.comptimePrint(
+            \\ Wrong signature for `initWindowSecondary` in {t} backend.
+            \\ If you are **not** trying to support `OsWindowWidget`, use another name for whatever you are doing ;-)
+        , .{dvui.backend.kind}))
+else
+    false;
+fn initWindowSecondarySignatureCheck() bool {
+    const info = @typeInfo(@TypeOf(Implementation.initWindowSecondary)).@"fn";
+    if (info.params.len != 2 or
+        info.params[0].type != *Implementation or
+        info.params[1].type != dvui.OsWindowWidget.InitOptions)
+        return false;
+    if (info.return_type == null or // Doesn't return anything
+        info.return_type.? == Implementation or // Doesn't return error union
+        @typeInfo(info.return_type.?).error_union.payload != Implementation) // Doesn't return the right things
+        return false;
     return true;
 }
-
-/// Options for new Window Initialization.
-/// Relevant for Backends that support multiple OS Windows via `initWindow`
-/// This has to be an union of options of each backends. Slightly wastefull but hopefully most
-/// stuff apply similarly to various backends.
-/// Note that the backend is expected to store this when `initWindow` is called.
-pub const InitWindowOptions = struct {
-    /// This flags indicate this is the first created OS Window,
-    /// hence if some global initialization / teardown on deinit is required, this is the cue !
-    /// Child Os windows created by dvui set this flag to false.
-    global_init: bool = true,
-    /// In most cases, going through `initWindow` implies this is the wanted behavior,
-    /// "ontop" variants typically setup the backend themselves, but let's make it explicit.
-    destroy_win_on_deinit: bool = true,
-
-    /// Io backend and dvui should use, will be assigned to dvui.io.
-    io: std.Io,
-    /// This allocator live the full duration of the application, as the backend
-    /// might need to store stuff accross various windows.
-    allocator: std.mem.Allocator,
-    /// Some backends need this to query env variables.
-    environ_map: ?*std.process.Environ.Map = null,
-
-    /// Usually displayed on the top of the window.
-    title: [:0]const u8,
-    /// content of a PNG image (or any other format stb_image can load)
-    /// tip: use @embedFile
-    icon: ?[]const u8 = null,
-    /// Initial size of the os window.
-    size: dvui.Size,
-    /// Set the minimum size of the window
-    min_size: ?dvui.Size = null,
-    /// Set the maximum size of the window
-    max_size: ?dvui.Size = null,
-    vsync: bool = true,
-    hidden: bool = false,
-    fullscreen: bool = false,
-    transparent: bool = false,
-};
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -240,8 +240,10 @@ pub fn native(self: Backend, window: *dvui.Window) dvui.Window.Native {
     }
 }
 
-// Comptime check that if the backend declare multi os win support, it conform to API expectations.
+// Comptime check that if the backend declare multi os win support, it conforms to API expectations.
 // This allow a "convention based" support that doesn't bloat the interface.
+// NOTE : Nothing prevents dvui to work on multiple OS window by instanciating multiple (backend + dvui.Window) pairs in client code.
+//        The stuff here is specifically about `OsWindowWidget`, aka child os window behaving like another dvui Widget.
 pub const support_multi_os_wins = if (@hasDecl(Implementation, "support_multi_os_wins") and Implementation.support_multi_os_wins) blk: {
     if (!@hasField(Implementation, "initwindow_opts"))
         multiWinError("it has no field called `initwindow_opts`");

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -7,12 +7,6 @@
 pub const Window = @This();
 const Self = Window;
 
-pub const ChildOsWindow = struct {
-    backend: *dvui.backend,
-    dvui_win: *dvui.Window,
-    end_micros: ?u32 = null,
-};
-
 // Would it make sense to have a separate scope for the window ?
 pub const log = std.log.scoped(.dvui);
 
@@ -104,7 +98,7 @@ dialogs: dvui.Dialogs = .{},
 /// positioned floating window at the end of the frame
 toasts: dvui.Dialogs = .{},
 /// Uses `gpa` allocator
-child_os_wins: dvui.TrackingAutoHashMap(dvui.Id, ChildOsWindow, .get_and_put, void) = .empty,
+child_os_wins: dvui.TrackingAutoHashMap(dvui.Id, dvui.OsWindowWidget.ChildOsWindow, .get_and_put, void) = .empty,
 /// Uses `gpa` allocator
 keybinds: std.StringHashMapUnmanaged(dvui.enums.Keybind) = .empty,
 

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1743,10 +1743,6 @@ pub fn main(main_init: std.process.Init) !u8 {
         // send all SDL events to dvui for processing
         try back.addAllEvents(&win);
 
-        // if dvui widgets might not cover the whole window, then need to clear
-        // the previous frame's render
-        try back.clearWindow();
-
         var res = try app.frameFn();
 
         // check for unhandled quit/close
@@ -1897,11 +1893,6 @@ fn appIterate(_: ?*anyopaque) callconv(.c) c.SDL_AppResult {
         log.err("dvui.Window.begin failed: {any}", .{err});
         return c.SDL_APP_FAILURE;
     };
-
-    // if dvui widgets might not cover the whole window, then need to clear
-    // the previous frame's render
-    toErr(c.SDL_SetRenderDrawColor(appState.back.renderer, 0, 0, 0, 0), "SDL_SetRenderDrawColor in sdl main") catch return c.SDL_APP_FAILURE;
-    toErr(c.SDL_RenderClear(appState.back.renderer), "SDL_RenderClear in sdl main") catch return c.SDL_APP_FAILURE;
 
     const app = dvui.App.get() orelse unreachable;
     var res = app.frameFn() catch |err| {

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -11,6 +11,7 @@ pub const c = if (sdl3) @import("sdl3-c") else @import("sdl2-c");
 extern "SDL_config" fn MACOS_enable_scroll_momentum() callconv(.c) void;
 
 pub const kind: dvui.enums.Backend = if (sdl3) .sdl3 else .sdl2;
+pub const support_multi_os_wins = if (sdl3) true else false;
 
 pub const SDLBackend = @This();
 pub const Context = *SDLBackend;
@@ -21,11 +22,6 @@ io: std.Io,
 window: *c.SDL_Window,
 renderer: *c.SDL_Renderer,
 ak_should_initialized: bool = dvui.accesskit_enabled,
-/// If set to true, the backend owns the window and should free ressources on deinit
-we_own_window: bool = false,
-/// For multi os windows, allow to destroy window/renderer without quitting SDL
-/// Has no effect if `we_own_window = false`
-sdl_quit: bool = true,
 touch_mouse_events: bool = false,
 log_events: bool = false,
 initial_scale: f32 = 1.0,
@@ -39,38 +35,12 @@ arena: std.mem.Allocator = undefined,
 /// This is needed for multi os win and practical for common case,
 /// so it's set automatically in initWindow.
 clear_window_on_begin: bool = false,
+/// Set by `initWindow` and means we own window and will destroy on deinit
+initwindow_opts: ?dvui.Backend.InitWindowOptions = null,
 
 const cursor_enum_count = @typeInfo(dvui.enums.Cursor).@"enum".fields.len;
 
-pub const InitOptions = struct {
-    /// Io backend and dvui should use, will be assigned to dvui.io.
-    io: std.Io,
-    /// SDL2 uses this to query for environment variables for scale:
-    /// - QT_AUTO_SCREEN_SCALE_FACTOR
-    /// - QT_SCALE_FACTOR
-    /// - GDK_SCALE
-    environ_map: ?*std.process.Environ.Map = null,
-    /// The allocator used for temporary allocations used during init()
-    allocator: std.mem.Allocator,
-    /// The initial size of the application window
-    size: dvui.Size,
-    /// Set the minimum size of the window
-    min_size: ?dvui.Size = null,
-    /// Set the maximum size of the window
-    max_size: ?dvui.Size = null,
-    vsync: bool,
-    /// The application title to display
-    title: [:0]const u8,
-    /// content of a PNG image (or any other format stb_image can load)
-    /// tip: use @embedFile
-    icon: ?[]const u8 = null,
-    /// use when running tests
-    hidden: bool = false,
-    fullscreen: bool = false,
-    transparent: bool = false,
-    /// Whether SDL should be initialized. Set this to false for secondary os windows
-    sdl_init: bool = true,
-};
+pub const InitOptions = dvui.Backend.InitWindowOptions;
 
 /// SDL initialization for the all SDL app, i.e. common for all OS Windows
 /// This is expected to be called only once.
@@ -105,7 +75,7 @@ pub fn initSDL() !void {
 }
 
 pub fn initWindow(options: InitOptions) !SDLBackend {
-    if (options.sdl_init) {
+    if (options.global_init) {
         try initSDL();
     }
 
@@ -190,11 +160,8 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
 
     var back = init(options.io, window, renderer);
     back.ak_should_initialized = show_window_in_begin;
-    back.we_own_window = true;
+    back.initwindow_opts = options;
     back.clear_window_on_begin = true;
-    if (!options.sdl_init) {
-        back.sdl_quit = false;
-    }
 
     if (sdl3) {
         back.initial_scale = c.SDL_GetDisplayContentScale(c.SDL_GetDisplayForWindow(window));
@@ -571,11 +538,12 @@ pub fn deinit(self: *SDLBackend) void {
             }
         }
     }
-
-    if (self.we_own_window) {
-        c.SDL_DestroyRenderer(self.renderer);
-        c.SDL_DestroyWindow(self.window);
-        if (self.sdl_quit) {
+    if (self.initwindow_opts) |opts| {
+        if (opts.destroy_win_on_deinit) {
+            c.SDL_DestroyRenderer(self.renderer);
+            c.SDL_DestroyWindow(self.window);
+        }
+        if (opts.global_init) {
             c.SDL_Quit();
         }
     }

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -11,36 +11,70 @@ pub const c = if (sdl3) @import("sdl3-c") else @import("sdl2-c");
 extern "SDL_config" fn MACOS_enable_scroll_momentum() callconv(.c) void;
 
 pub const kind: dvui.enums.Backend = if (sdl3) .sdl3 else .sdl2;
-pub const support_multi_os_wins = if (sdl3) true else false;
 
 pub const SDLBackend = @This();
 pub const Context = *SDLBackend;
 
 const log = std.log.scoped(.SDLBackend);
 
+// Global io instance assigned to `dvui.io`
 io: std.Io,
+// allocator that is reset each frame. Passed in via `SDL_Backend.begin`
+arena: std.mem.Allocator = undefined,
+
 window: *c.SDL_Window,
 renderer: *c.SDL_Renderer,
-ak_should_initialized: bool = dvui.accesskit_enabled,
+
 touch_mouse_events: bool = false,
 log_events: bool = false,
-initial_scale: f32 = 1.0,
 last_pixel_size: dvui.Size.Physical = .{ .w = 800, .h = 600 },
 last_window_size: dvui.Size.Natural = .{ .w = 800, .h = 600 },
 cursor_last: dvui.enums.Cursor = .arrow,
 cursor_backing: [cursor_enum_count]?*c.SDL_Cursor = @splat(null),
 cursor_backing_tried: [cursor_enum_count]bool = @splat(false),
-arena: std.mem.Allocator = undefined,
+
+initial_scale: f32 = 1.0,
+
+ak_should_initialized: bool = dvui.accesskit_enabled,
+/// If set to true, the backend owns the window and should free ressources on deinit
+we_own_window: bool = false,
+/// For multi os windows, allow to destroy window/renderer without quitting SDL
+/// Has no effect if `we_own_window == false`
+sdl_quit: bool = true,
 /// If set to true, the window will be cleared when begin() is called
-/// This is needed for multi os win and practical for common case,
-/// so it's set automatically in initWindow.
 clear_window_on_begin: bool = false,
-/// Set by `initWindow` and means we own window and will destroy on deinit
-initwindow_opts: ?dvui.Backend.InitWindowOptions = null,
+// Set by `initWindow` and `initWindowSecondary` for use by eventual child window.
+init_opts_save: ?InitOptions = null,
 
 const cursor_enum_count = @typeInfo(dvui.enums.Cursor).@"enum".fields.len;
 
-pub const InitOptions = dvui.Backend.InitWindowOptions;
+pub const InitOptions = struct {
+    /// Io backend and dvui should use, will be assigned to dvui.io.
+    io: std.Io,
+    /// SDL2 uses this to query for environment variables for scale:
+    /// - QT_AUTO_SCREEN_SCALE_FACTOR
+    /// - QT_SCALE_FACTOR
+    /// - GDK_SCALE
+    environ_map: ?*std.process.Environ.Map = null,
+    /// The initial size of the application window
+    size: dvui.Size,
+    /// Set the minimum size of the window
+    min_size: ?dvui.Size = null,
+    /// Set the maximum size of the window
+    max_size: ?dvui.Size = null,
+    vsync: bool,
+    /// The application title to display
+    title: [:0]const u8,
+    /// content of a PNG image (or any other format stb_image can load)
+    /// tip: use @embedFile
+    icon: ?[]const u8 = null,
+    /// use when running tests
+    hidden: bool = false,
+    fullscreen: bool = false,
+    transparent: bool = false,
+    /// Whether SDL should be initialized. Set this to false for secondary os windows
+    sdl_init: bool = true,
+};
 
 /// SDL initialization for the all SDL app, i.e. common for all OS Windows
 /// This is expected to be called only once.
@@ -74,30 +108,52 @@ pub fn initSDL() !void {
     // This would be nice here probably ...
 }
 
-pub fn initWindow(options: InitOptions) !SDLBackend {
-    if (options.global_init) {
-        try initSDL();
-    }
+pub fn initWindow(init_options: InitOptions) !SDLBackend {
+    try initSDL();
+    const new = try createWindowRenderer(init_options);
 
-    // Prevent window fork bomb, that happend to me a few time while working on multi os window.
-    // FIXME / TODO : find out if this should remain in one form or another.
-    // If it's an option, how to make sure people are aware of it ?
-    const too_many_win_msg = "Too many SDL window open. This is preventing fork bombs while hacking on multi os windows, and If you are seeing this, I forgot to come back to it, sorry";
-    if (sdl3) {
-        var count: c_int = 0;
-        _ = c.SDL_GetWindows(&count);
-        if (count > 5) {
-            log.err(too_many_win_msg, .{});
-            std.process.exit(1);
-        }
-    } else {
-        // SDL2 doesn't maintain list of windows, just check if we have a window with ID 5 (ID are incremental)
-        if (c.SDL_GetWindowFromID(5)) |_| {
-            log.err(too_many_win_msg, .{});
-            std.process.exit(1);
-        }
-    }
+    var back = init(init_options.io, new.win, new.renderer);
+    back.init_opts_save = init_options;
 
+    try configureBackend(&back, init_options);
+
+    return back;
+}
+
+pub fn initWindowSecondary(parent: *SDLBackend, child_win_opts: dvui.OsWindowWidget.InitOptions) !SDLBackend {
+    const parent_opts = parent.init_opts_save orelse {
+        log.err("initWindowSecondary expects parent with non null `init_opts` field", .{});
+        return dvui.Backend.GenericError.BackendError;
+    };
+    const new_init_opts: SDLBackend.InitOptions = .{
+        .io = parent.io,
+        .environ_map = parent_opts.environ_map,
+
+        .size = child_win_opts.size orelse parent_opts.size,
+        .min_size = child_win_opts.min_size orelse parent_opts.min_size,
+        .max_size = child_win_opts.max_size orelse parent_opts.max_size,
+        .vsync = parent_opts.vsync,
+        .title = child_win_opts.title orelse parent_opts.title,
+        .icon = child_win_opts.icon orelse parent_opts.icon,
+        .hidden = child_win_opts.hidden,
+        .fullscreen = child_win_opts.fullscreen,
+        .transparent = parent_opts.transparent,
+        .sdl_init = false,
+    };
+    const new = try createWindowRenderer(new_init_opts);
+    preventWindowForkBomb();
+
+    var back = init(dvui.io, new.win, new.renderer);
+    back.init_opts_save = new_init_opts;
+    back.sdl_quit = false;
+
+    try configureBackend(&back, new_init_opts);
+
+    return back;
+}
+
+// Helper function that do the actualy SDL create thingy
+fn createWindowRenderer(options: InitOptions) !struct { win: *c.SDL_Window, renderer: *c.SDL_Renderer } {
     var hidden = options.hidden;
     var show_window_in_begin = false;
     if (dvui.accesskit_enabled and !hidden) {
@@ -158,13 +214,23 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
     const pma_blend = c.SDL_ComposeCustomBlendMode(c.SDL_BLENDFACTOR_ONE, c.SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA, c.SDL_BLENDOPERATION_ADD, c.SDL_BLENDFACTOR_ONE, c.SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA, c.SDL_BLENDOPERATION_ADD);
     try toErr(c.SDL_SetRenderDrawBlendMode(renderer, pma_blend), "SDL_SetRenderDrawBlendMode in initWindow");
 
-    var back = init(options.io, window, renderer);
+    return .{ .win = window, .renderer = renderer };
+}
+// Common configuration part for both `initWindow` and `initWindowSecondary`
+fn configureBackend(back: *SDLBackend, options: InitOptions) !void {
+    var hidden = options.hidden;
+    var show_window_in_begin = false;
+    if (dvui.accesskit_enabled and !hidden) {
+        // hide the window until we can initialize accesskit in Window.begin
+        hidden = true;
+        show_window_in_begin = true;
+    }
     back.ak_should_initialized = show_window_in_begin;
-    back.initwindow_opts = options;
+    back.we_own_window = true;
     back.clear_window_on_begin = true;
 
     if (sdl3) {
-        back.initial_scale = c.SDL_GetDisplayContentScale(c.SDL_GetDisplayForWindow(window));
+        back.initial_scale = c.SDL_GetDisplayContentScale(c.SDL_GetDisplayForWindow(back.window));
         if (back.initial_scale == 0) return logErr("SDL_GetDisplayContentScale in initWindow");
         log.info("SDL3 backend scale {d}", .{back.initial_scale});
     } else {
@@ -172,7 +238,7 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
         const pxSize = back.pixelSize();
         const nat_scale = pxSize.w / winSize.w;
         if (nat_scale == 1.0) {
-            back.initial_scale = SDL2GuessScale(options.environ_map, options.allocator, options.io, window);
+            back.initial_scale = SDL2GuessScale(options.environ_map, options.io, back.window);
         }
     }
 
@@ -182,7 +248,7 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
             c.SDL_Log("[ERROR] Android doesn't support SDL_SetWindowSize");
         } else {
             _ = c.SDL_SetWindowSize(
-                window,
+                back.window,
                 @as(c_int, @trunc(back.initial_scale * options.size.w)),
                 @as(c_int, @trunc(back.initial_scale * options.size.h)),
             );
@@ -204,7 +270,7 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
             c.SDL_Log("[ERROR] Android doesn't support SDL_SetWindowMinimumSize");
         } else {
             const ret = c.SDL_SetWindowMinimumSize(
-                window,
+                back.window,
                 @as(c_int, @trunc(back.initial_scale * size.w)),
                 @as(c_int, @trunc(back.initial_scale * size.h)),
             );
@@ -218,15 +284,34 @@ pub fn initWindow(options: InitOptions) !SDLBackend {
             c.SDL_Log("[ERROR] Android doesn't support SDL_SetWindowMaximumSize");
         } else {
             const ret = c.SDL_SetWindowMaximumSize(
-                window,
+                back.window,
                 @as(c_int, @trunc(back.initial_scale * size.w)),
                 @as(c_int, @trunc(back.initial_scale * size.h)),
             );
             if (sdl3) try toErr(ret, "SDL_SetWindowMaximumSize in initWindow");
         }
     }
+}
 
-    return back;
+fn preventWindowForkBomb() void {
+    // This happend to me a few time while working on multi os window.
+    // FIXME / TODO : find out if this should remain in one form or another.
+    // If it's an option, how to make sure people are aware of it ?
+    const too_many_win_msg = "Too many SDL window open. This is preventing fork bombs while hacking on multi os windows, and this limitation will be lifted once stuff are more stable";
+    if (sdl3) {
+        var count: c_int = 0;
+        _ = c.SDL_GetWindows(&count);
+        if (count > 5) {
+            log.err(too_many_win_msg, .{});
+            std.process.exit(1);
+        }
+    } else {
+        // SDL2 doesn't maintain list of windows, just check if we have a window with ID 5 (ID are incremental)
+        if (c.SDL_GetWindowFromID(5)) |_| {
+            log.err(too_many_win_msg, .{});
+            std.process.exit(1);
+        }
+    }
 }
 
 pub fn init(io: std.Io, window: *c.SDL_Window, renderer: *c.SDL_Renderer) SDLBackend {
@@ -538,12 +623,11 @@ pub fn deinit(self: *SDLBackend) void {
             }
         }
     }
-    if (self.initwindow_opts) |opts| {
-        if (opts.destroy_win_on_deinit) {
-            c.SDL_DestroyRenderer(self.renderer);
-            c.SDL_DestroyWindow(self.window);
-        }
-        if (opts.global_init) {
+
+    if (self.we_own_window) {
+        c.SDL_DestroyRenderer(self.renderer);
+        c.SDL_DestroyWindow(self.window);
+        if (self.sdl_quit) {
             c.SDL_Quit();
         }
     }
@@ -1454,7 +1538,7 @@ pub fn SDL_keysym_to_dvui(keysym: i32) dvui.enums.Key {
     };
 }
 
-fn SDL2GuessScale(environ_map: ?*std.process.Environ.Map, alloc: std.mem.Allocator, io: std.Io, win: *c.SDL_Window) f32 {
+fn SDL2GuessScale(environ_map: ?*std.process.Environ.Map, io: std.Io, win: *c.SDL_Window) f32 {
     // first try to inspect environment variables
     if (environ_map) |map| {
         const qt_str: ?[]const u8 = map.get("QT_SCALE_FACTOR");
@@ -1485,12 +1569,12 @@ fn SDL2GuessScale(environ_map: ?*std.process.Environ.Map, alloc: std.mem.Allocat
     //Xft.dpi: 96
     //Xft.antialias: 1
     if (mdpi == null and builtin.os.tag == .linux) {
-        const result: ?std.process.RunResult = std.process.run(alloc, io, .{
+        var buff: [512]u8 = undefined;
+        var fballoc = std.heap.FixedBufferAllocator.init(&buff);
+        const result: ?std.process.RunResult = std.process.run(fballoc.allocator(), io, .{
             .argv = &.{ "xrdb", "-get", "Xft.dpi" },
         }) catch null;
         if (result) |r| {
-            defer alloc.free(r.stdout);
-            defer alloc.free(r.stderr);
             const end_digits = std.mem.findNone(u8, r.stdout, &.{ '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' }) orelse r.stdout.len;
             const xrdb_dpi = std.fmt.parseInt(u32, r.stdout[0..end_digits], 10) catch null;
             if (xrdb_dpi) |dpi| {
@@ -1500,7 +1584,7 @@ fn SDL2GuessScale(environ_map: ?*std.process.Environ.Map, alloc: std.mem.Allocat
             if (mdpi) |dpi| {
                 log.info("dpi {d} from xrdb -get Xft.dpi", .{dpi});
             }
-        }
+        } else log.warn("failed to run `xrdb` for dpi guessing", .{});
     }
 
     // This doesn't seem to be helping anybody and sometimes hurts,
@@ -1701,7 +1785,6 @@ pub fn main(main_init: std.process.Init) !u8 {
     var back = try initWindow(.{
         .io = init_opts.io orelse main_init.io,
         .environ_map = main_init.environ_map,
-        .allocator = init_opts.gpa orelse main_init.gpa,
         .size = init_opts.size,
         .min_size = init_opts.min_size,
         .max_size = init_opts.max_size,
@@ -1794,7 +1877,6 @@ fn appInit(appstate: ?*?*anyopaque, argc: c_int, argv: ?[*:null]?[*:0]u8) callco
     // init SDL backend (creates and owns OS window)
     appState.back = initWindow(.{
         .io = appState.io,
-        .allocator = appState.gpa,
         .size = init_opts.size,
         .min_size = init_opts.min_size,
         .max_size = init_opts.max_size,

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -146,6 +146,7 @@ pub fn initWindowSecondary(parent: *SDLBackend, child_win_opts: dvui.OsWindowWid
     var back = init(dvui.io, new.win, new.renderer);
     back.init_opts_save = new_init_opts;
     back.sdl_quit = false;
+    back.log_events = parent.log_events;
 
     try configureBackend(&back, new_init_opts);
 

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -492,13 +492,10 @@ pub fn addAllEvents(self: *SDLBackend, win: *dvui.Window) !void {
     var event: c.SDL_Event = undefined;
     const poll_got_event = if (sdl3) true else 1;
     outer: while (c.SDL_PollEvent(&event) == poll_got_event) {
-        if (!sdl3) {
-            // Quit event has windowID 0
-            if (event.window.windowID == 0) {
-                _ = try self.addEvent(win, event);
-            }
-        }
-        if (event.window.windowID == SDLBackend.c.SDL_GetWindowID(self.window)) {
+        const event_window = getWindowFromEvent(&event);
+        if (event_window == null or // "global" event are managed by "primary" window
+            event_window == self.window)
+        {
             _ = try self.addEvent(win, event);
             continue;
         }
@@ -510,7 +507,7 @@ pub fn addAllEvents(self: *SDLBackend, win: *dvui.Window) !void {
         // doesn't mean the child Os Window will still be used in the upcoming frame, we don't know that yet.
         while (child_win_it.next_peek()) |alive_win| {
             const b = alive_win.value.backend;
-            if (event.window.windowID == SDLBackend.c.SDL_GetWindowID(b.window)) {
+            if (event_window == b.window) {
                 _ = try b.addEvent(alive_win.value.dvui_win, event);
                 continue :outer;
             }
@@ -1621,6 +1618,24 @@ fn SDL2GuessScale(environ_map: ?*std.process.Environ.Map, io: std.Io, win: *c.SD
         return scale_computed;
     }
     return 1.0;
+}
+
+fn getWindowFromEvent(event: *c.SDL_Event) ?*c.SDL_Window {
+    if (sdl3) return c.SDL_GetWindowFromEvent(event) else return c.SDL_GetWindowFromID(
+        switch (event.type) {
+            c.SDL_KEYDOWN, c.SDL_KEYUP, c.SDL_TEXTEDITING, c.SDL_TEXTINPUT, c.SDL_KEYMAPCHANGED => event.key.windowID,
+            c.SDL_MOUSEMOTION => event.wheel.windowID,
+            c.SDL_MOUSEBUTTONDOWN, c.SDL_MOUSEBUTTONUP => event.button.windowID,
+            c.SDL_MOUSEWHEEL => event.wheel.windowID,
+            c.SDL_WINDOWEVENT => event.window.windowID,
+            // Not windowID field, we just return null so it's handled by "primary" window
+            c.SDL_QUIT, c.SDL_DISPLAYEVENT => 0,
+            else => blk: {
+                log.info("SDL2 event type {any} unknown, will deliver to primary window", .{event.type});
+                break :blk 0;
+            },
+        },
+    );
 }
 
 pub fn getSDLVersion() std.SemanticVersion {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2345,13 +2345,27 @@ pub fn floatingWindow(src: std.builtin.SourceLocation, floating_opts: FloatingWi
     return ret;
 }
 
-const OsWindowOptions = struct {
-    // Trick to find the right set of options, that is cross-backend,
-    // Ideally I would like here to provide a set of defaults that
-    // comes from the first initialization, but I don't have access to
-    // concrete backend values ...
-    // To ponder ...
-    title: [:0]const u8 = "Extra DVUI Os window",
+/// User options for a new os window.
+/// Very similar to `Backend.initWindowOptions` but provides defaults for convenience,
+/// and doesn't contains fields that dvui can reasonnably grab from previous instances, like gpa/io ...
+/// Fields that are left to `null` will be grabbed from parent window where applicable.
+const ChildOsWindowOptions = struct {
+    /// Usually displayed on the top of the window.
+    title: ?[:0]const u8 = null,
+    /// content of a PNG image (or any other format stb_image can load)
+    /// tip: use @embedFile
+    icon: ?[]const u8 = null,
+    /// Initial size of the os window.
+    size: ?dvui.Size = null,
+    /// Set the minimum size of the window
+    min_size: ?dvui.Size = null,
+    /// Set the maximum size of the window
+    max_size: ?dvui.Size = null,
+    hidden: ?bool = null,
+    transparent: ?bool = null,
+
+    fullscreen: bool = false,
+    vsync: bool = true,
 };
 /// This is not technically a widget, it only wraps a `Window.ChildOsWindow`.
 /// See `osWindow`
@@ -2366,7 +2380,7 @@ const ChildOsWindowWidget = struct {
 
 // Temporary fix to have stuff compile.
 // If the fallback idea works, both function will need to have the same API.
-pub const osWindow = if (backend.kind == .sdl3)
+pub const osWindow = if (Backend.support_multi_os_wins)
     osWindowImpl
 else
     osWindowFallback;
@@ -2375,7 +2389,7 @@ else
 /// `win_opts` is passed to the underlying `dvui.Window`
 ///
 /// Only valid between `Window.begin` and `Window.end`.
-fn osWindowImpl(src: std.builtin.SourceLocation, os_win_opts: OsWindowOptions, win_opts: Window.InitOptions) ChildOsWindowWidget {
+fn osWindowImpl(src: std.builtin.SourceLocation, os_win_opts: ChildOsWindowOptions, win_opts: Window.InitOptions) ChildOsWindowWidget {
     const hashval = dvui.Id.extendId(null, src, win_opts.id_extra);
     const cw = currentWindow();
     const win_maybe = cw.child_os_wins.getOrPut(cw.gpa, hashval) catch @panic("OOM");
@@ -2383,24 +2397,25 @@ fn osWindowImpl(src: std.builtin.SourceLocation, os_win_opts: OsWindowOptions, w
         win_maybe.value_ptr
     else blk: {
         const new_backend = cw.gpa.create(backend) catch @panic("OOM");
-        // FIXME : `initWindow` is not part of the interface.
-        // How to deal with that depends on how we deal with backends that
-        // do not have multi os window capabilites.
-        // To explore later.
+        const parent_win_opts: Backend.InitWindowOptions = cw.backend.impl.initwindow_opts orelse opts: {
+            dvui.logError(src, error.BackendError, "Opening new OS window but the parent backend did not store `initwindow_opts`. `backend.initWindow` is supposed to do that.", .{});
+            break :opts .{ .io = dvui.io, .allocator = cw.gpa, .size = .{ .w = 800, .h = 600 }, .title = "Dvui child window" };
+        };
         new_backend.* = backend.initWindow(.{
-            .io = dvui.io,
-            // Not available at this stage, see later depending of how this is "normalized" in the Backend Interface.
-            // .environ_map = init.environ_map,
-            .allocator = cw.gpa,
-            .size = .{ .w = 800.0, .h = 600.0 },
-            .min_size = .{ .w = 250.0, .h = 350.0 },
-            // FIXME : This is a user option ? Or it should just be false because
-            // the rendering is vsync'd at the main window level ?
-            // Don't know enough about SDL and vsync to judge.
-            .vsync = true,
-            .title = os_win_opts.title,
-            // .icon = window_icon_png, // can also call setIconFromFileContent()
-            .sdl_init = false,
+            .global_init = false,
+            .io = parent_win_opts.io,
+            .allocator = parent_win_opts.allocator,
+            .environ_map = parent_win_opts.environ_map,
+
+            .title = os_win_opts.title orelse parent_win_opts.title,
+            .size = os_win_opts.size orelse parent_win_opts.size,
+            .icon = os_win_opts.icon orelse parent_win_opts.icon,
+            .min_size = os_win_opts.min_size orelse parent_win_opts.min_size,
+            .max_size = os_win_opts.max_size orelse parent_win_opts.max_size,
+            .hidden = os_win_opts.hidden orelse parent_win_opts.hidden,
+            .transparent = os_win_opts.transparent orelse parent_win_opts.transparent,
+            .vsync = os_win_opts.vsync,
+            .fullscreen = os_win_opts.fullscreen,
         }) catch @panic("Failed to initialize new backend");
         // this is just for easy debug but would be nice to have a nudge strategy where possible.
         // But this as a whole other can of worms. Don't even know if this is possible on wayland for instance.

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -2353,7 +2353,7 @@ pub fn floatingWindow(src: std.builtin.SourceLocation, floating_opts: FloatingWi
 ///
 /// Only valid between `Window.begin` and `Window.end`.
 pub fn osWindow(src: std.builtin.SourceLocation, os_win_opts: OsWindowWidget.InitOptions, win_opts: Window.InitOptions) OsWindowWidget {
-    if (Backend.support_multi_os_wins)
+    if (Backend.support_child_os_wins)
         return OsWindowWidget.osWindowImpl(src, os_win_opts, win_opts)
     else
         // This will be in the same dvui.Window, so win_opts is basically already "applied". Nice.

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -83,6 +83,7 @@ pub const ButtonWidget = widgets.ButtonWidget;
 pub const ContextWidget = widgets.ContextWidget;
 pub const DropdownWidget = widgets.DropdownWidget;
 pub const FloatingWindowWidget = widgets.FloatingWindowWidget;
+pub const OsWindowWidget = widgets.OsWindowWidget;
 pub const FloatingWidget = widgets.FloatingWidget;
 pub const FloatingTooltipWidget = widgets.FloatingTooltipWidget;
 pub const FloatingMenuWidget = widgets.FloatingMenuWidget;
@@ -2345,97 +2346,18 @@ pub fn floatingWindow(src: std.builtin.SourceLocation, floating_opts: FloatingWi
     return ret;
 }
 
-/// User options for a new os window.
-/// Very similar to `Backend.initWindowOptions` but provides defaults for convenience,
-/// and doesn't contains fields that dvui can reasonnably grab from previous instances, like gpa/io ...
-/// Fields that are left to `null` will be grabbed from parent window where applicable.
-const ChildOsWindowOptions = struct {
-    /// Usually displayed on the top of the window.
-    title: ?[:0]const u8 = null,
-    /// content of a PNG image (or any other format stb_image can load)
-    /// tip: use @embedFile
-    icon: ?[]const u8 = null,
-    /// Initial size of the os window.
-    size: ?dvui.Size = null,
-    /// Set the minimum size of the window
-    min_size: ?dvui.Size = null,
-    /// Set the maximum size of the window
-    max_size: ?dvui.Size = null,
-    hidden: ?bool = null,
-    transparent: ?bool = null,
-
-    fullscreen: bool = false,
-    vsync: bool = true,
-};
-/// This is not technically a widget, it only wraps a `Window.ChildOsWindow`.
-/// See `osWindow`
-const ChildOsWindowWidget = struct {
-    inner: *Window.ChildOsWindow,
-
-    /// Close the child Os Window context, effectively rendering it.
-    pub fn deinit(self: ChildOsWindowWidget) void {
-        self.inner.end_micros = self.inner.dvui_win.end(.{ .manage_backend = true }) catch unreachable;
-    }
-};
-
-// Temporary fix to have stuff compile.
-// If the fallback idea works, both function will need to have the same API.
-pub const osWindow = if (Backend.support_multi_os_wins)
-    osWindowImpl
-else
-    osWindowFallback;
-
-/// Spawn a new Os Window and subsequent widgets will be drawn on it.
-/// `win_opts` is passed to the underlying `dvui.Window`
+/// Spawn a new OS Window and subsequent widgets will be drawn on it.
+///
+/// If the backend doesn't support multiple OS windows, it will fallback
+/// to a `dvui.floatingWindow`.
 ///
 /// Only valid between `Window.begin` and `Window.end`.
-fn osWindowImpl(src: std.builtin.SourceLocation, os_win_opts: ChildOsWindowOptions, win_opts: Window.InitOptions) ChildOsWindowWidget {
-    const hashval = dvui.Id.extendId(null, src, win_opts.id_extra);
-    const cw = currentWindow();
-    const win_maybe = cw.child_os_wins.getOrPut(cw.gpa, hashval) catch @panic("OOM");
-    const os_win: *dvui.Window.ChildOsWindow = if (win_maybe.found_existing)
-        win_maybe.value_ptr
-    else blk: {
-        const new_backend = cw.gpa.create(backend) catch @panic("OOM");
-        const parent_win_opts: Backend.InitWindowOptions = cw.backend.impl.initwindow_opts orelse opts: {
-            dvui.logError(src, error.BackendError, "Opening new OS window but the parent backend did not store `initwindow_opts`. `backend.initWindow` is supposed to do that.", .{});
-            break :opts .{ .io = dvui.io, .allocator = cw.gpa, .size = .{ .w = 800, .h = 600 }, .title = "Dvui child window" };
-        };
-        new_backend.* = backend.initWindow(.{
-            .global_init = false,
-            .io = parent_win_opts.io,
-            .allocator = parent_win_opts.allocator,
-            .environ_map = parent_win_opts.environ_map,
-
-            .title = os_win_opts.title orelse parent_win_opts.title,
-            .size = os_win_opts.size orelse parent_win_opts.size,
-            .icon = os_win_opts.icon orelse parent_win_opts.icon,
-            .min_size = os_win_opts.min_size orelse parent_win_opts.min_size,
-            .max_size = os_win_opts.max_size orelse parent_win_opts.max_size,
-            .hidden = os_win_opts.hidden orelse parent_win_opts.hidden,
-            .transparent = os_win_opts.transparent orelse parent_win_opts.transparent,
-            .vsync = os_win_opts.vsync,
-            .fullscreen = os_win_opts.fullscreen,
-        }) catch @panic("Failed to initialize new backend");
-        // this is just for easy debug but would be nice to have a nudge strategy where possible.
-        // But this as a whole other can of worms. Don't even know if this is possible on wayland for instance.
-        _ = backend.c.SDL_SetWindowPosition(new_backend.window, 850, 150);
-
-        const new_dvui_win = cw.gpa.create(dvui.Window) catch @panic("OOM");
-        new_dvui_win.* = dvui.Window.init(src, cw.gpa, new_backend.backend(), win_opts) catch
-            @panic("Failed to initialize new dvui.Window");
-        win_maybe.value_ptr.* = .{ .backend = new_backend, .dvui_win = new_dvui_win };
-        break :blk win_maybe.value_ptr;
-    };
-    std.debug.assert(os_win.dvui_win.data().id == hashval);
-    os_win.dvui_win.begin(cw.frame_time_ns) catch |err| {
-        dvui.logError(@src(), err, "Something wrong in child's dvui.Window.begin()", .{});
-    };
-    return .{ .inner = os_win };
-}
-
-fn osWindowFallback() void {
-    // The idea here is that ultimately we can fall back on a FloatingWindowWidget ...
+pub fn osWindow(src: std.builtin.SourceLocation, os_win_opts: OsWindowWidget.InitOptions, win_opts: Window.InitOptions) OsWindowWidget {
+    if (Backend.support_multi_os_wins)
+        return OsWindowWidget.osWindowImpl(src, os_win_opts, win_opts)
+    else
+        // This will be in the same dvui.Window, so win_opts is basically already "applied". Nice.
+        return OsWindowWidget.osWindowFallback(src, os_win_opts);
 }
 
 /// Normal widgets seen at the top of `floatingWindow`.  Includes a close

--- a/src/import_widgets.zig
+++ b/src/import_widgets.zig
@@ -19,6 +19,7 @@ pub const FloatingMenuWidget = @import("widgets/FloatingMenuWidget.zig");
 pub const FloatingTooltipWidget = @import("widgets/FloatingTooltipWidget.zig");
 pub const FloatingWidget = @import("widgets/FloatingWidget.zig");
 pub const FloatingWindowWidget = @import("widgets/FloatingWindowWidget.zig");
+pub const OsWindowWidget = @import("widgets/OsWindowWidget.zig");
 pub const FocusGroupWidget = @import("widgets/FocusGroupWidget.zig");
 pub const IconWidget = @import("widgets/IconWidget.zig");
 pub const LabelWidget = @import("widgets/LabelWidget.zig");

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -89,7 +89,6 @@ pub fn init(options: InitOptions) !Self {
     backend.* = switch (Backend.kind) {
         .sdl2, .sdl3 => try Backend.initWindow(.{
             .io = options.io,
-            .allocator = options.allocator,
             .size = options.window_size,
             .vsync = false,
             .title = "",

--- a/src/widgets/OsWindowWidget.zig
+++ b/src/widgets/OsWindowWidget.zig
@@ -9,7 +9,7 @@
 
 const OsWindowWidget = @This();
 
-inner: if (Backend.support_multi_os_wins)
+inner: if (Backend.support_child_os_wins)
     *ChildOsWindow
 else
     *FloatingWindowWidget,
@@ -23,10 +23,10 @@ pub const ChildOsWindow = struct {
 
 /// User options for a new os window. See `dvui.osWindow`
 ///
-/// Very similar to `dvui.Backend.InitWindowOptions` but provides defaults for convenience,
-/// and doesn't contains fields that dvui can reasonnably grab from previous instances, like gpa/io ...
+/// Note that each backend is free to maintain some global state and
+/// is responsible to interpret these options and the resulting effect may vary.
 ///
-/// Fields that are left to `null` will be grab from parent window where applicable.
+/// Fields that are left to `null` will be grab from parent window where possible.
 pub const InitOptions = struct {
     /// Usually displayed on the top of the window.
     title: ?[:0]const u8 = null,
@@ -39,22 +39,20 @@ pub const InitOptions = struct {
     min_size: ?dvui.Size = null,
     /// Set the maximum size of the window
     max_size: ?dvui.Size = null,
-    hidden: ?bool = null,
-    transparent: ?bool = null,
 
     fullscreen: bool = false,
-    vsync: bool = true,
+    hidden: bool = false,
 };
 
 /// Close the child Os Window context, effectively rendering it.
 pub fn deinit(self: OsWindowWidget) void {
-    if (Backend.support_multi_os_wins)
+    if (Backend.support_child_os_wins)
         self.inner.end_micros = self.inner.dvui_win.end(.{}) catch unreachable
     else
         self.inner.deinit();
 }
 
-pub fn osWindowImpl(src: std.builtin.SourceLocation, os_win_opts: OsWindowWidget.InitOptions, win_opts: Window.InitOptions) OsWindowWidget {
+pub fn osWindowImpl(src: std.builtin.SourceLocation, child_win_opts: OsWindowWidget.InitOptions, win_opts: Window.InitOptions) OsWindowWidget {
     const hashval = dvui.Id.extendId(null, src, win_opts.id_extra);
     const cw = dvui.currentWindow();
     const win_maybe = cw.child_os_wins.getOrPut(cw.gpa, hashval) catch @panic("OOM");
@@ -62,26 +60,8 @@ pub fn osWindowImpl(src: std.builtin.SourceLocation, os_win_opts: OsWindowWidget
         win_maybe.value_ptr
     else blk: {
         const new_backend = cw.gpa.create(dvui.backend) catch @panic("OOM");
-        const parent_win_opts: Backend.InitWindowOptions = cw.backend.impl.initwindow_opts orelse opts: {
-            dvui.logError(src, error.BackendError, "Opening new OS window but the parent backend did not store `initwindow_opts`. `backend.initWindow` is supposed to do that.", .{});
-            break :opts .{ .io = dvui.io, .allocator = cw.gpa, .size = .{ .w = 800, .h = 600 }, .title = "Dvui child window" };
-        };
-        new_backend.* = dvui.backend.initWindow(.{
-            .global_init = false,
-            .io = parent_win_opts.io,
-            .allocator = parent_win_opts.allocator,
-            .environ_map = parent_win_opts.environ_map,
+        new_backend.* = cw.backend.impl.initWindowSecondary(child_win_opts) catch @panic("Failed to initialize new backend");
 
-            .title = os_win_opts.title orelse parent_win_opts.title,
-            .size = os_win_opts.size orelse parent_win_opts.size,
-            .icon = os_win_opts.icon orelse parent_win_opts.icon,
-            .min_size = os_win_opts.min_size orelse parent_win_opts.min_size,
-            .max_size = os_win_opts.max_size orelse parent_win_opts.max_size,
-            .hidden = os_win_opts.hidden orelse parent_win_opts.hidden,
-            .transparent = os_win_opts.transparent orelse parent_win_opts.transparent,
-            .vsync = os_win_opts.vsync,
-            .fullscreen = os_win_opts.fullscreen,
-        }) catch @panic("Failed to initialize new backend");
         // this is just for easy debug but would be nice to have a nudge strategy where possible.
         // But this as a whole other can of worms. Don't even know if this is possible on wayland for instance.
         _ = dvui.backend.c.SDL_SetWindowPosition(new_backend.window, 850, 150);
@@ -103,12 +83,12 @@ pub fn osWindowImpl(src: std.builtin.SourceLocation, os_win_opts: OsWindowWidget
     return .{ .inner = os_win };
 }
 
-pub fn osWindowFallback(src: std.builtin.SourceLocation, os_win_opts: OsWindowWidget.InitOptions) OsWindowWidget {
+pub fn osWindowFallback(src: std.builtin.SourceLocation, child_win_opts: OsWindowWidget.InitOptions) OsWindowWidget {
     const float = dvui.floatingWindow(src, .{}, .{
         // TODO : review which os_win_opts make sense to "forward"
     });
     // TODO : deal with close flag somehow. osWindowFallback should have a close button, because an OS window do
-    float.dragAreaSet(dvui.windowHeader(os_win_opts.title orelse "Dvui child window", "", null));
+    float.dragAreaSet(dvui.windowHeader(child_win_opts.title orelse "Dvui child window", "", null));
     // TODO : deal with Floating window inside the floating window.
     // something is wrong with rendering order, but maybe we want the floating win declared
     // inside an osWindow to not be able to exceed it's boundaries ? Or on the contrary it's nice

--- a/src/widgets/OsWindowWidget.zig
+++ b/src/widgets/OsWindowWidget.zig
@@ -88,6 +88,7 @@ pub fn osWindowImpl(src: std.builtin.SourceLocation, os_win_opts: OsWindowWidget
 
         const new_dvui_win = cw.gpa.create(dvui.Window) catch @panic("OOM");
         new_dvui_win.* = dvui.Window.init(src, cw.gpa, new_backend.backend(), .{
+            .id_extra = win_opts.id_extra,
             .theme = win_opts.theme orelse cw.theme,
             .button_order = win_opts.button_order orelse cw.button_order,
         }) catch

--- a/src/widgets/OsWindowWidget.zig
+++ b/src/widgets/OsWindowWidget.zig
@@ -1,0 +1,123 @@
+//! Spawn a new OS Window
+//!
+//! If not supported by the backend, a `dvui.FloatingWindowWidget` will be used as fallback.
+//!
+//! This is not technically a widget (it doesn't conform to the interface) but is
+//! essentially a wrapping container around a heap allocated backend/dvui.Window, or around a FloatingWindowWidget in the fallback case.
+//!
+//! See `dvui.osWindow`
+
+const OsWindowWidget = @This();
+
+inner: if (Backend.support_multi_os_wins)
+    *ChildOsWindow
+else
+    *FloatingWindowWidget,
+
+/// Thin wrapper allowing to heap allocate a new os window.
+pub const ChildOsWindow = struct {
+    backend: *dvui.backend,
+    dvui_win: *dvui.Window,
+    end_micros: ?u32 = null,
+};
+
+/// User options for a new os window. See `dvui.osWindow`
+///
+/// Very similar to `dvui.Backend.InitWindowOptions` but provides defaults for convenience,
+/// and doesn't contains fields that dvui can reasonnably grab from previous instances, like gpa/io ...
+///
+/// Fields that are left to `null` will be grab from parent window where applicable.
+pub const InitOptions = struct {
+    /// Usually displayed on the top of the window.
+    title: ?[:0]const u8 = null,
+    /// content of a PNG image (or any other format stb_image can load)
+    /// tip: use @embedFile
+    icon: ?[]const u8 = null,
+    /// Initial size of the os window.
+    size: ?dvui.Size = null,
+    /// Set the minimum size of the window
+    min_size: ?dvui.Size = null,
+    /// Set the maximum size of the window
+    max_size: ?dvui.Size = null,
+    hidden: ?bool = null,
+    transparent: ?bool = null,
+
+    fullscreen: bool = false,
+    vsync: bool = true,
+};
+
+/// Close the child Os Window context, effectively rendering it.
+pub fn deinit(self: OsWindowWidget) void {
+    if (Backend.support_multi_os_wins)
+        self.inner.end_micros = self.inner.dvui_win.end(.{}) catch unreachable
+    else
+        self.inner.deinit();
+}
+
+pub fn osWindowImpl(src: std.builtin.SourceLocation, os_win_opts: OsWindowWidget.InitOptions, win_opts: Window.InitOptions) OsWindowWidget {
+    const hashval = dvui.Id.extendId(null, src, win_opts.id_extra);
+    const cw = dvui.currentWindow();
+    const win_maybe = cw.child_os_wins.getOrPut(cw.gpa, hashval) catch @panic("OOM");
+    const os_win: *ChildOsWindow = if (win_maybe.found_existing)
+        win_maybe.value_ptr
+    else blk: {
+        const new_backend = cw.gpa.create(dvui.backend) catch @panic("OOM");
+        const parent_win_opts: Backend.InitWindowOptions = cw.backend.impl.initwindow_opts orelse opts: {
+            dvui.logError(src, error.BackendError, "Opening new OS window but the parent backend did not store `initwindow_opts`. `backend.initWindow` is supposed to do that.", .{});
+            break :opts .{ .io = dvui.io, .allocator = cw.gpa, .size = .{ .w = 800, .h = 600 }, .title = "Dvui child window" };
+        };
+        new_backend.* = dvui.backend.initWindow(.{
+            .global_init = false,
+            .io = parent_win_opts.io,
+            .allocator = parent_win_opts.allocator,
+            .environ_map = parent_win_opts.environ_map,
+
+            .title = os_win_opts.title orelse parent_win_opts.title,
+            .size = os_win_opts.size orelse parent_win_opts.size,
+            .icon = os_win_opts.icon orelse parent_win_opts.icon,
+            .min_size = os_win_opts.min_size orelse parent_win_opts.min_size,
+            .max_size = os_win_opts.max_size orelse parent_win_opts.max_size,
+            .hidden = os_win_opts.hidden orelse parent_win_opts.hidden,
+            .transparent = os_win_opts.transparent orelse parent_win_opts.transparent,
+            .vsync = os_win_opts.vsync,
+            .fullscreen = os_win_opts.fullscreen,
+        }) catch @panic("Failed to initialize new backend");
+        // this is just for easy debug but would be nice to have a nudge strategy where possible.
+        // But this as a whole other can of worms. Don't even know if this is possible on wayland for instance.
+        _ = dvui.backend.c.SDL_SetWindowPosition(new_backend.window, 850, 150);
+
+        const new_dvui_win = cw.gpa.create(dvui.Window) catch @panic("OOM");
+        new_dvui_win.* = dvui.Window.init(src, cw.gpa, new_backend.backend(), .{
+            .theme = win_opts.theme orelse cw.theme,
+            .button_order = win_opts.button_order orelse cw.button_order,
+        }) catch
+            @panic("Failed to initialize new dvui.Window");
+        win_maybe.value_ptr.* = .{ .backend = new_backend, .dvui_win = new_dvui_win };
+        break :blk win_maybe.value_ptr;
+    };
+    std.debug.assert(os_win.dvui_win.data().id == hashval);
+    os_win.dvui_win.begin(cw.frame_time_ns) catch |err| {
+        dvui.logError(@src(), err, "Something wrong in child's dvui.Window.begin()", .{});
+    };
+    return .{ .inner = os_win };
+}
+
+pub fn osWindowFallback(src: std.builtin.SourceLocation, os_win_opts: OsWindowWidget.InitOptions) OsWindowWidget {
+    const float = dvui.floatingWindow(src, .{}, .{
+        // TODO : review which os_win_opts make sense to "forward"
+    });
+    // TODO : deal with close flag somehow. osWindowFallback should have a close button, because an OS window do
+    float.dragAreaSet(dvui.windowHeader(os_win_opts.title orelse "Dvui child window", "", null));
+    // TODO : deal with Floating window inside the floating window.
+    // something is wrong with rendering order, but maybe we want the floating win declared
+    // inside an osWindow to not be able to exceed it's boundaries ? Or on the contrary it's nice
+    // that they just become "sibling" floating window ?
+    return .{ .inner = float };
+}
+
+const std = @import("std");
+const dvui = @import("../dvui.zig");
+
+const Backend = dvui.Backend;
+const Window = dvui.Window;
+const FloatingWindowWidget = dvui.FloatingWindowWidget;


### PR DESCRIPTION
This PR is a proposition to tackle #870

- Moved osWindow logic to a dedicated file.
  I called it osWindowWidget despite not technically using the widget interface, but I believe it's an implementation detail that is irrelevant for the end user (and might change honestly)

- Added a basic FloatingWidget fallback. It's comptime parametrization over backend capability for now.
  Also added a mini something in the `examples/app.zig`. Try `zig build sdl3-app` and `zig build raylib-app` to test the fallback.

- "Normalization" strategy for `initWindow`. See compile time logic in `Backend.zig`.

The last point is the important one and where I'm wondering if it's the right way.

I choose this way over just making `initWindow` part of the interface because 
a) it's not required since you don't need to access the `impl` field.
b) I wanted to minimize the amount of code change needed in other backends. (zero in that case)
c) avoid littering backend without multi win support with no-op functions
d) provide "enforcing documentation" via @compileError()

I'm quite satisfied with the result but maybe I find it nice because I spent time with it. In dire need of fresh opinion ;-)

The think that I'm less sure about it the `Backend.InitWindowOptions`/`OsWindowWidget.InitOptions` thingy.

My thinking :
- we need a way for dvui to call `Backend.initWindow` that is backend agnostic
- we want the user to be able to call `dvui.osWindow(@src().{},.{})` and have reasonable defaults (e.g. grabbing icon from main window)
- therefore we need both a stable `initWindow` signature and access to the parent options ( backend must store `initwindow_opts` field requirement)
- some `InitWindowOptions` fields are mandatory for first init (e.g. io/allocator) but are irrelevant for end user (reused from parent). 
  Therefore we need a second struct that do not contain irrelevant fields and act as override only.

It's a bit of a stretch, and slightly memory wasteful (albeit we shouldn't have too much os windows)
On the bright side, once the backend store this big "superset init options", it is free to do whatever it wants the way it wants as long as it results in a fresh usable os window.

Again, in dire need of fresh eyes.
