### PR TITLE
Add open_flag to dvui.Window

### DIFF
--- a/examples/app.zig
+++ b/examples/app.zig
@@ -144,11 +144,16 @@ pub fn content() ?dvui.App.Result {
         dvui.toggleDebugWindow();
     }
 
-    if (dvui.button(@src(), "Extra OS Window (experimental)", .{}, .{})) {
+    const os_win_label = if (extra_os_win) "Close the Os Window" else "Extra OS Window (experimental)";
+    if (dvui.button(@src(), os_win_label, .{}, .{})) {
         extra_os_win = !extra_os_win;
     }
     if (extra_os_win) {
-        const os_win = dvui.osWindow(@src(), .{ .title = "Child os window (or so I hope)", .size = .{ .w = 500, .h = 300 } }, .{});
+        const os_win = dvui.osWindow(
+            @src(),
+            .{ .title = "Child os window (or so I hope)", .size = .{ .w = 500, .h = 300 } },
+            .{ .open_flag = &extra_os_win },
+        );
         defer os_win.deinit();
         const b = dvui.box(@src(), .{}, .{ .background = true });
         defer b.deinit();

--- a/examples/raylib-standalone.zig
+++ b/examples/raylib-standalone.zig
@@ -40,6 +40,7 @@ pub fn main(init: std.process.Init) !void {
     // turn off normal raylib behavior where escape closes the window
     c.SetExitKey(0);
 
+    var window_open = true;
     // init dvui Window (maps onto a single OS window)
     var win = try dvui.Window.init(@src(), init.gpa, backend.backend(), .{
         // you can set the default theme here in the init options
@@ -47,12 +48,13 @@ pub fn main(init: std.process.Init) !void {
             .light => dvui.Theme.builtin.adwaita_light,
             .dark => dvui.Theme.builtin.adwaita_dark,
         },
+        .open_flag = &window_open,
     });
     defer win.deinit();
 
     var interrupted = true;
 
-    main_loop: while (true) {
+    main_loop: while (window_open) {
         c.BeginDrawing();
 
         // beginWait coordinates with waitTime below to run frames only when needed
@@ -206,13 +208,6 @@ fn dvui_frame() bool {
     // only shows the demo if dvui.Examples.show_demo_window is true
     // .full -> .lite or comment out to speed up compile times
     dvui.Examples.demo(.full);
-
-    // check for quitting
-    for (dvui.events()) |*e| {
-        // assume we only have a single window
-        if (e.evt == .window and e.evt.window.action == .close) return false;
-        if (e.evt == .app and e.evt.app.action == .quit) return false;
-    }
 
     return true;
 }

--- a/examples/raylib-zig-standalone.zig
+++ b/examples/raylib-zig-standalone.zig
@@ -39,6 +39,7 @@ pub fn main(init: std.process.Init) !void {
     // turn off normal raylib behavior where escape closes the window
     raylib.setExitKey(.null);
 
+    var window_open = true;
     // init dvui Window (maps onto a single OS window)
     var win = try dvui.Window.init(@src(), init.gpa, backend.backend(), .{
         // you can set the default theme here in the init options
@@ -46,12 +47,13 @@ pub fn main(init: std.process.Init) !void {
             .light => dvui.Theme.builtin.adwaita_light,
             .dark => dvui.Theme.builtin.adwaita_dark,
         },
+        .open_flag = &window_open,
     });
     defer win.deinit();
 
     var interrupted = true;
 
-    main_loop: while (true) {
+    main_loop: while (window_open) {
         raylib.beginDrawing();
 
         // beginWait coordinates with waitTime below to run frames only when needed
@@ -203,12 +205,6 @@ fn dvui_frame() bool {
     // only shows the demo if dvui.Examples.show_demo_window is true
     // .full -> .lite or comment out to speed up compile times
     dvui.Examples.demo(.full);
-
-    for (dvui.events()) |*e| {
-        // assume we only have a single window
-        if (e.evt == .window and e.evt.window.action == .close) return false;
-        if (e.evt == .app and e.evt.app.action == .quit) return false;
-    }
 
     return true;
 }

--- a/examples/sdl-multi-win.zig
+++ b/examples/sdl-multi-win.zig
@@ -51,19 +51,21 @@ pub fn main(init: std.process.Init) !void {
 
     _ = SDLBackend.c.SDL_EnableScreenSaver();
 
+    var window_open = true;
     var win = try dvui.Window.init(@src(), init.gpa, backend.backend(), .{
         // you can set the default theme here in the init options
         .theme = switch (backend.preferredColorScheme() orelse .light) {
             .light => dvui.Theme.builtin.adwaita_light,
             .dark => dvui.Theme.builtin.adwaita_dark,
         },
+        .open_flag = &window_open,
     });
     defer win.deinit();
 
     var interrupted = false;
     var frame_no: u32 = 0;
 
-    main_loop: while (true) {
+    main_loop: while (window_open) {
         std.debug.print("begin frame no {}\n", .{frame_no});
         frame_no += 1;
 
@@ -150,7 +152,7 @@ fn gui_frame() bool {
                 // But I'm not sure how to deal with that.
                 // Should `dvui.Window.ChildOsWindow` have a "rendered" field so we can warn the user if it has multiple draw cycle in one main_loop ?
                 // Or maybe doing the rendering in `Window.end()` is not the best strategy after all ?
-                const os_win = dvui.osWindow(@src(), .{ .title = win_title }, .{ .id_extra = i });
+                const os_win = dvui.osWindow(@src(), .{ .title = win_title }, .{ .id_extra = i, .open_flag = &os_win_active[i] });
                 defer os_win.deinit();
 
                 var tl2 = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal, .font = .theme(.title) });
@@ -227,13 +229,6 @@ fn gui_frame() bool {
 
     if (dd_demo_res.choice == DemoChoice.on_main) {
         dvui.Examples.demo(.lite);
-    }
-
-    // check for quitting
-    for (dvui.events()) |*e| {
-        // assume we only have a single window
-        if (e.evt == .window and e.evt.window.action == .close) return false;
-        if (e.evt == .app and e.evt.app.action == .quit) return false;
     }
 
     return true;

--- a/examples/sdl-standalone.zig
+++ b/examples/sdl-standalone.zig
@@ -46,6 +46,7 @@ pub fn main(init: std.process.Init) !void {
 
     _ = SDLBackend.c.SDL_EnableScreenSaver();
 
+    var window_open = true;
     // init dvui Window (maps onto a single OS window)
     var win = try dvui.Window.init(@src(), init.gpa, backend.backend(), .{
         // you can set the default theme here in the init options
@@ -53,12 +54,13 @@ pub fn main(init: std.process.Init) !void {
             .light => dvui.Theme.builtin.adwaita_light,
             .dark => dvui.Theme.builtin.adwaita_dark,
         },
+        .open_flag = &window_open,
     });
     defer win.deinit();
 
     var interrupted = false;
 
-    main_loop: while (true) {
+    main_loop: while (window_open) {
         // beginWait coordinates with waitTime below to run frames only when needed
         const nstime = win.beginWait(interrupted);
 
@@ -233,13 +235,6 @@ fn gui_frame() bool {
     // only shows the demo if dvui.Examples.show_demo_window is true
     // .full -> .lite or comment out to speed up compile times
     dvui.Examples.demo(.full);
-
-    // check for quitting
-    for (dvui.events()) |*e| {
-        // assume we only have a single window
-        if (e.evt == .window and e.evt.window.action == .close) return false;
-        if (e.evt == .app and e.evt.app.action == .quit) return false;
-    }
 
     return true;
 }

--- a/examples/sdl3gpu-standalone.zig
+++ b/examples/sdl3gpu-standalone.zig
@@ -39,18 +39,20 @@ pub fn main(main_init: std.process.Init) !void {
 
     _ = c.SDL_EnableScreenSaver();
 
+    var window_open = true;
     // init dvui Window (maps onto a single OS window)
     var win = try dvui.Window.init(@src(), main_init.gpa, backend.backend(), .{
         .theme = switch (backend.preferredColorScheme() orelse .light) {
             .light => dvui.Theme.builtin.adwaita_light,
             .dark => dvui.Theme.builtin.adwaita_dark,
         },
+        .open_flag = &window_open,
     });
     defer win.deinit();
 
     var interrupted = false;
 
-    main_loop: while (true) {
+    main_loop: while (window_open) {
         // beginWait coordinates with waitTime below to run frames only when needed
         const nstime = win.beginWait(interrupted);
 
@@ -198,12 +200,6 @@ fn gui_frame() bool {
     // only shows the demo if dvui.Examples.show_demo_window is true
     // .full -> .lite or comment out to speed up compile times
     dvui.Examples.demo(.full);
-
-    // check for quitting
-    for (dvui.events()) |*e| {
-        if (e.evt == .window and e.evt.window.action == .close) return false;
-        if (e.evt == .app and e.evt.app.action == .quit) return false;
-    }
 
     return true;
 }

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -123,6 +123,9 @@ _widget_stack: WidgetStack,
 render_target: dvui.RenderTarget = .{ .texture = null, .offset = .{} },
 end_rendering_done: bool = false,
 
+/// See `InitOptions.open_flag`
+open_flag: ?*bool = null,
+
 debug: @import("Debug.zig") = .{},
 
 accesskit: dvui.AccessKit,
@@ -140,6 +143,11 @@ pub const InitOptions = struct {
         windows,
         mac,
     } = null,
+
+    /// If dvui process a "quit window" event for this window, it will set this flag to false.
+    ///
+    /// Leave to `null` if you are dealing with such events yourself.
+    open_flag: ?*bool = null,
 
     button_order: ?dvui.enums.DialogButtonOrder = null,
 };
@@ -172,6 +180,7 @@ pub fn init(
         // Set in `begin`
         .current_parent = undefined,
         .theme = undefined, // set below
+        .open_flag = init_opts.open_flag,
         .backend = backend_ctx,
         .accesskit = .{},
     };
@@ -1554,6 +1563,10 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
                 e.handle(@src(), self.data());
                 dvui.tabIndexPrev(e.num);
             }
+        } else if (e.evt == .window) {
+            if (e.evt.window.action == .close) self.close();
+        } else if (e.evt == .app) {
+            if (e.evt.app.action == .quit) self.close();
         }
     }
 
@@ -1654,6 +1667,14 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
     }
 
     return ret;
+}
+
+fn close(self: *Self) void {
+    if (self.open_flag) |of| {
+        of.* = false;
+    } else {
+        dvui.log.warn("{s}:{d} dvui.Window processed closing window event but it has no open_flag", .{ self.data().src.file, self.data().src.line });
+    }
 }
 
 fn initEvents(self: *Self) std.mem.Allocator.Error!void {

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -1749,6 +1749,11 @@ pub fn main(init: std.process.Init) !void {
 
     const win = b.getWindow();
 
+    if (init_opts.window_init_options.open_flag != null)
+        dvui.log.warn("`open_flag` option has no effect in dvui App. It is managed internally in that case.", .{});
+    var window_open = true;
+    win.open_flag = &window_open;
+
     if (app.initFn) |initFn| {
         try win.begin(win.frame_time_ns);
         try initFn(win);
@@ -1756,7 +1761,7 @@ pub fn main(init: std.process.Init) !void {
     }
     defer if (app.deinitFn) |deinitFn| deinitFn();
 
-    while (true) switch (serviceMessageQueue()) {
+    while (window_open) switch (serviceMessageQueue()) {
         .queue_empty => {
             // beginWait coordinates with waitTime below to run frames only when needed
             const nstime = win.beginWait(b.hasEvent());
@@ -1765,15 +1770,7 @@ pub fn main(init: std.process.Init) !void {
             try win.begin(nstime);
 
             // both dvui and dx11 drawing
-            var res = try app.frameFn();
-
-            // check for unhandled quit/close
-            for (dvui.events()) |*e| {
-                if (e.handled) continue;
-                // assuming we only have a single window
-                if (e.evt == .window and e.evt.window.action == .close) res = .close;
-                if (e.evt == .app and e.evt.app.action == .quit) res = .close;
-            }
+            const res = try app.frameFn();
 
             // marks end of dvui frame, don't call dvui functions after this
             // - sends all dvui stuff to backend for rendering

--- a/src/backends/glfw.zig
+++ b/src/backends/glfw.zig
@@ -668,9 +668,14 @@ pub fn main(main_init: std.process.Init) !void {
     var win = try dvui.Window.init(@src(), gpa, backend, .{});
     defer win.deinit();
 
+    if (config.window_init_options.open_flag != null)
+        dvui.log.warn("`open_flag` option has no effect in dvui App. It is managed internally in that case.", .{});
+    var window_open = true;
+    win.open_flag = &window_open;
+
     var interrupted = true;
 
-    while (!window.shouldClose()) {
+    while (!window.shouldClose() and window_open) {
         impl.addAllEvents(&win);
 
         // temporarily disabled due to "unable to perform tail call: compiler backend 'stage2_x86_64' does not support tail calls"
@@ -680,12 +685,7 @@ pub fn main(main_init: std.process.Init) !void {
         const nstime = win.beginWait(interrupted);
         try win.begin(nstime);
 
-        var res = try app.frameFn();
-        for (dvui.events()) |*e| {
-            if (e.handled) continue;
-            if (e.evt == .window and e.evt.window.action == .close) res = .close;
-            if (e.evt == .app and e.evt.app.action == .quit) res = .close;
-        }
+        const res = try app.frameFn();
 
         const end_micros = try win.end(.{});
         const wait_event_micros = win.waitTime(end_micros);

--- a/src/backends/raylib-c.zig
+++ b/src/backends/raylib-c.zig
@@ -1104,6 +1104,11 @@ pub fn main(main_init: std.process.Init) !void {
     var win = try dvui.Window.init(@src(), gpa, b.backend(), init_opts.window_init_options);
     defer win.deinit();
 
+    if (init_opts.window_init_options.open_flag != null)
+        dvui.log.warn("`open_flag` option has no effect in dvui App. It is managed internally in that case.", .{});
+    var window_open = true;
+    win.open_flag = &window_open;
+
     if (app.initFn) |initFn| {
         try win.begin(win.frame_time_ns);
         try initFn(&win);
@@ -1113,7 +1118,7 @@ pub fn main(main_init: std.process.Init) !void {
 
     var interrupted = true;
 
-    main_loop: while (true) {
+    main_loop: while (window_open) {
         c.BeginDrawing();
 
         // beginWait coordinates with waitTime below to run frames only when needed
@@ -1129,15 +1134,7 @@ pub fn main(main_init: std.process.Init) !void {
         // the previous frame's render
         b.clear();
 
-        var res = try app.frameFn();
-
-        // check for unhandled quit/close
-        for (dvui.events()) |*e| {
-            if (e.handled) continue;
-            // assuming we only have a single window
-            if (e.evt == .window and e.evt.window.action == .close) res = .close;
-            if (e.evt == .app and e.evt.app.action == .quit) res = .close;
-        }
+        const res = try app.frameFn();
 
         // marks end of dvui frame, don't call dvui functions after this
         // - sends all dvui stuff to backend for rendering, must be called before renderPresent()

--- a/src/backends/raylib-zig.zig
+++ b/src/backends/raylib-zig.zig
@@ -1090,6 +1090,11 @@ pub fn main(main_init: std.process.Init) !void {
     var win = try dvui.Window.init(@src(), gpa, b.backend(), init_opts.window_init_options);
     defer win.deinit();
 
+    if (init_opts.window_init_options.open_flag != null)
+        dvui.log.warn("`open_flag` option has no effect in dvui App. It is managed internally in that case.", .{});
+    var window_open = true;
+    win.open_flag = &window_open;
+
     if (app.initFn) |initFn| {
         try win.begin(win.frame_time_ns);
         try initFn(&win);
@@ -1099,7 +1104,7 @@ pub fn main(main_init: std.process.Init) !void {
 
     var interrupted = true;
 
-    main_loop: while (true) {
+    main_loop: while (window_open) {
         raylib.beginDrawing();
 
         // beginWait coordinates with waitTime below to run frames only when needed
@@ -1115,15 +1120,7 @@ pub fn main(main_init: std.process.Init) !void {
         // the previous frame's render
         b.clear();
 
-        var res = try app.frameFn();
-
-        // check for unhandled quit/close
-        for (dvui.events()) |*e| {
-            if (e.handled) continue;
-            // assuming we only have a single window
-            if (e.evt == .window and e.evt.window.action == .close) res = .close;
-            if (e.evt == .app and e.evt.app.action == .quit) res = .close;
-        }
+        const res = try app.frameFn();
 
         // marks end of dvui frame, don't call dvui functions after this
         // - sends all dvui stuff to backend for rendering, must be called before renderPresent()

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1862,6 +1862,11 @@ pub fn main(main_init: std.process.Init) !u8 {
     var win = try dvui.Window.init(@src(), main_init.gpa, back.backend(), init_opts.window_init_options);
     defer win.deinit();
 
+    if (init_opts.window_init_options.open_flag != null)
+        dvui.log.warn("`open_flag` option has no effect in dvui App. It is managed internally in that case.", .{});
+    var window_open = true;
+    win.open_flag = &window_open;
+
     if (app.initFn) |initFn| {
         try win.begin(win.frame_time_ns);
         try initFn(&win);
@@ -1871,7 +1876,7 @@ pub fn main(main_init: std.process.Init) !u8 {
 
     var interrupted = false;
 
-    main_loop: while (true) {
+    main_loop: while (window_open) {
 
         // beginWait coordinates with waitTime below to run frames only when needed
         const nstime = win.beginWait(interrupted);
@@ -1882,15 +1887,7 @@ pub fn main(main_init: std.process.Init) !u8 {
         // send all SDL events to dvui for processing
         try back.addAllEvents(&win);
 
-        var res = try app.frameFn();
-
-        // check for unhandled quit/close
-        for (dvui.events()) |*e| {
-            if (e.handled) continue;
-            // assuming we only have a single window
-            if (e.evt == .window and e.evt.window.action == .close) res = .close;
-            if (e.evt == .app and e.evt.app.action == .quit) res = .close;
-        }
+        const res = try app.frameFn();
 
         const end_micros = try win.end(.{});
 

--- a/src/backends/wio.zig
+++ b/src/backends/wio.zig
@@ -304,6 +304,11 @@ pub fn main(main_init: std.process.Init) !void {
     var win = try dvui.Window.init(@src(), gpa, dvui_wio.backend(&renderer), config.window_init_options);
     defer win.deinit();
 
+    if (config.window_init_options.open_flag != null)
+        dvui.log.warn("`open_flag` option has no effect in dvui App. It is managed internally in that case.", .{});
+    var window_open = true;
+    win.open_flag = &window_open;
+
     if (app.initFn) |initFn| {
         try win.begin(win.frame_time_ns);
         try initFn(&win);
@@ -311,7 +316,7 @@ pub fn main(main_init: std.process.Init) !void {
     }
     defer if (app.deinitFn) |deinitFn| deinitFn();
 
-    while (true) {
+    while (window_open) {
         wio.update();
         while (events.pop()) |event| {
             _ = try dvui_wio.addEvent(&win, event);
@@ -319,12 +324,7 @@ pub fn main(main_init: std.process.Init) !void {
 
         const time = win.beginWait(true);
         try win.begin(time);
-        var res = try app.frameFn();
-        for (dvui.events()) |*e| {
-            if (!e.handled) {
-                if (e.evt == .window and e.evt.window.action == .close) res = .close;
-            }
-        }
+        const res = try app.frameFn();
         const end_us = try win.end(.{});
         if (res != .ok) break;
 

--- a/src/widgets/OsWindowWidget.zig
+++ b/src/widgets/OsWindowWidget.zig
@@ -71,6 +71,9 @@ pub fn osWindowImpl(src: std.builtin.SourceLocation, child_win_opts: OsWindowWid
             .id_extra = win_opts.id_extra,
             .theme = win_opts.theme orelse cw.theme,
             .button_order = win_opts.button_order orelse cw.button_order,
+            // Do not grab the parent's one, because closing a child window is not the same as
+            // quitting the application. User should explicitly use the same open_flag for this behavior.
+            .open_flag = win_opts.open_flag,
         }) catch
             @panic("Failed to initialize new dvui.Window");
         win_maybe.value_ptr.* = .{ .backend = new_backend, .dvui_win = new_dvui_win };


### PR DESCRIPTION
This allows to solve very naturally and elegantly the "closing child os window" use case.

In "standalone" style, it's slightly more cryptic but brings consistency in and reduce the line count in the examples.

In "ontop" style, it's not used at all.

Tackle #872 