### PR TITLE
fix compile error when using dvui.App.config.startFn with sdl backend

### DIFF
--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1937,7 +1937,7 @@ fn appInit(appstate: ?*?*anyopaque, argc: c_int, argv: ?[*:null]?[*:0]u8) callco
     }
 
     //// init dvui Window (maps onto a single OS window)
-    appState.win = dvui.Window.init(@src(), appState.gpa, appState.back.backend(), app.config.options.window_init_options) catch |err| {
+    appState.win = dvui.Window.init(@src(), appState.gpa, appState.back.backend(), init_opts.window_init_options) catch |err| {
         log.err("dvui.Window.init failed: {any}", .{err});
         return c.SDL_APP_FAILURE;
     };


### PR DESCRIPTION
Supplying App.StartOptions via startFn would not compile because of direct access to App.config.options in sdl.zig. The correctly resolved init_opts are already available - easy fix.