### PR TITLE
Multi win debug window

### DIFF
--- a/examples/sdl-multi-win.zig
+++ b/examples/sdl-multi-win.zig
@@ -147,12 +147,7 @@ fn gui_frame() bool {
             }
             if (os_win_active[i]) {
                 const win_title = std.fmt.allocPrintSentinel(dvui.currentWindow().arena(), "Nice Window no {}", .{i}, 0) catch @panic("OOM");
-                // FIXME : this breaks DVUI expectation, because if you forget to pass
-                // the `id_extra`, you just get back the same window again, and draw
-                // on top, clear screen and render, so you don't necessarly notice.
-                // But I'm not sure how to deal with that.
-                // Should `dvui.Window.ChildOsWindow` have a "rendered" field so we can warn the user if it has multiple draw cycle in one main_loop ?
-                // Or maybe doing the rendering in `Window.end()` is not the best strategy after all ?
+
                 const os_win = dvui.osWindow(@src(), .{ .title = win_title }, .{ .id_extra = i, .open_flag = &os_win_active[i] });
                 defer os_win.deinit();
 
@@ -243,8 +238,8 @@ pub fn nestedOsWin(n: usize) void {
     }
     if (!nested_wins[n]) return;
 
-    // FIXME : need to make a warning thingy when you forget the id_extra somehow ?
-    const os_win = dvui.osWindow(@src(), .{ .title = "I have the ambition to be an OS win ... (if the backend allows)" }, .{ .id_extra = 0 });
+    // Note that here id_extra is superfluous because the hash is derived from current_window therefore it's really two different windows.
+    const os_win = dvui.osWindow(@src(), .{ .title = "I have the ambition to be an OS win ... (if the backend allows)" }, .{});
     defer os_win.deinit();
 
     nestedOsWin(n + 1);

--- a/examples/sdl-multi-win.zig
+++ b/examples/sdl-multi-win.zig
@@ -118,8 +118,9 @@ fn gui_frame() bool {
             print("clicked on simple test button\n", .{});
         }
 
-        // FIXME : debug is contained in one window.
-        // Opening the debugWindow in win2 works but it should be possible to make it highlight widgets in both windows.
+        // FIXME : debug floating currently always shown on the "primary" window.
+        // Either allow arbitrary window, or give the option to pop-out the debug window itself
+        // as a osWindow
         if (dvui.button(@src(), "Debug Window", .{}, .{})) {
             std.debug.print("  Debug Window button clicked\n", .{});
             dvui.toggleDebugWindow();
@@ -243,9 +244,6 @@ pub fn nestedOsWin(n: usize) void {
     if (!nested_wins[n]) return;
 
     // FIXME : need to make a warning thingy when you forget the id_extra somehow ?
-    // The weird thing is that if you forget the id_extra, you still have functional
-    // windows because each win receive it's own events, but the debug window
-    // rightfully highlight them bundle
     const os_win = dvui.osWindow(@src(), .{ .title = "I have the ambition to be an OS win ... (if the backend allows)" }, .{ .id_extra = 0 });
     defer os_win.deinit();
 

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -59,6 +59,12 @@ pub fn deinit(self: *Debug, gpa: std.mem.Allocator) void {
     }
     self.under_mouse_stack.clearAndFree(gpa);
     self.options_override.deinit(gpa);
+
+    // This is global, and deinit is usually called during Window.deinit.  But
+    // in a testing environment, multiple whole Window init/deinit cycles
+    // happen in the same process.  So prevent access-after-free.
+    self.under_mouse_stack = .empty;
+    self.options_override = .empty;
 }
 
 pub fn errorOutline(rect: Rect.Physical) void {

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -180,7 +180,7 @@ pub fn show(self: *Debug) void {
         }
 
         var wd: dvui.WidgetData = undefined;
-        _ = dvui.checkbox(@src(), &dvui.currentWindow().debug.touch_simulate_events, "Simulate Touch", .{ .data_out = &wd });
+        _ = dvui.checkbox(@src(), &dvui.debug.touch_simulate_events, "Simulate Touch", .{ .data_out = &wd });
 
         dvui.tooltip(@src(), .{ .active_rect = wd.borderRectScale().r, .position = .vertical }, "mouse drag will scroll\ntext layout/entry have draggables and menu", .{}, .{});
 

--- a/src/Event.zig
+++ b/src/Event.zig
@@ -43,7 +43,7 @@ pub fn format(self: *const Event, writer: *std.Io.Writer) !void {
 /// matched this event, using `dvui.matchEvent` or similar.
 /// This makes it possible to see which widget handled the event.
 pub fn handle(self: *Event, src: std.builtin.SourceLocation, wd: *const dvui.WidgetData) void {
-    if (dvui.currentWindow().debug.logEvents(null)) {
+    if (dvui.debug.logEvents(null)) {
         dvui.log.debug("{s}:{d} {f} handled by {s} ({x})", .{ src.file, src.line, self, wd.options.name orelse "???", wd.id });
     }
     self.handled = true;
@@ -149,6 +149,8 @@ pub const Window = struct {
         /// User clicked close (or did something) so the window manager is
         /// telling this window to close.
         close,
+        /// Mouse pointer left the window.
+        leave,
     };
 
     action: Action,

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -29,7 +29,7 @@ ak_node: if (dvui.accesskit_enabled) ?*dvui.AccessKit.Node else void = if (dvui.
 pub fn init(src: std.builtin.SourceLocation, init_options: InitOptions, opts: Options) WidgetData {
     const parent = dvui.parentGet();
     const id = parent.extendId(src, opts.idExtra());
-    const options = if (dvui.currentWindow().debug.options_override.get(id)) |val| val.@"0" else opts;
+    const options = if (dvui.debug.options_override.get(id)) |val| val.@"0" else opts;
     const min_size = options.min_sizeGet().min(options.max_sizeGet());
 
     const ms = dvui.minSize(id, min_size);
@@ -118,8 +118,8 @@ pub fn register(self: *WidgetData) void {
         hasher.update(std.mem.asBytes(&(self.id == focused_widget_id)));
     }
 
-    if (cw.debug.target == .focused and self.id == focused_widget_id) {
-        cw.debug.widget_id = self.id;
+    if (dvui.debug.target == .focused and self.id == focused_widget_id) {
+        dvui.debug.widget_id = self.id;
     }
 
     if (cw.min_sizes.containsUsed(self.id)) |used| {
@@ -130,33 +130,33 @@ pub fn register(self: *WidgetData) void {
         }
     }
 
-    if (cw.debug.target.mouse() or self.id == cw.debug.widget_id) {
+    if (dvui.debug.target.mouse() or self.id == dvui.debug.widget_id) {
         var rs = self.rectScale();
 
-        if (cw.debug.target.mouse() and
+        if (dvui.debug.target.mouse() and
             rs.r.contains(cw.mouse_pt) and
             // prevents stuff in scroll area outside viewport being caught
             dvui.clipGet().contains(cw.mouse_pt) and
             // prevents stuff in lower subwindows being caught
             cw.subwindows.windowFor(cw.mouse_pt) == dvui.subwindowCurrentId())
         {
-            cw.debug.under_mouse_stack.append(cw.gpa, .{
+            dvui.debug.under_mouse_stack.append(cw.gpa, .{
                 .id = self.id,
                 // Fallback must be empty so that freeing the name will be valid
                 .name = cw.gpa.dupe(u8, self.options.name orelse "") catch "",
             }) catch |err| {
                 dvui.logError(@src(), err, "Could not add debug info for widgets under mouse position. Widget {x} {s}", .{ self.id, self.options.name orelse "???" });
             };
-            cw.debug.widget_id = self.id;
+            dvui.debug.widget_id = self.id;
         }
 
-        if (self.id == cw.debug.widget_id) {
-            if (cw.debug.widget_panic) {
+        if (self.id == dvui.debug.widget_id) {
+            if (dvui.debug.widget_panic) {
                 @panic("Debug Window Panic");
             }
 
-            cw.debug.target_wd = self.*;
-            cw.debug.target_wd.?.parent = undefined;
+            dvui.debug.target_wd = self.*;
+            dvui.debug.target_wd.?.parent = undefined;
 
             dvui.Debug.errorOutline(rs.r);
         }

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -98,9 +98,13 @@ dialogs: dvui.Dialogs = .{},
 /// positioned floating window at the end of the frame
 toasts: dvui.Dialogs = .{},
 /// Uses `gpa` allocator
-child_os_wins: dvui.TrackingAutoHashMap(dvui.Id, dvui.OsWindowWidget.ChildOsWindow, .get_and_put, void) = .empty,
-/// Uses `gpa` allocator
 keybinds: std.StringHashMapUnmanaged(dvui.enums.Keybind) = .empty,
+
+/// Uses `gpa` allocator
+child_os_wins: dvui.TrackingAutoHashMap(dvui.Id, dvui.OsWindowWidget.ChildOsWindow, .get_and_put, void) = .empty,
+/// set to false by `dvui.OsWindow` to spot child windows.
+///  Noticably allow `dvui.debug` to know when we reach the "last" `dvui.end()`
+is_primary: bool = true,
 
 cursor_requested: ?dvui.enums.Cursor = null,
 
@@ -125,8 +129,6 @@ end_rendering_done: bool = false,
 
 /// See `InitOptions.open_flag`
 open_flag: ?*bool = null,
-
-debug: @import("Debug.zig") = .{},
 
 accesskit: dvui.AccessKit,
 
@@ -388,7 +390,8 @@ pub fn deinit(self: *Self) void {
     self.texture_cache.deinit(self.gpa, self.backend);
     self.fonts.deinit(self.gpa, self.backend);
 
-    self.debug.deinit(self.gpa);
+    if (self.is_primary)
+        dvui.debug.deinit(self.gpa);
 
     self.subwindows.deinit(self.gpa);
     self.min_sizes.deinit(self.gpa);
@@ -458,7 +461,7 @@ pub fn arena(self: *Self) std.mem.Allocator {
 
 /// called from gui thread
 pub fn refreshWindow(self: *Self, src: std.builtin.SourceLocation, id: ?Id) void {
-    if (self.debug.logRefresh(null)) {
+    if (dvui.debug.logRefresh(null)) {
         log.debug("{s}:{d} refresh {?x}", .{ src.file, src.line, id });
     }
     self.extra_frames_needed = 1;
@@ -466,7 +469,7 @@ pub fn refreshWindow(self: *Self, src: std.builtin.SourceLocation, id: ?Id) void
 
 /// called from any thread
 pub fn refreshBackend(self: *Self, src: std.builtin.SourceLocation, id: ?Id) void {
-    if (self.debug.logRefresh(null)) {
+    if (dvui.debug.logRefresh(null)) {
         log.debug("{s}:{d} refreshBackend {?x}", .{ src.file, src.line, id });
     }
     self.backend.refresh();
@@ -587,11 +590,11 @@ pub fn captureEvents(self: *Self, event_num: u16, widgetId: ?Id) void {
 /// for a frame either before begin() or just after begin() and before
 /// calling normal dvui widgets.  end() clears the event list.
 pub fn addEventKey(self: *Self, event: Event.Key) std.mem.Allocator.Error!bool {
-    if (self.debug.target == .mouse_until_esc and event.action == .down and event.code == .escape) {
+    if (dvui.debug.target == .mouse_until_esc and event.action == .down and event.code == .escape) {
         // an escape will stop the debug stuff from following the mouse,
         // but need to stop it at the end of the frame when we've gotten
         // the info
-        self.debug.target = .mouse_quitting;
+        dvui.debug.target = .mouse_quitting;
         return true;
     }
 
@@ -752,7 +755,7 @@ pub fn addEventMouseMotion(self: *Self, opts: AddEventMouseMotionOptions) std.me
         .evt = .{
             .mouse = .{
                 .action = .{ .motion = dp },
-                .button = if (self.debug.touch_simulate_events and self.debug.touch_simulate_down) .touch0 else .none,
+                .button = if (dvui.debug.touch_simulate_events and dvui.debug.touch_simulate_down) .touch0 else .none,
                 .mod = self.modifiers,
                 .p = self.mouse_pt,
                 .floating_win = winId,
@@ -788,21 +791,21 @@ pub const AddEventPointerOptions = struct {
 /// for a frame either before begin() or just after begin() and before
 /// calling normal dvui widgets.  end() clears the event list.
 pub fn addEventPointer(self: *Self, opts: AddEventPointerOptions) std.mem.Allocator.Error!bool {
-    if (self.debug.target == .mouse_until_click and opts.action == .press and opts.button.pointer()) {
+    if (dvui.debug.target == .mouse_until_click and opts.action == .press and opts.button.pointer()) {
         // a left click or touch will stop the debug stuff from following
         // the mouse, but need to stop it at the end of the frame when
         // we've gotten the info
-        self.debug.target = .mouse_quitting;
+        dvui.debug.target = .mouse_quitting;
         return true;
     }
 
     var bb = opts.button;
-    if (self.debug.touch_simulate_events and bb == .left) {
+    if (dvui.debug.touch_simulate_events and bb == .left) {
         bb = .touch0;
         if (opts.action == .press) {
-            self.debug.touch_simulate_down = true;
+            dvui.debug.touch_simulate_down = true;
         } else if (opts.action == .release) {
-            self.debug.touch_simulate_down = false;
+            dvui.debug.touch_simulate_down = false;
         }
     }
 
@@ -1220,7 +1223,8 @@ pub fn begin(
     // just in case something went wrong, start at zero
     dvui.TabIndexGroup.current = .zero;
 
-    self.debug.reset(self.gpa);
+    if (self.is_primary)
+        dvui.debug.reset(self.gpa);
 
     self.data_store.reset(self.gpa);
     self.texture_cache.reset(self.backend);
@@ -1498,7 +1502,8 @@ pub fn endRendering(self: *Self, opts: endOptions) void {
         };
     }
 
-    self.debug.show();
+    if (self.is_primary)
+        dvui.debug.show();
 
     for (self.subwindows.stack.items) |*sw| {
         self.renderCommands(sw.render_cmds.items) catch |err| {
@@ -1537,7 +1542,7 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
     const evts = dvui.events();
     for (evts) |*e| {
         if (self.dragging.state == .dragging and e.evt == .mouse and e.evt.mouse.action == .release) {
-            if (self.debug.logEvents(null)) {
+            if (dvui.debug.logEvents(null)) {
                 log.debug("Clearing drag ({?s}) for unhandled mouse release", .{self.dragging.name});
             }
             self.dragging.state = .none;
@@ -1564,13 +1569,21 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
                 dvui.tabIndexPrev(e.num);
             }
         } else if (e.evt == .window) {
-            if (e.evt.window.action == .close) self.close();
+            if (e.evt.window.action == .close)
+                self.close()
+            else if (e.evt.window.action == .leave) {
+                std.debug.assert(e.target_windowId == self.data().id);
+                e.handle(@src(), self.data());
+                // Put off-screen to avoid things like hover to appear stucked
+                self.mouse_pt = .{ .x = -1, .y = -1 };
+                self.refreshWindow(@src(), null);
+            }
         } else if (e.evt == .app) {
             if (e.evt.app.action == .quit) self.close();
         }
     }
 
-    if (self.debug.logEvents(null)) {
+    if (dvui.debug.logEvents(null)) {
         for (evts) |*e| {
             if (e.handled) continue;
             log.debug("Unhandled {f}", .{e});

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -160,7 +160,10 @@ pub fn init(
     backend_ctx: dvui.Backend,
     init_opts: InitOptions,
 ) !Self {
-    const hashval = dvui.Id.extendId(null, src, init_opts.id_extra);
+    const hashval = if (dvui.current_window) |cw|
+        cw.data().id.extendId(src, init_opts.id_extra)
+    else
+        dvui.Id.extendId(null, src, init_opts.id_extra);
 
     var self = Self{
         .gpa = gpa,
@@ -414,10 +417,7 @@ pub fn deinit(self: *Self) void {
 
     var child_win_it = self.child_os_wins.iterator();
     while (child_win_it.next()) |remaining_win| {
-        remaining_win.value_ptr.backend.deinit();
-        remaining_win.value_ptr.dvui_win.deinit();
-        self.gpa.destroy(remaining_win.value_ptr.backend);
-        self.gpa.destroy(remaining_win.value_ptr.dvui_win);
+        remaining_win.value_ptr.deinit(self.gpa);
     }
     self.child_os_wins.deinit(self.gpa);
 
@@ -1166,8 +1166,6 @@ pub fn waitTime(self: *Self, end_micros: ?u32) u32 {
     // Now that we have the waitTime result for this windows, collect the child's ones
     // and return the smallest to ensure the window in most pressing need gets satisfaction
     var child_win_it = self.child_os_wins.iterator();
-    // Note that this marks the windows as used again, but `Window.begin()`
-    // resets it's child window before the next frame.
     while (child_win_it.next()) |remaining_win| {
         const w = remaining_win.value_ptr.dvui_win;
         const child_wait_event_micros = w.waitTime(remaining_win.value_ptr.end_micros);
@@ -1651,13 +1649,17 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
         self.backend.renderPresent();
     }
 
-    // Now close the child os windows that we didn't see during this frame.
-    var child_win_it = self.child_os_wins.iterator();
-    while (child_win_it.next_resetting()) |missing_win| {
-        missing_win.value.backend.deinit();
-        missing_win.value.dvui_win.deinit();
-        self.gpa.destroy(missing_win.value.backend);
-        self.gpa.destroy(missing_win.value.dvui_win);
+    {
+        // Now close the child os windows that we didn't see during this frame.
+        var child_win_it = self.child_os_wins.iterator();
+        while (child_win_it.next_resetting()) |missing_win| {
+            missing_win.value.deinit(self.gpa);
+        }
+        // And reset the `has_begin` flag to spot duplicate
+        child_win_it = self.child_os_wins.iterator();
+        while (child_win_it.next()) |remaining_win| {
+            remaining_win.value_ptr.has_begin = false;
+        }
     }
 
     // This is what refresh affects

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1419,6 +1419,13 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
             }
             return false;
         },
+        if (sdl3) c.SDL_EVENT_WINDOW_MOUSE_LEAVE else c.SDL_WINDOWEVENT_LEAVE => {
+            if (self.log_events) {
+                log.debug("SDL mouse leave window {}\n", .{event.window.windowID});
+            }
+            try win.addEventWindow(.{ .action = .leave });
+            return false;
+        },
         else => {
             if (self.log_events) {
                 log.debug("unhandled SDL event type {any}\n", .{event.type});

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -418,6 +418,9 @@ pub var current_window: ?*Window = null;
 /// Global Io used by dvui functions, set by the backend when it is initialized.
 pub var io: Io = undefined;
 
+/// Global debug struct.
+pub var debug: dvui.Debug = .{};
+
 /// Get the current `dvui.Window` which corresponds to the OS window we are
 /// currently adding widgets to.
 ///
@@ -521,11 +524,8 @@ pub fn themeSet(theme: Theme) void {
 }
 
 /// Toggle showing the debug window (run during `Window.end`).
-///
-/// Only valid between `Window.begin`and `Window.end`.
 pub fn toggleDebugWindow() void {
-    var cw = currentWindow();
-    cw.debug.open = !cw.debug.open;
+    dvui.debug.open = !dvui.debug.open;
 }
 
 pub const TagData = struct {

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -16,7 +16,7 @@ const FloatingWindowWidget = @This();
 
 /// Defaults is for the embedded box widget
 pub var defaults: Options = .{
-    .name = "Window",
+    .name = "FloatingWindow",
     .role = .dialog,
     .corner_radius = Rect.all(5),
     .margin = Rect.all(2),

--- a/src/widgets/OsWindowWidget.zig
+++ b/src/widgets/OsWindowWidget.zig
@@ -76,6 +76,7 @@ pub fn osWindowImpl(src: std.builtin.SourceLocation, child_win_opts: OsWindowWid
             .open_flag = win_opts.open_flag,
         }) catch
             @panic("Failed to initialize new dvui.Window");
+        new_dvui_win.is_primary = false;
         win_maybe.value_ptr.* = .{ .backend = new_backend, .dvui_win = new_dvui_win };
         break :blk win_maybe.value_ptr;
     };

--- a/src/widgets/OsWindowWidget.zig
+++ b/src/widgets/OsWindowWidget.zig
@@ -19,6 +19,16 @@ pub const ChildOsWindow = struct {
     backend: *dvui.backend,
     dvui_win: *dvui.Window,
     end_micros: ?u32 = null,
+
+    // debug : allows to detect duplicate window
+    has_begin: bool = false,
+
+    pub fn deinit(self: ChildOsWindow, alloc: std.mem.Allocator) void {
+        self.backend.deinit();
+        self.dvui_win.deinit();
+        alloc.destroy(self.backend);
+        alloc.destroy(self.dvui_win);
+    }
 };
 
 /// User options for a new os window. See `dvui.osWindow`
@@ -53,8 +63,8 @@ pub fn deinit(self: OsWindowWidget) void {
 }
 
 pub fn osWindowImpl(src: std.builtin.SourceLocation, child_win_opts: OsWindowWidget.InitOptions, win_opts: Window.InitOptions) OsWindowWidget {
-    const hashval = dvui.Id.extendId(null, src, win_opts.id_extra);
     const cw = dvui.currentWindow();
+    const hashval = cw.data().id.extendId(src, win_opts.id_extra);
     const win_maybe = cw.child_os_wins.getOrPut(cw.gpa, hashval) catch @panic("OOM");
     const os_win: *ChildOsWindow = if (win_maybe.found_existing)
         win_maybe.value_ptr
@@ -84,6 +94,11 @@ pub fn osWindowImpl(src: std.builtin.SourceLocation, child_win_opts: OsWindowWid
     os_win.dvui_win.begin(cw.frame_time_ns) catch |err| {
         dvui.logError(@src(), err, "Something wrong in child's dvui.Window.begin()", .{});
     };
+    if (os_win.has_begin) {
+        dvui.log.err("duplicate os Window. id {f} (highlighted in red); you may need to pass .{{.id_extra=<loop index>}} as widget options (see https://github.com/david-vanderson/dvui/blob/master/readme-implementation.md#widget-ids )", .{hashval});
+        dvui.Debug.errorOutline(os_win.dvui_win.rectScale().r);
+    }
+    os_win.has_begin = true;
     return .{ .inner = os_win };
 }
 


### PR DESCRIPTION
Related to #828 

This PR makes the debug window work across multiple os window.

- Move `dvui.Debug` out of `dvui.Window` and in a `dvui.global` variable instead
- Added `dvui.Window.is_primary` field as we need to treat the "last Window.end()" slighly differently
- Implements a "Mouse left window" event to reset the debug widget stack properly between windows.

Also added a check for missing `id_extra` in case of loop declared `osWindow` and made sure the Window hash take into account previous parent window to disambiguate the case where `osWindow` calls are nested.