### PR TITLE
Content scale

### DIFF
--- a/src/Backend.zig
+++ b/src/Backend.zig
@@ -63,10 +63,12 @@ pub fn windowSize(self: Backend) dvui.Size.Natural {
     return self.impl.windowSize();
 }
 
-/// Return the detected additional scaling.  This represents the user's
-/// additional display scaling (usually set in their window system's
-/// settings).  Currently only called during `dvui.Window.init`, so currently
-/// this sets the initial content scale.
+/// Return current system content scaling.  This is separate from pixel scaling
+/// (like retina screens), which dvui gets from pixelSize()/windowSize().
+///
+/// This is usually set by the user in their window system settings.  It can
+/// change if the user changes it (rare), or if a window moves from one monitor
+/// to another.
 pub fn contentScale(self: Backend) f32 {
     return self.impl.contentScale();
 }

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -112,7 +112,8 @@ wd: WidgetData,
 current_parent: Widget,
 rect_pixels: dvui.Rect.Physical = .{},
 natural_scale: f32 = 1.0,
-/// can set separately but gets folded into natural_scale
+/// used for whole-app scaling, combined with backend/system/monitor content
+/// scale and all folded into natural_scale
 content_scale: f32 = 1.0,
 layout: dvui.BasicLayout = .{},
 
@@ -306,7 +307,7 @@ pub fn init(
 
     const winSize = self.backend.windowSize();
     const pxSize = self.backend.pixelSize();
-    self.content_scale = self.backend.contentScale();
+    const sysContentScale = self.backend.contentScale();
 
     // Even on hidpi screens I see slight flattening of the sides of glyphs
     // when snap_to_pixels is false, so we are going to default on for now.
@@ -315,7 +316,7 @@ pub fn init(
     //    self.snap_to_pixels = false;
     //}
 
-    log.info("window logical {f} pixels {f} natural scale {d} initial content scale {d} snap_to_pixels {any} accesskit {any}\n", .{ winSize, pxSize, pxSize.w / winSize.w, self.content_scale, self.snap_to_pixels, dvui.accesskit_enabled });
+    log.info("window logical {f} pixels {f} pixel scale {d} initial content scale {d} snap_to_pixels {any} accesskit {any}\n", .{ winSize, pxSize, pxSize.w / winSize.w, sysContentScale, self.snap_to_pixels, dvui.accesskit_enabled });
 
     errdefer self.deinit();
 
@@ -1258,7 +1259,8 @@ pub fn begin(
     self.rect_pixels = .fromSize(self.backend.pixelSize());
     dvui.clipSet(self.rect_pixels);
 
-    self.data().rect = Rect.Natural.fromSize(self.backend.windowSize()).scale(1.0 / self.content_scale, Rect);
+    const sysContentScale = self.backend.contentScale();
+    self.data().rect = Rect.Natural.fromSize(self.backend.windowSize()).scale(1.0 / sysContentScale / self.content_scale, Rect);
     self.natural_scale = if (self.data().rect.w == 0) 1.0 else self.rect_pixels.w / self.data().rect.w;
 
     // deal with floating point weirdness when content_scale is like 1.25
@@ -1267,7 +1269,7 @@ pub fn begin(
     self.data().rect.h = @round(self.data().rect.h * 100.0) / 100.0;
     self.natural_scale = @round(self.natural_scale * 100.0) / 100.0;
 
-    //dvui.log.debug("window size {d} x {d} renderer size {d} x {d} scale {d} content_scale {d}", .{ self.data().rect.w, self.data().rect.h, self.rect_pixels.w, self.rect_pixels.h, self.natural_scale, self.content_scale });
+    dvui.log.debug("window size {d} x {d} renderer size {d} x {d} scale {d} system content scale {d} dvui content_scale {d}", .{ self.data().rect.w, self.data().rect.h, self.rect_pixels.w, self.rect_pixels.h, self.natural_scale, sysContentScale, self.content_scale });
 
     try self.subwindows.add(self.gpa, self.data().id, self.data().rect, self.rect_pixels, false, null, true);
     _ = self.subwindows.setCurrent(self.data().id, .cast(self.data().rect));

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -1002,8 +1002,7 @@ pub fn windowSize(self: Context) dvui.Size.Natural {
 }
 
 pub fn contentScale(_: Context) f32 {
-    return 1.0;
-    //return @as(f32, @floatFromInt(win32.dpiFromHwnd(hwndFromContext(self)))) / 96.0;
+    return 1.0; // comes through windowSize/pixelSize
 }
 
 pub fn hasEvent(_: Context) bool {

--- a/src/backends/glfw.zig
+++ b/src/backends/glfw.zig
@@ -159,9 +159,8 @@ pub fn windowSize(ctx: *@This()) dvui.Size.Natural {
 }
 
 pub fn contentScale(ctx: *@This()) f32 {
-    _ = ctx;
-    // Figure out what to do here
-    return 1;
+    const scale = ctx.window.getContentScale();
+    return scale[0];
 }
 
 /// Get clipboard content (text only)
@@ -498,11 +497,11 @@ fn glfwCursorPosCallback(window: *zglfw.Window, xpos: f64, ypos: f64) callconv(.
 
 fn handleCursorPosEvent(dvui_window: *dvui.Window, window: *zglfw.Window, xpos: f64, ypos: f64) void {
     const ctx: *@This() = dvui_window.backend.impl;
-    const scale = ctx.window.getContentScale();
+    const scale = ctx.pixelSize().w / ctx.windowSize().w;
 
     const physical: dvui.Point.Physical = .{
-        .x = @floatCast(xpos * scale[0]),
-        .y = @floatCast(ypos * scale[1]),
+        .x = @floatCast(xpos * scale),
+        .y = @floatCast(ypos * scale),
     };
     if (!(dvui_window.addEventMouseMotion(.{ .pt = physical }) catch |err| {
         log.err("Encountered error when adding event! Err: {}", .{err});
@@ -636,6 +635,7 @@ pub fn main(main_init: std.process.Init) !void {
     var window: *zglfw.Window = undefined;
 
     try zglfw.init();
+    zglfw.windowHint(.scale_to_monitor, true);
 
     if (dvui.render_backend.kind == .opengl) {
         zglfw.windowHint(.context_version_major, 3);

--- a/src/backends/glfw.zig
+++ b/src/backends/glfw.zig
@@ -497,7 +497,8 @@ fn glfwCursorPosCallback(window: *zglfw.Window, xpos: f64, ypos: f64) callconv(.
 
 fn handleCursorPosEvent(dvui_window: *dvui.Window, window: *zglfw.Window, xpos: f64, ypos: f64) void {
     const ctx: *@This() = dvui_window.backend.impl;
-    const scale = ctx.pixelSize().w / ctx.windowSize().w;
+    const windowW = ctx.windowSize().w;
+    const scale = if (windowW == 0) 1.0 else (ctx.pixelSize().w / ctx.windowSize().w);
 
     const physical: dvui.Point.Physical = .{
         .x = @floatCast(xpos * scale),

--- a/src/backends/raylib-c.zig
+++ b/src/backends/raylib-c.zig
@@ -207,7 +207,7 @@ pub fn windowSize(_: *RaylibBackend) dvui.Size.Natural {
 }
 
 pub fn contentScale(_: *RaylibBackend) f32 {
-    return 1.0;
+    return 1.0; // comes through windowSize/pixelSize
 }
 
 pub fn drawClippedTriangles(self: *RaylibBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const u16, clipr_in: ?dvui.Rect.Physical) !void {

--- a/src/backends/raylib-zig.zig
+++ b/src/backends/raylib-zig.zig
@@ -210,7 +210,7 @@ pub fn windowSize(_: *RaylibBackend) dvui.Size.Natural {
 }
 
 pub fn contentScale(_: *RaylibBackend) f32 {
-    return 1.0;
+    return 1.0; // comes through windowSize/pixelSize
 }
 
 pub fn drawClippedTriangles(self: *RaylibBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const u16, clipr_in: ?dvui.Rect.Physical) !void {

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -763,7 +763,8 @@ pub fn windowSize(self: *SDLBackend) dvui.Size.Natural {
 }
 
 pub fn contentScale(self: *SDLBackend) f32 {
-    return c.SDL_GetWindowDisplayScale(self.window);
+    const display_id = c.SDL_GetDisplayForWindow(self.window);
+    return c.SDL_GetDisplayContentScale(display_id);
 }
 
 pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, maybe_clipr: ?dvui.Rect.Physical) !void {
@@ -1235,7 +1236,8 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
 
             // sdl gives us mouse coords in "window coords" which is kind of
             // like natural coords but ignores content scaling
-            const scale = self.pixelSize().w / self.windowSize().w;
+            const windowW = self.windowSize().w;
+            const scale = if (windowW == 0) 1.0 else (self.pixelSize().w / windowW);
 
             if (sdl3) {
                 return try win.addEventMouseMotion(.{

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -763,8 +763,12 @@ pub fn windowSize(self: *SDLBackend) dvui.Size.Natural {
 }
 
 pub fn contentScale(self: *SDLBackend) f32 {
-    const display_id = c.SDL_GetDisplayForWindow(self.window);
-    return c.SDL_GetDisplayContentScale(display_id);
+    if (sdl3) {
+        const display_id = c.SDL_GetDisplayForWindow(self.window);
+        return c.SDL_GetDisplayContentScale(display_id);
+    } else {
+        return self.initial_scale;
+    }
 }
 
 pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, maybe_clipr: ?dvui.Rect.Physical) !void {

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -763,7 +763,7 @@ pub fn windowSize(self: *SDLBackend) dvui.Size.Natural {
 }
 
 pub fn contentScale(self: *SDLBackend) f32 {
-    return self.initial_scale;
+    return c.SDL_GetWindowDisplayScale(self.window);
 }
 
 pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, maybe_clipr: ?dvui.Rect.Physical) !void {

--- a/src/backends/sdl3gpu.zig
+++ b/src/backends/sdl3gpu.zig
@@ -1265,7 +1265,8 @@ pub fn windowSize(self: *SDLBackend) dvui.Size.Natural {
 }
 
 pub fn contentScale(self: *SDLBackend) f32 {
-    return self.initial_scale;
+    const display_id = c.SDL_GetDisplayForWindow(self.window);
+    return c.SDL_GetDisplayContentScale(display_id);
 }
 
 pub fn drawClippedTriangles(self: *SDLBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, maybe_clipr: ?dvui.Rect.Physical) !void {

--- a/src/backends/web.zig
+++ b/src/backends/web.zig
@@ -572,7 +572,7 @@ pub fn windowSize(_: *WebBackend) dvui.Size.Natural {
 }
 
 pub fn contentScale(_: *WebBackend) f32 {
-    return 1.0;
+    return 1.0; // comes through windowSize/pixelSize
 }
 
 pub fn drawClippedTriangles(_: *WebBackend, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, maybe_clipr: ?dvui.Rect.Physical) !void {


### PR DESCRIPTION
fixes #893 

This fixes issues related to how different backends report pixel scaling vs display (content) scaling.

* sdl3 and glfw backends now properly change scaling when moving windows between monitors
* "pixel scale" is a purely dpi-related thing - this is what retina screens and macos generally change
  * it is reported to dvui via the difference between backend.windowSize and backend.pixelSize
* "display scale"/"content scale" is reported through backend.contentScale()
* `Window.content_scale` is now a dvui-internal scale value that is applied on top of everything else
  * this is used for stuff like pinch-zooming the whole app
* some backends (dx11, raylib) mix display scaling into pixel scaling
* wio backend still needs work