### PR TITLE
add warning for duplicated manage_backend calls

### DIFF
--- a/src/backends/common.zig
+++ b/src/backends/common.zig
@@ -49,3 +49,34 @@ pub fn windowsGetPreferredColorScheme() ?dvui.enums.ColorScheme {
     const val = std.mem.littleToNative(i32, @bitCast(out));
     return if (val > 0) .light else .dark;
 }
+
+/// Helper for backends to warn user in case the "manage_backends" functions get
+/// called multiple time. Useful now that `dvui.Window.end()` does it by default.
+pub const TrackManageBackend = struct {
+    has_renderPresent: bool = false,
+    has_setCursor: bool = false,
+    has_textInputRect: bool = false,
+    pub const Which = enum { renderPresent, setCursor, textInputRect };
+    pub fn reset_begin(self: *@This()) void {
+        self.* = .{}; // everybody to false
+    }
+    pub fn check(self: *@This(), which: Which) void {
+        switch (which) {
+            .renderPresent => {
+                if (self.has_renderPresent) warnDoubleCall(which);
+                self.has_renderPresent = true;
+            },
+            .setCursor => {
+                if (self.has_setCursor) warnDoubleCall(which);
+                self.has_setCursor = true;
+            },
+            .textInputRect => {
+                if (self.has_textInputRect) warnDoubleCall(which);
+                self.has_textInputRect = true;
+            },
+        }
+    }
+    fn warnDoubleCall(which: Which) void {
+        dvui.log.warn("backend.{t} has already been called once in this frame. Note that `dvui.Window.end(.{{}})` is doing it by default", .{which});
+    }
+};

--- a/src/backends/common.zig
+++ b/src/backends/common.zig
@@ -77,6 +77,6 @@ pub const TrackManageBackend = struct {
         }
     }
     fn warnDoubleCall(which: Which) void {
-        dvui.log.warn("backend.{t} has already been called once in this frame. Note that `dvui.Window.end(.{{}})` is doing it by default", .{which});
+        dvui.log.warn("backend.{t} has already been called once in this frame. `dvui.Window.end(.{{}})` is now doing it by default, pass `.manage_backend = false` if needed.", .{which});
     }
 };

--- a/src/backends/dx11.zig
+++ b/src/backends/dx11.zig
@@ -1776,9 +1776,6 @@ pub fn main(init: std.process.Init) !void {
             _ = try win.end(.{});
 
             if (res != .ok) break;
-
-            // cursor management
-            b.setCursor(win.cursorRequested());
         },
         .quit => break,
     };

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -33,6 +33,8 @@ cursor_last: dvui.enums.Cursor = .arrow,
 cursor_backing: [cursor_enum_count]?*c.SDL_Cursor = @splat(null),
 cursor_backing_tried: [cursor_enum_count]bool = @splat(false),
 
+manage_backend_tracking: dvui.Backend.Common.TrackManageBackend = .{},
+
 initial_scale: f32 = 1.0,
 
 ak_should_initialized: bool = dvui.accesskit_enabled,
@@ -579,6 +581,7 @@ pub fn setCursor(self: *SDLBackend, cursor: dvui.enums.Cursor) void {
         log.err("setCursor \"{s}\" failed", .{@tagName(cursor)});
         logErr("SDL_CreateSystemCursor in setCursor") catch return;
     }
+    self.manage_backend_tracking.check(.setCursor);
 }
 
 pub fn textInputRect(self: *SDLBackend, rect: ?dvui.Rect.Natural) void {
@@ -619,6 +622,7 @@ pub fn textInputRect(self: *SDLBackend, rect: ?dvui.Rect.Natural) void {
             c.SDL_StopTextInput();
         }
     }
+    self.manage_backend_tracking.check(.textInputRect);
 }
 
 pub fn deinit(self: *SDLBackend) void {
@@ -648,6 +652,7 @@ pub fn renderPresent(self: *SDLBackend) void {
     } else {
         c.SDL_RenderPresent(self.renderer);
     }
+    self.manage_backend_tracking.check(.renderPresent);
 }
 
 pub fn backend(self: *SDLBackend) dvui.Backend {
@@ -723,6 +728,7 @@ pub fn begin(self: *SDLBackend, arena: std.mem.Allocator) !void {
             .h = @trunc(size.h),
         }), "SDL_SetRenderClipRect in begin");
     }
+    self.manage_backend_tracking.reset_begin();
 }
 
 pub fn clearWindow(self: *SDLBackend) !void {

--- a/src/backends/sdl3gpu.zig
+++ b/src/backends/sdl3gpu.zig
@@ -389,6 +389,8 @@ cursor_backing_tried: [cursor_enum_count]bool = @splat(false),
 arena: std.mem.Allocator = undefined,
 textures_arena: std.heap.ArenaAllocator = undefined,
 
+manage_backend_tracking: dvui.Backend.Common.TrackManageBackend = .{},
+
 const cursor_enum_count = @typeInfo(dvui.enums.Cursor).@"enum".fields.len;
 
 const max_texture_size = 2048 * 2048 * 4;
@@ -1007,6 +1009,7 @@ pub fn setCursor(self: *SDLBackend, cursor: dvui.enums.Cursor) void {
         log.err("setCursor \"{s}\" failed", .{@tagName(cursor)});
         logErr("SDL_CreateSystemCursor in setCursor") catch return;
     }
+    self.manage_backend_tracking.check(.setCursor);
 }
 
 pub fn textInputRect(self: *SDLBackend, rect: ?dvui.Rect.Natural) void {
@@ -1032,6 +1035,7 @@ pub fn textInputRect(self: *SDLBackend, rect: ?dvui.Rect.Natural) void {
     } else {
         toErr(c.SDL_StopTextInput(self.window), "SDL_StopTextInput in textInputRect") catch return;
     }
+    self.manage_backend_tracking.check(.textInputRect);
 }
 
 pub fn deinit(self: *SDLBackend) void {
@@ -1150,6 +1154,7 @@ pub fn begin(self: *SDLBackend, arena: std.mem.Allocator) !void {
         self.swapchain_texture = null;
         return;
     }
+    self.manage_backend_tracking.reset_begin();
 }
 
 pub fn finishRenderingCurrentTarget(self: *SDLBackend, final: bool) !void {
@@ -1245,6 +1250,7 @@ pub fn renderPresent(self: *SDLBackend) void {
     self.external_cmdbuffer = false;
     self.cmd = null;
     self.swapchain_texture = null;
+    self.manage_backend_tracking.check(.renderPresent);
 }
 
 pub fn pixelSize(self: *SDLBackend) dvui.Size.Physical {
@@ -2251,11 +2257,6 @@ fn appIterate(_: ?*anyopaque) callconv(.c) c.SDL_AppResult {
         log.err("dvui.Window.end failed: {any}", .{err});
         return c.SDL_APP_FAILURE;
     };
-
-    appState.back.setCursor(appState.win.cursorRequested());
-    appState.back.textInputRect(appState.win.textInputRequested());
-
-    appState.back.renderPresent();
 
     if (res != .ok) return c.SDL_APP_SUCCESS;
 

--- a/src/backends/wio.zig
+++ b/src/backends/wio.zig
@@ -14,6 +14,8 @@ arena: std.mem.Allocator = undefined, // assigned in begin()
 mod: dvui.enums.Mod = .none,
 touch: [10]dvui.Point = @splat(.{ .x = std.math.inf(f32), .y = std.math.inf(f32) }),
 
+manage_backend_tracking: dvui.Backend.Common.TrackManageBackend = .{},
+
 pub fn backend(self: *@This(), renderer: *dvui.render_backend) dvui.Backend {
     return .init(self, renderer);
 }
@@ -53,6 +55,7 @@ pub fn sleep(self: *@This(), ns: u64) void {
 
 pub fn begin(self: *@This(), arena: std.mem.Allocator) !void {
     self.arena = arena;
+    self.manage_backend_tracking.reset_begin();
 }
 
 pub fn end(_: *@This()) !void {}
@@ -118,6 +121,7 @@ pub fn textInputRect(self: *@This(), maybe_rect: ?dvui.Rect.Natural) void {
     } else {
         self.window.disableTextInput();
     }
+    self.manage_backend_tracking.check(.textInputRect);
 }
 
 pub fn setCursor(self: *@This(), cursor: dvui.enums.Cursor) void {
@@ -136,6 +140,7 @@ pub fn setCursor(self: *@This(), cursor: dvui.enums.Cursor) void {
         .hand => .pointer,
         .hidden => .none,
     });
+    self.manage_backend_tracking.check(.setCursor);
 }
 
 pub fn addEvent(self: *@This(), win: *dvui.Window, event: wio.Event) !bool {


### PR DESCRIPTION
Multi os window dev implied that dvui must be able to "manage_backend" (renderPresent/setCursor/textInputRect) and these 3 calls are done by default in `dvui.Window.end()`.

While this seems a good default long term, this change is annoying for users that are already doing it in their code, especially renderPresent that, if called twice, mess up with rendering.

This commit introduce a warning for such cases.
It's implemented with a common helper to ease future transition (e.g. removing will trigger easy to locate syntax errors)