### PR TITLE
textEntryNumber: Add new init option to limit the length of the number entry

### DIFF
--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5090,7 +5090,7 @@ pub fn TextEntryNumberInitOptions(comptime T: type) type {
         value: ?*T = null,
         show_min_max: bool = false,
         text: ?[]const u8 = null,
-        text_limit: u8 = 30,
+        text_limit: ?u8 = null,
         placeholder: ?[]const u8 = null,
     };
 }
@@ -5130,7 +5130,7 @@ pub fn textEntryNumber(src: std.builtin.SourceLocation, comptime T: type, init_o
     const id = dvui.parentGet().extendId(src, opts.idExtra()).update(@typeName(T));
 
     const buffer = dataGetSlice(null, id, "buffer", []u8) orelse blk: {
-        dataSetSliceCopies(null, id, "buffer", @as([]const u8, &.{0}), init_opts.text_limit);
+        dataSetSliceCopies(null, id, "buffer", @as([]const u8, &.{0}), init_opts.text_limit orelse 30);
         break :blk dataGetSlice(null, id, "buffer", []u8).?;
     };
 
@@ -5157,11 +5157,19 @@ pub fn textEntryNumber(src: std.builtin.SourceLocation, comptime T: type, init_o
         }
     }
 
+    const font = default_opts.override(opts).fontGet();
+    var limit_size: ?Size = null;
+    if (init_opts.text_limit) |limit| {
+        limit_size = font.textSize("0");
+        limit_size.?.w *= limit;
+    }
+    const options = default_opts.override(.{ .min_size_content = limit_size }).override(opts);
+
     var te: TextEntryWidget = undefined;
     te.init(src, .{
         .text = .{ .buffer = buffer },
         .placeholder = init_opts.placeholder orelse if (init_opts.show_min_max) minmax_text else null,
-    }, default_opts.override(opts));
+    }, options);
 
     // if text was given, act like the user deleted everything and typed this
     if (init_opts.text) |text| {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5085,12 +5085,14 @@ pub fn textEntry(src: std.builtin.SourceLocation, init_opts: TextEntryWidget.Ini
 
 pub fn TextEntryNumberInitOptions(comptime T: type) type {
     return struct {
+        const max_characters = 32;
         min: ?T = null,
         max: ?T = null,
         value: ?*T = null,
         show_min_max: bool = false,
         text: ?[]const u8 = null,
         placeholder: ?[]const u8 = null,
+        character_limit: u8 = max_characters,
     };
 }
 
@@ -5128,8 +5130,11 @@ pub fn textEntryNumber(src: std.builtin.SourceLocation, comptime T: type, init_o
     // https://github.com/david-vanderson/dvui/issues/502
     const id = dvui.parentGet().extendId(src, opts.idExtra()).update(@typeName(T));
 
-    const default_bytes: [32]u8 = @splat(0);
-    const buffer = dataGetSliceDefault(null, id, "buffer", []u8, &default_bytes);
+    const max_chars = @TypeOf(init_opts).max_characters;
+    const char_limit = @min(init_opts.character_limit, max_chars);
+    var default_bytes: [max_chars]u8 = @splat(0);
+
+    const buffer = dataGetSliceDefault(null, id, "buffer", []u8, &default_bytes)[0..char_limit];
 
     // always initialize with value so we do the dataGet
     if (init_opts.value) |num| {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5085,14 +5085,13 @@ pub fn textEntry(src: std.builtin.SourceLocation, init_opts: TextEntryWidget.Ini
 
 pub fn TextEntryNumberInitOptions(comptime T: type) type {
     return struct {
-        const max_characters = 32;
         min: ?T = null,
         max: ?T = null,
         value: ?*T = null,
         show_min_max: bool = false,
         text: ?[]const u8 = null,
+        text_limit: u8 = 30,
         placeholder: ?[]const u8 = null,
-        character_limit: u8 = max_characters,
     };
 }
 
@@ -5130,11 +5129,10 @@ pub fn textEntryNumber(src: std.builtin.SourceLocation, comptime T: type, init_o
     // https://github.com/david-vanderson/dvui/issues/502
     const id = dvui.parentGet().extendId(src, opts.idExtra()).update(@typeName(T));
 
-    const max_chars = @TypeOf(init_opts).max_characters;
-    const char_limit = @min(init_opts.character_limit, max_chars);
-    var default_bytes: [max_chars]u8 = @splat(0);
-
-    const buffer = dataGetSliceDefault(null, id, "buffer", []u8, &default_bytes)[0..char_limit];
+    const buffer = dataGetSlice(null, id, "buffer", []u8) orelse blk: {
+        dataSetSliceCopies(null, id, "buffer", @as([]const u8, &.{0}), init_opts.text_limit);
+        break :blk dataGetSlice(null, id, "buffer", []u8).?;
+    };
 
     // always initialize with value so we do the dataGet
     if (init_opts.value) |num| {

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -5128,11 +5128,10 @@ pub fn textEntryNumber(src: std.builtin.SourceLocation, comptime T: type, init_o
     // @typeName is needed so that the id changes with the type for `data...` functions
     // https://github.com/david-vanderson/dvui/issues/502
     const id = dvui.parentGet().extendId(src, opts.idExtra()).update(@typeName(T));
+    const backing_buffer: [30]u8 = @splat(0);
+    const text_limit = init_opts.text_limit orelse 30;
 
-    const buffer = dataGetSlice(null, id, "buffer", []u8) orelse blk: {
-        dataSetSliceCopies(null, id, "buffer", @as([]const u8, &.{0}), init_opts.text_limit orelse 30);
-        break :blk dataGetSlice(null, id, "buffer", []u8).?;
-    };
+    const buffer = dataGetSliceDefault(null, id, "_buffer", []u8, &backing_buffer)[0..text_limit];
 
     // always initialize with value so we do the dataGet
     if (init_opts.value) |num| {
@@ -5160,8 +5159,7 @@ pub fn textEntryNumber(src: std.builtin.SourceLocation, comptime T: type, init_o
     const font = default_opts.override(opts).fontGet();
     var limit_size: ?Size = null;
     if (init_opts.text_limit) |limit| {
-        limit_size = font.textSize("0");
-        limit_size.?.w *= limit;
+        limit_size = font.sizeM(limit, 1);
     }
     const options = default_opts.override(.{ .min_size_content = limit_size }).override(opts);
 


### PR DESCRIPTION
This change adds the ability to limit the number of characters accepted in a textEntryNumber.
A new init_option `character_limit` is added to TextEntryNumberInitOptions.

The motivation for this change is implementing a mm/dd/yy date entry as shown below:

<img width="342" height="155" alt="image" src="https://github.com/user-attachments/assets/1c6a3297-78f3-4ae1-b698-2663a0f37fd3" />

Without the character limit, the text entry can scroll, making it hard to see what number is actually entered.

 