### PR TITLE
web: programmatic focus drops keypress

### DIFF
--- a/src/Examples/text_entry.zig
+++ b/src/Examples/text_entry.zig
@@ -79,6 +79,7 @@ pub fn textEntryWidgets() void {
     }
 
     var enter_pressed = false;
+    var te_id: dvui.Id = undefined;
     {
         var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
         defer hbox.deinit();
@@ -88,7 +89,7 @@ pub fn textEntryWidgets() void {
         left_alignment.spacer(@src(), 0);
 
         var te = dvui.textEntry(@src(), .{ .text = .{ .buffer = &text_entry_buf } }, .{ .max_size_content = .sizeM(20, 1) });
-        const te_id = te.data().id;
+        te_id = te.data().id;
         enter_pressed = te.enter_pressed;
         te.deinit();
 
@@ -97,10 +98,6 @@ pub fn textEntryWidgets() void {
         if (dvui.button(@src(), "Large Doc", .{}, .{ .gravity_x = 1.0 })) {
             show_large_doc.* = !show_large_doc.*;
         }
-
-        if (dvui.button(@src(), "Focus", .{}, .{ .gravity_x = 1.0 })) {
-            dvui.focusWidget(te_id, null, null);
-        }
     }
 
     {
@@ -108,6 +105,10 @@ pub fn textEntryWidgets() void {
         defer hbox.deinit();
 
         left_alignment.spacer(@src(), 0);
+
+        if (dvui.button(@src(), "Focus", .{}, .{})) {
+            dvui.focusWidget(te_id, null, null);
+        }
 
         dvui.label(@src(), "press enter", .{}, .{ .gravity_y = 0.5 });
 

--- a/src/Examples/text_entry.zig
+++ b/src/Examples/text_entry.zig
@@ -88,6 +88,7 @@ pub fn textEntryWidgets() void {
         left_alignment.spacer(@src(), 0);
 
         var te = dvui.textEntry(@src(), .{ .text = .{ .buffer = &text_entry_buf } }, .{ .max_size_content = .sizeM(20, 1) });
+        const te_id = te.data().id;
         enter_pressed = te.enter_pressed;
         te.deinit();
 
@@ -95,6 +96,10 @@ pub fn textEntryWidgets() void {
 
         if (dvui.button(@src(), "Large Doc", .{}, .{ .gravity_x = 1.0 })) {
             show_large_doc.* = !show_large_doc.*;
+        }
+
+        if (dvui.button(@src(), "Focus", .{}, .{ .gravity_x = 1.0 })) {
+            dvui.focusWidget(te_id, null, null);
         }
     }
 

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -223,7 +223,6 @@ export class Dvui {
      *
      * @type {[number, number, number, number] | []} */
     textInputRect = [];
-    need_oskCheck = false;
 
     // Used for file uploads. Only valid for one frame
     filesCacheModified = false;
@@ -237,6 +236,9 @@ export class Dvui {
         return this.gl instanceof WebGL2RenderingContext;
     }
 
+    // This does 2 things:
+    // * on desktop it's needed for us to get text events (not just char down/up)
+    // * on touch it's needed to show the on screen keyboard
     oskCheck() {
         if (this.textInputRect.length == 0) {
             this.gl.canvas.focus();
@@ -1236,10 +1238,10 @@ export class Dvui {
         this.gl.clear(this.gl.COLOR_BUFFER_BIT);
 
         let millis_to_wait = this.instance.exports.dvui_update();
-        if (this.need_oskCheck) {
-            this.need_oskCheck = false;
-            this.oskCheck();
-        }
+
+        // This oskCheck is for desktop to get text events.  Touch devices will
+        // show/hide the keyboard (but not all, see touchend handler).
+        this.oskCheck();
 
         if (!this.filesCacheModified) {
             // Only clear if we didn't add anything this frame. Async could add items after they were requested
@@ -1307,7 +1309,6 @@ export class Dvui {
         this.gl.canvas.addEventListener("mouseup", (ev) => {
             if (this.stopped) return;
             this.instance.exports.add_event(3, ev.button, 0, 0, 0);
-            this.need_oskCheck = true;
             this.requestRender();
         });
         this.gl.canvas.addEventListener("wheel", (ev) => {
@@ -1447,7 +1448,6 @@ export class Dvui {
                 (ev.metaKey << 3) + (ev.altKey << 2) + (ev.ctrlKey << 1) +
                 (ev.shiftKey << 0),
             );
-            this.need_oskCheck = true;
             this.requestRender();
         };
         this.gl.canvas.addEventListener("keyup", keyup.bind(this));
@@ -1527,7 +1527,8 @@ export class Dvui {
                 );
                 this.touches.splice(tidx, 1);
             }
-            // Osk has to be done within the event handler so that on-screen keyboard can show
+            // This oskCheck is for some platforms (iphone) where showing
+            // the keyboard has to be done inside an event handler.
             // https://stackoverflow.com/a/6837575
             this.oskCheck();
             this.requestRender();


### PR DESCRIPTION
See #902 for reproduction

The web handling for OSK (On Screen Keyboard) was messed up.  I think I screwed it up a while back while focusing on touch devices.

oskCheck() does two related things, and is now called in two places for them:
* signals to the browser that we want text events (by focusing our hidden input)
  * call oskCheck after each frame (this fixes this bug)
* signals to the platform that we want to show/hide the OSK
  * this is complicated by some platforms (iphone?) only allowing this inside an event handler
  * call oskCheck in the "touchend" handler

Also keep the "focus" button in the text entry demo section for testing this.
