### PR TITLE
feat(window): per-frame render stats and CPU phase timing

### DIFF
--- a/src/Texture.zig
+++ b/src/Texture.zig
@@ -394,6 +394,7 @@ pub fn create(pixels: []const Color.PMA, options: CreateOptions) TextureError!Te
     if (pixels.len != options.width * options.height) {
         dvui.log.err("Texture was created with an incorrect amount of pixels, expected {d} but got {d} (w: {d}, h: {d})", .{ pixels.len, options.width * options.height, options.width, options.height });
     }
+    dvui.currentWindow().render_stats.textures_created += 1;
     return dvui.currentWindow().backend.textureCreate(@ptrCast(pixels.ptr), options);
 }
 

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -102,6 +102,13 @@ pub fn register(self: *WidgetData) void {
 
     cw.last_registered_id_this_frame = self.id;
 
+    // First widget to register this frame marks the end of the event phase and
+    // the start of the build phase for frame timing (see `Window.frameTiming`).
+    if (cw.ft_awaiting_build) {
+        cw.ft_awaiting_build = false;
+        cw.ft_build_start = cw.backend.nanoTime();
+    }
+
     const focused_widget_id = dvui.focusedWidgetId();
     if (self.id == focused_widget_id) {
         cw.last_focused_id_this_frame = self.id;

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -64,6 +64,12 @@ loop_target_slop: i32 = 1000, // 1ms frame overhead seems a good place to start
 loop_target_slop_frames: i32 = 0,
 frame_times: [10]u32 = @splat(0),
 
+/// Render stats accumulated during the in-progress frame. Reset in `begin`,
+/// snapshotted at the end of rendering. Query the last completed frame with
+/// `renderStats`.
+render_stats: RenderStats = .{},
+render_stats_last: RenderStats = .{},
+
 /// Debugging aid, only used in waitTime(), null means no max
 max_fps: ?f32 = null,
 
@@ -135,6 +141,21 @@ end_rendering_done: bool = false,
 open_flag: ?*bool = null,
 
 accesskit: dvui.AccessKit,
+
+/// Per-frame rendering cost counters. Accumulated above the backend, so the
+/// numbers are backend-agnostic. See `Window.renderStats`.
+pub const RenderStats = struct {
+    /// Calls to `Backend.drawClippedTriangles` (one per `render.renderTriangles`).
+    draw_calls: u32 = 0,
+    /// Triangles submitted (sum of index counts / 3).
+    triangles: u32 = 0,
+    /// Vertices submitted.
+    vertices: u32 = 0,
+    /// Draw calls that bound a texture.
+    texture_binds: u32 = 0,
+    /// Textures created this frame via `Texture.create`.
+    textures_created: u32 = 0,
+};
 
 pub const InitOptions = struct {
     id_extra: usize = 0,
@@ -1025,6 +1046,14 @@ pub fn FPS(self: *const Self) f32 {
     return fps;
 }
 
+/// `RenderStats` from the last completed frame: draw calls, triangles,
+/// vertices, texture binds, and textures created. Counters are reset at the
+/// start of each frame and snapshotted once rendering finishes, so this is
+/// stable to read at any point in the frame loop.
+pub fn renderStats(self: *const Self) RenderStats {
+    return self.render_stats_last;
+}
+
 /// Coordinates with `Window.waitTime` to run frames only when needed.
 ///
 /// If on the previous frame you called `Window.waitTime` and waited with event
@@ -1226,6 +1255,7 @@ pub fn begin(
     }
 
     self.end_rendering_done = false;
+    self.render_stats = .{};
     self.cursor_requested = null;
     self.text_input_rect = null;
     self.last_focused_id_this_frame = .zero;
@@ -1532,6 +1562,7 @@ pub fn endRendering(self: *Self, opts: endOptions) void {
         sw.render_cmds_after = .empty;
     }
 
+    self.render_stats_last = self.render_stats;
     self.end_rendering_done = true;
 }
 

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -70,6 +70,22 @@ frame_times: [10]u32 = @splat(0),
 render_stats: RenderStats = .{},
 render_stats_last: RenderStats = .{},
 
+/// `FrameTiming` snapshot of the last completed frame. Query with
+/// `frameTiming`. The `ft_*` fields below are per-frame scratch used to
+/// compute it; they are not meant to be read directly.
+frame_timing_last: FrameTiming = .{},
+/// `backend.nanoTime` at the top of `begin` (start of the whole frame).
+ft_total_start: i128 = 0,
+/// `backend.nanoTime` at the bottom of `begin` (start of the event-injection
+/// phase, before the backend pumps OS events into the window).
+ft_events_start: i128 = 0,
+/// `backend.nanoTime` when the first widget of the frame registered (start of
+/// the build phase). Defaults to `ft_events_start` so empty frames are sane.
+ft_build_start: i128 = 0,
+/// True between `begin` returning and the first widget registering, i.e. while
+/// the window is still in the event phase. See `WidgetData.register`.
+ft_awaiting_build: bool = false,
+
 /// Debugging aid, only used in waitTime(), null means no max
 max_fps: ?f32 = null,
 
@@ -155,6 +171,25 @@ pub const RenderStats = struct {
     texture_binds: u32 = 0,
     /// Textures created this frame via `Texture.create`.
     textures_created: u32 = 0,
+};
+
+/// CPU phase timing for one dvui frame, in nanoseconds. Measured with the
+/// backend's `nanoTime`, the same clock used by `waitTime`. The phases are the
+/// major work and do not necessarily sum to `total_ns` (the small `begin`/`end`
+/// bookkeeping in between is not attributed to a phase). See `Window.frameTiming`.
+pub const FrameTiming = struct {
+    /// Event-injection phase: `begin` returning until the first widget registers
+    /// (the backend pumping OS events into the window via `addEvent*`).
+    events_ns: u64 = 0,
+    /// Build phase: user widget code, from the first widget registering until
+    /// rendering starts in `endRendering`.
+    build_ns: u64 = 0,
+    /// Render phase: submitting the deferred render commands in `endRendering`.
+    render_ns: u64 = 0,
+    /// Whole frame's CPU work, from the top of `begin` to the end of `end`, but
+    /// stopping before the backend presents so a blocking/vsync present is
+    /// excluded. Includes the small bookkeeping the phases above leave out.
+    total_ns: u64 = 0,
 };
 
 pub const InitOptions = struct {
@@ -1054,6 +1089,20 @@ pub fn renderStats(self: *const Self) RenderStats {
     return self.render_stats_last;
 }
 
+/// `FrameTiming` from the last completed frame: CPU nanoseconds spent in the
+/// event, build, and render phases plus the frame total. Computed at phase
+/// boundaries and snapshotted in `end`, so this is stable to read at any point
+/// in the frame loop.
+pub fn frameTiming(self: *const Self) FrameTiming {
+    return self.frame_timing_last;
+}
+
+/// `a - b` clamped to a non-negative `u64`. Used for phase durations from the
+/// monotonic-ish backend clock, guarding against clock jumps.
+fn nsSince(a: i128, b: i128) u64 {
+    return @intCast(@max(0, a - b));
+}
+
 /// Coordinates with `Window.waitTime` to run frames only when needed.
 ///
 /// If on the previous frame you called `Window.waitTime` and waited with event
@@ -1224,6 +1273,8 @@ pub fn begin(
     self: *Self,
     time_ns: i128,
 ) dvui.Backend.GenericError!void {
+    self.ft_total_start = self.backend.nanoTime();
+
     try self.backend.accessKitInitInBegin(&self.accesskit);
 
     // If time_ns jumps backward, then we will stay on the current
@@ -1352,6 +1403,14 @@ pub fn begin(
     self.data().register();
 
     self.layout = .{};
+
+    // Frame phase timing: begin() is done, the app will now pump OS events and
+    // then run widget code. The first widget to register ends the event phase
+    // and starts the build phase (see `WidgetData.register`). Default
+    // ft_build_start to here so an empty frame (no widgets) stays sane.
+    self.ft_events_start = self.backend.nanoTime();
+    self.ft_build_start = self.ft_events_start;
+    self.ft_awaiting_build = true;
 }
 
 fn positionMouseEventAdd(self: *Self) std.mem.Allocator.Error!void {
@@ -1535,6 +1594,14 @@ pub const endOptions = struct {
 /// Normally this is called for you in `end`, but you can call it separately in
 /// case you want to do something after everything has been rendered.
 pub fn endRendering(self: *Self, opts: endOptions) void {
+    // Frame phase timing: the build phase ends here and the render phase begins.
+    // Close out the event/build phases before the toasts/dialogs/debug below,
+    // since those register widgets that must not be taken for the build phase.
+    const render_start = self.backend.nanoTime();
+    self.ft_awaiting_build = false;
+    self.frame_timing_last.events_ns = nsSince(self.ft_build_start, self.ft_events_start);
+    self.frame_timing_last.build_ns = nsSince(render_start, self.ft_build_start);
+
     if (opts.show_toasts) {
         dvui.toastsShow(null, dvui.windowRect());
     }
@@ -1563,6 +1630,7 @@ pub fn endRendering(self: *Self, opts: endOptions) void {
     }
 
     self.render_stats_last = self.render_stats;
+    self.frame_timing_last.render_ns = nsSince(self.backend.nanoTime(), render_start);
     self.end_rendering_done = true;
 }
 
@@ -1696,6 +1764,11 @@ pub fn end(self: *Self, opts: endOptions) !?u32 {
 
     defer dvui.current_window = self.previous_window;
 
+    // Frame phase timing: all CPU work is done (event/build/render were filled
+    // in by endRendering). Snapshot the total before the backend presents, so a
+    // blocking/vsync renderPresent doesn't pollute this CPU timing.
+    self.frame_timing_last.total_ns = nsSince(self.backend.nanoTime(), self.ft_total_start);
+
     if (opts.manage_backend) {
         self.backend.setCursor(self.cursorRequested());
         self.backend.textInputRect(self.textInputRequested());
@@ -1806,6 +1879,40 @@ const std = @import("std");
 const math = std.math;
 const builtin = @import("builtin");
 const dvui = @import("dvui.zig");
+
+test "renderStats and frameTiming are populated after a frame" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var box = dvui.box(@src(), .{}, .{ .expand = .both, .background = true, .style = .window });
+            defer box.deinit();
+            dvui.label(@src(), "hello {d}", .{42}, .{});
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+
+    const win = dvui.currentWindow();
+
+    // Render stats (#1): a backgrounded box with a label must produce draws.
+    const rs = win.renderStats();
+    try std.testing.expect(rs.draw_calls > 0);
+    try std.testing.expect(rs.triangles > 0);
+    try std.testing.expect(rs.vertices > 0);
+
+    // Frame timing (#3): every phase ran this frame. The testing backend's
+    // nanoTime is a fake clock that strictly increments per call, so each phase
+    // boundary lands on a later tick and every span is non-zero. The build and
+    // render phases are nested in (and disjoint within) the frame total.
+    const ft = win.frameTiming();
+    try std.testing.expect(ft.events_ns > 0);
+    try std.testing.expect(ft.build_ns > 0);
+    try std.testing.expect(ft.render_ns > 0);
+    try std.testing.expect(ft.total_ns >= ft.build_ns + ft.render_ns);
+}
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/render.zig
+++ b/src/render.zig
@@ -97,6 +97,11 @@ pub fn renderTriangles(triangles: Triangles, tex: ?Texture) Backend.GenericError
         }
     }
 
+    cw.render_stats.draw_calls += 1;
+    cw.render_stats.vertices +|= @intCast(triangles.vertexes.len);
+    cw.render_stats.triangles +|= @intCast(triangles.indices.len / 3);
+    if (tex != null) cw.render_stats.texture_binds += 1;
+
     try cw.backend.drawClippedTriangles(tex, triangles.vertexes, triangles.indices, clipr);
 }
 


### PR DESCRIPTION
Hi David, I'm Massa. I'm building a game engine called Turian ([site](https://turian.mass4.org), [repo](https://gitlab.com/mass4org/mega4/turian)), and we use DVUI for studio/editor and now implementing it as in-game GUI system, and I forked your code to add debugging/profiling instrumentation — games are very sensitive to frame-time overhead and I needed visibility into what DVUI was doing each frame. I think it's time to send that work back upstream!

I reorganized all the changes I did and I'm opening 3 PRs. None of them is super 100% complete, but they're all sufficiently robust and tested (and totally decoupled from Turian — nothing references engine concepts):

1. [Render stats + CPU phase timing](https://github.com/david-vanderson/dvui/pull/917) — per-frame counters and nanosecond-phase timing. Smallest, cleanest, most generically useful.
2. [Machine-readable widget-tree JSON dump](https://github.com/david-vanderson/dvui/pull/918) — opt-in frame capture with flat/nested JSON output and frame diffing. Useful for CI snapshots and tooling.
3. [Devtools profiler loop](https://github.com/david-vanderson/dvui/pull/919) — a simple Profiler widget that wraps a target GUI function, times it, captures its widget tree, and renders a perf chart + inspector. Most opinionated of the three.

## Summary

2 small, additive instrumentation features for DVUI windows, submitted together because they share the same test infrastructure:

### 1. Per-frame render stats (`RenderStats`)

Counters for draw calls, triangles, vertices, texture binds, and texture creates — accumulated during rendering in `render.zig` and `Texture.zig`, snapshotted at the end of each frame. Query with `Window.renderStats()`.

### 2. CPU phase timing (`FrameTiming`)

Nanosecond timing of the 3 DVUI frame phases (event injection, build/widget-tree, render) measured with the backend's clock (so vsync/blocking present doesn't pollute CPU timing). Query with `Window.frameTiming()`.