### PR TITLE
feat: machine-readable widget-tree JSON dump (Debug.captureFrame / dumpFrame)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -415,6 +415,7 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                 .backend_mod = testing_mod,
             };
             _ = addExample("testing-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
+            _ = addExample("frame-dump", b.path("examples/frame-dump.zig"), false, example_opts, dvui_opts);
         },
         .proxy => {
             dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = false, .stb_image = true, .tree_sitter = true });

--- a/examples/frame-dump.zig
+++ b/examples/frame-dump.zig
@@ -1,0 +1,88 @@
+//! Headless CLI that renders one dvui frame with the (windowless) testing
+//! backend and prints a machine-readable JSON dump of the resolved widget tree
+//! to stdout. Intended for LLM-assisted UI analysis, CI golden snapshots, and
+//! Turian Studio's "inspect frame" panel.
+//!
+//! Build/run: `zig build frame-dump` (nested JSON, default)
+//!            `zig build frame-dump -- --flat`
+//!
+//! See `dvui.Debug.captureFrame` / `dvui.Debug.dumpFrame`.
+
+const std = @import("std");
+const dvui = @import("dvui");
+const Backend = @import("testing-backend");
+
+/// The UI whose frame we dump. A small but non-trivial tree (boxes, labels,
+/// buttons) so the output exercises nesting, rects, styles, and fonts.
+fn frame() !dvui.App.Result {
+    var vbox = dvui.box(@src(), .{ .dir = .vertical }, .{
+        .expand = .both,
+        .background = true,
+        .style = .window,
+        .name = "root",
+    });
+    defer vbox.deinit();
+
+    dvui.label(@src(), "Guinevere frame dump", .{}, .{ .name = "title" });
+
+    {
+        var row = dvui.box(@src(), .{ .dir = .horizontal }, .{ .name = "buttons" });
+        defer row.deinit();
+        _ = dvui.button(@src(), "OK", .{}, .{ .name = "ok" });
+        _ = dvui.button(@src(), "Cancel", .{}, .{ .name = "cancel" });
+    }
+
+    dvui.label(@src(), "status: ready", .{}, .{ .name = "status" });
+
+    return .ok;
+}
+
+/// One begin/frame/end cycle, the minimal headless equivalent of an app loop.
+fn runFrame(win: *dvui.Window) !void {
+    try win.begin(win.backend.nanoTime());
+    _ = try frame();
+    _ = try win.end(.{});
+}
+
+pub fn main(init: std.process.Init) !void {
+    // --flat / --nested selects the dump shape (nested is the default).
+    var shape: dvui.Debug.DumpShape = .nested;
+    var it = try std.process.Args.Iterator.initAllocator(init.minimal.args, init.gpa);
+    defer it.deinit();
+    _ = it.next(); // exe name
+    while (it.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--flat")) {
+            shape = .flat;
+        } else if (std.mem.eql(u8, arg, "--nested")) {
+            shape = .nested;
+        }
+    }
+
+    // Headless dvui window via the testing backend (no OS window, no rendering).
+    dvui.io = init.io;
+    var backend: Backend = .init(.{
+        .allocator = init.gpa,
+        .size = .{ .w = 800, .h = 600 },
+        .size_pixels = .{ .w = 1600, .h = 1200 },
+    });
+    defer backend.deinit();
+
+    var win = try dvui.Window.init(@src(), init.gpa, backend.backend(), .{
+        .color_scheme = .light,
+        .keybinds = .windows,
+    });
+    defer win.deinit();
+
+    // Run a few frames so layout and fonts settle, then capture one. Because we
+    // drive begin/frame/end in the natural order, `captureFrame` arms at the
+    // next `begin` and that single frame is captured in full (see `dumpFrame`).
+    for (0..4) |_| try runFrame(&win);
+    dvui.debug.captureFrame();
+    try runFrame(&win);
+
+    var out_buf: [64 * 1024]u8 = undefined;
+    var fw = std.Io.File.stdout().writer(init.io, &out_buf);
+    try dvui.debug.dumpFrame(&fw.interface, .{ .shape = shape });
+    try fw.interface.writeByte('\n');
+    try fw.flush();
+}

--- a/examples/frame-dump.zig
+++ b/examples/frame-dump.zig
@@ -1,19 +1,27 @@
-//! Headless CLI that renders one dvui frame with the (windowless) testing
-//! backend and prints a machine-readable JSON dump of the resolved widget tree
-//! to stdout. Intended for LLM-assisted UI analysis, CI golden snapshots, and
+//! Headless CLI that renders dvui frames with the (windowless) testing backend
+//! and prints a machine-readable JSON dump of the resolved widget tree to
+//! stdout. Intended for LLM-assisted UI analysis, CI golden snapshots, and
 //! Turian Studio's "inspect frame" panel.
 //!
-//! Build/run: `zig build frame-dump` (nested JSON, default)
-//!            `zig build frame-dump -- --flat`
+//! Build/run:
+//!   zig build frame-dump                 one frame, nested JSON (default)
+//!   zig build frame-dump -- --flat       one frame, flat JSON
+//!   zig build frame-dump -- --frames 3   three consecutive frames
+//!   zig build frame-dump -- --diff       diff of two consecutive frames
 //!
-//! See `dvui.Debug.captureFrame` / `dvui.Debug.dumpFrame`.
+//! See `dvui.Debug.captureFrame` / `captureFrames` / `dumpFrame` / `dumpFrames`
+//! / `dumpDiff`.
 
 const std = @import("std");
 const dvui = @import("dvui");
 const Backend = @import("testing-backend");
 
-/// The UI whose frame we dump. A small but non-trivial tree (boxes, labels,
-/// buttons) so the output exercises nesting, rects, styles, and fonts.
+/// Frame counter so the demo UI changes slightly each frame (an extra label and
+/// a flipped background on even ticks), making `--diff` show real differences.
+var tick: u32 = 0;
+
+/// The UI whose frames we dump. A small but non-trivial tree (boxes, labels,
+/// buttons) so the output exercises nesting, rects, styles, fonts, and changes.
 fn frame() !dvui.App.Result {
     var vbox = dvui.box(@src(), .{ .dir = .vertical }, .{
         .expand = .both,
@@ -23,13 +31,20 @@ fn frame() !dvui.App.Result {
     });
     defer vbox.deinit();
 
-    dvui.label(@src(), "Guinevere frame dump", .{}, .{ .name = "title" });
+    dvui.label(@src(), "Guinevere frame dump (tick {d})", .{tick}, .{ .name = "title" });
 
     {
-        var row = dvui.box(@src(), .{ .dir = .horizontal }, .{ .name = "buttons" });
+        var row = dvui.box(@src(), .{ .dir = .horizontal }, .{
+            .name = "buttons",
+            .background = (tick % 2 == 0),
+        });
         defer row.deinit();
         _ = dvui.button(@src(), "OK", .{}, .{ .name = "ok" });
         _ = dvui.button(@src(), "Cancel", .{}, .{ .name = "cancel" });
+    }
+
+    if (tick % 2 == 0) {
+        dvui.label(@src(), "extra row", .{}, .{ .name = "extra" });
     }
 
     dvui.label(@src(), "status: ready", .{}, .{ .name = "status" });
@@ -42,11 +57,15 @@ fn runFrame(win: *dvui.Window) !void {
     try win.begin(win.backend.nanoTime());
     _ = try frame();
     _ = try win.end(.{});
+    tick += 1;
 }
 
+const Mode = union(enum) { single, frames: u32, diff };
+
 pub fn main(init: std.process.Init) !void {
-    // --flat / --nested selects the dump shape (nested is the default).
     var shape: dvui.Debug.DumpShape = .nested;
+    var mode: Mode = .single;
+
     var it = try std.process.Args.Iterator.initAllocator(init.minimal.args, init.gpa);
     defer it.deinit();
     _ = it.next(); // exe name
@@ -55,6 +74,11 @@ pub fn main(init: std.process.Init) !void {
             shape = .flat;
         } else if (std.mem.eql(u8, arg, "--nested")) {
             shape = .nested;
+        } else if (std.mem.eql(u8, arg, "--diff")) {
+            mode = .diff;
+        } else if (std.mem.eql(u8, arg, "--frames")) {
+            const n = it.next() orelse return error.MissingFramesArgument;
+            mode = .{ .frames = try std.fmt.parseInt(u32, n, 10) };
         }
     }
 
@@ -73,16 +97,33 @@ pub fn main(init: std.process.Init) !void {
     });
     defer win.deinit();
 
-    // Run a few frames so layout and fonts settle, then capture one. Because we
-    // drive begin/frame/end in the natural order, `captureFrame` arms at the
-    // next `begin` and that single frame is captured in full (see `dumpFrame`).
+    // Run a few frames so layout and fonts settle. Because we drive
+    // begin/frame/end in the natural order, an armed capture records exactly the
+    // requested number of subsequent frames in full.
     for (0..4) |_| try runFrame(&win);
-    dvui.debug.captureFrame();
-    try runFrame(&win);
 
     var out_buf: [64 * 1024]u8 = undefined;
     var fw = std.Io.File.stdout().writer(init.io, &out_buf);
-    try dvui.debug.dumpFrame(&fw.interface, .{ .shape = shape });
-    try fw.interface.writeByte('\n');
+    const out = &fw.interface;
+
+    switch (mode) {
+        .single => {
+            dvui.debug.captureFrame();
+            try runFrame(&win);
+            try dvui.debug.dumpFrame(out, .{ .shape = shape });
+        },
+        .frames => |n| {
+            dvui.debug.captureFrames(n);
+            for (0..n) |_| try runFrame(&win);
+            try dvui.debug.dumpFrames(out, .{ .shape = shape });
+        },
+        .diff => {
+            dvui.debug.captureFrames(2);
+            try runFrame(&win);
+            try runFrame(&win);
+            try dvui.debug.dumpDiff(out, .{});
+        },
+    }
+    try out.writeByte('\n');
     try fw.flush();
 }

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -29,14 +29,22 @@ widget_panic: bool = false,
 touch_simulate_events: bool = false,
 touch_simulate_down: bool = false,
 
-/// Frame capture for `dumpFrame` (machine-readable widget-tree JSON). Off unless
-/// a one-frame capture was requested via `captureFrame`. The captured list uses
-/// `gpa` and persists until the next capture, so it can be dumped after
-/// `Window.end`. See `captureFrame`, `dumpFrame`.
-capture_state: CaptureState = .off,
-/// Widgets recorded during the captured frame, in registration (pre-order)
-/// order. Uses `gpa`; widget names are duplicated into it.
-captured: std.ArrayList(CapturedWidget) = .empty,
+/// Multi-frame capture for `dumpFrame`/`dumpFrames`/`dumpDiff` (machine-readable
+/// widget-tree JSON). Off unless armed via `captureFrame` (one frame) or
+/// `captureFrames` (a consecutive range). Captured frames accumulate (newest
+/// kept, oldest dropped past `capture_max`) so discrete snapshots can be diffed.
+/// All `gpa`-owned and persist past the frame, so they can be dumped after
+/// `Window.end`. See `captureFrame`, `captureFrames`, `clearCaptures`.
+frames: std.ArrayList(CapturedFrame) = .empty,
+/// Upcoming frames still to capture (a continuous range, or one armed frame).
+capture_remaining: u32 = 0,
+/// True only while the in-progress frame is being captured, i.e. between
+/// `reset` and `Window.endRendering`.
+capturing: bool = false,
+/// Cap on retained captured frames; the oldest are dropped beyond this.
+capture_max: u32 = 32,
+/// Monotonic capture counter, used as each `CapturedFrame.index`.
+capture_seq: u64 = 0,
 
 const Debug = @This();
 
@@ -52,10 +60,16 @@ pub const DebugTarget = enum {
     }
 };
 
-/// Lifecycle of a `dumpFrame` capture. `requested` (set by `captureFrame`)
-/// becomes `capturing` at the next `Window.begin` and `off` again once that
-/// frame's `Window.endRendering` runs; the captured data outlives all three.
-pub const CaptureState = enum { off, requested, capturing };
+/// One captured frame: the widget tree recorded between a `Window.begin` and its
+/// `Window.endRendering`, in registration (pre-order) order.
+pub const CapturedFrame = struct {
+    /// Monotonic capture sequence number (`Debug.capture_seq` when recorded).
+    index: u64,
+    /// `Window.frame_time_ns` of the captured frame.
+    time_ns: i128,
+    /// Uses `gpa`; widget names are duplicated into it.
+    widgets: std.ArrayList(CapturedWidget) = .empty,
+};
 
 /// One widget's resolved state, recorded for `dumpFrame`. The rects are physical
 /// (screen) pixels. `name` is `gpa`-duplicated; `src_*` point at static strings.
@@ -95,6 +109,13 @@ pub const DumpOptions = struct {
     shape: DumpShape = .nested,
 };
 
+/// Which two captured frames `dumpDiff` compares (positions in `frames`,
+/// 0-based, oldest first). Defaults compare the two most recent.
+pub const DiffOptions = struct {
+    from: ?usize = null,
+    to: ?usize = null,
+};
+
 pub fn reset(self: *Debug, gpa: std.mem.Allocator) void {
     if (self.target.mouse()) {
         for (self.under_mouse_stack.items) |item| {
@@ -104,11 +125,13 @@ pub fn reset(self: *Debug, gpa: std.mem.Allocator) void {
     }
     self.target_wd = null;
 
-    // A capture requested last frame starts now: drop the previous capture and
-    // begin recording. `Window.endRendering` flips this back to `off`.
-    if (self.capture_state == .requested) {
-        self.freeCaptured(gpa);
-        self.capture_state = .capturing;
+    // If frames are still queued to capture, start one now: push a fresh frame
+    // and record into it until `Window.endRendering` clears `capturing`.
+    if (self.capture_remaining > 0) {
+        self.capture_remaining -= 1;
+        self.startFrameCapture(gpa);
+    } else {
+        self.capturing = false;
     }
 }
 
@@ -118,40 +141,82 @@ pub fn deinit(self: *Debug, gpa: std.mem.Allocator) void {
     }
     self.under_mouse_stack.clearAndFree(gpa);
     self.options_override.deinit(gpa);
-    self.freeCaptured(gpa);
-    self.captured.clearAndFree(gpa);
+    self.clearCaptures(gpa);
+    self.frames.clearAndFree(gpa);
 
     // This is global, and deinit is usually called during Window.deinit.  But
     // in a testing environment, multiple whole Window init/deinit cycles
     // happen in the same process.  So prevent access-after-free.
     self.under_mouse_stack = .empty;
     self.options_override = .empty;
-    self.captured = .empty;
-    self.capture_state = .off;
+    self.frames = .empty;
+    self.capture_remaining = 0;
+    self.capturing = false;
 }
 
-fn freeCaptured(self: *Debug, gpa: std.mem.Allocator) void {
-    for (self.captured.items) |w| if (w.name) |n| gpa.free(n);
-    self.captured.clearRetainingCapacity();
-}
-
-/// Request a machine-readable capture of the next frame's widget tree, then read
-/// it back with `dumpFrame`. Opt-in: nothing is captured until this is called,
-/// so it costs nothing when off. The capture covers the build phase only (not
-/// the debug inspector or dialogs that render afterwards).
+/// Arm a machine-readable capture of the next frame's widget tree, read back
+/// with `dumpFrame`/`dumpFrames`/`dumpDiff`. Opt-in: nothing is captured until
+/// armed, so it costs nothing when off. Repeated calls on different frames
+/// accumulate discrete snapshots that can be diffed. The capture covers the
+/// build phase only (not the debug inspector or dialogs rendered afterwards).
 ///
 /// Typical headless use: `dvui.debug.captureFrame()`, run one frame, then
 /// `dvui.debug.dumpFrame(writer, .{})`.
 pub fn captureFrame(self: *Debug) void {
-    self.capture_state = .requested;
+    self.captureFrames(1);
 }
 
-/// Record one widget into the active capture. Called from `WidgetData.register`
-/// while `capture_state == .capturing`. Best-effort: a failed allocation drops
-/// the widget rather than the frame.
+/// Arm capture of the next `n` consecutive frames (a continuous range), in
+/// addition to any frames still queued.
+pub fn captureFrames(self: *Debug, n: u32) void {
+    self.capture_remaining +|= n;
+}
+
+/// Drop all captured frames.
+pub fn clearCaptures(self: *Debug, gpa: std.mem.Allocator) void {
+    for (self.frames.items) |*f| freeFrame(gpa, f);
+    self.frames.clearRetainingCapacity();
+}
+
+/// Number of captured frames currently retained.
+pub fn capturedFrameCount(self: *const Debug) usize {
+    return self.frames.items.len;
+}
+
+fn freeFrame(gpa: std.mem.Allocator, frame: *CapturedFrame) void {
+    for (frame.widgets.items) |w| if (w.name) |name| gpa.free(name);
+    frame.widgets.deinit(gpa);
+}
+
+/// Begin recording a new frame (called from `reset`). Enforces `capture_max` by
+/// dropping the oldest frames, then appends an empty frame and sets `capturing`.
+fn startFrameCapture(self: *Debug, gpa: std.mem.Allocator) void {
+    const max = @max(self.capture_max, 1);
+    while (self.frames.items.len + 1 > max) {
+        var oldest = self.frames.orderedRemove(0);
+        freeFrame(gpa, &oldest);
+    }
+    self.capture_seq += 1;
+    self.frames.append(gpa, .{
+        .index = self.capture_seq,
+        .time_ns = dvui.currentWindow().frame_time_ns,
+    }) catch |err| {
+        self.capture_remaining = 0;
+        self.capturing = false;
+        dvui.logError(@src(), err, "Debug.startFrameCapture could not append frame", .{});
+        return;
+    };
+    self.capturing = true;
+}
+
+/// Record one widget into the in-progress frame. Called from
+/// `WidgetData.register` while `capturing`. Best-effort: a failed allocation
+/// drops the widget rather than the frame.
 pub fn captureWidget(self: *Debug, gpa: std.mem.Allocator, wd: *const dvui.WidgetData) void {
+    if (self.frames.items.len == 0) return;
+    const frame = &self.frames.items[self.frames.items.len - 1];
     const name: ?[]const u8 = if (wd.options.name) |n| (gpa.dupe(u8, n) catch null) else null;
-    self.captured.append(gpa, .{
+    frame.widgets.append(gpa, .{
         .id = wd.id,
         .parent_id = wd.parent.data().id,
         .name = name,
@@ -179,13 +244,96 @@ pub fn captureWidget(self: *Debug, gpa: std.mem.Allocator, wd: *const dvui.Widge
     };
 }
 
-/// Emit the last captured frame (see `captureFrame`) as JSON to `writer`.
-/// `nested` (default) rebuilds the widget tree with `children` arrays; `flat`
-/// emits a flat `widgets` array where each node carries `parent_id`. Safe to
-/// call with no capture: emits an empty `widgets` array.
+/// Emit the most recent captured frame as JSON: `{"widgets":[...]}`. `nested`
+/// (default) rebuilds the tree with `children` arrays; `flat` emits a flat array
+/// where each node carries `parent_id`. Safe with no capture (empty array).
 pub fn dumpFrame(self: *const Debug, writer: *std.Io.Writer, opts: DumpOptions) std.Io.Writer.Error!void {
-    const nodes = self.captured.items;
-    try writer.writeAll("{\"widgets\":[");
+    const empty: []const CapturedWidget = &.{};
+    const nodes = if (self.frames.items.len > 0) self.frames.items[self.frames.items.len - 1].widgets.items else empty;
+    try writer.writeByte('{');
+    try dumpWidgetList(writer, nodes, opts);
+    try writer.writeByte('}');
+}
+
+/// Emit every captured frame as JSON:
+/// `{"frames":[{"index":..,"time_ns":..,"widgets":[...]}, ...]}`.
+pub fn dumpFrames(self: *const Debug, writer: *std.Io.Writer, opts: DumpOptions) std.Io.Writer.Error!void {
+    try writer.writeAll("{\"frames\":[");
+    for (self.frames.items, 0..) |*f, i| {
+        if (i != 0) try writer.writeByte(',');
+        try writer.print("{{\"index\":{d},\"time_ns\":{d},", .{ f.index, f.time_ns });
+        try dumpWidgetList(writer, f.widgets.items, opts);
+        try writer.writeByte('}');
+    }
+    try writer.writeAll("]}");
+}
+
+/// Emit the difference between two captured frames, matched by widget `id`:
+/// widgets `added` (in `to`, not `from`), `removed` (in `from`, not `to`), and
+/// `changed` (in both, with per-field `{from,to}`). `{"diff":null}` if fewer
+/// than two frames are captured. See `DiffOptions`.
+pub fn dumpDiff(self: *const Debug, writer: *std.Io.Writer, opts: DiffOptions) std.Io.Writer.Error!void {
+    const n = self.frames.items.len;
+    if (n < 2) {
+        try writer.writeAll("{\"diff\":null}");
+        return;
+    }
+    const to_i = @min(opts.to orelse n - 1, n - 1);
+    const from_i = @min(opts.from orelse (to_i -| 1), n - 1);
+    const a = &self.frames.items[from_i];
+    const b = &self.frames.items[to_i];
+    try writer.print("{{\"diff\":{{\"from\":{{\"index\":{d},\"time_ns\":{d}}},\"to\":{{\"index\":{d},\"time_ns\":{d}}}", .{ a.index, a.time_ns, b.index, b.time_ns });
+
+    // added: present in `to`, absent from `from`.
+    try writer.writeAll(",\"added\":[");
+    var first = true;
+    for (b.widgets.items) |*w| {
+        if (findById(a.widgets.items, w.id) != null) continue;
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try writer.writeByte('{');
+        try dumpFields(writer, w);
+        try writer.writeByte('}');
+    }
+
+    // removed: present in `from`, absent from `to`.
+    try writer.writeAll("],\"removed\":[");
+    first = true;
+    for (a.widgets.items) |*w| {
+        if (findById(b.widgets.items, w.id) != null) continue;
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try writer.writeByte('{');
+        try dumpFields(writer, w);
+        try writer.writeByte('}');
+    }
+
+    // changed: present in both, some dumped field differs.
+    try writer.writeAll("],\"changed\":[");
+    first = true;
+    for (b.widgets.items) |*wb| {
+        const wa = findById(a.widgets.items, wb.id) orelse continue;
+        if (!widgetChanged(wa, wb)) continue;
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try writer.writeAll("{\"id\":");
+        try dumpValue(writer, wb.id);
+        try dumpLabeled(writer, "name", wb.name);
+        try writer.writeAll(",\"changes\":{");
+        try dumpWidgetChanges(writer, wa, wb);
+        try writer.writeAll("}}");
+    }
+    try writer.writeAll("]}}");
+}
+
+fn findById(nodes: []const CapturedWidget, id: dvui.Id) ?*const CapturedWidget {
+    for (nodes) |*n| if (n.id == id) return n;
+    return null;
+}
+
+/// Emit `"widgets":[...]` in the requested shape (no surrounding object braces).
+fn dumpWidgetList(writer: *std.Io.Writer, nodes: []const CapturedWidget, opts: DumpOptions) std.Io.Writer.Error!void {
+    try writer.writeAll("\"widgets\":[");
     switch (opts.shape) {
         .flat => for (nodes, 0..) |*n, i| {
             if (i != 0) try writer.writeByte(',');
@@ -198,14 +346,14 @@ pub fn dumpFrame(self: *const Debug, writer: *std.Io.Writer, opts: DumpOptions) 
             for (nodes, 0..) |*n, i| {
                 // Roots: the self-parented window root, or any node whose parent
                 // wasn't captured (e.g. capture started mid-tree).
-                if (n.parent_id != n.id and containsId(nodes, n.parent_id)) continue;
+                if (n.parent_id != n.id and findById(nodes, n.parent_id) != null) continue;
                 if (!first) try writer.writeByte(',');
                 first = false;
                 try dumpNested(writer, nodes, i);
             }
         },
     }
-    try writer.writeAll("]}");
+    try writer.writeByte(']');
 }
 
 fn dumpNested(writer: *std.Io.Writer, nodes: []const CapturedWidget, i: usize) std.Io.Writer.Error!void {
@@ -223,52 +371,135 @@ fn dumpNested(writer: *std.Io.Writer, nodes: []const CapturedWidget, i: usize) s
     try writer.writeAll("]}");
 }
 
-fn containsId(nodes: []const CapturedWidget, id: dvui.Id) bool {
-    for (nodes) |*n| if (n.id == id) return true;
-    return false;
-}
-
 /// Emit a node's fields (no surrounding braces, no `children`), shared by the
-/// flat and nested shapes.
+/// flat/nested shapes and the diff `added`/`removed` lists.
 fn dumpFields(writer: *std.Io.Writer, n: *const CapturedWidget) std.Io.Writer.Error!void {
-    try writer.print("\"id\":\"0x{x}\",\"parent_id\":", .{n.id.asU64()});
-    if (n.parent_id == n.id) {
-        try writer.writeAll("null");
-    } else {
-        try writer.print("\"0x{x}\"", .{n.parent_id.asU64()});
-    }
-    try writer.writeAll(",\"name\":");
-    if (n.name) |nm| try dumpString(writer, nm) else try writer.writeAll("null");
+    try writer.writeAll("\"id\":");
+    try dumpValue(writer, n.id);
+    try writer.writeAll(",\"parent_id\":");
+    if (n.parent_id == n.id) try writer.writeAll("null") else try dumpValue(writer, n.parent_id);
+    try dumpLabeled(writer, "name", n.name);
     try writer.writeAll(",\"src\":{\"file\":");
     try dumpString(writer, n.src_file);
     try writer.writeAll(",\"fn\":");
     try dumpString(writer, n.src_fn);
     try writer.print(",\"line\":{d}}}", .{n.src_line});
-    try dumpRect(writer, "rect_border", n.rect_border);
-    try dumpRect(writer, "rect_content", n.rect_content);
-    try dumpRect(writer, "rect_background", n.rect_background);
-    try writer.print(",\"expand\":\"{s}\",\"gravity\":{{\"x\":{d},\"y\":{d}}}", .{ @tagName(n.expand), n.gravity.x, n.gravity.y });
-    try writer.print(",\"background\":{},\"style\":\"{s}\"", .{ n.background, @tagName(n.style) });
-    try writer.writeAll(",\"colors\":{");
-    try dumpColor(writer, "fill", n.color_fill);
-    try writer.writeByte(',');
-    try dumpColor(writer, "text", n.color_text);
-    try writer.writeByte(',');
-    try dumpColor(writer, "border", n.color_border);
-    try writer.print("}},\"font\":{{\"family\":", .{});
-    try dumpString(writer, dvui.Font.string(&n.font.family));
-    try writer.print(",\"size\":{d},\"weight\":\"{s}\",\"style\":\"{s}\"}}", .{ n.font.size, @tagName(n.font.weight), @tagName(n.font.style) });
-    try writer.print(",\"subwindow_id\":\"0x{x}\"", .{n.subwindow_id.asU64()});
-    try writer.print(",\"focused\":{},\"active\":{},\"visible\":{}", .{ n.focused, n.active, n.visible });
+    try dumpLabeled(writer, "rect_border", n.rect_border);
+    try dumpLabeled(writer, "rect_content", n.rect_content);
+    try dumpLabeled(writer, "rect_background", n.rect_background);
+    try dumpLabeled(writer, "expand", n.expand);
+    try dumpLabeled(writer, "gravity", n.gravity);
+    try dumpLabeled(writer, "background", n.background);
+    try dumpLabeled(writer, "style", n.style);
+    try writer.writeAll(",\"colors\":{\"fill\":");
+    try dumpValue(writer, n.color_fill);
+    try writer.writeAll(",\"text\":");
+    try dumpValue(writer, n.color_text);
+    try writer.writeAll(",\"border\":");
+    try dumpValue(writer, n.color_border);
+    try writer.writeByte('}');
+    try dumpLabeled(writer, "font", n.font);
+    try dumpLabeled(writer, "subwindow_id", n.subwindow_id);
+    try dumpLabeled(writer, "focused", n.focused);
+    try dumpLabeled(writer, "active", n.active);
+    try dumpLabeled(writer, "visible", n.visible);
 }
 
-fn dumpRect(writer: *std.Io.Writer, comptime label: []const u8, r: Rect.Physical) std.Io.Writer.Error!void {
-    try writer.print(",\"" ++ label ++ "\":{{\"x\":{d},\"y\":{d},\"w\":{d},\"h\":{d}}}", .{ r.x, r.y, r.w, r.h });
+/// Whether any dumped field differs between two captures of the same widget.
+fn widgetChanged(a: *const CapturedWidget, b: *const CapturedWidget) bool {
+    return a.parent_id != b.parent_id or
+        !optStrEql(a.name, b.name) or
+        !std.meta.eql(a.rect_border, b.rect_border) or
+        !std.meta.eql(a.rect_content, b.rect_content) or
+        !std.meta.eql(a.rect_background, b.rect_background) or
+        a.expand != b.expand or
+        !std.meta.eql(a.gravity, b.gravity) or
+        a.subwindow_id != b.subwindow_id or
+        a.background != b.background or
+        a.style != b.style or
+        !std.meta.eql(a.color_fill, b.color_fill) or
+        !std.meta.eql(a.color_text, b.color_text) or
+        !std.meta.eql(a.color_border, b.color_border) or
+        !std.meta.eql(a.font, b.font) or
+        a.focused != b.focused or
+        a.active != b.active or
+        a.visible != b.visible;
 }
 
-/// Emit `"<label>":"#rrggbbaa"`.
-fn dumpColor(writer: *std.Io.Writer, comptime label: []const u8, c: dvui.Color) std.Io.Writer.Error!void {
-    try writer.print("\"" ++ label ++ "\":\"#{x:0>2}{x:0>2}{x:0>2}{x:0>2}\"", .{ c.r, c.g, c.b, c.a });
+/// Emit the differing fields as `"<field>":{"from":..,"to":..}`, comma-separated.
+fn dumpWidgetChanges(writer: *std.Io.Writer, a: *const CapturedWidget, b: *const CapturedWidget) std.Io.Writer.Error!void {
+    var first = true;
+    try diffField(writer, &first, "parent_id", a.parent_id, b.parent_id);
+    if (!optStrEql(a.name, b.name)) try diffEmit(writer, &first, "name", a.name, b.name);
+    try diffField(writer, &first, "rect_border", a.rect_border, b.rect_border);
+    try diffField(writer, &first, "rect_content", a.rect_content, b.rect_content);
+    try diffField(writer, &first, "rect_background", a.rect_background, b.rect_background);
+    try diffField(writer, &first, "expand", a.expand, b.expand);
+    try diffField(writer, &first, "gravity", a.gravity, b.gravity);
+    try diffField(writer, &first, "subwindow_id", a.subwindow_id, b.subwindow_id);
+    try diffField(writer, &first, "background", a.background, b.background);
+    try diffField(writer, &first, "style", a.style, b.style);
+    try diffField(writer, &first, "color_fill", a.color_fill, b.color_fill);
+    try diffField(writer, &first, "color_text", a.color_text, b.color_text);
+    try diffField(writer, &first, "color_border", a.color_border, b.color_border);
+    try diffField(writer, &first, "font", a.font, b.font);
+    try diffField(writer, &first, "focused", a.focused, b.focused);
+    try diffField(writer, &first, "active", a.active, b.active);
+    try diffField(writer, &first, "visible", a.visible, b.visible);
+}
+
+/// Emit a `from`/`to` field if `a` and `b` differ (compared with `std.meta.eql`,
+/// so not for slices — see the `name` special case in `dumpWidgetChanges`).
+fn diffField(writer: *std.Io.Writer, first: *bool, comptime label: []const u8, a: anytype, b: @TypeOf(a)) std.Io.Writer.Error!void {
+    if (std.meta.eql(a, b)) return;
+    try diffEmit(writer, first, label, a, b);
+}
+
+fn diffEmit(writer: *std.Io.Writer, first: *bool, comptime label: []const u8, a: anytype, b: @TypeOf(a)) std.Io.Writer.Error!void {
+    if (!first.*) try writer.writeByte(',');
+    first.* = false;
+    try writer.writeAll("\"" ++ label ++ "\":{\"from\":");
+    try dumpValue(writer, a);
+    try writer.writeAll(",\"to\":");
+    try dumpValue(writer, b);
+    try writer.writeByte('}');
+}
+
+fn optStrEql(a: ?[]const u8, b: ?[]const u8) bool {
+    if (a == null and b == null) return true;
+    if (a == null or b == null) return false;
+    return std.mem.eql(u8, a.?, b.?);
+}
+
+fn dumpLabeled(writer: *std.Io.Writer, comptime label: []const u8, v: anytype) std.Io.Writer.Error!void {
+    try writer.writeAll(",\"" ++ label ++ "\":");
+    try dumpValue(writer, v);
+}
+
+/// Emit a single JSON value for one of the captured field types. Used by both
+/// the node dump and the diff, so they stay in sync.
+fn dumpValue(writer: *std.Io.Writer, v: anytype) std.Io.Writer.Error!void {
+    const T = @TypeOf(v);
+    if (T == Rect.Physical) {
+        try writer.print("{{\"x\":{d},\"y\":{d},\"w\":{d},\"h\":{d}}}", .{ v.x, v.y, v.w, v.h });
+    } else if (T == dvui.Color) {
+        try writer.print("\"#{x:0>2}{x:0>2}{x:0>2}{x:0>2}\"", .{ v.r, v.g, v.b, v.a });
+    } else if (T == dvui.Font) {
+        try writer.writeAll("{\"family\":");
+        try dumpString(writer, dvui.Font.string(&v.family));
+        try writer.print(",\"size\":{d},\"weight\":\"{s}\",\"style\":\"{s}\"}}", .{ v.size, @tagName(v.weight), @tagName(v.style) });
+    } else if (T == Options.Gravity) {
+        try writer.print("{{\"x\":{d},\"y\":{d}}}", .{ v.x, v.y });
+    } else if (T == dvui.Id) {
+        try writer.print("\"0x{x}\"", .{v.asU64()});
+    } else if (T == bool) {
+        try writer.print("{}", .{v});
+    } else if (T == ?[]const u8) {
+        if (v) |s| try dumpString(writer, s) else try writer.writeAll("null");
+    } else switch (@typeInfo(T)) {
+        .@"enum" => try writer.print("\"{s}\"", .{@tagName(v)}),
+        else => @compileError("dumpValue: unsupported type " ++ @typeName(T)),
+    }
 }
 
 fn dumpString(writer: *std.Io.Writer, s: []const u8) std.Io.Writer.Error!void {
@@ -1590,6 +1821,64 @@ test "dumpFrame captures the widget tree as JSON" {
     const flat = w2.buffered();
     try std.testing.expect(std.mem.indexOf(u8, flat, "\"children\":") == null);
     try std.testing.expect(std.mem.indexOf(u8, flat, "\"parent_id\":") != null);
+}
+
+/// Frame counter for `diffFrame`, which renders slightly different content on
+/// even vs odd ticks so consecutive captures differ.
+var diff_test_tick: u32 = 0;
+
+fn diffFrame() !dvui.App.Result {
+    defer diff_test_tick += 1;
+    var root = dvui.box(@src(), .{ .dir = .vertical }, .{
+        .expand = .both,
+        .name = "root",
+        .background = (diff_test_tick % 2 == 0),
+    });
+    defer root.deinit();
+    dvui.label(@src(), "hi", .{}, .{ .name = "title" });
+    if (diff_test_tick % 2 == 0) {
+        dvui.label(@src(), "extra", .{}, .{ .name = "extra" });
+    }
+    return .ok;
+}
+
+test "multi-frame capture, dumpFrames and dumpDiff" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    diff_test_tick = 0;
+    try dvui.testing.settle(diffFrame);
+
+    // Continuous range: arm two frames. `testing.step` runs frame() before its
+    // begin, so 2 captured frames need 3 steps (the first only arms).
+    dvui.debug.captureFrames(2);
+    _ = try dvui.testing.step(diffFrame);
+    _ = try dvui.testing.step(diffFrame);
+    _ = try dvui.testing.step(diffFrame);
+    try std.testing.expectEqual(@as(usize, 2), dvui.debug.capturedFrameCount());
+
+    const buf = try std.testing.allocator.alloc(u8, 128 * 1024);
+    defer std.testing.allocator.free(buf);
+
+    // dumpFrames: both frames, each with an index/time_ns and a widget list.
+    var w = std.Io.Writer.fixed(buf);
+    try dvui.debug.dumpFrames(&w, .{});
+    const frames_json = w.buffered();
+    try std.testing.expect(std.mem.startsWith(u8, frames_json, "{\"frames\":["));
+    try std.testing.expect(std.mem.indexOf(u8, frames_json, "\"index\":") != null);
+    try std.testing.expect(std.mem.indexOf(u8, frames_json, "\"time_ns\":") != null);
+
+    // dumpDiff: the "extra" label is added/removed and "root" background flips,
+    // across the two captured frames (one even tick, one odd).
+    var w2 = std.Io.Writer.fixed(buf);
+    try dvui.debug.dumpDiff(&w2, .{});
+    const diff = w2.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, diff, "\"diff\":{") != null);
+    try std.testing.expect(std.mem.indexOf(u8, diff, "\"added\":[") != null);
+    try std.testing.expect(std.mem.indexOf(u8, diff, "\"removed\":[") != null);
+    try std.testing.expect(std.mem.indexOf(u8, diff, "\"changed\":[") != null);
+    try std.testing.expect(std.mem.indexOf(u8, diff, "extra") != null);
+    try std.testing.expect(std.mem.indexOf(u8, diff, "\"background\":{\"from\":") != null);
 }
 
 const Options = dvui.Options;

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -29,6 +29,15 @@ widget_panic: bool = false,
 touch_simulate_events: bool = false,
 touch_simulate_down: bool = false,
 
+/// Frame capture for `dumpFrame` (machine-readable widget-tree JSON). Off unless
+/// a one-frame capture was requested via `captureFrame`. The captured list uses
+/// `gpa` and persists until the next capture, so it can be dumped after
+/// `Window.end`. See `captureFrame`, `dumpFrame`.
+capture_state: CaptureState = .off,
+/// Widgets recorded during the captured frame, in registration (pre-order)
+/// order. Uses `gpa`; widget names are duplicated into it.
+captured: std.ArrayList(CapturedWidget) = .empty,
+
 const Debug = @This();
 
 pub const DebugTarget = enum {
@@ -43,6 +52,39 @@ pub const DebugTarget = enum {
     }
 };
 
+/// Lifecycle of a `dumpFrame` capture. `requested` (set by `captureFrame`)
+/// becomes `capturing` at the next `Window.begin` and `off` again once that
+/// frame's `Window.endRendering` runs; the captured data outlives all three.
+pub const CaptureState = enum { off, requested, capturing };
+
+/// One widget's resolved state, recorded for `dumpFrame`. The rects are physical
+/// (screen) pixels. `name` is `gpa`-duplicated; `src_*` point at static strings.
+pub const CapturedWidget = struct {
+    id: dvui.Id,
+    /// Equals `id` for the window root (emitted as null parent in the dump).
+    parent_id: dvui.Id,
+    name: ?[]const u8,
+    src_file: []const u8,
+    src_fn: []const u8,
+    src_line: u32,
+    rect_border: Rect.Physical,
+    rect_content: Rect.Physical,
+    rect_background: Rect.Physical,
+    expand: Options.Expand,
+    gravity: Options.Gravity,
+    focused: bool,
+    active: bool,
+    visible: bool,
+};
+
+/// Output shape for `dumpFrame`. `nested` rebuilds the parent/child tree (DOM
+/// like); `flat` emits a flat array where each node carries its `parent_id`.
+pub const DumpShape = enum { nested, flat };
+
+pub const DumpOptions = struct {
+    shape: DumpShape = .nested,
+};
+
 pub fn reset(self: *Debug, gpa: std.mem.Allocator) void {
     if (self.target.mouse()) {
         for (self.under_mouse_stack.items) |item| {
@@ -51,6 +93,13 @@ pub fn reset(self: *Debug, gpa: std.mem.Allocator) void {
         self.under_mouse_stack.clearRetainingCapacity();
     }
     self.target_wd = null;
+
+    // A capture requested last frame starts now: drop the previous capture and
+    // begin recording. `Window.endRendering` flips this back to `off`.
+    if (self.capture_state == .requested) {
+        self.freeCaptured(gpa);
+        self.capture_state = .capturing;
+    }
 }
 
 pub fn deinit(self: *Debug, gpa: std.mem.Allocator) void {
@@ -59,12 +108,147 @@ pub fn deinit(self: *Debug, gpa: std.mem.Allocator) void {
     }
     self.under_mouse_stack.clearAndFree(gpa);
     self.options_override.deinit(gpa);
+    self.freeCaptured(gpa);
+    self.captured.clearAndFree(gpa);
 
     // This is global, and deinit is usually called during Window.deinit.  But
     // in a testing environment, multiple whole Window init/deinit cycles
     // happen in the same process.  So prevent access-after-free.
     self.under_mouse_stack = .empty;
     self.options_override = .empty;
+    self.captured = .empty;
+    self.capture_state = .off;
+}
+
+fn freeCaptured(self: *Debug, gpa: std.mem.Allocator) void {
+    for (self.captured.items) |w| if (w.name) |n| gpa.free(n);
+    self.captured.clearRetainingCapacity();
+}
+
+/// Request a machine-readable capture of the next frame's widget tree, then read
+/// it back with `dumpFrame`. Opt-in: nothing is captured until this is called,
+/// so it costs nothing when off. The capture covers the build phase only (not
+/// the debug inspector or dialogs that render afterwards).
+///
+/// Typical headless use: `dvui.debug.captureFrame()`, run one frame, then
+/// `dvui.debug.dumpFrame(writer, .{})`.
+pub fn captureFrame(self: *Debug) void {
+    self.capture_state = .requested;
+}
+
+/// Record one widget into the active capture. Called from `WidgetData.register`
+/// while `capture_state == .capturing`. Best-effort: a failed allocation drops
+/// the widget rather than the frame.
+pub fn captureWidget(self: *Debug, gpa: std.mem.Allocator, wd: *const dvui.WidgetData) void {
+    const name: ?[]const u8 = if (wd.options.name) |n| (gpa.dupe(u8, n) catch null) else null;
+    self.captured.append(gpa, .{
+        .id = wd.id,
+        .parent_id = wd.parent.data().id,
+        .name = name,
+        .src_file = wd.src.file,
+        .src_fn = wd.src.fn_name,
+        .src_line = wd.src.line,
+        .rect_border = wd.borderRectScale().r,
+        .rect_content = wd.contentRectScale().r,
+        .rect_background = wd.backgroundRectScale().r,
+        .expand = wd.options.expandGet(),
+        .gravity = wd.options.gravityGet(),
+        .focused = wd.id == dvui.focusedWidgetId(),
+        .active = dvui.captured(wd.id),
+        .visible = wd.visible(),
+    }) catch |err| {
+        if (name) |n| gpa.free(n);
+        dvui.logError(@src(), err, "Debug.captureWidget could not append", .{});
+    };
+}
+
+/// Emit the last captured frame (see `captureFrame`) as JSON to `writer`.
+/// `nested` (default) rebuilds the widget tree with `children` arrays; `flat`
+/// emits a flat `widgets` array where each node carries `parent_id`. Safe to
+/// call with no capture: emits an empty `widgets` array.
+pub fn dumpFrame(self: *const Debug, writer: *std.Io.Writer, opts: DumpOptions) std.Io.Writer.Error!void {
+    const nodes = self.captured.items;
+    try writer.writeAll("{\"widgets\":[");
+    switch (opts.shape) {
+        .flat => for (nodes, 0..) |*n, i| {
+            if (i != 0) try writer.writeByte(',');
+            try writer.writeByte('{');
+            try dumpFields(writer, n);
+            try writer.writeByte('}');
+        },
+        .nested => {
+            var first = true;
+            for (nodes, 0..) |*n, i| {
+                // Roots: the self-parented window root, or any node whose parent
+                // wasn't captured (e.g. capture started mid-tree).
+                if (n.parent_id != n.id and containsId(nodes, n.parent_id)) continue;
+                if (!first) try writer.writeByte(',');
+                first = false;
+                try dumpNested(writer, nodes, i);
+            }
+        },
+    }
+    try writer.writeAll("]}");
+}
+
+fn dumpNested(writer: *std.Io.Writer, nodes: []const CapturedWidget, i: usize) std.Io.Writer.Error!void {
+    const n = &nodes[i];
+    try writer.writeByte('{');
+    try dumpFields(writer, n);
+    try writer.writeAll(",\"children\":[");
+    var first = true;
+    for (nodes, 0..) |*c, j| {
+        if (j == i or c.parent_id != n.id) continue;
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try dumpNested(writer, nodes, j);
+    }
+    try writer.writeAll("]}");
+}
+
+fn containsId(nodes: []const CapturedWidget, id: dvui.Id) bool {
+    for (nodes) |*n| if (n.id == id) return true;
+    return false;
+}
+
+/// Emit a node's fields (no surrounding braces, no `children`), shared by the
+/// flat and nested shapes.
+fn dumpFields(writer: *std.Io.Writer, n: *const CapturedWidget) std.Io.Writer.Error!void {
+    try writer.print("\"id\":\"0x{x}\",\"parent_id\":", .{n.id.asU64()});
+    if (n.parent_id == n.id) {
+        try writer.writeAll("null");
+    } else {
+        try writer.print("\"0x{x}\"", .{n.parent_id.asU64()});
+    }
+    try writer.writeAll(",\"name\":");
+    if (n.name) |nm| try dumpString(writer, nm) else try writer.writeAll("null");
+    try writer.writeAll(",\"src\":{\"file\":");
+    try dumpString(writer, n.src_file);
+    try writer.writeAll(",\"fn\":");
+    try dumpString(writer, n.src_fn);
+    try writer.print(",\"line\":{d}}}", .{n.src_line});
+    try dumpRect(writer, "rect_border", n.rect_border);
+    try dumpRect(writer, "rect_content", n.rect_content);
+    try dumpRect(writer, "rect_background", n.rect_background);
+    try writer.print(",\"expand\":\"{s}\",\"gravity\":{{\"x\":{d},\"y\":{d}}}", .{ @tagName(n.expand), n.gravity.x, n.gravity.y });
+    try writer.print(",\"focused\":{},\"active\":{},\"visible\":{}", .{ n.focused, n.active, n.visible });
+}
+
+fn dumpRect(writer: *std.Io.Writer, comptime label: []const u8, r: Rect.Physical) std.Io.Writer.Error!void {
+    try writer.print(",\"" ++ label ++ "\":{{\"x\":{d},\"y\":{d},\"w\":{d},\"h\":{d}}}", .{ r.x, r.y, r.w, r.h });
+}
+
+fn dumpString(writer: *std.Io.Writer, s: []const u8) std.Io.Writer.Error!void {
+    try writer.writeByte('"');
+    for (s) |ch| switch (ch) {
+        '"' => try writer.writeAll("\\\""),
+        '\\' => try writer.writeAll("\\\\"),
+        '\n' => try writer.writeAll("\\n"),
+        '\r' => try writer.writeAll("\\r"),
+        '\t' => try writer.writeAll("\\t"),
+        else => if (ch < 0x20) try writer.print("\\u{x:0>4}", .{ch}) else try writer.writeByte(ch),
+    };
+    try writer.writeByte('"');
 }
 
 pub fn errorOutline(rect: Rect.Physical) void {
@@ -1324,6 +1508,51 @@ test asZigCode {
         \\.c
     , writer.buffered());
     _ = writer.consumeAll();
+}
+
+test "dumpFrame captures the widget tree as JSON" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            var box = dvui.box(@src(), .{}, .{ .expand = .both, .background = true, .name = "outer" });
+            defer box.deinit();
+            dvui.label(@src(), "hi", .{}, .{});
+            return .ok;
+        }
+    }.frame;
+
+    // Settle first, then capture a stable frame. `captureFrame` starts at the
+    // next `Window.begin`; in a real begin/frame/end loop one frame suffices,
+    // but `testing.step` runs `frame()` before its `begin`, so two steps are
+    // needed here: the first arms capture at its trailing begin, the second
+    // builds the captured widgets.
+    try dvui.testing.settle(frame);
+    dvui.debug.captureFrame();
+    _ = try dvui.testing.step(frame);
+    _ = try dvui.testing.step(frame);
+
+    const buf = try std.testing.allocator.alloc(u8, 64 * 1024);
+    defer std.testing.allocator.free(buf);
+
+    // nested (default): a tree with `children` arrays, a self-parented root.
+    var w = std.Io.Writer.fixed(buf);
+    try dvui.debug.dumpFrame(&w, .{});
+    const nested = w.buffered();
+    try std.testing.expect(std.mem.startsWith(u8, nested, "{\"widgets\":["));
+    try std.testing.expect(std.mem.indexOf(u8, nested, "\"children\":") != null);
+    try std.testing.expect(std.mem.indexOf(u8, nested, "\"parent_id\":null") != null);
+    try std.testing.expect(std.mem.indexOf(u8, nested, "\"name\":\"outer\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, nested, "\"rect_border\":") != null);
+    try std.testing.expect(std.mem.indexOf(u8, nested, "Debug.zig") != null);
+
+    // flat: no `children`, every node carries `parent_id`.
+    var w2 = std.Io.Writer.fixed(buf);
+    try dvui.debug.dumpFrame(&w2, .{ .shape = .flat });
+    const flat = w2.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, flat, "\"children\":") == null);
+    try std.testing.expect(std.mem.indexOf(u8, flat, "\"parent_id\":") != null);
 }
 
 const Options = dvui.Options;

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -72,6 +72,16 @@ pub const CapturedWidget = struct {
     rect_background: Rect.Physical,
     expand: Options.Expand,
     gravity: Options.Gravity,
+    /// Subwindow (floating window / popup) this widget belongs to.
+    subwindow_id: dvui.Id,
+    background: bool,
+    style: dvui.Theme.Style.Name,
+    /// Resolved colors (option value or theme fallback), as actually drawn.
+    color_fill: dvui.Color,
+    color_text: dvui.Color,
+    color_border: dvui.Color,
+    /// Resolved font (option value or theme body font).
+    font: dvui.Font,
     focused: bool,
     active: bool,
     visible: bool,
@@ -153,6 +163,13 @@ pub fn captureWidget(self: *Debug, gpa: std.mem.Allocator, wd: *const dvui.Widge
         .rect_background = wd.backgroundRectScale().r,
         .expand = wd.options.expandGet(),
         .gravity = wd.options.gravityGet(),
+        .subwindow_id = dvui.subwindowCurrentId(),
+        .background = wd.options.backgroundGet(),
+        .style = wd.options.styleGet(),
+        .color_fill = wd.options.color(.fill),
+        .color_text = wd.options.color(.text),
+        .color_border = wd.options.color(.border),
+        .font = wd.options.fontGet(),
         .focused = wd.id == dvui.focusedWidgetId(),
         .active = dvui.captured(wd.id),
         .visible = wd.visible(),
@@ -231,11 +248,27 @@ fn dumpFields(writer: *std.Io.Writer, n: *const CapturedWidget) std.Io.Writer.Er
     try dumpRect(writer, "rect_content", n.rect_content);
     try dumpRect(writer, "rect_background", n.rect_background);
     try writer.print(",\"expand\":\"{s}\",\"gravity\":{{\"x\":{d},\"y\":{d}}}", .{ @tagName(n.expand), n.gravity.x, n.gravity.y });
+    try writer.print(",\"background\":{},\"style\":\"{s}\"", .{ n.background, @tagName(n.style) });
+    try writer.writeAll(",\"colors\":{");
+    try dumpColor(writer, "fill", n.color_fill);
+    try writer.writeByte(',');
+    try dumpColor(writer, "text", n.color_text);
+    try writer.writeByte(',');
+    try dumpColor(writer, "border", n.color_border);
+    try writer.print("}},\"font\":{{\"family\":", .{});
+    try dumpString(writer, dvui.Font.string(&n.font.family));
+    try writer.print(",\"size\":{d},\"weight\":\"{s}\",\"style\":\"{s}\"}}", .{ n.font.size, @tagName(n.font.weight), @tagName(n.font.style) });
+    try writer.print(",\"subwindow_id\":\"0x{x}\"", .{n.subwindow_id.asU64()});
     try writer.print(",\"focused\":{},\"active\":{},\"visible\":{}", .{ n.focused, n.active, n.visible });
 }
 
 fn dumpRect(writer: *std.Io.Writer, comptime label: []const u8, r: Rect.Physical) std.Io.Writer.Error!void {
     try writer.print(",\"" ++ label ++ "\":{{\"x\":{d},\"y\":{d},\"w\":{d},\"h\":{d}}}", .{ r.x, r.y, r.w, r.h });
+}
+
+/// Emit `"<label>":"#rrggbbaa"`.
+fn dumpColor(writer: *std.Io.Writer, comptime label: []const u8, c: dvui.Color) std.Io.Writer.Error!void {
+    try writer.print("\"" ++ label ++ "\":\"#{x:0>2}{x:0>2}{x:0>2}{x:0>2}\"", .{ c.r, c.g, c.b, c.a });
 }
 
 fn dumpString(writer: *std.Io.Writer, s: []const u8) std.Io.Writer.Error!void {
@@ -1516,7 +1549,7 @@ test "dumpFrame captures the widget tree as JSON" {
 
     const frame = struct {
         fn frame() !dvui.App.Result {
-            var box = dvui.box(@src(), .{}, .{ .expand = .both, .background = true, .name = "outer" });
+            var box = dvui.box(@src(), .{}, .{ .expand = .both, .background = true, .name = "outer", .style = .window });
             defer box.deinit();
             dvui.label(@src(), "hi", .{}, .{});
             return .ok;
@@ -1546,6 +1579,10 @@ test "dumpFrame captures the widget tree as JSON" {
     try std.testing.expect(std.mem.indexOf(u8, nested, "\"name\":\"outer\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, nested, "\"rect_border\":") != null);
     try std.testing.expect(std.mem.indexOf(u8, nested, "Debug.zig") != null);
+    // enriched fields: resolved style/colors/font.
+    try std.testing.expect(std.mem.indexOf(u8, nested, "\"colors\":{\"fill\":\"#") != null);
+    try std.testing.expect(std.mem.indexOf(u8, nested, "\"font\":{\"family\":") != null);
+    try std.testing.expect(std.mem.indexOf(u8, nested, "\"style\":\"window\"") != null);
 
     // flat: no `children`, every node carries `parent_id`.
     var w2 = std.Io.Writer.fixed(buf);

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -102,9 +102,9 @@ pub fn register(self: *WidgetData) void {
 
     cw.last_registered_id_this_frame = self.id;
 
-    // Record this widget if a machine-readable frame dump was requested (see
+    // Record this widget if a machine-readable frame dump is being captured (see
     // `Debug.captureFrame`/`dumpFrame`). Off by default, so this is one branch.
-    if (dvui.debug.capture_state == .capturing) {
+    if (dvui.debug.capturing) {
         dvui.debug.captureWidget(cw.gpa, self);
     }
 

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -102,6 +102,12 @@ pub fn register(self: *WidgetData) void {
 
     cw.last_registered_id_this_frame = self.id;
 
+    // Record this widget if a machine-readable frame dump was requested (see
+    // `Debug.captureFrame`/`dumpFrame`). Off by default, so this is one branch.
+    if (dvui.debug.capture_state == .capturing) {
+        dvui.debug.captureWidget(cw.gpa, self);
+    }
+
     const focused_widget_id = dvui.focusedWidgetId();
     if (self.id == focused_widget_id) {
         cw.last_focused_id_this_frame = self.id;

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1507,7 +1507,7 @@ pub const endOptions = struct {
 pub fn endRendering(self: *Self, opts: endOptions) void {
     // The build phase is over, so stop capturing the widget tree for
     // `Debug.dumpFrame` before the inspector/dialogs below register widgets.
-    if (dvui.debug.capture_state == .capturing) dvui.debug.capture_state = .off;
+    dvui.debug.capturing = false;
 
     if (opts.show_toasts) {
         dvui.toastsShow(null, dvui.windowRect());

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1505,6 +1505,10 @@ pub const endOptions = struct {
 /// Normally this is called for you in `end`, but you can call it separately in
 /// case you want to do something after everything has been rendered.
 pub fn endRendering(self: *Self, opts: endOptions) void {
+    // The build phase is over, so stop capturing the widget tree for
+    // `Debug.dumpFrame` before the inspector/dialogs below register widgets.
+    if (dvui.debug.capture_state == .capturing) dvui.debug.capture_state = .off;
+
     if (opts.show_toasts) {
         dvui.toastsShow(null, dvui.windowRect());
     }


### PR DESCRIPTION
Hi David, I'm Bruno Massa. I'm building a game engine called Turian ([site](https://turian.mass4.org), [repo](https://gitlab.com/mass4org/mega4/turian)), and we use DVUI for studio/editor and now implementing it as in-game GUI system, and I forked your code to add debugging/profiling instrumentation — games are very sensitive to frame-time overhead and I needed visibility into what DVUI was doing each frame. I think it's time to send that work back upstream!

I reorganized all the changes I did and I'm opening 3 PRs. None of them is super 100% complete, but they're all sufficiently robust and tested (and totally decoupled from Turian — nothing references engine concepts):

1. [Render stats + CPU phase timing](https://github.com/david-vanderson/dvui/pull/917) — per-frame counters and nanosecond-phase timing. Smallest, cleanest, most generically useful.
2. [Machine-readable widget-tree JSON dump](https://github.com/david-vanderson/dvui/pull/918) — opt-in frame capture with flat/nested JSON output and frame diffing. Useful for CI snapshots and tooling.
3. [Devtools profiler loop](https://github.com/david-vanderson/dvui/pull/919) — a simple Profiler widget that wraps a target GUI function, times it, captures its widget tree, and renders a perf chart + inspector. Most opinionated of the three.

## Summary

A machine-readable JSON dump of DVUI's resolved widget tree, designed mostly for LLM-assisted UI analysis, CI "golden snapshots", and tooling. The captures are opt-in (nothing recorded when off) and accumulate so discrete frames can be diffed (compare one frame to another).

### API
- `Debug.captureFrame()` / `Debug.captureFrames(n)` — arm capture for the next frame(s)
- `Debug.dumpFrame(writer, opts)` / `Debug.dumpFrames(writer, opts)` — emit JSON (flat or nested tree shape)
- `Debug.dumpDiff(writer, opts)` — diff two captured frames (added/removed/changed widgets)
- `Debug.clearCaptures(gpa)` / `Debug.capturedFrameCount()`

### Example
```
zig build frame-dump                  # one frame, nested JSON
zig build frame-dump -- --flat        # flat JSON
zig build frame-dump -- --frames 3    # three consecutive frames
zig build frame-dump -- --diff        # diff of two consecutive frames
```
