### PR TITLE
build: add web-serve steps for web examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Tested with Zig v0.16.0 (for Zig v0.15.2, use DVUI branch zig15 or [tag v0.4.0](
 
 ### Troubleshooting Web
 - To load examples for this backend, they must first be served through a (local) web server using:
+  - Zig `zig build serve-web-app -Dbackend=web`
   - Python `python -m http.server -d ./zig-out/bin/web-app`
   - Caddy `caddy file-server --root ./zig-out/bin/web-app --listen :8000`
   - Any other web server

--- a/build.zig
+++ b/build.zig
@@ -263,8 +263,17 @@ pub fn build(b: *std.Build) !void {
         .android_include_path = android_include_path,
     };
 
+    const web_serve_exe = b.addExecutable(.{
+        .name = "serve-web-demo",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tools/serve_web_demo.zig"),
+            .target = b.graph.host,
+            .optimize = .ReleaseFast,
+        }),
+    });
+
     if (back_to_build) |backend| {
-        try buildBackend(backend, true, dvui_opts);
+        try buildBackend(backend, true, dvui_opts, web_serve_exe);
     } else {
         for (std.meta.tags(Backend)) |backend| {
             switch (backend) {
@@ -274,7 +283,7 @@ pub fn build(b: *std.Build) !void {
             }
             // if we are building all the backends, here's where we do dvui tests
             const test_dvui_and_app = backend == .sdl3;
-            try buildBackend(backend, test_dvui_and_app, dvui_opts);
+            try buildBackend(backend, test_dvui_and_app, dvui_opts, web_serve_exe);
         }
     }
 
@@ -365,7 +374,12 @@ pub fn build(b: *std.Build) !void {
     }
 }
 
-pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: DvuiModuleOptions) !void {
+pub fn buildBackend(
+    backend: Backend,
+    test_dvui_and_app: bool,
+    dvui_opts_in: DvuiModuleOptions,
+    web_serve_exe: *Compile,
+) !void {
     var dvui_opts = dvui_opts_in;
     const b = dvui_opts.b;
     const target = dvui_opts.target;
@@ -983,8 +997,8 @@ pub fn buildBackend(backend: Backend, test_dvui_and_app: bool, dvui_opts_in: Dvu
                     .backend_name = "web-backend",
                     .backend_mod = web_mod_wasm,
                 };
-                addWebExample("web-test", b.path("examples/web-test.zig"), example_opts, wasm_dvui_opts);
-                addWebExample("web-app", b.path("examples/app.zig"), example_opts, wasm_dvui_opts);
+                addWebExample("web-test", b.path("examples/web-test.zig"), example_opts, wasm_dvui_opts, web_serve_exe);
+                addWebExample("web-app", b.path("examples/app.zig"), example_opts, wasm_dvui_opts, web_serve_exe);
             }
         },
         .wio => {
@@ -1433,6 +1447,7 @@ fn addWebExample(
     file: std.Build.LazyPath,
     example_opts: ExampleOptions,
     opts: DvuiModuleOptions,
+    web_serve_exe: *Compile,
 ) void {
     const b = opts.b;
 
@@ -1474,7 +1489,7 @@ fn addWebExample(
     cb_run.addFileArg(b.path("src/backends/index.html"));
     cb_run.addFileArg(b.path("src/backends/web.js"));
     cb_run.addFileArg(web_test.getEmittedBin());
-    const output = cb_run.captureStdOut(.{});
+    const output = cb_run.captureStdOut(.{ .basename = "index.html" });
 
     const install_noto = b.addInstallFileWithDir(b.path("src/fonts/NotoSansKR-Regular.ttf"), install_dir, "NotoSansKR-Regular.ttf");
 
@@ -1485,6 +1500,13 @@ fn addWebExample(
     b.addNamedLazyPath("web.js", web_js);
     compile_step.dependOn(&install_wasm.step);
     compile_step.dependOn(&install_noto.step);
+
+    const run_step = b.step("serve-" ++ name, "Serve " ++ name);
+    const run_serve = b.addRunArtifact(web_serve_exe);
+    run_step.dependOn(&run_serve.step);
+    run_serve.addFileArg(output);
+    run_serve.addFileArg(web_js);
+    run_serve.addArtifactArg(web_test);
 
     b.getInstallStep().dependOn(compile_step);
 }

--- a/tools/serve_web_demo.zig
+++ b/tools/serve_web_demo.zig
@@ -1,0 +1,159 @@
+const std = @import("std");
+const base64 = std.base64;
+const Allocator = std.mem.Allocator;
+const Io = std.Io;
+const net = Io.net;
+const log = std.log;
+const Sha256 = std.crypto.hash.sha2.Sha256;
+
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const arena = init.arena.allocator();
+
+    const args = try init.minimal.args.toSlice(arena);
+    if (args.len < 4) return error.MissingArguments;
+    const addr = comptime net.IpAddress.parse("127.0.0.1", 8080) catch unreachable;
+
+    try readFiles(io, arena, args);
+
+    var server = try addr.listen(io, .{ .reuse_address = true });
+    defer server.deinit(io);
+
+    var io_group: Io.Group = .init;
+    defer io_group.cancel(io);
+
+    log.info("View the demo at http://localhost:8080", .{});
+
+    while (true) {
+        const stream = server.accept(io) catch |err| {
+            log.err("Failed to accept connection: {t}", .{ err });
+            continue;
+        };
+        errdefer stream.close(io);
+        try io_group.concurrent(io, accept, .{ stream, io });
+    }
+}
+
+var html: Response = .{ .mime = "text/html", .location = undefined, .content = undefined, .etag = undefined };
+var js: Response = .{ .mime = "text/javascript", .location = undefined, .content = undefined, .etag = undefined };
+var wasm: Response = .{ .mime = "application/wasm", .location = undefined, .content = undefined, .etag = undefined };
+
+const not_found: std.http.Status = .not_found;
+const not_found_phrase = not_found.phrase().?;
+
+const Response = struct {
+    mime: []const u8,
+    location: []const u8,
+    content: []const u8,
+    etag: []const u8,
+};
+
+fn responseForLocation(location: []const u8) ?Response {
+    const uri = std.Uri.parseAfterScheme("http", location) catch return null;
+    var path_buf: [32]u8 = undefined;
+    const path = uri.path.toRaw(&path_buf) catch return null;
+    return if (path.len == 0 or std.mem.eql(u8, path, "/") or std.mem.eql(u8, path, html.location))
+        html
+    else if (std.mem.eql(u8, path, js.location))
+        js
+    else if (std.mem.eql(u8, path, wasm.location))
+        wasm
+    else
+        null;
+}
+
+fn readFiles(io: Io, arena: Allocator, args: []const [:0]const u8) !void {
+    const cwd: Io.Dir = .cwd();
+    var read_buf: [1024]u8 = undefined;
+    for (args[1..4], [_]*Response{ &html, &js, &wasm }) |path, response| {
+        const file = try cwd.openFile(io, path, .{});
+        defer file.close(io);
+
+        response.location = try std.fmt.allocPrint(arena, "/{s}", .{ std.fs.path.basename(path) });
+
+        var file_reader = file.reader(io, &read_buf);
+        const reader = &file_reader.interface;
+        const content = try reader.allocRemaining(arena, .unlimited);
+        response.content = content;
+
+        var hash: [32]u8 = undefined;
+        Sha256.hash(content, &hash, .{});
+        const etag = try arena.create([2 + base64.url_safe.Encoder.calcSize(hash.len)]u8);
+        etag[0] = '"';
+        etag[etag.len - 1] = '"';
+        _ = base64.url_safe.Encoder.encode(etag[1..etag.len - 1], &hash);
+        response.etag = etag;
+    }
+}
+
+fn accept(stream: net.Stream, io: Io) Io.Cancelable!void {
+    acceptInner(stream, io) catch |err| log.err("Connection error: {t}", .{ err });
+}
+
+fn acceptInner(stream: net.Stream, io: Io) !void {
+    defer stream.close(io);
+
+    var recv_buffer: [1024]u8 = undefined;
+    var send_buffer: [1024]u8 = undefined;
+
+    var stream_reader = stream.reader(io, &recv_buffer);
+    var stream_writer = stream.writer(io, &send_buffer);
+    var server: std.http.Server = .init(&stream_reader.interface, &stream_writer.interface);
+
+    while (server.reader.state == .ready) {
+        var request = server.receiveHead() catch |err| switch (err) {
+            error.HttpConnectionClosing => return,
+            else => |e| return e,
+        };
+        try serve(&request);
+    }
+}
+
+fn serve(request: *std.http.Server.Request) !void {
+    if (request.head.method != .GET and request.head.method != .HEAD) {
+        request.respond(not_found_phrase, .{ .status = not_found, .keep_alive = false }) catch {};
+        return;
+    }
+    const response = responseForLocation(request.head.target) orelse {
+        request.respond(not_found_phrase, .{ .status = not_found, .keep_alive = false }) catch {};
+        return;
+    };
+
+    var header_iterator = request.iterateHeaders();
+    var none_match = true;
+    while (header_iterator.next()) |header| {
+        if (std.ascii.eqlIgnoreCase(header.name, "if-none-match")) {
+            none_match = ifNoneMatch(response.etag, header.value);
+        }
+    }
+    if (none_match) {
+        try request.respond(response.content, .{
+            .keep_alive = false,
+            .extra_headers = &.{
+                .{ .name = "etag", .value = response.etag },
+                .{ .name = "content-type", .value = response.mime },
+                .{ .name = "cross-origin-opener-policy", .value = "same-origin" },
+                .{ .name = "cross-origin-embedder-policy", .value = "require-corp" },
+            },
+        });
+    } else {
+        try request.respond("", .{
+            .keep_alive = false,
+            .status = .not_modified,
+            .extra_headers = &.{
+                .{ .name = "etag", .value = response.etag },
+            },
+        });
+    }
+}
+
+fn ifNoneMatch(etag: []const u8, header_value: []const u8) bool {
+    var i: usize = 0;
+    while (std.mem.findScalarPos(u8, header_value, i, '"')) |start| {
+        const end = std.mem.findScalarPos(u8, header_value, start + 1, '"') orelse break;
+        if (std.mem.eql(u8, etag, header_value[start..end + 1])) return false;
+        if (header_value.len < end + 2 or header_value[end + 2] != ',') break;
+        i = end + 2;
+    }
+    return true;
+}


### PR DESCRIPTION
As requested on Discord, web examples can now be served locally without external dependencies such as Python or Caddy.

```
zig build serve-web-app -Dbackend=web
zig build serve-web-test -Dbackend=web
```

The web server will output something like this which can be clicked or ctrl+clicked to open the browser in many terminal emulators:
```
info: View the demo at http://localhost:8080
```

This did require adding a new argument to `buildBackend` and `addWebExample`, but it is ignored most of the time due to the lazy nature of the Zig build system. Without using a shared argument like this, each example that used the `serve_web_demo` tool might compile its own tool artifact instead of reusing the same one.

The cache buster tool is still run, but my implementation of the demo-serving tool will send [`ETag`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/ETag) headers and respect [`If-None-Match`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/If-None-Match) request headers as well to allow the browser itself to query whether to re-cache each file. Additionally, for increased precision of the `performance.now()` API on most browsers, I [cross-origin isolate](https://developer.mozilla.org/en-US/docs/Web/API/Window/crossOriginIsolated) the served website.