### PR TITLE
OS drag-and-drop file events on SDL

### DIFF
--- a/src/Event.zig
+++ b/src/Event.zig
@@ -11,6 +11,7 @@ pub const EventTypes = union(enum) {
     text: Text,
     window: Window,
     app: App,
+    drop: Drop,
 };
 
 /// Should not be set directly, use the `handle` method
@@ -32,6 +33,7 @@ pub fn format(self: *const Event, writer: *std.Io.Writer) !void {
         .text => try writer.print("}}", .{}),
         .window => |w| try writer.print("{s}}}", .{@tagName(w.action)}),
         .app => |a| try writer.print("{s}}}", .{@tagName(a.action)}),
+        .drop => |d| try writer.print("{s}}}", .{@tagName(d.action)}),
     }
 }
 
@@ -165,6 +167,36 @@ pub const App = struct {
     };
 
     action: Action,
+};
+
+pub const Drop = struct {
+    /// Currently only supporting SDL drag-and-drop types.
+    pub const Content = union(enum) {
+        /// Absolute path to a dropped file.  One `drop` event is added per file.
+        file: []const u8,
+        /// Dropped text (e.g. a dragged text selection or URL).
+        text: []const u8,
+    };
+
+    pub const Action = union(enum) {
+        /// A drag carrying droppable content entered the window. Available
+        /// only for backends that support tracking a live drag (e.g., SDL3).
+        enter,
+        /// The drag moved to a new position (`p`) while hovering the window.
+        motion,
+        /// The drag left the window, or a drop finished delivering its content.
+        /// Marks the end of a drag session so it's a good time to clear any
+        /// drop-target highlighting.
+        leave,
+        /// The content that was dropped on the window (one event per item).
+        content: Content,
+    };
+
+    action: Action,
+
+    /// Position of the drag/drop within the window, in physical pixels.
+    /// This is set for .motion and .content where supported.
+    p: dvui.Point.Physical,
 };
 
 test {

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -638,7 +638,7 @@ pub fn focusEvents(self: *Self, event_num: u16, widgetId: ?Id) void {
                     e.target_widgetId = widgetId;
                 },
                 .mouse => {},
-                .window, .app => {},
+                .window, .app, .drop => {},
             }
         }
     }
@@ -655,7 +655,7 @@ pub fn captureEvents(self: *Self, event_num: u16, widgetId: ?Id) void {
                         e.target_widgetId = widgetId;
                     }
                 },
-                .window, .app => {},
+                .window, .app, .drop => {},
             }
         }
     }
@@ -1059,6 +1059,29 @@ pub fn addEventApp(self: *Self, evt: Event.App) std.mem.Allocator.Error!void {
     try self.events.append(self.arena(), Event{
         .num = self.event_num,
         .evt = .{ .app = evt },
+    });
+
+    try self.positionMouseEventAdd();
+}
+
+/// Add an event for OS drag-and-drop.
+pub fn addEventDrop(self: *Self, action: Event.Drop.Action, p: Point.Physical) std.mem.Allocator.Error!void {
+    self.positionMouseEventRemove();
+
+    self.event_num += 1;
+    try self.events.append(self.arena(), Event{
+        .num = self.event_num,
+        .target_windowId = self.data().id,
+        .evt = .{ .drop = .{
+            .action = switch (action) {
+                .content => |content| .{ .content = switch (content) {
+                    .file => |path| .{ .file = try self.arena().dupe(u8, path) },
+                    .text => |txt| .{ .text = try self.arena().dupe(u8, txt) },
+                } },
+                else => action,
+            },
+            .p = p,
+        } },
     });
 
     try self.positionMouseEventAdd();

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1071,7 +1071,6 @@ pub fn addEventDrop(self: *Self, action: Event.Drop.Action, p: Point.Physical) s
     self.event_num += 1;
     try self.events.append(self.arena(), Event{
         .num = self.event_num,
-        .target_windowId = self.data().id,
         .evt = .{ .drop = .{
             .action = switch (action) {
                 .content => |content| .{ .content = switch (content) {

--- a/src/backends/sdl.zig
+++ b/src/backends/sdl.zig
@@ -1453,7 +1453,75 @@ fn trackGeometry(self: *SDLBackend) void {
 ///
 /// This allows "ontop" application main loop to ignore such events since they
 /// are meant for something visually floating on top of the main application.
+/// Physical-pixel position reported by an sdl3 drag/drop event. sdl3 gives
+/// window coords (like natural coords but ignoring content scaling), the same
+/// as mouse motion. sdl2 carries no position, so this returns zero there.
+fn dropPoint(self: *SDLBackend, event: c.SDL_Event) dvui.Point.Physical {
+    if (sdl3) {
+        const windowW = self.windowSize().w;
+        const scale = if (windowW == 0) 1.0 else (self.pixelSize().w / windowW);
+        return .{ .x = event.drop.x * scale, .y = event.drop.y * scale };
+    } else {
+        return .{ .x = 0, .y = 0 };
+    }
+}
+
+/// Translate SDL's drag-and-drop event family (SDL_EVENT_DROP_*) into dvui 
+/// `.drop` events. Returns true if `event` was a drop event and was consumed
+/// here. sdl3 reports the full lifecycle (enter / hover motion / drop / end).
+/// sdl2 only reports files at drop time, so it degrades to `.file` events with
+/// no hover position.
+fn addDropEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool {
+    if (sdl3) {
+        switch (event.type) {
+            c.SDL_EVENT_DROP_BEGIN => try win.addEventDrop(.enter, self.dropPoint(event)),
+            c.SDL_EVENT_DROP_POSITION => try win.addEventDrop(.motion, self.dropPoint(event)),
+            c.SDL_EVENT_DROP_COMPLETE => try win.addEventDrop(.leave, self.dropPoint(event)),
+            c.SDL_EVENT_DROP_FILE => {
+                if (event.drop.data != null) {
+                    if (self.log_events) log.debug("SDL event drop file: {s}\n", .{event.drop.data});
+                    try win.addEventDrop(.{ .content = .{ .file = std.mem.span(event.drop.data) } }, self.dropPoint(event));
+                }
+            },
+            c.SDL_EVENT_DROP_TEXT => {
+                if (event.drop.data != null) {
+                    if (self.log_events) log.debug("SDL event drop text: {s}\n", .{event.drop.data});
+                    try win.addEventDrop(.{ .content = .{ .text = std.mem.span(event.drop.data) } }, self.dropPoint(event));
+                }
+            },
+            else => return false,
+        }
+        return true;
+    } else {
+        switch (event.type) {
+            // sdl2 carries the string for both file and text drops in `.file`,
+            // and hands ownership to us (freed after copying).
+            c.SDL_DROPFILE => {
+                if (event.drop.file != null) {
+                    if (self.log_events) log.debug("SDL event drop file: {s}\n", .{event.drop.file});
+                    try win.addEventDrop(.{ .content = .{ .file = std.mem.span(event.drop.file) } }, .{ .x = 0, .y = 0 });
+                    c.SDL_free(event.drop.file);
+                }
+            },
+            c.SDL_DROPTEXT => {
+                if (event.drop.file != null) {
+                    if (self.log_events) log.debug("SDL event drop text: {s}\n", .{event.drop.file});
+                    try win.addEventDrop(.{ .content = .{ .text = std.mem.span(event.drop.file) } }, .{ .x = 0, .y = 0 });
+                    c.SDL_free(event.drop.file);
+                }
+            },
+            else => return false,
+        }
+        return true;
+    }
+}
+
 pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool {
+    // OS drag-and-drop arrives as a family of events, and sdl3's live hover
+    // position (SDL_EVENT_DROP_POSITION) has no sdl2 equivalent, so handle the
+    // whole family here rather than as cases in the shared switch below.
+    if (try self.addDropEvent(win, event)) return false;
+
     switch (event.type) {
         if (sdl3) c.SDL_EVENT_KEY_DOWN else c.SDL_KEYDOWN => {
             const sdl_key: i32 = if (sdl3) @intCast(event.key.key) else event.key.keysym.sym;
@@ -1707,12 +1775,8 @@ pub fn addEvent(self: *SDLBackend, win: *dvui.Window, event: c.SDL_Event) !bool 
             try win.addEventApp(.{ .action = .quit });
             return false;
         },
-        if (sdl3) c.SDL_EVENT_DROP_FILE else c.SDL_DROPFILE => {
-            if (self.log_events) {
-                log.debug("SDL event drop file: {s}\n", .{if (sdl3) event.drop.data else event.drop.file});
-            }
-            return false;
-        },
+        // OS drag-and-drop (all SDL_EVENT_DROP_*) is handled by addDropEvent,
+        // before this switch — see the top of addEvent.
         if (sdl3) c.SDL_EVENT_WINDOW_MOUSE_LEAVE else c.SDL_WINDOWEVENT_LEAVE => {
             if (self.log_events) {
                 log.debug("SDL mouse leave window {}\n", .{event.window.windowID});

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1665,6 +1665,7 @@ pub fn eventMatch(e: *Event, opts: EventMatchOptions) bool {
 
     switch (e.evt) {
         .app => {}, // app events always match
+        .drop => {}, // file drops always match
         .window => {
             if (e.target_widgetId) |wid| {
                 if (wid != opts.id) {


### PR DESCRIPTION
[I put all of this in the commit message too.]

SDL backend receives `SDL_EVENT_DROP_FILE` but it's logged and discarded.

- added `Event.Drop` in `EventTypes`, like the `.mouse`, `.key`.
- it's of `Action` type.
 - `.enter` = drag entered the window
 - `.motion` = drag moved while hovering
 - `.leave` = drag left or drop finished
 - `.content` = content was dropped (one event per content)
- `p` (of type `dvui.Point.Physical`) is set for `.motion` and `.file`

The content can be a lot of stuff. SDL supports both file (`SDL_EVENT_DROP_FILE`) and text (`SDL_EVENT_DROP_TEXT`), but other systems might support much more. Across macOS NSPasteboard, Windows IDataObject, and GTK/Qt, there might be file URLs, plain text, RTF, HTML, images, URLs, app-defined custom types. So best to just separate it to Content.

For now, Content only has the two types that SDL has. I'm not sure if in the future it would be better to have backend-specific values or not.

Added `Window.addEventDrop(action, p)`.

Tried to provide implementations for both SDL2 and SDL3. In SDL3, we need to translate the positions from window coordinates to physical pixels with the same scale factor as mouse motion.

SDL2 has no hover tracking, so it just uses `.file`.

Can use it with:

    for (dvui.events()) |*e| switch (e.evt) {
        .drop => |d| switch (d.action) {
            .enter, .motion => highlight = true,
            .leave => highlight = false,
            .file => |path| openOrAppendImport(path), // copy to keep it
        },
        else => {},
    };