### PR TITLE
Batching draw calls

### DIFF
--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -786,6 +786,30 @@ test "DOCIMG demo" {
     //}
 }
 
+// ponytail: measurement-only, delete with pre_batch_calls at Phase-5 cleanup.
+// Run: zig build test -Dtest-filter="batching draw-call"
+test "batching draw-call measurement" {
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 800, .h = 600 } });
+    defer t.deinit();
+
+    dvui.Examples.show_demo_window = true;
+    dvui.Examples.show_widgetpedia_window = true;
+
+    const frame = struct {
+        fn frame() !dvui.App.Result {
+            dvui.Examples.demo(.full);
+            return .ok;
+        }
+    }.frame;
+
+    try dvui.testing.settle(frame);
+    const rs = dvui.currentWindow().renderStats();
+    std.debug.print(
+        "\n[batching] demo full frame: pre_batch={d} draw_calls={d} ratio={d:.1}x (tris={d} verts={d} tex_binds={d})\n",
+        .{ rs.pre_batch_calls, rs.draw_calls, @as(f32, @floatFromInt(rs.pre_batch_calls)) / @as(f32, @floatFromInt(@max(1, rs.draw_calls))), rs.triangles, rs.vertices, rs.texture_binds },
+    );
+}
+
 const std = @import("std");
 const dvui = @import("dvui.zig");
 const Options = dvui.Options;

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -355,6 +355,17 @@ pub const Cache = struct {
     database: std.ArrayList(Source) = .empty,
     cache: dvui.TrackingAutoHashMap(u64, Entry, .get_and_put, void) = .empty,
 
+    /// One atlas texture packing the white texel + every glyph of every cached
+    /// sized font. Grows (rebuilds) whenever a font or glyph is added so all
+    /// text + untextured fills reference a single texture and batch together.
+    /// Persists across frames; rebuilt lazily by `getAtlas`.
+    atlas: ?Texture = null,
+    atlas_size: Size = .{},
+    /// UV of the opaque-white texel baked into `atlas` (fills sample this).
+    atlas_white_uv: @Vector(2, f32) = .{ 0, 0 },
+
+    pub const Atlas = struct { texture: Texture, size: Size, white_uv: @Vector(2, f32) };
+
     pub fn deinit(self: *Cache, gpa: std.mem.Allocator, backend: Backend) void {
         defer self.* = undefined;
         var it = self.cache.iterator();
@@ -363,12 +374,194 @@ pub const Cache = struct {
         }
         self.cache.deinit(gpa);
 
+        if (self.atlas) |tex| backend.textureDestroy(tex);
+
         for (self.database.items) |*source| {
             if (source.allocator) |a| {
                 a.free(source.bytes);
             }
         }
         self.database.deinit(gpa);
+    }
+
+    /// Returns the shared atlas, rebuilding it if any cached font gained glyphs
+    /// (or a font was added/evicted) since the last build. The dirty check
+    /// reads the tracking map directly so it doesn't mark fonts as used.
+    pub fn getAtlas(self: *Cache, gpa: std.mem.Allocator, backend: Backend) Backend.TextureError!Atlas {
+        var dirty = self.atlas == null;
+        if (!dirty) {
+            var it = self.cache.map.iterator();
+            while (it.next()) |e| {
+                if (e.value_ptr.inner.atlas_glyphs != e.value_ptr.inner.glyphCount()) {
+                    dirty = true;
+                    break;
+                }
+            }
+        }
+        if (dirty) try self.rebuildAtlas(gpa, backend);
+        return .{ .texture = self.atlas.?, .size = self.atlas_size, .white_uv = self.atlas_white_uv };
+    }
+
+    /// Repack every glyph of every cached font (+ a white texel) into one
+    /// texture, rewriting each glyph's `uv` to be atlas-relative. Grow-only.
+    /// ponytail: rebuilds the whole atlas on any new glyph; fine after warmup
+    /// (glyphs settle), thrashes only on first frames streaming new codepoints.
+    /// Upgrade to incremental sub-rect packing only if that shows up in a profile.
+    fn rebuildAtlas(self: *Cache, gpa: std.mem.Allocator, backend: Backend) Backend.TextureError!void {
+        const pad = 1;
+
+        // Collect a stable, flat list of every glyph across all fonts. Pointers
+        // stay valid because we don't mutate the maps during the rebuild.
+        const GlyphRef = struct { entry: *Entry, gi: *Entry.GlyphInfo, codepoint: u32 };
+        var refs: std.ArrayList(GlyphRef) = .empty;
+        defer refs.deinit(gpa);
+        {
+            var it = self.cache.map.iterator();
+            while (it.next()) |e| {
+                const entry = &e.value_ptr.inner;
+                for (&entry.glyph_info_ascii, 0..) |*gi, i| {
+                    try refs.append(gpa, .{ .entry = entry, .gi = gi, .codepoint = @intCast(i + Entry.ascii_start) });
+                }
+                var git = entry.glyph_info.iterator();
+                while (git.next()) |ge| {
+                    try refs.append(gpa, .{ .entry = entry, .gi = ge.value_ptr, .codepoint = ge.key_ptr.* });
+                }
+            }
+        }
+
+        const total = refs.items.len;
+        const row_glyphs: u32 = @max(1, @as(u32, @intFromFloat(@ceil(@sqrt(@as(f32, @floatFromInt(total)))))));
+
+        // Pass 1: measure the packed grid.
+        var s = Size{};
+        {
+            var row: Size = .{};
+            for (refs.items, 0..) |r, i| {
+                row.w += r.gi.w + 2 * pad;
+                row.h = @max(row.h, r.gi.h + 2 * pad);
+                if ((i + 1) % row_glyphs == 0) {
+                    s.w = @max(s.w, row.w);
+                    s.h += row.h;
+                    row = .{};
+                }
+            }
+            s.w = @max(s.w, row.w);
+            s.h += row.h;
+            s = s.ceil();
+        }
+
+        // extra padding around the whole texture
+        s.w += 2 * pad;
+        s.h += 2 * pad;
+
+        // Reserve an opaque-white block below the glyphs (see atlas_white_uv).
+        const white_px: i32 = 2;
+        const white_x: i32 = pad;
+        const white_y: i32 = @as(i32, @intFromFloat(s.h)) + pad;
+        s.h += @floatFromInt(white_px + 2 * pad);
+        s.w = @max(s.w, @as(f32, @floatFromInt(white_x + white_px + pad)));
+
+        var pixels = try gpa.alloc(dvui.Color.PMA, @as(usize, @trunc(s.w * s.h)));
+        defer gpa.free(pixels);
+        @memset(pixels, .transparent);
+
+        {
+            const stride: usize = @intFromFloat(s.w);
+            var yy: i32 = white_y;
+            while (yy < white_y + white_px) : (yy += 1) {
+                var xx: i32 = white_x;
+                while (xx < white_x + white_px) : (xx += 1) {
+                    pixels[@as(usize, @intCast(yy)) * stride + @as(usize, @intCast(xx))] = .{ .r = 255, .g = 255, .b = 255, .a = 255 };
+                }
+            }
+            self.atlas_white_uv = .{
+                (@as(f32, @floatFromInt(white_x)) + @as(f32, white_px) / 2.0) / s.w,
+                (@as(f32, @floatFromInt(white_y)) + @as(f32, white_px) / 2.0) / s.h,
+            };
+        }
+
+        // Pass 2: render each glyph and set its atlas-relative uv.
+        var x: i32 = pad;
+        var y: i32 = pad;
+        var row_height: u32 = 0;
+        for (refs.items, 0..) |r, i| {
+            const entry = r.entry;
+            const gi = r.gi;
+            const codepoint = r.codepoint;
+
+            gi.uv[0] = @as(f32, @floatFromInt(x + pad)) / s.w;
+            gi.uv[1] = @as(f32, @floatFromInt(y + pad)) / s.h;
+
+            if (impl == .FreeType) blk: {
+                FreeType.intToError(c.FT_Load_Char(entry.face, codepoint, @as(i32, @bitCast(FreeType.LoadFlags{ .render = true })))) catch |err| {
+                    dvui.log.warn("rebuildAtlas: freetype error {any} trying to FT_Load_Char codepoint {d}", .{ err, codepoint });
+                    break :blk; // will skip the failing glyph
+                };
+
+                if (entry.face.*.glyph.*.format != c.FT_GLYPH_FORMAT_BITMAP) {
+                    FreeType.intToError(c.FT_Render_Glyph(entry.face.*.glyph, c.FT_RENDER_MODE_NORMAL)) catch |err| {
+                        dvui.log.warn("rebuildAtlas: freetype error {any} trying to FT_Render_Glyph codepoint {d}", .{ err, codepoint });
+                        break :blk; // will skip the failing glyph
+                    };
+                }
+
+                const bitmap = entry.face.*.glyph.*.bitmap;
+                row_height = @max(row_height, bitmap.rows);
+                var row: i32 = 0;
+                while (row < bitmap.rows) : (row += 1) {
+                    var col: i32 = 0;
+                    while (col < bitmap.width) : (col += 1) {
+                        const src = bitmap.buffer[@as(usize, @intCast(row * bitmap.pitch + col))];
+                        const di = @as(usize, @intCast((y + row + pad) * @as(i32, @trunc(s.w)) + (x + col + pad)));
+                        // premultiplied white
+                        pixels[di] = .{ .r = src, .g = src, .b = src, .a = src };
+                    }
+                }
+            } else {
+                const out_w: u32 = @trunc(gi.w);
+                const out_h: u32 = @trunc(gi.h);
+                row_height = @max(row_height, out_h);
+
+                // single channel
+                const bitmap = try gpa.alloc(u8, @as(usize, out_w * out_h));
+                defer gpa.free(bitmap);
+
+                c.stbtt_MakeCodepointBitmapSubpixel(&entry.face, bitmap.ptr, @as(c_int, @intCast(out_w)), @as(c_int, @intCast(out_h)), @as(c_int, @intCast(out_w)), entry.scaleFactor, entry.scaleFactor, 0.0, 0.0, @as(c_int, @intCast(codepoint)));
+
+                const stride: usize = @trunc(s.w);
+                const di = @as(usize, @intCast(y)) * stride + @as(usize, @intCast(x));
+                for (0..out_h) |row| {
+                    for (0..out_w) |col| {
+                        const src = bitmap[row * out_w + col];
+                        const dest = di + (row + pad) * stride + (col + pad);
+                        // premultiplied white
+                        pixels[dest] = .{ .r = src, .g = src, .b = src, .a = src };
+                    }
+                }
+            }
+
+            x += @as(i32, @trunc(gi.w)) + 2 * pad;
+
+            if ((i + 1) % row_glyphs == 0) {
+                x = pad;
+                y += @intCast(row_height + 2 * pad);
+                row_height = 0;
+            }
+        }
+
+        const new_atlas = try backend.textureCreate(@ptrCast(pixels.ptr), .{ .width = @trunc(s.w), .height = @trunc(s.h) });
+        // Defer destroying the old atlas: geometry already queued this frame may
+        // still reference it until the queue flushes at end of frame.
+        if (self.atlas) |old| dvui.textureDestroyLater(old);
+        self.atlas = new_atlas;
+        self.atlas_size = s;
+
+        // Mark every current font as fully baked so getAtlas stays clean until
+        // the next new glyph.
+        var mit = self.cache.map.iterator();
+        while (mit.next()) |e| {
+            e.value_ptr.inner.atlas_glyphs = e.value_ptr.inner.glyphCount();
+        }
     }
 
     pub fn reset(self: *Cache, gpa: std.mem.Allocator, backend: Backend) void {
@@ -447,10 +640,16 @@ pub const Cache = struct {
         em_height: f32, // height of M
         glyph_info: std.AutoHashMapUnmanaged(u32, GlyphInfo) = .empty,
         glyph_info_ascii: [ascii_size - ascii_start]GlyphInfo,
-        texture_atlas_cache: ?Texture = null,
+        /// Number of this font's glyphs baked into the shared `Cache.atlas`.
+        /// When it lags `glyphCount()` the atlas is stale (see `Cache.getAtlas`).
+        atlas_glyphs: u32 = 0,
 
         const ascii_size = 127;
         const ascii_start = 32;
+
+        pub fn glyphCount(self: *const Entry) u32 {
+            return @intCast(self.glyph_info_ascii.len + self.glyph_info.count());
+        }
 
         const GlyphInfo = struct {
             advance: f32, // horizontal distance to move the pen
@@ -573,164 +772,13 @@ pub const Cache = struct {
         }
 
         pub fn deinit(self: *Entry, gpa: std.mem.Allocator, backend: Backend) void {
+            _ = backend; // atlas now owned by Cache, not per-entry
             defer self.* = undefined;
             gpa.free(self.name);
             self.glyph_info.deinit(gpa);
             if (impl == .FreeType) {
                 _ = c.FT_Done_Face(self.face);
             }
-            if (self.texture_atlas_cache) |tex| backend.textureDestroy(tex);
-        }
-
-        pub fn invalidateTextureAtlas(self: *Entry) void {
-            if (self.texture_atlas_cache) |tex| {
-                dvui.textureDestroyLater(tex);
-            }
-            self.texture_atlas_cache = null;
-        }
-
-        /// This needs to be called before rendering of glyphs as the uv coordinates
-        /// of the glyphs will not be correct if the atlas needs to be generated.
-        pub fn getTextureAtlas(self: *Entry, gpa: std.mem.Allocator, backend: Backend) Backend.TextureError!Texture {
-            if (self.texture_atlas_cache) |tex| return tex;
-
-            // number of extra pixels to add on each side of each glyph
-            const pad = 1;
-
-            const total = self.glyph_info_ascii.len + self.glyph_info.count();
-            const row_glyphs: u32 = @ceil(@as(f32, @sqrt(@as(f32, @floatFromInt(total)))));
-
-            var s = Size{};
-            {
-                var i: u32 = 0;
-                var row: Size = .{};
-                var it = self.glyph_info.iterator();
-
-                while (i < total) {
-                    const gi, const codepoint = if (i < self.glyph_info_ascii.len) .{ &self.glyph_info_ascii[i], i + ascii_start } else blk: {
-                        const e = it.next().?;
-                        break :blk .{ e.value_ptr, e.key_ptr.* };
-                    };
-                    _ = codepoint;
-
-                    row.w += gi.w + 2 * pad;
-                    row.h = @max(row.h, gi.h + 2 * pad);
-
-                    i += 1;
-                    if (i % row_glyphs == 0) {
-                        s.w = @max(s.w, row.w);
-                        s.h += row.h;
-                        row = .{};
-                    }
-                } else {
-                    s.w = @max(s.w, row.w);
-                    s.h += row.h;
-                }
-
-                s = s.ceil();
-            }
-
-            // also add an extra padding around whole texture
-            s.w += 2 * pad;
-            s.h += 2 * pad;
-
-            var pixels = try gpa.alloc(dvui.Color.PMA, @as(usize, @trunc(s.w * s.h)));
-            defer gpa.free(pixels);
-            // set all pixels to zero alpha
-            @memset(pixels, .transparent);
-
-            //const num_glyphs = fce.glyph_info.count();
-            //std.debug.print("font size {d} regen glyph atlas num {d} max size {}\n", .{ sized_font.size, num_glyphs, s });
-
-            var x: i32 = pad;
-            var y: i32 = pad;
-            var it = self.glyph_info.iterator();
-            var row_height: u32 = 0;
-            var i: u32 = 0;
-            while (i < total) {
-                var gi, const codepoint = if (i < self.glyph_info_ascii.len) .{ &self.glyph_info_ascii[i], i + ascii_start } else blk: {
-                    const e = it.next().?;
-                    break :blk .{ e.value_ptr, e.key_ptr.* };
-                };
-
-                gi.uv[0] = @as(f32, @floatFromInt(x + pad)) / s.w;
-                gi.uv[1] = @as(f32, @floatFromInt(y + pad)) / s.h;
-
-                if (impl == .FreeType) blk: {
-                    FreeType.intToError(c.FT_Load_Char(self.face, codepoint, @as(i32, @bitCast(FreeType.LoadFlags{ .render = true })))) catch |err| {
-                        dvui.log.warn("renderText: freetype error {any} trying to FT_Load_Char codepoint {d}", .{ err, codepoint });
-                        break :blk; // will skip the failing glyph
-                    };
-
-                    // https://freetype.org/freetype2/docs/tutorial/step1.html#section-6
-                    if (self.face.*.glyph.*.format != c.FT_GLYPH_FORMAT_BITMAP) {
-                        FreeType.intToError(c.FT_Render_Glyph(self.face.*.glyph, c.FT_RENDER_MODE_NORMAL)) catch |err| {
-                            dvui.log.warn("renderText freetype error {any} trying to FT_Render_Glyph codepoint {d}", .{ err, codepoint });
-                            break :blk; // will skip the failing glyph
-                        };
-                    }
-
-                    const bitmap = self.face.*.glyph.*.bitmap;
-                    //std.debug.print("bitmap,{d},{d},{d}\n", .{codepoint, bitmap.width, bitmap.rows});
-                    row_height = @max(row_height, bitmap.rows);
-                    var row: i32 = 0;
-                    while (row < bitmap.rows) : (row += 1) {
-                        var col: i32 = 0;
-                        while (col < bitmap.width) : (col += 1) {
-                            const src = bitmap.buffer[@as(usize, @intCast(row * bitmap.pitch + col))];
-
-                            // because of the extra edge, offset by 1 row and 1 col
-                            const di = @as(usize, @intCast((y + row + pad) * @as(i32, @trunc(s.w)) + (x + col + pad)));
-
-                            // premultiplied white
-                            pixels[di] = .{ .r = src, .g = src, .b = src, .a = src };
-                        }
-                    }
-                } else {
-                    //var ow: c_int = undefined;
-                    //var oh: c_int = undefined;
-                    //const bm = c.stbtt_GetCodepointBitmap(&self.face, self.scaleFactor, self.scaleFactor, @as(c_int, @intCast(codepoint)), &ow, &oh, null, null);
-                    //std.debug.print("bitmap,{d},{d},{d}\n", .{codepoint, ow, oh});
-
-                    //c.stbtt_FreeBitmap(bm, null);
-
-                    const out_w: u32 = @trunc(gi.w);
-                    const out_h: u32 = @trunc(gi.h);
-                    row_height = @max(row_height, out_h);
-
-                    // single channel
-                    const bitmap = try gpa.alloc(u8, @as(usize, out_w * out_h));
-                    defer gpa.free(bitmap);
-
-                    //log.debug("makecodepointBitmap size x {d} y {d} w {d} h {d} out w {d} h {d}", .{ x, y, s.w, s.h, out_w, out_h });
-
-                    c.stbtt_MakeCodepointBitmapSubpixel(&self.face, bitmap.ptr, @as(c_int, @intCast(out_w)), @as(c_int, @intCast(out_h)), @as(c_int, @intCast(out_w)), self.scaleFactor, self.scaleFactor, 0.0, 0.0, @as(c_int, @intCast(codepoint)));
-
-                    const stride: usize = @trunc(s.w);
-                    const di = @as(usize, @intCast(y)) * stride + @as(usize, @intCast(x));
-                    for (0..out_h) |row| {
-                        for (0..out_w) |col| {
-                            const src = bitmap[row * out_w + col];
-                            const dest = di + (row + pad) * stride + (col + pad);
-
-                            // premultiplied white
-                            pixels[dest] = .{ .r = src, .g = src, .b = src, .a = src };
-                        }
-                    }
-                }
-
-                x += @as(i32, @trunc(gi.w)) + 2 * pad;
-
-                i += 1;
-                if (i % row_glyphs == 0) {
-                    x = pad;
-                    y += @intCast(row_height + 2 * pad);
-                    row_height = 0;
-                }
-            }
-
-            self.texture_atlas_cache = try backend.textureCreate(@ptrCast(pixels.ptr), .{ .width = @trunc(s.w), .height = @trunc(s.h) });
-            return self.texture_atlas_cache.?;
         }
 
         /// If a codepoint is missing in the font it gets the glyph for
@@ -750,10 +798,8 @@ pub const Cache = struct {
 
             const gi = try self.glyphInfoGenerate(codepoint);
 
-            // new glyph, need to regen texture atlas on next render
-            //std.debug.print("new glyph {}\n", .{codepoint});
-            self.invalidateTextureAtlas();
-
+            // new glyph: glyphCount() now exceeds atlas_glyphs, so the shared
+            // atlas rebuilds on the next getAtlas (see Cache.getAtlas).
             try self.glyph_info.put(gpa, codepoint, gi);
             return gi;
         }

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -432,7 +432,6 @@ pub const Cache = struct {
         const total = refs.items.len;
         const row_glyphs: u32 = @max(1, @as(u32, @intFromFloat(@ceil(@sqrt(@as(f32, @floatFromInt(total)))))));
 
-        // Pass 1: measure the packed grid.
         var s = Size{};
         {
             var row: Size = .{};
@@ -450,7 +449,6 @@ pub const Cache = struct {
             s = s.ceil();
         }
 
-        // extra padding around the whole texture
         s.w += 2 * pad;
         s.h += 2 * pad;
 
@@ -480,7 +478,6 @@ pub const Cache = struct {
             };
         }
 
-        // Pass 2: render each glyph and set its atlas-relative uv.
         var x: i32 = pad;
         var y: i32 = pad;
         var row_height: u32 = 0;
@@ -513,7 +510,6 @@ pub const Cache = struct {
                     while (col < bitmap.width) : (col += 1) {
                         const src = bitmap.buffer[@as(usize, @intCast(row * bitmap.pitch + col))];
                         const di = @as(usize, @intCast((y + row + pad) * @as(i32, @trunc(s.w)) + (x + col + pad)));
-                        // premultiplied white
                         pixels[di] = .{ .r = src, .g = src, .b = src, .a = src };
                     }
                 }
@@ -534,7 +530,6 @@ pub const Cache = struct {
                     for (0..out_w) |col| {
                         const src = bitmap[row * out_w + col];
                         const dest = di + (row + pad) * stride + (col + pad);
-                        // premultiplied white
                         pixels[dest] = .{ .r = src, .g = src, .b = src, .a = src };
                     }
                 }

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -155,6 +155,19 @@ _widget_stack: WidgetStack,
 render_target: dvui.RenderTarget = .{ .texture = null, .offset = .{} },
 end_rendering_done: bool = false,
 
+/// Coalesces adjacent `drawClippedTriangles` calls that share the same
+/// (texture, clip_rect) into one backend call. Flushed whenever that state
+/// changes, at render-target switches, and at `endRendering`. See
+/// `trianglesQueue` / `trianglesFlush`.
+triQueue: TriQueue = .{},
+
+/// The shared font atlas as seen by `renderText` this frame. Untextured fills
+/// sample its white texel (see `render.renderTriangles`) so fill+text batch
+/// into one draw call. Set once the first text renders; reset each frame in
+/// `begin`. Only ever holds a texture fetched this frame, so it can't outlive a
+/// deferred `textureDestroy` of a rebuilt atlas.
+current_atlas: ?struct { texture: dvui.Texture, white_uv: @Vector(2, f32) } = null,
+
 /// See `InitOptions.open_flag`
 open_flag: ?*bool = null,
 
@@ -162,9 +175,22 @@ accesskit: dvui.AccessKit,
 
 /// Per-frame rendering cost counters. Accumulated above the backend, so the
 /// numbers are backend-agnostic. See `Window.renderStats`.
+pub const TriQueue = struct {
+    texture: ?dvui.Texture = null,
+    clipr: ?dvui.Rect.Physical = null,
+    vtx: std.ArrayList(dvui.Vertex) = .empty,
+    idx: std.ArrayList(dvui.Vertex.Index) = .empty,
+    /// false until the first queued batch, so an initial null/null draw isn't
+    /// mistaken for "same state as empty queue".
+    active: bool = false,
+};
+
 pub const RenderStats = struct {
-    /// Calls to `Backend.drawClippedTriangles` (one per `render.renderTriangles`).
+    /// Calls to `Backend.drawClippedTriangles` (one per queue flush).
     draw_calls: u32 = 0,
+    /// ponytail: measurement-only, delete at Phase-5 cleanup. Counts
+    /// `renderTriangles` calls = the draw_calls we'd have without batching.
+    pre_batch_calls: u32 = 0,
     /// Triangles submitted (sum of index counts / 3).
     triangles: u32 = 0,
     /// Vertices submitted.
@@ -494,6 +520,8 @@ pub fn deinit(self: *Self) void {
     self.child_os_wins.deinit(self.gpa);
 
     self.keybinds.deinit(self.gpa);
+    self.triQueue.vtx.deinit(self.gpa);
+    self.triQueue.idx.deinit(self.gpa);
     self._arena.deinit();
     self._lifo_arena.deinit();
     self._widget_stack.deinit();
@@ -1310,6 +1338,7 @@ pub fn begin(
 
     self.end_rendering_done = false;
     self.render_stats = .{};
+    self.current_atlas = null;
     self.cursor_requested = null;
     self.text_input_rect = null;
     self.last_focused_id_this_frame = .zero;
@@ -1494,6 +1523,62 @@ pub fn addRenderCommand(self: *Self, cmd: dvui.RenderCommand.Command, after: boo
     }
 }
 
+fn texEql(a: ?dvui.Texture, b: ?dvui.Texture) bool {
+    if (a == null and b == null) return true;
+    if (a == null or b == null) return false;
+    return a.?.ptr == b.?.ptr;
+}
+
+fn cliprEql(a: ?dvui.Rect.Physical, b: ?dvui.Rect.Physical) bool {
+    if (a == null and b == null) return true;
+    if (a == null or b == null) return false;
+    return a.?.equals(b.?);
+}
+
+/// Append triangles to the coalescing queue, flushing first if the
+/// (texture, clip_rect) state differs from what's already queued. Indices
+/// are rebased by the current queued vertex count.
+pub fn trianglesQueue(self: *Self, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, clipr: ?dvui.Rect.Physical) !void {
+    if (self.triQueue.active and !(texEql(self.triQueue.texture, texture) and cliprEql(self.triQueue.clipr, clipr))) {
+        self.trianglesFlush();
+    }
+    self.render_stats.pre_batch_calls += 1;
+    self.triQueue.texture = texture;
+    self.triQueue.clipr = clipr;
+    self.triQueue.active = true;
+
+    const offset: dvui.Vertex.Index = @intCast(self.triQueue.vtx.items.len);
+    try self.triQueue.vtx.appendSlice(self.gpa, vtx);
+    try self.triQueue.idx.ensureUnusedCapacity(self.gpa, idx.len);
+    for (idx) |i| self.triQueue.idx.appendAssumeCapacity(i + offset);
+}
+
+/// Submit the queued batch to the backend as a single draw call and reset
+/// the queue (retaining capacity — no per-frame alloc churn after warmup).
+pub fn trianglesFlush(self: *Self) void {
+    if (self.triQueue.idx.items.len == 0) {
+        self.triQueue.active = false;
+        return;
+    }
+
+    self.render_stats.draw_calls += 1;
+    self.render_stats.vertices +|= @intCast(self.triQueue.vtx.items.len);
+    self.render_stats.triangles +|= @intCast(self.triQueue.idx.items.len / 3);
+    if (self.triQueue.texture) |_| {
+        self.render_stats.texture_binds += 1;
+    }
+
+    self.backend.drawClippedTriangles(self.triQueue.texture, self.triQueue.vtx.items, self.triQueue.idx.items, self.triQueue.clipr) catch |err| {
+        dvui.logError(@src(), err, "drawClippedTriangles failed", .{});
+    };
+
+    self.triQueue.vtx.clearRetainingCapacity();
+    self.triQueue.idx.clearRetainingCapacity();
+    self.triQueue.texture = null;
+    self.triQueue.clipr = null;
+    self.triQueue.active = false;
+}
+
 pub fn renderCommands(self: *Self, queue: []const dvui.RenderCommand) !void {
     const old_snap = self.snap_to_pixels;
     defer self.snap_to_pixels = old_snap;
@@ -1643,6 +1728,9 @@ pub fn endRendering(self: *Self, opts: endOptions) void {
         // Set to empty because it's allocated on the arena and will be freed there
         sw.render_cmds_after = .empty;
     }
+
+    // Flush any tris still queued from the last batch before we're done.
+    self.trianglesFlush();
 
     self.render_stats_last = self.render_stats;
     self.frame_timing_last.render_ns = nsSince(self.backend.nanoTime(), render_start);
@@ -1927,6 +2015,34 @@ test "renderStats and frameTiming are populated after a frame" {
     try std.testing.expect(ft.build_ns > 0);
     try std.testing.expect(ft.render_ns > 0);
     try std.testing.expect(ft.total_ns >= ft.build_ns + ft.render_ns);
+}
+
+test "trianglesQueue coalesces matching state and rebases indices" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+    const win = dvui.currentWindow();
+
+    const verts = [_]dvui.Vertex{ .{ .pos = .{ .x = 0, .y = 0 } }, .{ .pos = .{ .x = 1, .y = 0 } }, .{ .pos = .{ .x = 0, .y = 1 } } };
+    const inds = [_]dvui.Vertex.Index{ 0, 1, 2 };
+
+    // Two draws with identical (null tex, null clip) coalesce: second batch's
+    // indices are rebased by the first batch's vertex count, nothing flushed yet.
+    try win.trianglesQueue(null, &verts, &inds, null);
+    try win.trianglesQueue(null, &verts, &inds, null);
+    try std.testing.expectEqual(@as(usize, 6), win.triQueue.vtx.items.len);
+    try std.testing.expectEqualSlices(dvui.Vertex.Index, &.{ 0, 1, 2, 3, 4, 5 }, win.triQueue.idx.items);
+
+    const before = win.render_stats.draw_calls;
+    win.trianglesFlush();
+    try std.testing.expectEqual(before + 1, win.render_stats.draw_calls);
+    try std.testing.expectEqual(@as(usize, 0), win.triQueue.idx.items.len);
+
+    // A differing clip rect flushes the prior batch before queuing the new one.
+    try win.trianglesQueue(null, &verts, &inds, null);
+    try win.trianglesQueue(null, &verts, &inds, .{ .x = 0, .y = 0, .w = 5, .h = 5 });
+    try std.testing.expectEqual(before + 2, win.render_stats.draw_calls);
+    try std.testing.expectEqual(@as(usize, 3), win.triQueue.vtx.items.len);
+    win.trianglesFlush();
 }
 
 test {

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -159,7 +159,7 @@ end_rendering_done: bool = false,
 /// (texture, clip_rect) into one backend call. Flushed whenever that state
 /// changes, at render-target switches, and at `endRendering`. See
 /// `trianglesQueue` / `trianglesFlush`.
-triQueue: TriQueue = .{},
+triangle_queue: TriangleQueue = .{},
 
 /// The shared font atlas as seen by `renderText` this frame. Untextured fills
 /// sample its white texel (see `render.renderTriangles`) so fill+text batch
@@ -175,7 +175,7 @@ accesskit: dvui.AccessKit,
 
 /// Per-frame rendering cost counters. Accumulated above the backend, so the
 /// numbers are backend-agnostic. See `Window.renderStats`.
-pub const TriQueue = struct {
+pub const TriangleQueue = struct {
     texture: ?dvui.Texture = null,
     clipr: ?dvui.Rect.Physical = null,
     vtx: std.ArrayList(dvui.Vertex) = .empty,
@@ -520,8 +520,8 @@ pub fn deinit(self: *Self) void {
     self.child_os_wins.deinit(self.gpa);
 
     self.keybinds.deinit(self.gpa);
-    self.triQueue.vtx.deinit(self.gpa);
-    self.triQueue.idx.deinit(self.gpa);
+    self.triangle_queue.vtx.deinit(self.gpa);
+    self.triangle_queue.idx.deinit(self.gpa);
     self._arena.deinit();
     self._lifo_arena.deinit();
     self._widget_stack.deinit();
@@ -1539,44 +1539,44 @@ fn cliprEql(a: ?dvui.Rect.Physical, b: ?dvui.Rect.Physical) bool {
 /// (texture, clip_rect) state differs from what's already queued. Indices
 /// are rebased by the current queued vertex count.
 pub fn trianglesQueue(self: *Self, texture: ?dvui.Texture, vtx: []const dvui.Vertex, idx: []const dvui.Vertex.Index, clipr: ?dvui.Rect.Physical) !void {
-    if (self.triQueue.active and !(texEql(self.triQueue.texture, texture) and cliprEql(self.triQueue.clipr, clipr))) {
+    if (self.triangle_queue.active and !(texEql(self.triangle_queue.texture, texture) and cliprEql(self.triangle_queue.clipr, clipr))) {
         self.trianglesFlush();
     }
     self.render_stats.pre_batch_calls += 1;
-    self.triQueue.texture = texture;
-    self.triQueue.clipr = clipr;
-    self.triQueue.active = true;
+    self.triangle_queue.texture = texture;
+    self.triangle_queue.clipr = clipr;
+    self.triangle_queue.active = true;
 
-    const offset: dvui.Vertex.Index = @intCast(self.triQueue.vtx.items.len);
-    try self.triQueue.vtx.appendSlice(self.gpa, vtx);
-    try self.triQueue.idx.ensureUnusedCapacity(self.gpa, idx.len);
-    for (idx) |i| self.triQueue.idx.appendAssumeCapacity(i + offset);
+    const offset: dvui.Vertex.Index = @intCast(self.triangle_queue.vtx.items.len);
+    try self.triangle_queue.vtx.appendSlice(self.gpa, vtx);
+    try self.triangle_queue.idx.ensureUnusedCapacity(self.gpa, idx.len);
+    for (idx) |i| self.triangle_queue.idx.appendAssumeCapacity(i + offset);
 }
 
 /// Submit the queued batch to the backend as a single draw call and reset
 /// the queue (retaining capacity — no per-frame alloc churn after warmup).
 pub fn trianglesFlush(self: *Self) void {
-    if (self.triQueue.idx.items.len == 0) {
-        self.triQueue.active = false;
+    if (self.triangle_queue.idx.items.len == 0) {
+        self.triangle_queue.active = false;
         return;
     }
 
     self.render_stats.draw_calls += 1;
-    self.render_stats.vertices +|= @intCast(self.triQueue.vtx.items.len);
-    self.render_stats.triangles +|= @intCast(self.triQueue.idx.items.len / 3);
-    if (self.triQueue.texture) |_| {
+    self.render_stats.vertices +|= @intCast(self.triangle_queue.vtx.items.len);
+    self.render_stats.triangles +|= @intCast(self.triangle_queue.idx.items.len / 3);
+    if (self.triangle_queue.texture) |_| {
         self.render_stats.texture_binds += 1;
     }
 
-    self.backend.drawClippedTriangles(self.triQueue.texture, self.triQueue.vtx.items, self.triQueue.idx.items, self.triQueue.clipr) catch |err| {
+    self.backend.drawClippedTriangles(self.triangle_queue.texture, self.triangle_queue.vtx.items, self.triangle_queue.idx.items, self.triangle_queue.clipr) catch |err| {
         dvui.logError(@src(), err, "drawClippedTriangles failed", .{});
     };
 
-    self.triQueue.vtx.clearRetainingCapacity();
-    self.triQueue.idx.clearRetainingCapacity();
-    self.triQueue.texture = null;
-    self.triQueue.clipr = null;
-    self.triQueue.active = false;
+    self.triangle_queue.vtx.clearRetainingCapacity();
+    self.triangle_queue.idx.clearRetainingCapacity();
+    self.triangle_queue.texture = null;
+    self.triangle_queue.clipr = null;
+    self.triangle_queue.active = false;
 }
 
 pub fn renderCommands(self: *Self, queue: []const dvui.RenderCommand) !void {
@@ -2029,19 +2029,19 @@ test "trianglesQueue coalesces matching state and rebases indices" {
     // indices are rebased by the first batch's vertex count, nothing flushed yet.
     try win.trianglesQueue(null, &verts, &inds, null);
     try win.trianglesQueue(null, &verts, &inds, null);
-    try std.testing.expectEqual(@as(usize, 6), win.triQueue.vtx.items.len);
-    try std.testing.expectEqualSlices(dvui.Vertex.Index, &.{ 0, 1, 2, 3, 4, 5 }, win.triQueue.idx.items);
+    try std.testing.expectEqual(@as(usize, 6), win.triangle_queue.vtx.items.len);
+    try std.testing.expectEqualSlices(dvui.Vertex.Index, &.{ 0, 1, 2, 3, 4, 5 }, win.triangle_queue.idx.items);
 
     const before = win.render_stats.draw_calls;
     win.trianglesFlush();
     try std.testing.expectEqual(before + 1, win.render_stats.draw_calls);
-    try std.testing.expectEqual(@as(usize, 0), win.triQueue.idx.items.len);
+    try std.testing.expectEqual(@as(usize, 0), win.triangle_queue.idx.items.len);
 
     // A differing clip rect flushes the prior batch before queuing the new one.
     try win.trianglesQueue(null, &verts, &inds, null);
     try win.trianglesQueue(null, &verts, &inds, .{ .x = 0, .y = 0, .w = 5, .h = 5 });
     try std.testing.expectEqual(before + 2, win.render_stats.draw_calls);
-    try std.testing.expectEqual(@as(usize, 3), win.triQueue.vtx.items.len);
+    try std.testing.expectEqual(@as(usize, 3), win.triangle_queue.vtx.items.len);
     win.trianglesFlush();
 }
 

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -4051,19 +4051,12 @@ pub fn image(src: std.builtin.SourceLocation, init_opts: ImageInitOptions, opts:
 pub fn debugFontAtlases(src: std.builtin.SourceLocation, opts: Options) void {
     const cw = currentWindow();
 
-    var width: u32 = 0;
-    var height: u32 = 0;
-    var it = cw.fonts.cache.iterator();
-    while (it.next()) |kv| {
-        const texture_atlas = kv.value_ptr.getTextureAtlas(cw.gpa, cw.backend) catch |err| {
-            dvui.logError(@src(), err, "Could not get texture atlast for '{s}' at height {d}", .{ kv.value_ptr.name, kv.value_ptr.height });
-            continue;
-        };
-        width = @max(width, texture_atlas.width);
-        height += texture_atlas.height;
-    }
+    const atlas = cw.fonts.getAtlas(cw.gpa, cw.backend) catch |err| {
+        dvui.logError(@src(), err, "Could not get font atlas", .{});
+        return;
+    };
 
-    const sizePhys: Size.Physical = .{ .w = @floatFromInt(width), .h = @floatFromInt(height) };
+    const sizePhys: Size.Physical = .{ .w = @floatFromInt(atlas.texture.width), .h = @floatFromInt(atlas.texture.height) };
 
     const ss = parentGet().screenRectScale(Rect{}).s;
     const size = sizePhys.scale(1.0 / ss, Size);
@@ -4076,18 +4069,10 @@ pub fn debugFontAtlases(src: std.builtin.SourceLocation, opts: Options) void {
     var rs = wd.parent.screenRectScale(placeIn(wd.contentRect(), size, .none, opts.gravityGet()));
     const color = opts.color(.text);
 
-    it = cw.fonts.cache.iterator();
-    while (it.next()) |kv| {
-        const texture_atlas = kv.value_ptr.getTextureAtlas(cw.gpa, cw.backend) catch continue;
-        rs.r = rs.r.toSize(.{
-            .w = @floatFromInt(texture_atlas.width),
-            .h = @floatFromInt(texture_atlas.height),
-        });
-        renderTexture(texture_atlas, rs, .{ .colormod = color }) catch |err| {
-            logError(@src(), err, "Could not render font atlast for '{s}'", .{kv.value_ptr.name});
-        };
-        rs.r.y += rs.r.h;
-    }
+    rs.r = rs.r.toSize(.{ .w = @floatFromInt(atlas.texture.width), .h = @floatFromInt(atlas.texture.height) });
+    renderTexture(atlas.texture, rs, .{ .colormod = color }) catch |err| {
+        logError(@src(), err, "Could not render font atlas", .{});
+    };
 
     wd.minSizeSetAndRefresh();
     wd.minSizeReportToParent();

--- a/src/render.zig
+++ b/src/render.zig
@@ -16,6 +16,9 @@ pub const Target = struct {
     pub fn setAsCurrent(target: Target) Target {
         var cw = dvui.currentWindow();
         const ret = cw.render_target;
+        // Flush queued tris to the current target before switching, or they'd
+        // land on the wrong render target.
+        cw.trianglesFlush();
         cw.backend.renderTarget(target.texture) catch |err| {
             // TODO: This might be unrecoverable? Or brake rendering too badly?
             dvui.logError(@src(), err, "Failed to set render target", .{});
@@ -101,12 +104,16 @@ pub fn renderTriangles(triangles: Triangles, tex: ?Texture) Backend.GenericError
         }
     }
 
-    cw.render_stats.draw_calls += 1;
-    cw.render_stats.vertices +|= @intCast(triangles.vertexes.len);
-    cw.render_stats.triangles +|= @intCast(triangles.indices.len / 3);
-    if (tex != null) cw.render_stats.texture_binds += 1;
+    // Route untextured geometry through the current atlas's white texel so it
+    // shares a texture with surrounding text and coalesces (white * color ==
+    // color, so this is visually identical to an untextured draw).
+    var eff_tex = tex;
+    if (tex == null) if (cw.current_atlas) |atl| {
+        for (triangles.vertexes) |*v| v.uv = atl.white_uv;
+        eff_tex = atl.texture;
+    };
 
-    try cw.backend.drawClippedTriangles(tex, triangles.vertexes, triangles.indices, clipr);
+    try cw.trianglesQueue(eff_tex, triangles.vertexes, triangles.indices, clipr);
 }
 
 pub const TextOptions = struct {
@@ -185,8 +192,9 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
         }
     }
 
-    // Generate new texture atlas if needed to update glyph uv coords
-    const texture_atlas = fce.getTextureAtlas(cw.gpa, cw.backend) catch |err| switch (err) {
+    // Rebuild the shared atlas if needed so glyph uv coords are current. This
+    // packs every cached font into one texture, so all text + fills batch.
+    const atlas = cw.fonts.getAtlas(cw.gpa, cw.backend) catch |err| switch (err) {
         error.OutOfMemory => |e| return e,
         else => {
             const fname = opts.font.name(cw.arena());
@@ -196,6 +204,7 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
             return;
         },
     };
+    const texture_atlas = atlas.texture;
 
     // Over allocate the internal buffers assuming each byte is a character
     var builder = try dvui.Triangles.Builder.init(cw.lifo(), 4 * utf8_text.len, 6 * utf8_text.len);
@@ -228,7 +237,11 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
     // if we will definitely have a selected region or not
     const sel: bool = sel_start < sel_end;
 
-    const atlas_size: Size = .{ .w = @floatFromInt(texture_atlas.width), .h = @floatFromInt(texture_atlas.height) };
+    const atlas_size = atlas.size;
+
+    // Untextured fills after this text sample the atlas's white texel, so they
+    // batch with the glyphs instead of flipping the bound texture to null.
+    cw.current_atlas = .{ .texture = texture_atlas, .white_uv = atlas.white_uv };
 
     var bytes_seen: usize = 0;
     var last_codepoint: u32 = 0;


### PR DESCRIPTION
on #766, #637, #635
Main problem:
Texture switches (fill→font→fill) are dominant for draw call explosion in dense scenes.
i.e. Button first draws Shape -> Triangles (no texture), draws text (font atlas texture), maybe another font (another texture)
next widget -> draws Shape (no texture).

this PR attempts to reduce this behavior by using global atlas with white texel.

changes
- (Window.zig, render.zig): per-window TriangleQueue, flushes on
  (texture,clip) change / render-target switch / endRendering. No backend API
  change.
- (Font.zig, render.zig, dvui.zig): one shared atlas (all fonts + a
  white texel) instead of one atlas per font. Untextured fills sample the white
  texel → share a texture with text → merge into one batch. Lazy rebuild, zero
  cost after warmup. this removes the fill -> font -> fill switches.

i tested cpu and gpu time in demo -> flat (too little geometry to matter), 
in a synthetic dense benchmark scene its ~10% faster on gpu and reduced 572 to 22 draw calls. 
fewer draw calls means fewer api overhead, but in practice its marginal in my testing.

note: batching is always on, so the checkbox in the demo has to go if this is merged.

what do you think? critique welcome