### PR TITLE
feat: dockable panels: tabs, drag-and-drop, and floating panels

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -682,6 +682,7 @@ pub fn buildBackend(
                 _ = addExample("sdl3-ontop", b.path("examples/sdl-ontop.zig"), true, example_opts, dvui_opts);
                 _ = addExample("sdl3-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
                 _ = addExample("sdl3-multi-win", b.path("examples/sdl-multi-win.zig"), true, example_opts, dvui_opts);
+                _ = addExample("sdl3-docking", b.path("examples/docking-standalone.zig"), true, example_opts, dvui_opts);
             }
         },
         .raylib => {

--- a/examples/docking-standalone.zig
+++ b/examples/docking-standalone.zig
@@ -1,8 +1,12 @@
-//! Standalone IDE-mock demonstrating `dvui.dockspace` with full layout
-//! persistence: the layout is loaded from `docking-example-layout.json` (next
-//! to the executable's cwd) on startup and saved back on quit, showing
-//! reviewers the complete save/load story `DockLayout.writeJson`/`parseJson`
-//! enable.
+//! Standalone IDE-mock demonstrating `dvui.dockspace`: drag tabs between
+//! panels, split, float, and reset back to the default layout.
+//!
+//! The "..." button after each tab strip shows `drawHeaderExtra` — dvui draws
+//! nothing in that trailing space, so the menu there is entirely this example's.
+//!
+//! Persisting a layout is the app's job: `DockLayout.snapshot` hands back a
+//! plain `Snapshot` value and `DockLayout.fromSnapshot` rebuilds one, so any
+//! serializer (JSON, ZON, msgpack, ...) works. The widget itself picks none.
 const std = @import("std");
 const dvui = @import("dvui");
 const SDLBackend = @import("sdl-backend");
@@ -13,7 +17,9 @@ comptime {
 
 const Layout = dvui.DockingWidget.Layout;
 
-const layout_file = "docking-example-layout.json";
+/// Queued by the header menu, applied after the dockspace walk: `dockspace`
+/// treats the layout tree as immutable while it is open.
+var pending: ?struct { panel: Layout.PanelId, action: enum { float, close } } = null;
 
 fn buildDefaultLayout(allocator: std.mem.Allocator) !Layout.DockLayout {
     var l = try Layout.DockLayout.initSingleLeaf(allocator, "viewport");
@@ -25,43 +31,39 @@ fn buildDefaultLayout(allocator: std.mem.Allocator) !Layout.DockLayout {
     return l;
 }
 
-fn loadLayout(allocator: std.mem.Allocator, io: std.Io) Layout.DockLayout {
-    const contents = std.Io.Dir.cwd().readFileAlloc(io, layout_file, allocator, .limited(1024 * 1024)) catch |err| {
-        std.log.info("docking-standalone: no saved layout ({t}), starting from default", .{err});
-        return buildDefaultLayout(allocator) catch @panic("OOM building default layout");
-    };
-    defer allocator.free(contents);
-
-    return Layout.DockLayout.parseJson(allocator, contents) catch |err| {
-        std.log.warn("docking-standalone: {s} failed to parse ({t}), starting from default", .{ layout_file, err });
-        return buildDefaultLayout(allocator) catch @panic("OOM building default layout");
-    };
-}
-
-fn saveLayout(layout: *const Layout.DockLayout, gpa: std.mem.Allocator, io: std.Io) void {
-    var out: std.Io.Writer.Allocating = .init(gpa);
-    defer out.deinit();
-    layout.writeJson(&out.writer) catch |err| {
-        std.log.warn("docking-standalone: failed to serialize layout: {t}", .{err});
-        return;
-    };
-    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = layout_file, .data = out.written() }) catch |err| {
-        std.log.warn("docking-standalone: failed to write {s}: {t}", .{ layout_file, err });
-    };
-}
-
 fn panelInfo(id: Layout.PanelId) dvui.DockingWidget.PanelInfo {
     return .{ .title = id, .closable = true };
+}
+
+/// Keeps each leaf's otherwise-identical menu widgets distinct.
+fn panelIdExtra(id: Layout.PanelId) usize {
+    return @truncate(std.hash.Wyhash.hash(0, id));
+}
+
+fn drawHeaderExtra(id: Layout.PanelId) void {
+    var m = dvui.menu(@src(), .horizontal, .{ .id_extra = panelIdExtra(id), .gravity_x = 1.0, .gravity_y = 0.5 });
+    defer m.deinit();
+
+    if (dvui.menuItemLabel(@src(), "...", .{ .submenu = true }, .{ .id_extra = panelIdExtra(id) })) |r| {
+        var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+        defer fw.deinit();
+
+        if (dvui.menuItemLabel(@src(), "Float Panel", .{}, .{ .expand = .horizontal }) != null) {
+            fw.close();
+            pending = .{ .panel = id, .action = .float };
+        }
+        if (dvui.menuItemLabel(@src(), "Close Panel", .{}, .{ .expand = .horizontal }) != null) {
+            fw.close();
+            pending = .{ .panel = id, .action = .close };
+        }
+    }
 }
 
 pub fn main(init: std.process.Init) !void {
     const gpa = init.gpa;
 
-    var layout = loadLayout(gpa, init.io);
-    defer {
-        saveLayout(&layout, gpa, init.io);
-        layout.deinit();
-    }
+    var layout = try buildDefaultLayout(gpa);
+    defer layout.deinit();
 
     var backend = try SDLBackend.initWindow(.{
         .io = init.io,
@@ -95,20 +97,37 @@ pub fn main(init: std.process.Init) !void {
             if (dvui.button(@src(), "Reset Layout", .{}, .{})) {
                 layout.deinit();
                 layout = buildDefaultLayout(gpa) catch @panic("OOM building default layout");
-            }
-            if (dvui.button(@src(), "Save Now", .{}, .{})) {
-                saveLayout(&layout, gpa, init.io);
+                pending = null;
             }
         }
 
         {
-            var dock = dvui.dockspace(@src(), .{ .layout = &layout, .panelInfo = panelInfo }, .{ .expand = .both });
+            var dock = dvui.dockspace(@src(), .{
+                .layout = &layout,
+                .panelInfo = panelInfo,
+                .drawHeaderExtra = drawHeaderExtra,
+                // A panel's frame is themeable like any other widget: `corners`
+                // rounds it, omitting them leaves sharp 90° corners.
+                .panel_background = .{
+                    .background = true,
+                    .border = dvui.Rect.all(1),
+                    .corners = dvui.CornerRect.all(5),
+                    .margin = dvui.Rect.all(2),
+                },
+            }, .{ .expand = .both });
             defer dock.deinit();
             while (dock.panel()) |p| {
                 defer p.end();
                 dvui.label(@src(), "{s} panel content", .{p.id}, .{});
             }
-            if (dock.changed) saveLayout(&layout, gpa, init.io);
+        }
+
+        if (pending) |p| {
+            pending = null;
+            switch (p.action) {
+                .float => layout.floatPanel(p.panel, .{ .x = 60, .y = 60, .w = 260, .h = 180 }) catch {},
+                .close => layout.removePanel(p.panel),
+            }
         }
 
         const end_micros = try win.end(.{});

--- a/examples/docking-standalone.zig
+++ b/examples/docking-standalone.zig
@@ -1,0 +1,118 @@
+//! Standalone IDE-mock demonstrating `dvui.dockspace` with full layout
+//! persistence: the layout is loaded from `docking-example-layout.json` (next
+//! to the executable's cwd) on startup and saved back on quit, showing
+//! reviewers the complete save/load story `DockLayout.writeJson`/`parseJson`
+//! enable.
+const std = @import("std");
+const dvui = @import("dvui");
+const SDLBackend = @import("sdl-backend");
+
+comptime {
+    std.debug.assert(@hasDecl(SDLBackend, "SDLBackend"));
+}
+
+const Layout = dvui.DockingWidget.Layout;
+
+const layout_file = "docking-example-layout.json";
+
+fn buildDefaultLayout(allocator: std.mem.Allocator) !Layout.DockLayout {
+    var l = try Layout.DockLayout.initSingleLeaf(allocator, "viewport");
+    try l.splitLeaf(l.root, .left, "hierarchy");
+    const viewport_leaf = l.findPanel("viewport").?;
+    try l.splitLeaf(viewport_leaf, .right, "inspector");
+    const inspector_leaf = l.findPanel("inspector").?;
+    try l.splitLeaf(inspector_leaf, .bottom, "console");
+    return l;
+}
+
+fn loadLayout(allocator: std.mem.Allocator, io: std.Io) Layout.DockLayout {
+    const contents = std.Io.Dir.cwd().readFileAlloc(io, layout_file, allocator, .limited(1024 * 1024)) catch |err| {
+        std.log.info("docking-standalone: no saved layout ({t}), starting from default", .{err});
+        return buildDefaultLayout(allocator) catch @panic("OOM building default layout");
+    };
+    defer allocator.free(contents);
+
+    return Layout.DockLayout.parseJson(allocator, contents) catch |err| {
+        std.log.warn("docking-standalone: {s} failed to parse ({t}), starting from default", .{ layout_file, err });
+        return buildDefaultLayout(allocator) catch @panic("OOM building default layout");
+    };
+}
+
+fn saveLayout(layout: *const Layout.DockLayout, gpa: std.mem.Allocator, io: std.Io) void {
+    var out: std.Io.Writer.Allocating = .init(gpa);
+    defer out.deinit();
+    layout.writeJson(&out.writer) catch |err| {
+        std.log.warn("docking-standalone: failed to serialize layout: {t}", .{err});
+        return;
+    };
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = layout_file, .data = out.written() }) catch |err| {
+        std.log.warn("docking-standalone: failed to write {s}: {t}", .{ layout_file, err });
+    };
+}
+
+fn panelInfo(id: Layout.PanelId) dvui.DockingWidget.PanelInfo {
+    return .{ .title = id, .closable = true };
+}
+
+pub fn main(init: std.process.Init) !void {
+    const gpa = init.gpa;
+
+    var layout = loadLayout(gpa, init.io);
+    defer {
+        saveLayout(&layout, gpa, init.io);
+        layout.deinit();
+    }
+
+    var backend = try SDLBackend.initWindow(.{
+        .io = init.io,
+        .environ_map = init.environ_map,
+        .size = .{ .w = 900.0, .h = 600.0 },
+        .min_size = .{ .w = 400.0, .h = 300.0 },
+        .vsync = true,
+        .title = "DVUI Docking Standalone Example",
+    });
+    defer backend.deinit();
+
+    var window_open = true;
+    var win = try dvui.Window.init(@src(), gpa, backend.backend(), .{
+        .theme = switch (backend.preferredColorScheme() orelse .light) {
+            .light => dvui.Theme.builtin.adwaita_light,
+            .dark => dvui.Theme.builtin.adwaita_dark,
+        },
+        .open_flag = &window_open,
+    });
+    defer win.deinit();
+
+    var interrupted = false;
+    while (window_open) {
+        const nstime = win.beginWait(interrupted);
+        try win.begin(nstime);
+        try backend.addAllEvents(&win);
+
+        {
+            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .style = .window, .background = true, .expand = .horizontal });
+            defer hbox.deinit();
+            if (dvui.button(@src(), "Reset Layout", .{}, .{})) {
+                layout.deinit();
+                layout = buildDefaultLayout(gpa) catch @panic("OOM building default layout");
+            }
+            if (dvui.button(@src(), "Save Now", .{}, .{})) {
+                saveLayout(&layout, gpa, init.io);
+            }
+        }
+
+        {
+            var dock = dvui.dockspace(@src(), .{ .layout = &layout, .panelInfo = panelInfo }, .{ .expand = .both });
+            defer dock.deinit();
+            while (dock.panel()) |p| {
+                defer p.end();
+                dvui.label(@src(), "{s} panel content", .{p.id}, .{});
+            }
+            if (dock.changed) saveLayout(&layout, gpa, init.io);
+        }
+
+        const end_micros = try win.end(.{});
+        const wait_event_micros = win.waitTime(end_micros);
+        interrupted = try backend.waitEventTimeout(wait_event_micros);
+    }
+}

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -31,6 +31,7 @@ pub const demoKind = enum {
     grid,
     struct_ui,
     debugging,
+    docking,
 
     pub fn name(self: demoKind) []const u8 {
         return switch (self) {
@@ -51,6 +52,7 @@ pub const demoKind = enum {
             .struct_ui => "Struct UI",
             .debugging => "Debugging",
             .grid => "Grid/Table",
+            .docking => "Docking",
         };
     }
 
@@ -73,6 +75,7 @@ pub const demoKind = enum {
             .struct_ui => .{ .scale = 0.45, .offset = .{} },
             .debugging => .{ .scale = 0.45, .offset = .{} },
             .grid => .{ .scale = 0.45, .offset = .{} },
+            .docking => .{ .scale = 0.45, .offset = .{} },
         };
     }
 };
@@ -222,6 +225,7 @@ pub fn demo(comptime include: DemoInclude) void {
                     .struct_ui => if (include == .full) structUI() else {},
                     .debugging => debuggingErrors(),
                     .grid => grids(),
+                    .docking => docking(),
                 }
             }
 
@@ -287,6 +291,7 @@ pub fn demo(comptime include: DemoInclude) void {
             .struct_ui => if (include == .full) structUI() else {},
             .debugging => debuggingErrors(),
             .grid => grids(),
+            .docking => docking(),
         }
     }
 
@@ -803,6 +808,7 @@ const layout = @import("Examples/layout.zig").layout;
 const layoutText = @import("Examples/text_layout.zig").layoutText;
 const plots = @import("Examples/plots.zig").plots;
 const reorderLists = @import("Examples/reorder_tree.zig").reorderLists;
+const docking = @import("Examples/docking.zig").docking;
 const menus = @import("Examples/menus.zig").menus;
 const scrolling = @import("Examples/scrolling.zig").scrolling;
 const scrollCanvas = @import("Examples/scroll_canvas.zig").scrollCanvas;

--- a/src/Examples/docking.zig
+++ b/src/Examples/docking.zig
@@ -1,6 +1,11 @@
 //! Docking demo: a small IDE mock (hierarchy/viewport/inspector/console)
 //! showing `dvui.dockspace` — drag tabs between panels, split, float, and
 //! reset back to the default layout.
+//!
+//! The "..." button after each tab strip shows `drawHeaderExtra`: dvui draws
+//! nothing in that trailing space, so the menu there is entirely this demo's.
+//! `panel_background` shows a panel frame is themeable like any other widget —
+//! `corners` rounds it, omitting them leaves sharp 90° corners.
 const std = @import("std");
 const dvui = @import("../dvui.zig");
 
@@ -11,6 +16,10 @@ var docking_buffer: [8192]u8 = undefined;
 var docking_fba = std.heap.FixedBufferAllocator.init(&docking_buffer);
 
 var docking_layout: ?Layout.DockLayout = null;
+
+/// Queued by the header menu, applied after the dockspace walk: `dockspace`
+/// treats the layout tree as immutable while it is open.
+var pending: ?struct { panel: Layout.PanelId, action: enum { float, close } } = null;
 
 fn buildDefaultLayout(allocator: std.mem.Allocator) Layout.DockLayout {
     var l = Layout.DockLayout.initSingleLeaf(allocator, "viewport") catch unreachable;
@@ -26,6 +35,30 @@ fn panelInfo(id: Layout.PanelId) DockingWidget.PanelInfo {
     return .{ .title = id, .closable = true };
 }
 
+/// Keeps each leaf's otherwise-identical menu widgets distinct.
+fn panelIdExtra(id: Layout.PanelId) usize {
+    return @truncate(std.hash.Wyhash.hash(0, id));
+}
+
+fn drawHeaderExtra(id: Layout.PanelId) void {
+    var m = dvui.menu(@src(), .horizontal, .{ .id_extra = panelIdExtra(id), .gravity_x = 1.0, .gravity_y = 0.5 });
+    defer m.deinit();
+
+    if (dvui.menuItemLabel(@src(), "...", .{ .submenu = true }, .{ .id_extra = panelIdExtra(id) })) |r| {
+        var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+        defer fw.deinit();
+
+        if (dvui.menuItemLabel(@src(), "Float Panel", .{}, .{ .expand = .horizontal }) != null) {
+            fw.close();
+            pending = .{ .panel = id, .action = .float };
+        }
+        if (dvui.menuItemLabel(@src(), "Close Panel", .{}, .{ .expand = .horizontal }) != null) {
+            fw.close();
+            pending = .{ .panel = id, .action = .close };
+        }
+    }
+}
+
 pub fn docking() void {
     if (docking_layout == null) docking_layout = buildDefaultLayout(docking_fba.allocator());
 
@@ -35,14 +68,36 @@ pub fn docking() void {
         if (dvui.button(@src(), "Reset Layout", .{}, .{})) {
             docking_fba.reset();
             docking_layout = buildDefaultLayout(docking_fba.allocator());
+            pending = null;
         }
     }
 
-    var dock = dvui.dockspace(@src(), .{ .layout = &docking_layout.?, .panelInfo = panelInfo }, .{ .expand = .both });
-    defer dock.deinit();
-    while (dock.panel()) |p| {
-        defer p.end();
-        dvui.label(@src(), "{s} panel content", .{p.id}, .{});
+    {
+        var dock = dvui.dockspace(@src(), .{
+            .layout = &docking_layout.?,
+            .panelInfo = panelInfo,
+            .drawHeaderExtra = drawHeaderExtra,
+            .panel_background = .{
+                .background = true,
+                .border = dvui.Rect.all(1),
+                .corners = dvui.CornerRect.all(5),
+                .margin = dvui.Rect.all(2),
+            },
+        }, .{ .expand = .both });
+        defer dock.deinit();
+        while (dock.panel()) |p| {
+            defer p.end();
+            dvui.label(@src(), "{s} panel content", .{p.id}, .{});
+        }
+    }
+
+    if (pending) |p| {
+        pending = null;
+        const l = &docking_layout.?;
+        switch (p.action) {
+            .float => l.floatPanel(p.panel, .{ .x = 60, .y = 60, .w = 260, .h = 180 }) catch {},
+            .close => l.removePanel(p.panel),
+        }
     }
 }
 

--- a/src/Examples/docking.zig
+++ b/src/Examples/docking.zig
@@ -1,0 +1,51 @@
+//! Docking demo: a small IDE mock (hierarchy/viewport/inspector/console)
+//! showing `dvui.dockspace` — drag tabs between panels, split, float, and
+//! reset back to the default layout.
+const std = @import("std");
+const dvui = @import("../dvui.zig");
+
+const DockingWidget = dvui.DockingWidget;
+const Layout = DockingWidget.Layout;
+
+var docking_buffer: [8192]u8 = undefined;
+var docking_fba = std.heap.FixedBufferAllocator.init(&docking_buffer);
+
+var docking_layout: ?Layout.DockLayout = null;
+
+fn buildDefaultLayout(allocator: std.mem.Allocator) Layout.DockLayout {
+    var l = Layout.DockLayout.initSingleLeaf(allocator, "viewport") catch unreachable;
+    l.splitLeaf(l.root, .left, "hierarchy") catch unreachable;
+    const viewport_leaf = l.findPanel("viewport").?;
+    l.splitLeaf(viewport_leaf, .right, "inspector") catch unreachable;
+    const inspector_leaf = l.findPanel("inspector").?;
+    l.splitLeaf(inspector_leaf, .bottom, "console") catch unreachable;
+    return l;
+}
+
+fn panelInfo(id: Layout.PanelId) DockingWidget.PanelInfo {
+    return .{ .title = id, .closable = true };
+}
+
+pub fn docking() void {
+    if (docking_layout == null) docking_layout = buildDefaultLayout(docking_fba.allocator());
+
+    {
+        var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+        defer hbox.deinit();
+        if (dvui.button(@src(), "Reset Layout", .{}, .{})) {
+            docking_fba.reset();
+            docking_layout = buildDefaultLayout(docking_fba.allocator());
+        }
+    }
+
+    var dock = dvui.dockspace(@src(), .{ .layout = &docking_layout.?, .panelInfo = panelInfo }, .{ .expand = .both });
+    defer dock.deinit();
+    while (dock.panel()) |p| {
+        defer p.end();
+        dvui.label(@src(), "{s} panel content", .{p.id}, .{});
+    }
+}
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -3315,6 +3315,16 @@ pub fn paned(src: std.builtin.SourceLocation, init_opts: PanedWidget.InitOptions
     return ret;
 }
 
+/// A layout tree of splits and tabbed leaves that panels can be dragged
+/// between. See `DockingWidget` for usage.
+///
+/// Only valid between `Window.begin`and `Window.end`.
+pub fn dockspace(src: std.builtin.SourceLocation, init_opts: DockingWidget.InitOptions, opts: Options) *DockingWidget {
+    var ret = widgetAlloc(DockingWidget);
+    ret.init(src, init_opts, opts);
+    return ret;
+}
+
 /// Show text with wrapping (optional).  Supports mouse and touch selection.
 ///
 /// Text is added incrementally with `TextLayoutWidget.addText` or

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -84,6 +84,7 @@ pub const ReorderWidget = widgets.ReorderWidget;
 pub const Reorderable = ReorderWidget.Reorderable;
 pub const ButtonWidget = widgets.ButtonWidget;
 pub const ContextWidget = widgets.ContextWidget;
+pub const DockingWidget = widgets.DockingWidget;
 pub const DropdownWidget = widgets.DropdownWidget;
 pub const FloatingWindowWidget = widgets.FloatingWindowWidget;
 pub const OsWindowWidget = widgets.OsWindowWidget;

--- a/src/import_widgets.zig
+++ b/src/import_widgets.zig
@@ -13,6 +13,7 @@ pub const CacheWidget = @import("widgets/CacheWidget.zig");
 pub const CacheSizeWidget = @import("widgets/CacheSizeWidget.zig");
 pub const ColorPickerWidget = @import("widgets/ColorPickerWidget.zig");
 pub const ContextWidget = @import("widgets/ContextWidget.zig");
+pub const DockingWidget = @import("widgets/DockingWidget.zig");
 pub const DropdownWidget = @import("widgets/DropdownWidget.zig");
 pub const FlexBoxWidget = @import("widgets/FlexBoxWidget.zig");
 pub const FloatingMenuWidget = @import("widgets/FloatingMenuWidget.zig");

--- a/src/widgets/DockingWidget.zig
+++ b/src/widgets/DockingWidget.zig
@@ -366,15 +366,18 @@ fn closeContent(self: *Dockspace) void {
         b.deinit();
         self.content_box = null;
     }
-    if (self.current_float) |f| {
-        f.deinit();
-        self.current_float = null;
-    }
-    // Closed last (outermost): wraps this leaf's header + content. Only set for
-    // docked leaves, never floats.
+    // `panel_wrapper` wraps this leaf's header + content and, for a float, is
+    // opened *inside* `current_float`'s FloatingWindowWidget subwindow (see
+    // `openLeaf`, called from both `enterNode` and `nextFloat`) — it must
+    // close before that subwindow does, or the widget stack unwinds out of
+    // LIFO order and corrupts `current_parent`.
     if (self.panel_wrapper) |w| {
         w.deinit();
         self.panel_wrapper = null;
+    }
+    if (self.current_float) |f| {
+        f.deinit();
+        self.current_float = null;
     }
 }
 
@@ -383,6 +386,12 @@ fn closeContent(self: *Dockspace) void {
 fn drawHeader(self: *Dockspace, node: Layout.NodeIndex, leaf: Layout.Node.Leaf) Rect.Physical {
     var header_row = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .id_extra = node });
     defer header_row.deinit();
+
+    // Captured per tab below so `onTabContextMenu` can read a rect back after
+    // the tab strip closes, without a round trip through `dvui.tag()` — that
+    // registry is global per window, so keying it by the bare slug would
+    // collide across two dockspaces that happen to share a panel id.
+    const tab_rects: []Rect.Physical = dvui.currentWindow().arena().alloc(Rect.Physical, leaf.tabs.items.len) catch &[_]Rect.Physical{};
 
     {
         // When `drawHeaderExtra` is set, its box (below) claims the leftover
@@ -397,8 +406,11 @@ fn drawHeader(self: *Dockspace, node: Layout.NodeIndex, leaf: Layout.Node.Leaf) 
             const selected = i == leaf.active;
 
             // App styling first, then the selected-only layer, and finally the
-            // tab's identity — which must win, since the strip's event handling
-            // and `onTabContextMenu` both look tabs back up by id/tag.
+            // tab's identity — which must win, since the strip's own event
+            // handling looks tabs back up by id. `.tag = slug` is the public
+            // hook for addressing a tab from outside (tests, automation);
+            // it's a plain slug so two dockspaces sharing a panel id will
+            // collide there, same as any other dvui tag.
             var tab_opts: Options = self.init_opts.tab_options orelse .{};
             if (selected) {
                 if (self.init_opts.tab_options_selected) |sel| tab_opts = tab_opts.override(sel);
@@ -407,6 +419,8 @@ fn drawHeader(self: *Dockspace, node: Layout.NodeIndex, leaf: Layout.Node.Leaf) 
 
             var tab = tw.addTab(selected, .{ .process_events = false }, tab_opts);
             defer tab.deinit();
+
+            if (i < tab_rects.len) tab_rects[i] = tab.data().rectScale().r;
 
             {
                 var row = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .both });
@@ -438,10 +452,9 @@ fn drawHeader(self: *Dockspace, node: Layout.NodeIndex, leaf: Layout.Node.Leaf) 
     }
 
     if (self.init_opts.onTabContextMenu) |cb| {
-        for (leaf.tabs.items) |slug| {
-            // Each tab was tagged with its slug above; read that rect back.
-            const td = dvui.tagGet(slug) orelse continue;
-            var cxt = dvui.context(@src(), .{ .rect = td.rect }, .{ .id_extra = slugIdExtra(slug) });
+        for (leaf.tabs.items, 0..) |slug, i| {
+            if (i >= tab_rects.len) continue;
+            var cxt = dvui.context(@src(), .{ .rect = tab_rects[i] }, .{ .id_extra = slugIdExtra(slug) });
             defer cxt.deinit();
             if (cxt.activePoint()) |cp| cb(slug, cp);
         }
@@ -721,6 +734,84 @@ test "dockspace onTabContextMenu: fires while a tab's context menu is open, clos
     try std.testing.expectEqual(count_after_pick, fns.call_count);
 }
 
+test "dockspace onTabContextMenu: reads each dockspace's own tab rect, not a stale one from another dockspace open the same frame" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const fns = struct {
+        var layout_a: Layout.DockLayout = undefined;
+        var layout_b: Layout.DockLayout = undefined;
+        var inited = false;
+        var calls_a: usize = 0;
+        var calls_b: usize = 0;
+
+        fn onCtxA(id: Layout.PanelId, pt: dvui.Point.Natural) void {
+            _ = id;
+            calls_a += 1;
+            var fw = dvui.floatingMenu(@src(), .{ .from = dvui.Rect.Natural.fromPoint(pt) }, .{ .id_extra = 1 });
+            defer fw.deinit();
+        }
+        fn onCtxB(id: Layout.PanelId, pt: dvui.Point.Natural) void {
+            _ = id;
+            calls_b += 1;
+            var fw = dvui.floatingMenu(@src(), .{ .from = dvui.Rect.Natural.fromPoint(pt) }, .{ .id_extra = 2 });
+            defer fw.deinit();
+        }
+
+        fn frame() !dvui.App.Result {
+            if (!inited) {
+                layout_a = try Layout.DockLayout.initSingleLeaf(std.testing.allocator, "panel_a");
+                layout_b = try Layout.DockLayout.initSingleLeaf(std.testing.allocator, "panel_b");
+                inited = true;
+            }
+
+            var row = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .both });
+            defer row.deinit();
+
+            {
+                var side = dvui.box(@src(), .{}, .{ .expand = .both, .tag = "side_a" });
+                defer side.deinit();
+                var dock = dvui.dockspace(@src(), .{ .layout = &layout_a, .panelInfo = testPanelInfo, .onTabContextMenu = onCtxA }, .{ .expand = .both, .id_extra = 1 });
+                defer dock.deinit();
+                while (dock.panel()) |p| {
+                    defer p.end();
+                    dvui.label(@src(), "content:{s}", .{p.id}, .{});
+                }
+            }
+            {
+                var side = dvui.box(@src(), .{}, .{ .expand = .both, .tag = "side_b" });
+                defer side.deinit();
+                var dock = dvui.dockspace(@src(), .{ .layout = &layout_b, .panelInfo = testPanelInfo, .onTabContextMenu = onCtxB }, .{ .expand = .both, .id_extra = 2 });
+                defer dock.deinit();
+                while (dock.panel()) |p| {
+                    defer p.end();
+                    dvui.label(@src(), "content:{s}", .{p.id}, .{});
+                }
+            }
+
+            return .ok;
+        }
+    };
+    defer fns.layout_a.deinit();
+    defer fns.layout_b.deinit();
+
+    try dvui.testing.settle(fns.frame);
+
+    // Right-click near the top-left of side A's box, where its (only) tab
+    // sits — found via the container's own tag, not the panel's.
+    const cw = dvui.currentWindow();
+    const side_a_rect = (try dvui.testing.tagGet("side_a")).rect;
+    const click_pt = side_a_rect.topLeft().plus(.{ .x = 15, .y = 10 });
+    _ = try cw.addEventMouseMotion(.{ .pt = click_pt });
+    try dvui.testing.click(.right);
+    try dvui.testing.settle(fns.frame);
+
+    // Fires every frame the context menu is open (see the single-dockspace
+    // `onTabContextMenu` test above), so assert presence/absence, not count.
+    try std.testing.expect(fns.calls_a > 0);
+    try std.testing.expectEqual(@as(usize, 0), fns.calls_b);
+}
+
 test "dockspace drag: dropping directly onto another leaf's tab (not just its content) adds a tab there" {
     var t = try dvui.testing.init(.{});
     defer t.deinit();
@@ -873,6 +964,78 @@ test "dockspace drag: release outside any zone floats the panel at the drop poin
 
     const a_leaf = fns.layout.findPanel("a").?;
     try std.testing.expect(fns.layout.isFloat(a_leaf));
+}
+
+test "dockspace: floating a panel via a drawHeaderExtra menu doesn't corrupt the widget stack" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const fns = struct {
+        var layout: Layout.DockLayout = undefined;
+        var inited = false;
+        var pending: ?Layout.PanelId = null;
+
+        fn drawHeaderExtra(id: Layout.PanelId) void {
+            var m = dvui.menu(@src(), .horizontal, .{ .id_extra = slugIdExtra(id), .gravity_x = 1.0 });
+            defer m.deinit();
+
+            const dots_tag = std.fmt.allocPrint(dvui.currentWindow().arena(), "hdr_dots:{s}", .{id}) catch return;
+            if (dvui.menuItemLabel(@src(), "...", .{ .submenu = true }, .{ .id_extra = slugIdExtra(id), .tag = dots_tag })) |r| {
+                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+                defer fw.deinit();
+
+                const float_tag = std.fmt.allocPrint(dvui.currentWindow().arena(), "hdr_float:{s}", .{id}) catch return;
+                if (dvui.menuItemLabel(@src(), "Float Panel", .{}, .{ .tag = float_tag }) != null) {
+                    fw.close();
+                    pending = id;
+                }
+            }
+        }
+
+        fn frame() !dvui.App.Result {
+            if (!inited) {
+                layout = try Layout.DockLayout.initSingleLeaf(std.testing.allocator, "viewport");
+                try layout.splitLeaf(layout.root, .left, "hierarchy");
+                const viewport_leaf = layout.findPanel("viewport").?;
+                try layout.splitLeaf(viewport_leaf, .right, "inspector");
+                const inspector_leaf = layout.findPanel("inspector").?;
+                try layout.splitLeaf(inspector_leaf, .bottom, "console");
+                inited = true;
+            }
+
+            {
+                var dock = dvui.dockspace(@src(), .{
+                    .layout = &layout,
+                    .panelInfo = testPanelInfo,
+                    .drawHeaderExtra = drawHeaderExtra,
+                    .panel_background = .{ .background = true, .border = Rect.all(1) },
+                }, .{ .expand = .both });
+                defer dock.deinit();
+                while (dock.panel()) |p| {
+                    defer p.end();
+                    dvui.label(@src(), "content:{s}", .{p.id}, .{});
+                }
+            }
+
+            if (pending) |id| {
+                pending = null;
+                try layout.floatPanel(id, .{ .x = 60, .y = 60, .w = 260, .h = 180 });
+            }
+
+            return .ok;
+        }
+    };
+    defer fns.layout.deinit();
+
+    try dvui.testing.settle(fns.frame);
+
+    try dvui.testing.moveTo("hdr_dots:console");
+    try dvui.testing.click(.left);
+    try dvui.testing.settle(fns.frame);
+
+    try dvui.testing.moveTo("hdr_float:console");
+    try dvui.testing.click(.left);
+    try dvui.testing.settle(fns.frame);
 }
 
 test {

--- a/src/widgets/DockingWidget.zig
+++ b/src/widgets/DockingWidget.zig
@@ -37,9 +37,17 @@ pub const PanelInfo = struct {
     closable: bool = true,
 };
 
+pub const CloseButtonVisibility = enum {
+    /// Every closable tab always shows its close button.
+    always,
+    /// Only the active tab and the currently-hovered tab show a close button.
+    hover,
+};
+
 pub const InitOptions = struct {
     layout: *Layout.DockLayout,
     panelInfo: *const fn (Layout.PanelId) PanelInfo,
+    close_button_visibility: CloseButtonVisibility = .always,
 };
 
 wd: WidgetData,
@@ -337,7 +345,11 @@ fn drawHeader(self: *Dockspace, node: Layout.NodeIndex, leaf: Layout.Node.Leaf) 
             defer row.deinit();
             if (info.icon) |ic| dvui.icon(@src(), "docktab_icon", ic, .{}, .{ .gravity_y = 0.5 });
             dvui.label(@src(), "{s}", .{info.title}, .{ .gravity_y = 0.5 });
-            if (info.closable) {
+            const show_close = info.closable and switch (self.init_opts.close_button_visibility) {
+                .always => true,
+                .hover => i == leaf.active or tab.hovered(),
+            };
+            if (show_close) {
                 const close_tag = std.fmt.allocPrint(dvui.currentWindow().arena(), "docktab_close:{s}", .{slug}) catch null;
                 // Draw (and fully process) the close button before the tab's
                 // own click handling below, so a close click doesn't also

--- a/src/widgets/DockingWidget.zig
+++ b/src/widgets/DockingWidget.zig
@@ -57,11 +57,36 @@ float_index: usize = 0,
 current_float: ?*dvui.FloatingWindowWidget = null,
 content_box: ?*dvui.BoxWidget = null,
 
+/// Drop target under the mouse during an active "dvui_dock" drag, found
+/// while walking leaves (root-edge zones are only checked as a fallback, in
+/// `deinit`, if no leaf already claimed it: innermost zones win).
+hover_target: ?DropTarget = null,
+hover_rect: Rect.Physical = .{},
+
+/// A drag-release seen mid-walk, resolved against `hover_target` in `deinit`
+/// once every leaf (so every zone) has actually been visited this frame —
+/// the leaf whose tab was released is not necessarily the last one walked.
+pending_drop: ?struct { slug: Layout.PanelId, point: dvui.Point.Physical } = null,
+
 const StackFrame = struct {
     node: Layout.NodeIndex,
     paned: *dvui.PanedWidget,
     visited_first: bool = false,
     visited_second: bool = false,
+};
+
+const DropTarget = union(enum) {
+    tab: struct { leaf: Layout.NodeIndex, index: usize },
+    split: struct { leaf: Layout.NodeIndex, side: Layout.Side },
+    split_root: Layout.Side,
+
+    fn toMoveTarget(self: DropTarget) Layout.MoveTarget {
+        return switch (self) {
+            .tab => |t| .{ .tab = .{ .leaf = t.leaf, .index = t.index } },
+            .split => |s| .{ .split = .{ .leaf = s.leaf, .side = s.side } },
+            .split_root => |side| .{ .split_root = side },
+        };
+    }
 };
 
 /// Yielded by `panel()`; caller draws content then calls `end()` (typically via `defer`).
@@ -128,6 +153,7 @@ pub fn panel(self: *Dockspace) ?Panel {
             if (!self.started) {
                 self.started = true;
                 if (self.enterNode(layout.root)) |p| return p;
+                continue;
             }
             return self.nextFloat();
         }
@@ -187,7 +213,103 @@ fn openLeaf(self: *Dockspace, node: Layout.NodeIndex) ?Panel {
     const box = dvui.box(@src(), .{ .dir = .vertical }, .{ .expand = .both, .id_extra = slugIdExtra(active_slug) });
     self.content_box = box;
 
+    if (dvui.dragName("dvui_dock")) {
+        self.checkLeafZones(node, box.data().contentRectScale().r);
+    }
+
     return .{ .id = active_slug, .leaf = node, .dockspace = self };
+}
+
+/// Drop-zone geometry for one leaf's content rect `r` (physical): a center
+/// zone (append as a new tab) inset 30% each side from `r`, and N/S/E/W edge
+/// strips (split that side) filling the rest, clamped to 40 logical px thick.
+fn checkLeafZones(self: *Dockspace, node: Layout.NodeIndex, r: Rect.Physical) void {
+    const mouse = dvui.currentWindow().mouse_pt;
+    if (!r.contains(mouse)) return;
+
+    const max_edge = 40.0 * dvui.windowNaturalScale();
+    const inset_x = @min(r.w * 0.3, max_edge);
+    const inset_y = @min(r.h * 0.3, max_edge);
+
+    const center: Rect.Physical = .{ .x = r.x + inset_x, .y = r.y + inset_y, .w = @max(0, r.w - 2 * inset_x), .h = @max(0, r.h - 2 * inset_y) };
+    if (center.contains(mouse)) {
+        const leaf = self.init_opts.layout.nodes.items[node].leaf;
+        self.hover_target = .{ .tab = .{ .leaf = node, .index = leaf.tabs.items.len } };
+        self.hover_rect = center;
+        return;
+    }
+
+    const left: Rect.Physical = .{ .x = r.x, .y = r.y, .w = inset_x, .h = r.h };
+    if (left.contains(mouse)) {
+        self.hover_target = .{ .split = .{ .leaf = node, .side = .left } };
+        self.hover_rect = left;
+        return;
+    }
+    const right: Rect.Physical = .{ .x = r.x + r.w - inset_x, .y = r.y, .w = inset_x, .h = r.h };
+    if (right.contains(mouse)) {
+        self.hover_target = .{ .split = .{ .leaf = node, .side = .right } };
+        self.hover_rect = right;
+        return;
+    }
+    const top: Rect.Physical = .{ .x = r.x, .y = r.y, .w = r.w, .h = inset_y };
+    if (top.contains(mouse)) {
+        self.hover_target = .{ .split = .{ .leaf = node, .side = .top } };
+        self.hover_rect = top;
+        return;
+    }
+    const bottom: Rect.Physical = .{ .x = r.x, .y = r.y + r.h - inset_y, .w = r.w, .h = inset_y };
+    if (bottom.contains(mouse)) {
+        self.hover_target = .{ .split = .{ .leaf = node, .side = .bottom } };
+        self.hover_rect = bottom;
+    }
+}
+
+/// Root-edge drop zones (24 logical px), checked only if no leaf already
+/// claimed the mouse point: innermost (leaf) zones win over root zones.
+fn checkRootZones(self: *Dockspace) void {
+    if (self.hover_target != null) return;
+    if (!dvui.dragName("dvui_dock")) return;
+
+    const r = self.data().contentRectScale().r;
+    const mouse = dvui.currentWindow().mouse_pt;
+    if (!r.contains(mouse)) return;
+    const thick = 24.0 * dvui.windowNaturalScale();
+
+    const left: Rect.Physical = .{ .x = r.x, .y = r.y, .w = thick, .h = r.h };
+    if (left.contains(mouse)) {
+        self.hover_target = .{ .split_root = .left };
+        self.hover_rect = left;
+        return;
+    }
+    const right: Rect.Physical = .{ .x = r.x + r.w - thick, .y = r.y, .w = thick, .h = r.h };
+    if (right.contains(mouse)) {
+        self.hover_target = .{ .split_root = .right };
+        self.hover_rect = right;
+        return;
+    }
+    const top: Rect.Physical = .{ .x = r.x, .y = r.y, .w = r.w, .h = thick };
+    if (top.contains(mouse)) {
+        self.hover_target = .{ .split_root = .top };
+        self.hover_rect = top;
+        return;
+    }
+    const bottom: Rect.Physical = .{ .x = r.x, .y = r.y + r.h - thick, .w = r.w, .h = thick };
+    if (bottom.contains(mouse)) {
+        self.hover_target = .{ .split_root = .bottom };
+        self.hover_rect = bottom;
+    }
+}
+
+/// Resolves a completed drop: moves `slug` to the currently hovered zone, or
+/// (per spec) floats it at the release point if it was dropped outside any zone.
+fn resolveDrop(self: *Dockspace, slug: Layout.PanelId, release_point: dvui.Point.Physical) void {
+    if (self.hover_target) |target| {
+        self.queueMutation(.{ .move = .{ .panel = slug, .target = target.toMoveTarget() } });
+    } else {
+        const p = release_point.toNatural();
+        const size: Size = .{ .w = 300, .h = 200 };
+        self.queueMutation(.{ .float = .{ .panel = slug, .rect = .{ .x = p.x - size.w / 2, .y = p.y - size.h / 2, .w = size.w, .h = size.h } } });
+    }
 }
 
 fn closeContent(self: *Dockspace) void {
@@ -232,9 +354,47 @@ fn drawHeader(self: *Dockspace, node: Layout.NodeIndex, leaf: Layout.Node.Leaf) 
             }
         }
 
-        tab.processEvents();
-        if (tab.clicked()) {
-            self.queueMutation(.{ .set_active = .{ .leaf = node, .index = i } });
+        self.processTabEvents(tab.data(), node, i, slug);
+    }
+}
+
+/// Raw press/motion/release handling for one tab button: a plain press+release
+/// with no significant motion selects the tab (mirrors `dvui.clicked`); once
+/// the drag threshold is exceeded it becomes a named "dvui_dock" cross-widget
+/// drag instead, resolved against `hover_target` on release. Bypasses
+/// `ButtonWidget`'s own click detection (which has no notion of a drag) —
+/// same reason `PanedWidget`'s sash handles its own raw mouse events.
+fn processTabEvents(self: *Dockspace, wd: *WidgetData, node: Layout.NodeIndex, index: usize, slug: Layout.PanelId) void {
+    for (dvui.events()) |*e| {
+        if (!dvui.eventMatchSimple(e, wd)) continue;
+        const me = switch (e.evt) {
+            .mouse => |me| me,
+            else => continue,
+        };
+        switch (me.action) {
+            .press => if (me.button.pointer()) {
+                e.handle(@src(), wd);
+                dvui.captureMouse(wd, e.num);
+                dvui.dragPreStart(me.button, me.p, .{ .name = "dvui_dock", .cursor = .arrow_all });
+            },
+            .motion => if (dvui.captured(wd.id)) {
+                e.handle(@src(), wd);
+                _ = dvui.dragging(me.p, "dvui_dock");
+            },
+            .release => if (me.button.pointer() and dvui.captured(wd.id)) {
+                e.handle(@src(), wd);
+                dvui.captureMouse(null, e.num);
+                if (dvui.dragName("dvui_dock")) {
+                    // Don't `dragEnd()` yet: other leaves later in this same
+                    // walk still need `dvui.dragName("dvui_dock")` to be true
+                    // so they can compute their own drop zones.
+                    self.pending_drop = .{ .slug = slug, .point = me.p };
+                } else {
+                    dvui.dragEnd();
+                    self.queueMutation(.{ .set_active = .{ .leaf = node, .index = index } });
+                }
+            },
+            else => {},
         }
     }
 }
@@ -262,6 +422,17 @@ fn nextFloat(self: *Dockspace) ?Panel {
 pub fn deinit(self: *Dockspace) void {
     defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
+
+    self.checkRootZones();
+    if (self.hover_target != null) {
+        // Drawn last (on top of everything else this widget drew this frame).
+        self.hover_rect.fill(dvui.CornerRect.Physical.all(0), .{ .color = dvui.themeGet().focus.opacity(0.25) });
+    }
+
+    if (self.pending_drop) |pd| {
+        self.resolveDrop(pd.slug, pd.point);
+        dvui.dragEnd();
+    }
 
     for (self.mutations.items) |m| self.init_opts.layout.apply(m) catch {};
 
@@ -329,6 +500,110 @@ test "dockspace renders nested splits, floats, and applies tab mutations" {
     try dvui.testing.settle(fns.frame);
     try std.testing.expect(fns.last_changed);
     try std.testing.expect(!fns.layout.contains("a"));
+}
+
+test "dockspace drag: press+motion+release onto another leaf's center adds a new tab there" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const fns = struct {
+        var layout: Layout.DockLayout = undefined;
+        var inited = false;
+
+        fn frame() !dvui.App.Result {
+            if (!inited) {
+                layout = try Layout.DockLayout.initSingleLeaf(std.testing.allocator, "a");
+                try layout.splitLeaf(layout.root, .right, "b");
+                inited = true;
+            }
+
+            var dock = dvui.dockspace(@src(), .{ .layout = &layout, .panelInfo = testPanelInfo }, .{ .expand = .both });
+            defer dock.deinit();
+            while (dock.panel()) |p| {
+                defer p.end();
+                dvui.label(@src(), "content:{s}", .{p.id}, .{});
+            }
+
+            return .ok;
+        }
+    };
+    defer fns.layout.deinit();
+
+    try dvui.testing.settle(fns.frame);
+
+    const cw = dvui.currentWindow();
+    const a_center = dvui.tagGet("a").?.rect.center();
+    // Window is 600x400 logical, "b" is the right half; scale to physical
+    // so this lands well inside "b"'s content center zone regardless of dpi.
+    const scale = dvui.windowNaturalScale();
+    const b_target: dvui.Point.Physical = .{ .x = 450 * scale, .y = 200 * scale };
+
+    _ = try cw.addEventMouseMotion(.{ .pt = a_center });
+    _ = try cw.addEventMouseButton(.left, .press);
+    _ = try dvui.testing.step(fns.frame);
+
+    _ = try cw.addEventMouseMotion(.{ .pt = b_target });
+    _ = try dvui.testing.step(fns.frame);
+
+    _ = try cw.addEventMouseButton(.left, .release);
+    try dvui.testing.settle(fns.frame);
+
+    try std.testing.expect(fns.layout.contains("a"));
+    try std.testing.expect(fns.layout.contains("b"));
+    const b_leaf = fns.layout.findPanel("b").?;
+    try std.testing.expect(!fns.layout.isFloat(b_leaf));
+    try std.testing.expectEqual(Layout.Node.leaf, std.meta.activeTag(fns.layout.nodes.items[b_leaf]));
+    try std.testing.expectEqual(@as(usize, 2), fns.layout.nodes.items[b_leaf].leaf.tabs.items.len);
+    // "a"'s original leaf (empty) collapsed away: the whole tree is one leaf now.
+    try std.testing.expectEqual(fns.layout.root, b_leaf);
+}
+
+test "dockspace drag: release outside any zone floats the panel at the drop point" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const fns = struct {
+        var layout: Layout.DockLayout = undefined;
+        var inited = false;
+
+        fn frame() !dvui.App.Result {
+            if (!inited) {
+                layout = try Layout.DockLayout.initSingleLeaf(std.testing.allocator, "a");
+                try layout.insertTab(layout.root, 1, "b");
+                inited = true;
+            }
+
+            var dock = dvui.dockspace(@src(), .{ .layout = &layout, .panelInfo = testPanelInfo }, .{ .expand = .both });
+            defer dock.deinit();
+            while (dock.panel()) |p| {
+                defer p.end();
+                dvui.label(@src(), "content:{s}", .{p.id}, .{});
+            }
+
+            return .ok;
+        }
+    };
+    defer fns.layout.deinit();
+
+    try dvui.testing.settle(fns.frame);
+
+    const cw = dvui.currentWindow();
+    const a_center = dvui.tagGet("a").?.rect.center();
+
+    _ = try cw.addEventMouseMotion(.{ .pt = a_center });
+    _ = try cw.addEventMouseButton(.left, .press);
+    _ = try dvui.testing.step(fns.frame);
+
+    // Drag well outside the whole dockspace rect: no leaf or root zone can
+    // possibly contain this point, so the drop should float instead.
+    _ = try cw.addEventMouseMotion(.{ .pt = .{ .x = a_center.x, .y = -50 } });
+    _ = try dvui.testing.step(fns.frame);
+
+    _ = try cw.addEventMouseButton(.left, .release);
+    try dvui.testing.settle(fns.frame);
+
+    const a_leaf = fns.layout.findPanel("a").?;
+    try std.testing.expect(fns.layout.isFloat(a_leaf));
 }
 
 test {

--- a/src/widgets/DockingWidget.zig
+++ b/src/widgets/DockingWidget.zig
@@ -1,7 +1,335 @@
-//! Docking widget: a layout tree of splits and tabbed leaves that panels can
-//! be dragged between. See `Layout` for the pure-data tree; the widget itself
-//! (rendering, drag-and-drop, floating leaves) is built up incrementally.
+//! Docking widget: walks a `Layout.DockLayout` tree, opening a `PanedWidget`
+//! per split and a tabbed header + content box per leaf. Floating leaves are
+//! drawn afterwards in their own `FloatingWindowWidget`s.
+//!
+//! Usage:
+//! ```
+//! var dock = dvui.dockspace(@src(), .{ .layout = &layout, .panelInfo = myPanelInfo }, .{ .expand = .both });
+//! defer dock.deinit(); // applies queued mutations, sets dock.changed
+//! while (dock.panel()) |p| {
+//!     defer p.end();
+//!     app.drawPanel(p.id);
+//! }
+//! ```
+//!
+//! The layout tree is treated as immutable for the duration of the walk:
+//! tab clicks, closes, and (later) drag-and-drop only queue `Layout.Mutation`
+//! entries, applied by `deinit` once the last pane has closed. This keeps
+//! node indices (and thus `split_ratio` pointers) valid for the whole frame.
+const std = @import("std");
+const dvui = @import("../dvui.zig");
+
+const Options = dvui.Options;
+const Rect = dvui.Rect;
+const RectScale = dvui.RectScale;
+const Size = dvui.Size;
+const Widget = dvui.Widget;
+const WidgetData = dvui.WidgetData;
+
 pub const Layout = @import("DockingWidget/Layout.zig");
+
+const Dockspace = @This();
+
+/// App-supplied display info for a panel slug, used to draw its tab.
+pub const PanelInfo = struct {
+    title: []const u8,
+    icon: ?[]const u8 = null,
+    closable: bool = true,
+};
+
+pub const InitOptions = struct {
+    layout: *Layout.DockLayout,
+    panelInfo: *const fn (Layout.PanelId) PanelInfo,
+};
+
+wd: WidgetData,
+init_opts: InitOptions,
+
+/// Mutations queued by tab clicks/closes (and, later, drag-and-drop) this
+/// frame; applied to `init_opts.layout` in `deinit`.
+mutations: std.ArrayList(Layout.Mutation) = .empty,
+/// True after `deinit` if any mutation was applied (caller should persist).
+changed: bool = false,
+
+stack: std.ArrayList(StackFrame) = .empty,
+started: bool = false,
+float_index: usize = 0,
+current_float: ?*dvui.FloatingWindowWidget = null,
+content_box: ?*dvui.BoxWidget = null,
+
+const StackFrame = struct {
+    node: Layout.NodeIndex,
+    paned: *dvui.PanedWidget,
+    visited_first: bool = false,
+    visited_second: bool = false,
+};
+
+/// Yielded by `panel()`; caller draws content then calls `end()` (typically via `defer`).
+pub const Panel = struct {
+    id: Layout.PanelId,
+    leaf: Layout.NodeIndex,
+    dockspace: *Dockspace,
+
+    pub fn end(self: Panel) void {
+        self.dockspace.closeContent();
+    }
+};
+
+/// It's expected to call this when `self` is `undefined`
+pub fn init(self: *Dockspace, src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) void {
+    const defaults = Options{ .name = "Dockspace" };
+    self.* = .{ .wd = WidgetData.init(src, .{}, defaults.override(opts)), .init_opts = init_opts };
+    dvui.parentSet(self.widget());
+    self.data().register();
+}
+
+pub fn widget(self: *Dockspace) Widget {
+    return Widget.init(self, data, rectFor, screenRectScale, minSizeForChild);
+}
+
+pub fn data(self: *Dockspace) *WidgetData {
+    return self.wd.validate();
+}
+
+pub fn rectFor(self: *Dockspace, id: dvui.Id, min_size: Size, e: Options.Expand, g: Options.Gravity) Rect {
+    _ = id;
+    return dvui.placeIn(self.data().contentRect().justSize(), min_size, e, g);
+}
+
+pub fn screenRectScale(self: *Dockspace, rect: Rect) RectScale {
+    return self.data().contentRectScale().rectToRectScale(rect);
+}
+
+pub fn minSizeForChild(self: *Dockspace, s: Size) void {
+    self.data().minSizeMax(self.data().options.padSize(s));
+}
+
+/// Stable id for widgets tied to a specific panel (tab button, close button,
+/// content box): must not depend on tree position so state (scroll, etc.)
+/// survives the panel being dragged elsewhere.
+fn slugIdExtra(slug: Layout.PanelId) usize {
+    return @truncate(std.hash.Wyhash.hash(0, slug));
+}
+
+/// Queues `m` for application in `deinit`, and marks `self.changed` right
+/// away: callers typically read `changed` right after the `while (dock.panel())`
+/// loop, before the `defer dock.deinit()` that applies the mutation actually runs.
+fn queueMutation(self: *Dockspace, m: Layout.Mutation) void {
+    self.mutations.append(dvui.currentWindow().arena(), m) catch return;
+    self.changed = true;
+}
+
+/// Advances the walk by one leaf, returning its active panel, or null once
+/// the whole tree (and all floats) have been walked.
+pub fn panel(self: *Dockspace) ?Panel {
+    const layout = self.init_opts.layout;
+    while (true) {
+        if (self.stack.items.len == 0) {
+            if (!self.started) {
+                self.started = true;
+                if (self.enterNode(layout.root)) |p| return p;
+            }
+            return self.nextFloat();
+        }
+
+        const frame = &self.stack.items[self.stack.items.len - 1];
+        if (!frame.visited_first) {
+            frame.visited_first = true;
+            if (frame.paned.showFirst()) {
+                const child = layout.nodes.items[frame.node].split.first;
+                if (self.enterNode(child)) |p| return p;
+            }
+            continue;
+        }
+        if (!frame.visited_second) {
+            frame.visited_second = true;
+            if (frame.paned.showSecond()) {
+                const child = layout.nodes.items[frame.node].split.second;
+                if (self.enterNode(child)) |p| return p;
+            }
+            continue;
+        }
+
+        frame.paned.deinit();
+        _ = self.stack.pop();
+    }
+}
+
+/// Enters `node`: for a split, opens a `PanedWidget` and pushes a stack frame
+/// (returns null so the caller loop continues); for a leaf, draws the header
+/// and opens the content box, returning the yielded `Panel`.
+fn enterNode(self: *Dockspace, node: Layout.NodeIndex) ?Panel {
+    const layout = self.init_opts.layout;
+    switch (layout.nodes.items[node]) {
+        .split => |sp| {
+            const p = dvui.paned(@src(), .{
+                .direction = sp.dir,
+                .collapsed_size = 0,
+                .split_ratio = &layout.nodes.items[node].split.ratio,
+                .handle_margin = 4,
+            }, .{ .expand = .both, .id_extra = node });
+            self.stack.append(dvui.currentWindow().arena(), .{ .node = node, .paned = p }) catch {};
+            return null;
+        },
+        .leaf => return self.openLeaf(node),
+        .free => unreachable,
+    }
+}
+
+fn openLeaf(self: *Dockspace, node: Layout.NodeIndex) ?Panel {
+    const layout = self.init_opts.layout;
+    const leaf = layout.nodes.items[node].leaf;
+    if (leaf.tabs.items.len == 0) return null; // tolerated empty root leaf
+
+    self.drawHeader(node, leaf);
+
+    const active_slug = leaf.tabs.items[leaf.active];
+    const box = dvui.box(@src(), .{ .dir = .vertical }, .{ .expand = .both, .id_extra = slugIdExtra(active_slug) });
+    self.content_box = box;
+
+    return .{ .id = active_slug, .leaf = node, .dockspace = self };
+}
+
+fn closeContent(self: *Dockspace) void {
+    if (self.content_box) |b| {
+        b.deinit();
+        self.content_box = null;
+    }
+    if (self.current_float) |f| {
+        f.deinit();
+        self.current_float = null;
+    }
+}
+
+fn drawHeader(self: *Dockspace, node: Layout.NodeIndex, leaf: Layout.Node.Leaf) void {
+    var tw = dvui.tabs(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .id_extra = node });
+    defer tw.deinit();
+
+    for (leaf.tabs.items, 0..) |slug, i| {
+        const info = self.init_opts.panelInfo(slug);
+        var tab = tw.addTab(i == leaf.active, .{ .process_events = false }, .{ .id_extra = slugIdExtra(slug), .tag = slug });
+        defer tab.deinit();
+
+        {
+            var row = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .both });
+            defer row.deinit();
+            if (info.icon) |ic| dvui.icon(@src(), "docktab_icon", ic, .{}, .{ .gravity_y = 0.5 });
+            dvui.label(@src(), "{s}", .{info.title}, .{ .gravity_y = 0.5 });
+            if (info.closable) {
+                const close_tag = std.fmt.allocPrint(dvui.currentWindow().arena(), "docktab_close:{s}", .{slug}) catch null;
+                // Draw (and fully process) the close button before the tab's
+                // own click handling below, so a close click doesn't also
+                // register as a tab-select click.
+                if (dvui.buttonIcon(@src(), "docktab_close", dvui.entypo.cross, .{}, .{}, .{
+                    .id_extra = slugIdExtra(slug),
+                    .tag = close_tag,
+                    .gravity_y = 0.5,
+                    .padding = Rect.all(2),
+                    .margin = Rect.all(2),
+                })) {
+                    self.queueMutation(.{ .remove = slug });
+                }
+            }
+        }
+
+        tab.processEvents();
+        if (tab.clicked()) {
+            self.queueMutation(.{ .set_active = .{ .leaf = node, .index = i } });
+        }
+    }
+}
+
+fn nextFloat(self: *Dockspace) ?Panel {
+    const layout = self.init_opts.layout;
+    while (self.float_index < layout.floats.items.len) {
+        const idx = self.float_index;
+        self.float_index += 1;
+
+        const fwin = dvui.floatingWindow(@src(), .{
+            .rect = &layout.floats.items[idx].rect,
+        }, .{ .id_extra = layout.floats.items[idx].leaf });
+        self.current_float = fwin;
+
+        if (self.openLeaf(layout.floats.items[idx].leaf)) |p| return p;
+
+        // Empty float leaf (shouldn't normally happen): close and try the next one.
+        fwin.deinit();
+        self.current_float = null;
+    }
+    return null;
+}
+
+pub fn deinit(self: *Dockspace) void {
+    defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
+    defer self.* = undefined;
+
+    for (self.mutations.items) |m| self.init_opts.layout.apply(m) catch {};
+
+    self.data().minSizeSetAndRefresh();
+    self.data().minSizeReportToParent();
+    dvui.parentReset(self.data().id, self.data().parent);
+}
+
+fn testPanelInfo(id: Layout.PanelId) PanelInfo {
+    return .{ .title = id, .closable = true };
+}
+
+test "dockspace renders nested splits, floats, and applies tab mutations" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const fns = struct {
+        var layout: Layout.DockLayout = undefined;
+        var inited = false;
+        var last_changed = false;
+
+        fn frame() !dvui.App.Result {
+            if (!inited) {
+                layout = try Layout.DockLayout.initSingleLeaf(std.testing.allocator, "a");
+                try layout.splitLeaf(layout.root, .right, "b");
+                try layout.insertTab(layout.findPanel("b").?, 1, "c");
+                // Kept away from the header row (y ~0-30) of either dock leaf,
+                // so it doesn't sit on top of and steal clicks meant for them.
+                try layout.floatPanel("c", .{ .x = 150, .y = 300, .w = 150, .h = 80 });
+                inited = true;
+            }
+
+            var dock = dvui.dockspace(@src(), .{ .layout = &layout, .panelInfo = testPanelInfo }, .{ .expand = .both });
+            defer dock.deinit();
+            while (dock.panel()) |p| {
+                defer p.end();
+                dvui.label(@src(), "content:{s}", .{p.id}, .{});
+            }
+            if (dock.changed) last_changed = true;
+
+            return .ok;
+        }
+    };
+    defer fns.layout.deinit();
+
+    try dvui.testing.settle(fns.frame);
+    try std.testing.expect(fns.layout.contains("a"));
+    try std.testing.expect(fns.layout.contains("b"));
+    try std.testing.expect(fns.layout.contains("c"));
+    try std.testing.expect(fns.layout.isFloat(fns.layout.findPanel("c").?));
+
+    // Clicking tab "b" activates it (set_active mutation applied on deinit).
+    fns.last_changed = false;
+    try dvui.testing.moveTo("b");
+    try dvui.testing.click(.left);
+    try dvui.testing.settle(fns.frame);
+    try std.testing.expect(fns.last_changed);
+    const b_leaf = fns.layout.findPanel("b").?;
+    try std.testing.expectEqualStrings("b", fns.layout.nodes.items[b_leaf].leaf.tabs.items[fns.layout.nodes.items[b_leaf].leaf.active]);
+
+    // Closing tab "a" removes it from the layout (remove mutation applied on deinit).
+    fns.last_changed = false;
+    try dvui.testing.moveTo("docktab_close:a");
+    try dvui.testing.click(.left);
+    try dvui.testing.settle(fns.frame);
+    try std.testing.expect(fns.last_changed);
+    try std.testing.expect(!fns.layout.contains("a"));
+}
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/widgets/DockingWidget.zig
+++ b/src/widgets/DockingWidget.zig
@@ -1,0 +1,8 @@
+//! Docking widget: a layout tree of splits and tabbed leaves that panels can
+//! be dragged between. See `Layout` for the pure-data tree; the widget itself
+//! (rendering, drag-and-drop, floating leaves) is built up incrementally.
+pub const Layout = @import("DockingWidget/Layout.zig");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/widgets/DockingWidget.zig
+++ b/src/widgets/DockingWidget.zig
@@ -62,6 +62,14 @@ pub const InitOptions = struct {
     /// header too, which wrapping `panel()`'s content alone can't reach. Null
     /// (default) opens no such box.
     panel_background: ?Options = null,
+    /// Options layered onto every tab button in a leaf's strip, over
+    /// `TabsWidget`'s own defaults. Lets an app restyle the strip — flat tabs,
+    /// an underlined selection, a different corner — without dvui having to
+    /// prescribe one look. Null (default) keeps the stock tab styling.
+    tab_options: ?Options = null,
+    /// Options layered onto the *active* tab only, over `tab_options`. Null
+    /// (default) keeps `TabsWidget`'s stock selected-tab styling.
+    tab_options_selected: ?Options = null,
 };
 
 wd: WidgetData,
@@ -386,7 +394,18 @@ fn drawHeader(self: *Dockspace, node: Layout.NodeIndex, leaf: Layout.Node.Leaf) 
 
         for (leaf.tabs.items, 0..) |slug, i| {
             const info = self.init_opts.panelInfo(slug);
-            var tab = tw.addTab(i == leaf.active, .{ .process_events = false }, .{ .id_extra = slugIdExtra(slug), .tag = slug });
+            const selected = i == leaf.active;
+
+            // App styling first, then the selected-only layer, and finally the
+            // tab's identity — which must win, since the strip's event handling
+            // and `onTabContextMenu` both look tabs back up by id/tag.
+            var tab_opts: Options = self.init_opts.tab_options orelse .{};
+            if (selected) {
+                if (self.init_opts.tab_options_selected) |sel| tab_opts = tab_opts.override(sel);
+            }
+            tab_opts = tab_opts.override(.{ .id_extra = slugIdExtra(slug), .tag = slug });
+
+            var tab = tw.addTab(selected, .{ .process_events = false }, tab_opts);
             defer tab.deinit();
 
             {

--- a/src/widgets/DockingWidget.zig
+++ b/src/widgets/DockingWidget.zig
@@ -48,28 +48,27 @@ pub const InitOptions = struct {
     layout: *Layout.DockLayout,
     panelInfo: *const fn (Layout.PanelId) PanelInfo,
     close_button_visibility: CloseButtonVisibility = .always,
-    /// Draws into the trailing header space after a leaf's tab strip, for
-    /// `panel` (the leaf's active tab). This widget expands to fill
-    /// whatever room is left in the header row, so the caller owns *all* of
-    /// it: dvui draws nothing here itself (no settings button, no icon) —
-    /// what goes there (a Unity-style "..." menu, a lock/pin icon, both, or
-    /// a right-click handler for the empty space) is entirely up to the
-    /// app. Null (the default) leaves the header with just the tab strip.
+    /// Draws into the trailing header space after a leaf's tab strip, given
+    /// the leaf's active `panel`. The area expands to fill the rest of the
+    /// header row and is entirely the app's — dvui draws nothing there. Null
+    /// (default) leaves just the tab strip.
     drawHeaderExtra: ?*const fn (Layout.PanelId) void = null,
-    /// Called every frame a tab's right-click context menu should be open
-    /// (each tab is wrapped in its own `dvui.context()`, same mechanism any
-    /// other right-click menu in a dvui app uses — dvui owns open/close
-    /// persistence, the app just draws content reactively). `pt` is where
-    /// to anchor a `floatingMenu`; call `.close()` on it when the app's
-    /// menu item is picked, same as any other context-menu callback.
+    /// Called every frame a tab's right-click context menu is open (each tab
+    /// is wrapped in its own `dvui.context()`). `pt` anchors a `floatingMenu`;
+    /// call `.close()` on it when a menu item is picked.
     onTabContextMenu: ?*const fn (panel: Layout.PanelId, pt: dvui.Point.Natural) void = null,
+    /// Options for a box wrapping each docked leaf's whole area — tab strip and
+    /// content together — so an app can theme the background/border around the
+    /// header too, which wrapping `panel()`'s content alone can't reach. Null
+    /// (default) opens no such box.
+    panel_background: ?Options = null,
 };
 
 wd: WidgetData,
 init_opts: InitOptions,
 
-/// Mutations queued by tab clicks/closes (and, later, drag-and-drop) this
-/// frame; applied to `init_opts.layout` in `deinit`.
+/// Mutations queued by tab clicks/closes/drags this frame; applied to
+/// `init_opts.layout` in `deinit`.
 mutations: std.ArrayList(Layout.Mutation) = .empty,
 /// True after `deinit` if any mutation was applied (caller should persist).
 changed: bool = false,
@@ -79,16 +78,19 @@ started: bool = false,
 float_index: usize = 0,
 current_float: ?*dvui.FloatingWindowWidget = null,
 content_box: ?*dvui.BoxWidget = null,
+/// The `panel_background` box wrapping the current leaf's header + content,
+/// when that option is set. Opened in `openLeaf`, closed last in
+/// `closeContent` (outermost box).
+panel_wrapper: ?*dvui.BoxWidget = null,
 
-/// Drop target under the mouse during an active "dvui_dock" drag, found
-/// while walking leaves (root-edge zones are only checked as a fallback, in
-/// `deinit`, if no leaf already claimed it: innermost zones win).
+/// Drop target under the mouse during a "dvui_dock" drag, found while walking
+/// leaves. Root-edge zones are a fallback checked in `deinit` only if no leaf
+/// claimed the point (innermost zones win).
 hover_target: ?DropTarget = null,
 hover_rect: Rect.Physical = .{},
 
 /// A drag-release seen mid-walk, resolved against `hover_target` in `deinit`
-/// once every leaf (so every zone) has actually been visited this frame —
-/// the leaf whose tab was released is not necessarily the last one walked.
+/// once every leaf (and thus every zone) has been visited this frame.
 pending_drop: ?struct { slug: Layout.PanelId, point: dvui.Point.Physical } = null,
 
 const StackFrame = struct {
@@ -152,16 +154,15 @@ pub fn minSizeForChild(self: *Dockspace, s: Size) void {
     self.data().minSizeMax(self.data().options.padSize(s));
 }
 
-/// Stable id for widgets tied to a specific panel (tab button, close button,
-/// content box): must not depend on tree position so state (scroll, etc.)
-/// survives the panel being dragged elsewhere.
+/// Position-independent id for a panel's widgets (tab, close button, content
+/// box), so their state (scroll, etc.) survives the panel being dragged
+/// elsewhere.
 fn slugIdExtra(slug: Layout.PanelId) usize {
     return @truncate(std.hash.Wyhash.hash(0, slug));
 }
 
-/// Queues `m` for application in `deinit`, and marks `self.changed` right
-/// away: callers typically read `changed` right after the `while (dock.panel())`
-/// loop, before the `defer dock.deinit()` that applies the mutation actually runs.
+/// Queues `m` for `deinit` to apply, and sets `self.changed` now so callers can
+/// read it right after the `while (dock.panel())` loop, before `deinit` runs.
 fn queueMutation(self: *Dockspace, m: Layout.Mutation) void {
     self.mutations.append(dvui.currentWindow().arena(), m) catch return;
     self.changed = true;
@@ -230,6 +231,11 @@ fn openLeaf(self: *Dockspace, node: Layout.NodeIndex) ?Panel {
     const leaf = layout.nodes.items[node].leaf;
     if (leaf.tabs.items.len == 0) return null; // tolerated empty root leaf
 
+    if (self.init_opts.panel_background) |bg_opts| {
+        const defaults = Options{ .name = "Dockspace.panel_background", .expand = .both };
+        self.panel_wrapper = dvui.box(@src(), .{}, defaults.override(bg_opts).override(.{ .id_extra = node }));
+    }
+
     const header_rect = self.drawHeader(node, leaf);
 
     const active_slug = leaf.tabs.items[leaf.active];
@@ -244,11 +250,9 @@ fn openLeaf(self: *Dockspace, node: Layout.NodeIndex) ?Panel {
     return .{ .id = active_slug, .leaf = node, .dockspace = self };
 }
 
-/// The header itself (tab strip + trailing extra space) is always an
-/// "insert as tab" target: dropping onto another leaf's tabs, or the empty
-/// space after them, adds the dragged tab there as a sibling — no N/S/E/W
-/// subdivision the way `checkLeafZones`' content-rect zones have, dropping
-/// on a header never means "split this leaf".
+/// The header (tab strip + trailing space) is always an "insert as tab" target:
+/// a drop there adds the dragged tab as a sibling, never a split (unlike
+/// `checkLeafZones`' N/S/E/W content zones).
 fn checkHeaderZone(self: *Dockspace, node: Layout.NodeIndex, r: Rect.Physical) void {
     const mouse = dvui.currentWindow().mouse_pt;
     if (!r.contains(mouse)) return;
@@ -358,21 +362,24 @@ fn closeContent(self: *Dockspace) void {
         f.deinit();
         self.current_float = null;
     }
+    // Closed last (outermost): wraps this leaf's header + content. Only set for
+    // docked leaves, never floats.
+    if (self.panel_wrapper) |w| {
+        w.deinit();
+        self.panel_wrapper = null;
+    }
 }
 
-/// Draws the tab strip plus (if the app supplied `drawHeaderExtra`)
-/// whatever it wants in the trailing space, and returns the whole header
-/// row's rect (used by `checkHeaderZone`).
+/// Draws the tab strip (plus `drawHeaderExtra`'s trailing content, if set) and
+/// returns the header row's rect (used by `checkHeaderZone`).
 fn drawHeader(self: *Dockspace, node: Layout.NodeIndex, leaf: Layout.Node.Leaf) Rect.Physical {
     var header_row = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .id_extra = node });
     defer header_row.deinit();
 
     {
-        // Not `.expand` when `drawHeaderExtra` is set: that box (below)
-        // claims the leftover width instead, so right-clicking or dropping
-        // onto the empty space after the tabs reaches the app's content
-        // there rather than landing on an oversized (but visually empty)
-        // tab strip.
+        // When `drawHeaderExtra` is set, its box (below) claims the leftover
+        // width instead, so drops and right-clicks on the empty space reach the
+        // app rather than an oversized tab strip.
         const tw_expand: Options.Expand = if (self.init_opts.drawHeaderExtra != null) .none else .horizontal;
         var tw = dvui.tabs(@src(), .{ .dir = .horizontal }, .{ .expand = tw_expand, .id_extra = node });
         defer tw.deinit();
@@ -393,9 +400,8 @@ fn drawHeader(self: *Dockspace, node: Layout.NodeIndex, leaf: Layout.Node.Leaf) 
                 };
                 if (show_close) {
                     const close_tag = std.fmt.allocPrint(dvui.currentWindow().arena(), "docktab_close:{s}", .{slug}) catch null;
-                    // Draw (and fully process) the close button before the tab's
-                    // own click handling below, so a close click doesn't also
-                    // register as a tab-select click.
+                    // Processed before the tab's own click handling below, so a
+                    // close click isn't also read as a tab-select.
                     if (dvui.buttonIcon(@src(), "docktab_close", dvui.entypo.cross, .{}, .{}, .{
                         .id_extra = slugIdExtra(slug),
                         .tag = close_tag,
@@ -414,8 +420,7 @@ fn drawHeader(self: *Dockspace, node: Layout.NodeIndex, leaf: Layout.Node.Leaf) 
 
     if (self.init_opts.onTabContextMenu) |cb| {
         for (leaf.tabs.items) |slug| {
-            // `tagGet` reads this frame's already-registered rect (each tab
-            // was tagged with its slug above, earlier this same frame).
+            // Each tab was tagged with its slug above; read that rect back.
             const td = dvui.tagGet(slug) orelse continue;
             var cxt = dvui.context(@src(), .{ .rect = td.rect }, .{ .id_extra = slugIdExtra(slug) });
             defer cxt.deinit();
@@ -424,10 +429,9 @@ fn drawHeader(self: *Dockspace, node: Layout.NodeIndex, leaf: Layout.Node.Leaf) 
     }
 
     if (self.init_opts.drawHeaderExtra) |drawFn| {
-        // Claims all the leftover width (see the `tw_expand` note above) —
-        // the app's callback gets the *whole* trailing area, not just
-        // whatever it visibly draws, so it can (for example) catch a
-        // right-click anywhere in the empty space, not only on a button.
+        // Claims the leftover width so the callback owns the whole trailing
+        // area (e.g. to catch a right-click on empty space), not just what it
+        // visibly draws.
         var extra = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .gravity_y = 0.5 });
         defer extra.deinit();
         drawFn(leaf.tabs.items[leaf.active]);
@@ -436,12 +440,10 @@ fn drawHeader(self: *Dockspace, node: Layout.NodeIndex, leaf: Layout.Node.Leaf) 
     return header_row.data().contentRectScale().r;
 }
 
-/// Raw press/motion/release handling for one tab button: a plain press+release
-/// with no significant motion selects the tab (mirrors `dvui.clicked`); once
-/// the drag threshold is exceeded it becomes a named "dvui_dock" cross-widget
-/// drag instead, resolved against `hover_target` on release. Bypasses
-/// `ButtonWidget`'s own click detection (which has no notion of a drag) —
-/// same reason `PanedWidget`'s sash handles its own raw mouse events.
+/// Raw press/motion/release handling for one tab button: a press+release with no
+/// significant motion selects the tab; crossing the drag threshold starts a named
+/// "dvui_dock" drag instead, resolved against `hover_target` on release. Bypasses
+/// `ButtonWidget`'s click detection, which has no notion of a drag.
 fn processTabEvents(self: *Dockspace, wd: *WidgetData, node: Layout.NodeIndex, index: usize, slug: Layout.PanelId) void {
     for (dvui.events()) |*e| {
         if (!dvui.eventMatchSimple(e, wd)) continue;
@@ -463,9 +465,8 @@ fn processTabEvents(self: *Dockspace, wd: *WidgetData, node: Layout.NodeIndex, i
                 e.handle(@src(), wd);
                 dvui.captureMouse(null, e.num);
                 if (dvui.dragName("dvui_dock")) {
-                    // Don't `dragEnd()` yet: other leaves later in this same
-                    // walk still need `dvui.dragName("dvui_dock")` to be true
-                    // so they can compute their own drop zones.
+                    // Don't `dragEnd()` yet: leaves later in this walk still need
+                    // the drag active to compute their own drop zones.
                     self.pending_drop = .{ .slug = slug, .point = me.p };
                 } else {
                     dvui.dragEnd();

--- a/src/widgets/DockingWidget.zig
+++ b/src/widgets/DockingWidget.zig
@@ -48,6 +48,21 @@ pub const InitOptions = struct {
     layout: *Layout.DockLayout,
     panelInfo: *const fn (Layout.PanelId) PanelInfo,
     close_button_visibility: CloseButtonVisibility = .always,
+    /// Draws into the trailing header space after a leaf's tab strip, for
+    /// `panel` (the leaf's active tab). This widget expands to fill
+    /// whatever room is left in the header row, so the caller owns *all* of
+    /// it: dvui draws nothing here itself (no settings button, no icon) —
+    /// what goes there (a Unity-style "..." menu, a lock/pin icon, both, or
+    /// a right-click handler for the empty space) is entirely up to the
+    /// app. Null (the default) leaves the header with just the tab strip.
+    drawHeaderExtra: ?*const fn (Layout.PanelId) void = null,
+    /// Called every frame a tab's right-click context menu should be open
+    /// (each tab is wrapped in its own `dvui.context()`, same mechanism any
+    /// other right-click menu in a dvui app uses — dvui owns open/close
+    /// persistence, the app just draws content reactively). `pt` is where
+    /// to anchor a `floatingMenu`; call `.close()` on it when the app's
+    /// menu item is picked, same as any other context-menu callback.
+    onTabContextMenu: ?*const fn (panel: Layout.PanelId, pt: dvui.Point.Natural) void = null,
 };
 
 wd: WidgetData,
@@ -215,17 +230,31 @@ fn openLeaf(self: *Dockspace, node: Layout.NodeIndex) ?Panel {
     const leaf = layout.nodes.items[node].leaf;
     if (leaf.tabs.items.len == 0) return null; // tolerated empty root leaf
 
-    self.drawHeader(node, leaf);
+    const header_rect = self.drawHeader(node, leaf);
 
     const active_slug = leaf.tabs.items[leaf.active];
     const box = dvui.box(@src(), .{ .dir = .vertical }, .{ .expand = .both, .id_extra = slugIdExtra(active_slug) });
     self.content_box = box;
 
     if (dvui.dragName("dvui_dock")) {
+        self.checkHeaderZone(node, header_rect);
         self.checkLeafZones(node, box.data().contentRectScale().r);
     }
 
     return .{ .id = active_slug, .leaf = node, .dockspace = self };
+}
+
+/// The header itself (tab strip + trailing extra space) is always an
+/// "insert as tab" target: dropping onto another leaf's tabs, or the empty
+/// space after them, adds the dragged tab there as a sibling — no N/S/E/W
+/// subdivision the way `checkLeafZones`' content-rect zones have, dropping
+/// on a header never means "split this leaf".
+fn checkHeaderZone(self: *Dockspace, node: Layout.NodeIndex, r: Rect.Physical) void {
+    const mouse = dvui.currentWindow().mouse_pt;
+    if (!r.contains(mouse)) return;
+    const leaf = self.init_opts.layout.nodes.items[node].leaf;
+    self.hover_target = .{ .tab = .{ .leaf = node, .index = leaf.tabs.items.len } };
+    self.hover_rect = r;
 }
 
 /// Drop-zone geometry for one leaf's content rect `r` (physical): a center
@@ -331,43 +360,80 @@ fn closeContent(self: *Dockspace) void {
     }
 }
 
-fn drawHeader(self: *Dockspace, node: Layout.NodeIndex, leaf: Layout.Node.Leaf) void {
-    var tw = dvui.tabs(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .id_extra = node });
-    defer tw.deinit();
+/// Draws the tab strip plus (if the app supplied `drawHeaderExtra`)
+/// whatever it wants in the trailing space, and returns the whole header
+/// row's rect (used by `checkHeaderZone`).
+fn drawHeader(self: *Dockspace, node: Layout.NodeIndex, leaf: Layout.Node.Leaf) Rect.Physical {
+    var header_row = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .id_extra = node });
+    defer header_row.deinit();
 
-    for (leaf.tabs.items, 0..) |slug, i| {
-        const info = self.init_opts.panelInfo(slug);
-        var tab = tw.addTab(i == leaf.active, .{ .process_events = false }, .{ .id_extra = slugIdExtra(slug), .tag = slug });
-        defer tab.deinit();
+    {
+        // Not `.expand` when `drawHeaderExtra` is set: that box (below)
+        // claims the leftover width instead, so right-clicking or dropping
+        // onto the empty space after the tabs reaches the app's content
+        // there rather than landing on an oversized (but visually empty)
+        // tab strip.
+        const tw_expand: Options.Expand = if (self.init_opts.drawHeaderExtra != null) .none else .horizontal;
+        var tw = dvui.tabs(@src(), .{ .dir = .horizontal }, .{ .expand = tw_expand, .id_extra = node });
+        defer tw.deinit();
 
-        {
-            var row = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .both });
-            defer row.deinit();
-            if (info.icon) |ic| dvui.icon(@src(), "docktab_icon", ic, .{}, .{ .gravity_y = 0.5 });
-            dvui.label(@src(), "{s}", .{info.title}, .{ .gravity_y = 0.5 });
-            const show_close = info.closable and switch (self.init_opts.close_button_visibility) {
-                .always => true,
-                .hover => i == leaf.active or tab.hovered(),
-            };
-            if (show_close) {
-                const close_tag = std.fmt.allocPrint(dvui.currentWindow().arena(), "docktab_close:{s}", .{slug}) catch null;
-                // Draw (and fully process) the close button before the tab's
-                // own click handling below, so a close click doesn't also
-                // register as a tab-select click.
-                if (dvui.buttonIcon(@src(), "docktab_close", dvui.entypo.cross, .{}, .{}, .{
-                    .id_extra = slugIdExtra(slug),
-                    .tag = close_tag,
-                    .gravity_y = 0.5,
-                    .padding = Rect.all(2),
-                    .margin = Rect.all(2),
-                })) {
-                    self.queueMutation(.{ .remove = slug });
+        for (leaf.tabs.items, 0..) |slug, i| {
+            const info = self.init_opts.panelInfo(slug);
+            var tab = tw.addTab(i == leaf.active, .{ .process_events = false }, .{ .id_extra = slugIdExtra(slug), .tag = slug });
+            defer tab.deinit();
+
+            {
+                var row = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .both });
+                defer row.deinit();
+                if (info.icon) |ic| dvui.icon(@src(), "docktab_icon", ic, .{}, .{ .gravity_y = 0.5 });
+                dvui.label(@src(), "{s}", .{info.title}, .{ .gravity_y = 0.5 });
+                const show_close = info.closable and switch (self.init_opts.close_button_visibility) {
+                    .always => true,
+                    .hover => i == leaf.active or tab.hovered(),
+                };
+                if (show_close) {
+                    const close_tag = std.fmt.allocPrint(dvui.currentWindow().arena(), "docktab_close:{s}", .{slug}) catch null;
+                    // Draw (and fully process) the close button before the tab's
+                    // own click handling below, so a close click doesn't also
+                    // register as a tab-select click.
+                    if (dvui.buttonIcon(@src(), "docktab_close", dvui.entypo.cross, .{}, .{}, .{
+                        .id_extra = slugIdExtra(slug),
+                        .tag = close_tag,
+                        .gravity_y = 0.5,
+                        .padding = Rect.all(2),
+                        .margin = Rect.all(2),
+                    })) {
+                        self.queueMutation(.{ .remove = slug });
+                    }
                 }
             }
-        }
 
-        self.processTabEvents(tab.data(), node, i, slug);
+            self.processTabEvents(tab.data(), node, i, slug);
+        }
     }
+
+    if (self.init_opts.onTabContextMenu) |cb| {
+        for (leaf.tabs.items) |slug| {
+            // `tagGet` reads this frame's already-registered rect (each tab
+            // was tagged with its slug above, earlier this same frame).
+            const td = dvui.tagGet(slug) orelse continue;
+            var cxt = dvui.context(@src(), .{ .rect = td.rect }, .{ .id_extra = slugIdExtra(slug) });
+            defer cxt.deinit();
+            if (cxt.activePoint()) |cp| cb(slug, cp);
+        }
+    }
+
+    if (self.init_opts.drawHeaderExtra) |drawFn| {
+        // Claims all the leftover width (see the `tw_expand` note above) —
+        // the app's callback gets the *whole* trailing area, not just
+        // whatever it visibly draws, so it can (for example) catch a
+        // right-click anywhere in the empty space, not only on a button.
+        var extra = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal, .gravity_y = 0.5 });
+        defer extra.deinit();
+        drawFn(leaf.tabs.items[leaf.active]);
+    }
+
+    return header_row.data().contentRectScale().r;
 }
 
 /// Raw press/motion/release handling for one tab button: a plain press+release
@@ -512,6 +578,177 @@ test "dockspace renders nested splits, floats, and applies tab mutations" {
     try dvui.testing.settle(fns.frame);
     try std.testing.expect(fns.last_changed);
     try std.testing.expect(!fns.layout.contains("a"));
+}
+
+test "dockspace drawHeaderExtra: called once per leaf for the active tab, app owns the content" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const fns = struct {
+        var layout: Layout.DockLayout = undefined;
+        var inited = false;
+        var drawn_for: std.ArrayList(Layout.PanelId) = .empty;
+
+        fn drawHeaderExtra(id: Layout.PanelId) void {
+            drawn_for.append(std.testing.allocator, id) catch {};
+            // The app can put whatever it wants here — a button, an icon,
+            // several of each — dvui neither knows nor cares. `id_extra`
+            // disambiguates the two leaves' otherwise-identical buttons,
+            // same as any other app code drawing per-panel widgets.
+            _ = dvui.button(@src(), "extra", .{}, .{ .id_extra = slugIdExtra(id) });
+        }
+
+        fn frame() !dvui.App.Result {
+            if (!inited) {
+                layout = try Layout.DockLayout.initSingleLeaf(std.testing.allocator, "a");
+                try layout.splitLeaf(layout.root, .right, "b");
+                inited = true;
+            }
+
+            var dock = dvui.dockspace(@src(), .{
+                .layout = &layout,
+                .panelInfo = testPanelInfo,
+                .drawHeaderExtra = drawHeaderExtra,
+            }, .{ .expand = .both });
+            defer dock.deinit();
+            while (dock.panel()) |p| {
+                defer p.end();
+                dvui.label(@src(), "content:{s}", .{p.id}, .{});
+            }
+
+            return .ok;
+        }
+    };
+    defer fns.layout.deinit();
+    defer fns.drawn_for.deinit(std.testing.allocator);
+
+    try dvui.testing.settle(fns.frame);
+
+    // `settle` may run `frame` more than once, so don't assume an exact
+    // call count — just that both leaves' active tabs got a call.
+    try std.testing.expect(fns.drawn_for.items.len >= 2);
+    var saw_a = false;
+    var saw_b = false;
+    for (fns.drawn_for.items) |id| {
+        if (std.mem.eql(u8, id, "a")) saw_a = true;
+        if (std.mem.eql(u8, id, "b")) saw_b = true;
+    }
+    try std.testing.expect(saw_a);
+    try std.testing.expect(saw_b);
+}
+
+test "dockspace onTabContextMenu: fires while a tab's context menu is open, closes on pick" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const fns = struct {
+        var layout: Layout.DockLayout = undefined;
+        var inited = false;
+        var call_count: usize = 0;
+        var last_id: ?Layout.PanelId = null;
+
+        fn onTabContextMenu(id: Layout.PanelId, pt: dvui.Point.Natural) void {
+            call_count += 1;
+            last_id = id;
+
+            var fw = dvui.floatingMenu(@src(), .{ .from = dvui.Rect.Natural.fromPoint(pt) }, .{});
+            defer fw.deinit();
+            if (dvui.menuItemLabel(@src(), "Add Something", .{}, .{ .tag = "ctx_add" }) != null) {
+                fw.close();
+            }
+        }
+
+        fn frame() !dvui.App.Result {
+            if (!inited) {
+                layout = try Layout.DockLayout.initSingleLeaf(std.testing.allocator, "a");
+                try layout.insertTab(layout.root, 1, "b");
+                inited = true;
+            }
+
+            var dock = dvui.dockspace(@src(), .{
+                .layout = &layout,
+                .panelInfo = testPanelInfo,
+                .onTabContextMenu = onTabContextMenu,
+            }, .{ .expand = .both });
+            defer dock.deinit();
+            while (dock.panel()) |p| {
+                defer p.end();
+                dvui.label(@src(), "content:{s}", .{p.id}, .{});
+            }
+
+            return .ok;
+        }
+    };
+    defer fns.layout.deinit();
+
+    try dvui.testing.settle(fns.frame);
+    try std.testing.expectEqual(@as(usize, 0), fns.call_count);
+
+    try dvui.testing.moveTo("a");
+    try dvui.testing.click(.right);
+    try dvui.testing.settle(fns.frame);
+
+    try std.testing.expect(fns.call_count > 0);
+    try std.testing.expectEqualStrings("a", fns.last_id.?);
+
+    // Picking the item closes the context menu: further frames stop calling back.
+    try dvui.testing.moveTo("ctx_add");
+    try dvui.testing.click(.left);
+    try dvui.testing.settle(fns.frame);
+
+    const count_after_pick = fns.call_count;
+    try dvui.testing.settle(fns.frame);
+    try std.testing.expectEqual(count_after_pick, fns.call_count);
+}
+
+test "dockspace drag: dropping directly onto another leaf's tab (not just its content) adds a tab there" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const fns = struct {
+        var layout: Layout.DockLayout = undefined;
+        var inited = false;
+
+        fn frame() !dvui.App.Result {
+            if (!inited) {
+                layout = try Layout.DockLayout.initSingleLeaf(std.testing.allocator, "a");
+                try layout.splitLeaf(layout.root, .right, "b");
+                inited = true;
+            }
+
+            var dock = dvui.dockspace(@src(), .{ .layout = &layout, .panelInfo = testPanelInfo }, .{ .expand = .both });
+            defer dock.deinit();
+            while (dock.panel()) |p| {
+                defer p.end();
+                dvui.label(@src(), "content:{s}", .{p.id}, .{});
+            }
+
+            return .ok;
+        }
+    };
+    defer fns.layout.deinit();
+
+    try dvui.testing.settle(fns.frame);
+
+    const cw = dvui.currentWindow();
+    const a_center = dvui.tagGet("a").?.rect.center();
+    // "b"'s own tab button (in the header, not its content area below).
+    const b_tab = dvui.tagGet("b").?.rect.center();
+
+    _ = try cw.addEventMouseMotion(.{ .pt = a_center });
+    _ = try cw.addEventMouseButton(.left, .press);
+    _ = try dvui.testing.step(fns.frame);
+
+    _ = try cw.addEventMouseMotion(.{ .pt = b_tab });
+    _ = try dvui.testing.step(fns.frame);
+
+    _ = try cw.addEventMouseButton(.left, .release);
+    try dvui.testing.settle(fns.frame);
+
+    const b_leaf = fns.layout.findPanel("b").?;
+    try std.testing.expect(!fns.layout.isFloat(b_leaf));
+    try std.testing.expectEqual(@as(usize, 2), fns.layout.nodes.items[b_leaf].leaf.tabs.items.len);
+    try std.testing.expectEqual(fns.layout.root, b_leaf);
 }
 
 test "dockspace drag: press+motion+release onto another leaf's center adds a new tab there" {

--- a/src/widgets/DockingWidget/Layout.zig
+++ b/src/widgets/DockingWidget/Layout.zig
@@ -61,6 +61,12 @@ nodes: std.ArrayList(Node) = .empty,
 free_head: ?NodeIndex = null,
 root: NodeIndex = 0,
 floats: std.ArrayList(Float) = .empty,
+/// Set by `parseJson`: unlike the normal live-tree contract (app-owned
+/// static `PanelId` strings), a parsed file has no other stable source for
+/// the slugs, so `parseJson` duplicates them with `allocator` and `deinit`
+/// frees those copies. Don't set this yourself unless you also allocated
+/// every current and future `PanelId` you hand this layout with `allocator`.
+owns_panel_ids: bool = false,
 
 pub fn init(allocator: std.mem.Allocator) DockLayout {
     return .{ .allocator = allocator };
@@ -79,13 +85,22 @@ pub fn initSingleLeaf(allocator: std.mem.Allocator, panel: PanelId) !DockLayout 
 pub fn deinit(self: *DockLayout) void {
     for (self.nodes.items) |*n| {
         switch (n.*) {
-            .leaf => |*l| l.tabs.deinit(self.allocator),
+            .leaf => |*l| self.freeLeafTabs(l),
             .split, .free => {},
         }
     }
     self.nodes.deinit(self.allocator);
     self.floats.deinit(self.allocator);
     self.* = undefined;
+}
+
+/// Frees the tab slug strings too when `owns_panel_ids` (set by `parseJson`),
+/// then the tab list container itself either way.
+fn freeLeafTabs(self: *DockLayout, l: *Node.Leaf) void {
+    if (self.owns_panel_ids) {
+        for (l.tabs.items) |t| self.allocator.free(t);
+    }
+    l.tabs.deinit(self.allocator);
 }
 
 fn allocNode(self: *DockLayout) !NodeIndex {
@@ -100,7 +115,7 @@ fn allocNode(self: *DockLayout) !NodeIndex {
 
 fn freeNode(self: *DockLayout, idx: NodeIndex) void {
     switch (self.nodes.items[idx]) {
-        .leaf => |*l| l.tabs.deinit(self.allocator),
+        .leaf => |*l| self.freeLeafTabs(l),
         .split, .free => {},
     }
     self.nodes.items[idx] = .{ .free = self.free_head };
@@ -256,12 +271,17 @@ fn reorderTab(self: *DockLayout, leaf_idx: NodeIndex, panel: PanelId, new_index:
 /// Removes `panel` from `leaf_idx` (must currently contain it), fixing up
 /// `active` and collapsing the tree/floats if the leaf becomes empty.
 /// Removal of the active tab activates the previous tab index, not 0.
-fn removeFromLeaf(self: *DockLayout, leaf_idx: NodeIndex, panel: PanelId) void {
+/// Removes `panel` from `leaf_idx` and returns the removed `PanelId` (the
+/// same string that was stored — still alive, just no longer in the tree),
+/// or null if it wasn't there. Callers relocating the panel elsewhere should
+/// ignore the return value; only a true deletion (`removePanel`) should free
+/// it (and only when `owns_panel_ids`).
+fn removeFromLeaf(self: *DockLayout, leaf_idx: NodeIndex, panel: PanelId) ?PanelId {
     const leaf = &self.nodes.items[leaf_idx].leaf;
     const removed_idx = for (leaf.tabs.items, 0..) |t, i| {
         if (std.mem.eql(u8, t, panel)) break i;
-    } else return;
-    _ = leaf.tabs.orderedRemove(removed_idx);
+    } else return null;
+    const removed = leaf.tabs.orderedRemove(removed_idx);
 
     if (leaf.tabs.items.len == 0) {
         leaf.active = 0;
@@ -270,20 +290,20 @@ fn removeFromLeaf(self: *DockLayout, leaf_idx: NodeIndex, panel: PanelId) void {
         leaf.active = @min(leaf.active, leaf.tabs.items.len - 1);
     }
 
-    if (leaf.tabs.items.len > 0) return;
+    if (leaf.tabs.items.len > 0) return removed;
 
     // Empty leaf: collapse it out of whichever structure holds it.
     for (self.floats.items, 0..) |f, i| {
         if (f.leaf == leaf_idx) {
             _ = self.floats.swapRemove(i);
             self.freeNode(leaf_idx);
-            return;
+            return removed;
         }
     }
 
-    if (leaf_idx == self.root) return; // tolerate an empty root leaf
+    if (leaf_idx == self.root) return removed; // tolerate an empty root leaf
 
-    const parent = self.findParent(leaf_idx) orelse return;
+    const parent = self.findParent(leaf_idx) orelse return removed;
     const split = self.nodes.items[parent.idx].split;
     const sibling = switch (parent.side) {
         .first => split.second,
@@ -296,12 +316,16 @@ fn removeFromLeaf(self: *DockLayout, leaf_idx: NodeIndex, panel: PanelId) void {
     self.nodes.items[sibling] = .{ .free = null };
     self.freeNode(sibling);
     self.freeNode(leaf_idx);
+    return removed;
 }
 
 /// Removes `panel` from wherever it currently is (no-op if not present).
 pub fn removePanel(self: *DockLayout, panel: PanelId) void {
     const leaf_idx = self.findPanel(panel) orelse return;
-    self.removeFromLeaf(leaf_idx, panel);
+    const removed = self.removeFromLeaf(leaf_idx, panel);
+    if (self.owns_panel_ids) {
+        if (removed) |r| self.allocator.free(r);
+    }
 }
 
 pub fn setActive(self: *DockLayout, leaf_idx: NodeIndex, index: usize) void {
@@ -321,29 +345,29 @@ pub fn movePanel(self: *DockLayout, panel: PanelId, target: MoveTarget) !void {
                 return;
             }
             try self.insertTab(t.leaf, t.index, panel);
-            self.removeFromLeaf(source_leaf, panel);
+            _ = self.removeFromLeaf(source_leaf, panel);
         },
         .split => |s| {
             if (s.leaf == source_leaf) {
                 const tabs_len = self.nodes.items[source_leaf].leaf.tabs.items.len;
                 if (tabs_len <= 1) return; // only tab in this leaf: nothing to split against
-                self.removeFromLeaf(source_leaf, panel);
+                _ = self.removeFromLeaf(source_leaf, panel);
                 try self.splitLeaf(source_leaf, s.side, panel);
                 return;
             }
             try self.splitLeaf(s.leaf, s.side, panel);
-            self.removeFromLeaf(source_leaf, panel);
+            _ = self.removeFromLeaf(source_leaf, panel);
         },
         .split_root => |side| {
             if (source_leaf == self.root) {
                 const tabs_len = self.nodes.items[source_leaf].leaf.tabs.items.len;
                 if (tabs_len <= 1) return; // only tab in the whole tree: nothing to split against
-                self.removeFromLeaf(source_leaf, panel);
+                _ = self.removeFromLeaf(source_leaf, panel);
                 try self.splitRoot(side, panel);
                 return;
             }
             try self.splitRoot(side, panel);
-            self.removeFromLeaf(source_leaf, panel);
+            _ = self.removeFromLeaf(source_leaf, panel);
         },
     }
 }
@@ -358,7 +382,7 @@ pub fn floatPanel(self: *DockLayout, panel: PanelId, rect: dvui.Rect) !void {
     self.nodes.items[idx] = .{ .leaf = .{ .tabs = tabs, .active = 0 } };
     try self.floats.append(self.allocator, .{ .leaf = idx, .rect = rect });
 
-    if (source_leaf) |sl| self.removeFromLeaf(sl, panel);
+    if (source_leaf) |sl| _ = self.removeFromLeaf(sl, panel);
 }
 
 pub fn apply(self: *DockLayout, m: Mutation) !void {
@@ -455,10 +479,13 @@ fn writeLeafJson(s: *std.json.Stringify, l: Node.Leaf) !void {
 ///
 /// Panel slug strings are duplicated with `allocator` (the `PanelId` contract
 /// elsewhere in this file — layout never dupes/frees — assumes app-owned
-/// static strings, which a parsed file can't provide). `DockLayout.deinit`
-/// only frees the per-leaf tab list containers, not the strings themselves,
-/// so pass an arena as `allocator` if you want one `arena.deinit()` to free
-/// both the layout and these slug copies together.
+/// static strings, which a parsed file can't provide). This sets
+/// `owns_panel_ids`, so a plain `deinit()` frees those slug copies too, same
+/// as any other allocation this layout owns — no arena required. If you
+/// reconcile the parsed slugs against your own static registry (dropping
+/// unknown ones, say), do that before relying on `owns_panel_ids`-driven
+/// freeing, since it frees whatever strings are still in the tree at
+/// `deinit()`, not specifically "the ones parseJson allocated".
 pub fn parseJson(allocator: std.mem.Allocator, slice: []const u8) !DockLayout {
     var parsed = try std.json.parseFromSlice(std.json.Value, allocator, slice, .{});
     defer parsed.deinit();
@@ -475,6 +502,7 @@ pub fn parseJson(allocator: std.mem.Allocator, slice: []const u8) !DockLayout {
     if (version != 1) return error.InvalidVersion;
 
     var self = DockLayout.init(allocator);
+    self.owns_panel_ids = true;
     errdefer self.deinit();
 
     self.root = try parseNode(&self, root_obj.get("root") orelse return error.InvalidFormat);
@@ -785,11 +813,13 @@ test "writeJson/parseJson round-trip preserves tree, tabs, and floats" {
     defer out.deinit();
     try layout.writeJson(&out.writer);
 
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    var loaded = try DockLayout.parseJson(arena.allocator(), out.written());
+    // Plain `std.testing.allocator` (no arena): exercises that `deinit`
+    // actually frees the slug strings `parseJson` duplicated, not just the
+    // node/tab-list containers — `owns_panel_ids` is what makes that safe.
+    var loaded = try DockLayout.parseJson(std.testing.allocator, out.written());
     defer loaded.deinit();
 
+    try std.testing.expect(loaded.owns_panel_ids);
     try std.testing.expect(loaded.contains("a"));
     try std.testing.expect(loaded.contains("b"));
     try std.testing.expect(loaded.contains("c"));
@@ -799,6 +829,10 @@ test "writeJson/parseJson round-trip preserves tree, tabs, and floats" {
     const b_float = loaded.floats.items[0];
     try std.testing.expectApproxEqAbs(@as(f32, 10), b_float.rect.x, 0.01);
     try std.testing.expectApproxEqAbs(@as(f32, 300), b_float.rect.w, 0.01);
+
+    // Also exercise removePanel actually freeing an owned slug (not just deinit).
+    loaded.removePanel("c");
+    try std.testing.expect(!loaded.contains("c"));
 }
 
 test "parseJson forward-fails on missing or wrong version" {

--- a/src/widgets/DockingWidget/Layout.zig
+++ b/src/widgets/DockingWidget/Layout.zig
@@ -1,0 +1,501 @@
+//! Pure-data layout tree for the docking widget: a binary tree of splits with
+//! tabbed leaves at the fringes, plus a list of floating leaves. No GUI
+//! dependencies beyond `dvui.enums.Direction` and `dvui.Rect` (plain data
+//! types), so this can be unit tested without a Window.
+const std = @import("std");
+const dvui = @import("../../dvui.zig");
+
+/// App-owned slug identifying a dockable panel. `DockLayout` never dupes or
+/// frees these: the caller must keep the underlying bytes alive for the
+/// lifetime of the layout (typically a static string).
+pub const PanelId = []const u8;
+
+pub const NodeIndex = u32;
+
+pub const Side = enum { left, right, top, bottom };
+
+pub const Node = union(enum) {
+    split: Split,
+    leaf: Leaf,
+    /// Free-list entry: node slots are stable and never compacted, so
+    /// removed nodes are recycled via this singly linked free list.
+    free: ?NodeIndex,
+
+    pub const Split = struct {
+        dir: dvui.enums.Direction,
+        ratio: f32 = 0.5,
+        first: NodeIndex,
+        second: NodeIndex,
+    };
+
+    pub const Leaf = struct {
+        tabs: std.ArrayList(PanelId) = .empty,
+        active: usize = 0,
+    };
+};
+
+pub const Float = struct {
+    leaf: NodeIndex,
+    rect: dvui.Rect,
+};
+
+pub const MoveTarget = union(enum) {
+    tab: struct { leaf: NodeIndex, index: usize },
+    split: struct { leaf: NodeIndex, side: Side },
+};
+
+pub const Mutation = union(enum) {
+    move: struct { panel: PanelId, target: MoveTarget },
+    remove: PanelId,
+    set_active: struct { leaf: NodeIndex, index: usize },
+    float: struct { panel: PanelId, rect: dvui.Rect },
+};
+
+pub const DockLayout = @This();
+
+allocator: std.mem.Allocator,
+nodes: std.ArrayList(Node) = .empty,
+free_head: ?NodeIndex = null,
+root: NodeIndex = 0,
+floats: std.ArrayList(Float) = .empty,
+
+pub fn init(allocator: std.mem.Allocator) DockLayout {
+    return .{ .allocator = allocator };
+}
+
+/// Convenience constructor: a single leaf holding one panel as root.
+pub fn initSingleLeaf(allocator: std.mem.Allocator, panel: PanelId) !DockLayout {
+    var self = init(allocator);
+    const idx = try self.allocNode();
+    self.nodes.items[idx] = .{ .leaf = .{} };
+    try self.nodes.items[idx].leaf.tabs.append(allocator, panel);
+    self.root = idx;
+    return self;
+}
+
+pub fn deinit(self: *DockLayout) void {
+    for (self.nodes.items) |*n| {
+        switch (n.*) {
+            .leaf => |*l| l.tabs.deinit(self.allocator),
+            .split, .free => {},
+        }
+    }
+    self.nodes.deinit(self.allocator);
+    self.floats.deinit(self.allocator);
+    self.* = undefined;
+}
+
+fn allocNode(self: *DockLayout) !NodeIndex {
+    if (self.free_head) |idx| {
+        self.free_head = self.nodes.items[idx].free;
+        return idx;
+    }
+    const idx: NodeIndex = @intCast(self.nodes.items.len);
+    try self.nodes.append(self.allocator, .{ .free = null });
+    return idx;
+}
+
+fn freeNode(self: *DockLayout, idx: NodeIndex) void {
+    switch (self.nodes.items[idx]) {
+        .leaf => |*l| l.tabs.deinit(self.allocator),
+        .split, .free => {},
+    }
+    self.nodes.items[idx] = .{ .free = self.free_head };
+    self.free_head = idx;
+}
+
+/// Finds the leaf node containing `panel` as one of its tabs (main tree or floats).
+pub fn findPanel(self: *const DockLayout, panel: PanelId) ?NodeIndex {
+    for (self.nodes.items, 0..) |n, i| {
+        switch (n) {
+            .leaf => |l| for (l.tabs.items) |t| {
+                if (std.mem.eql(u8, t, panel)) return @intCast(i);
+            },
+            .split, .free => {},
+        }
+    }
+    return null;
+}
+
+pub fn contains(self: *const DockLayout, panel: PanelId) bool {
+    return self.findPanel(panel) != null;
+}
+
+pub fn isFloat(self: *const DockLayout, leaf_idx: NodeIndex) bool {
+    for (self.floats.items) |f| {
+        if (f.leaf == leaf_idx) return true;
+    }
+    return false;
+}
+
+/// Returns the first leaf reached by always descending into `first`, starting at `start`.
+pub fn firstLeaf(self: *const DockLayout, start: NodeIndex) NodeIndex {
+    var idx = start;
+    while (true) {
+        switch (self.nodes.items[idx]) {
+            .split => |s| idx = s.first,
+            .leaf => return idx,
+            .free => unreachable,
+        }
+    }
+}
+
+/// Appends the active panel of every leaf (main tree, depth-first, then floats) to `list`.
+pub fn collectActivePanels(self: *const DockLayout, list: *std.ArrayList(PanelId), allocator: std.mem.Allocator) !void {
+    try self.collectActiveFrom(self.root, list, allocator);
+    for (self.floats.items) |f| try self.collectActiveFrom(f.leaf, list, allocator);
+}
+
+fn collectActiveFrom(self: *const DockLayout, idx: NodeIndex, list: *std.ArrayList(PanelId), allocator: std.mem.Allocator) !void {
+    switch (self.nodes.items[idx]) {
+        .split => |s| {
+            try self.collectActiveFrom(s.first, list, allocator);
+            try self.collectActiveFrom(s.second, list, allocator);
+        },
+        .leaf => |l| if (l.tabs.items.len > 0) try list.append(allocator, l.tabs.items[l.active]),
+        .free => unreachable,
+    }
+}
+
+const Parent = struct { idx: NodeIndex, side: enum { first, second } };
+
+/// Linear search from root for the split node whose first/second == `target`.
+/// Floats have no parent (returns null for a float leaf).
+fn findParent(self: *const DockLayout, target: NodeIndex) ?Parent {
+    return self.findParentFrom(self.root, target);
+}
+
+fn findParentFrom(self: *const DockLayout, idx: NodeIndex, target: NodeIndex) ?Parent {
+    switch (self.nodes.items[idx]) {
+        .split => |s| {
+            if (s.first == target) return .{ .idx = idx, .side = .first };
+            if (s.second == target) return .{ .idx = idx, .side = .second };
+            if (self.findParentFrom(s.first, target)) |p| return p;
+            return self.findParentFrom(s.second, target);
+        },
+        .leaf, .free => return null,
+    }
+}
+
+/// Splits `leaf_idx` into a new split node (same index, so external
+/// references stay valid) with the existing content moved to one side and a
+/// fresh single-tab leaf holding `panel` on the other side.
+pub fn splitLeaf(self: *DockLayout, leaf_idx: NodeIndex, side: Side, panel: PanelId) !void {
+    const old_leaf = self.nodes.items[leaf_idx].leaf;
+
+    const moved_idx = try self.allocNode();
+    self.nodes.items[moved_idx] = .{ .leaf = old_leaf };
+
+    const new_idx = try self.allocNode();
+    var new_tabs: std.ArrayList(PanelId) = .empty;
+    try new_tabs.append(self.allocator, panel);
+    self.nodes.items[new_idx] = .{ .leaf = .{ .tabs = new_tabs, .active = 0 } };
+
+    const dir: dvui.enums.Direction = switch (side) {
+        .left, .right => .horizontal,
+        .top, .bottom => .vertical,
+    };
+    const first, const second = switch (side) {
+        .left, .top => .{ new_idx, moved_idx },
+        .right, .bottom => .{ moved_idx, new_idx },
+    };
+
+    self.nodes.items[leaf_idx] = .{ .split = .{ .dir = dir, .ratio = 0.5, .first = first, .second = second } };
+}
+
+/// Inserts `panel` as a new tab in `leaf_idx` at `tab_idx` (clamped) and activates it.
+pub fn insertTab(self: *DockLayout, leaf_idx: NodeIndex, tab_idx: usize, panel: PanelId) !void {
+    const leaf = &self.nodes.items[leaf_idx].leaf;
+    const idx = @min(tab_idx, leaf.tabs.items.len);
+    try leaf.tabs.insert(self.allocator, idx, panel);
+    leaf.active = idx;
+}
+
+/// Reorders `panel` (already in `leaf_idx`) to `new_index` within the same leaf.
+fn reorderTab(self: *DockLayout, leaf_idx: NodeIndex, panel: PanelId, new_index: usize) void {
+    const leaf = &self.nodes.items[leaf_idx].leaf;
+    const cur = for (leaf.tabs.items, 0..) |t, i| {
+        if (std.mem.eql(u8, t, panel)) break i;
+    } else return;
+    const item = leaf.tabs.orderedRemove(cur);
+    const idx = @min(new_index, leaf.tabs.items.len);
+    leaf.tabs.insert(self.allocator, idx, item) catch return;
+    leaf.active = idx;
+}
+
+/// Removes `panel` from `leaf_idx` (must currently contain it), fixing up
+/// `active` and collapsing the tree/floats if the leaf becomes empty.
+/// Removal of the active tab activates the previous tab index, not 0.
+fn removeFromLeaf(self: *DockLayout, leaf_idx: NodeIndex, panel: PanelId) void {
+    const leaf = &self.nodes.items[leaf_idx].leaf;
+    const removed_idx = for (leaf.tabs.items, 0..) |t, i| {
+        if (std.mem.eql(u8, t, panel)) break i;
+    } else return;
+    _ = leaf.tabs.orderedRemove(removed_idx);
+
+    if (leaf.tabs.items.len == 0) {
+        leaf.active = 0;
+    } else {
+        if (removed_idx <= leaf.active and leaf.active > 0) leaf.active -= 1;
+        leaf.active = @min(leaf.active, leaf.tabs.items.len - 1);
+    }
+
+    if (leaf.tabs.items.len > 0) return;
+
+    // Empty leaf: collapse it out of whichever structure holds it.
+    for (self.floats.items, 0..) |f, i| {
+        if (f.leaf == leaf_idx) {
+            _ = self.floats.swapRemove(i);
+            self.freeNode(leaf_idx);
+            return;
+        }
+    }
+
+    if (leaf_idx == self.root) return; // tolerate an empty root leaf
+
+    const parent = self.findParent(leaf_idx) orelse return;
+    const split = self.nodes.items[parent.idx].split;
+    const sibling = switch (parent.side) {
+        .first => split.second,
+        .second => split.first,
+    };
+
+    // Promote the sibling's content into the parent's slot (stable index),
+    // then free the emptied leaf and the now-unreferenced sibling slot.
+    self.nodes.items[parent.idx] = self.nodes.items[sibling];
+    self.nodes.items[sibling] = .{ .free = null };
+    self.freeNode(sibling);
+    self.freeNode(leaf_idx);
+}
+
+/// Removes `panel` from wherever it currently is (no-op if not present).
+pub fn removePanel(self: *DockLayout, panel: PanelId) void {
+    const leaf_idx = self.findPanel(panel) orelse return;
+    self.removeFromLeaf(leaf_idx, panel);
+}
+
+pub fn setActive(self: *DockLayout, leaf_idx: NodeIndex, index: usize) void {
+    const leaf = &self.nodes.items[leaf_idx].leaf;
+    if (index < leaf.tabs.items.len) leaf.active = index;
+}
+
+/// Moves `panel` (wherever it currently is) to `target`. No-op if `target`
+/// re-specifies the panel's only current location.
+pub fn movePanel(self: *DockLayout, panel: PanelId, target: MoveTarget) !void {
+    const source_leaf = self.findPanel(panel) orelse return;
+
+    switch (target) {
+        .tab => |t| {
+            if (t.leaf == source_leaf) {
+                self.reorderTab(source_leaf, panel, t.index);
+                return;
+            }
+            try self.insertTab(t.leaf, t.index, panel);
+            self.removeFromLeaf(source_leaf, panel);
+        },
+        .split => |s| {
+            if (s.leaf == source_leaf) {
+                const tabs_len = self.nodes.items[source_leaf].leaf.tabs.items.len;
+                if (tabs_len <= 1) return; // only tab in this leaf: nothing to split against
+                self.removeFromLeaf(source_leaf, panel);
+                try self.splitLeaf(source_leaf, s.side, panel);
+                return;
+            }
+            try self.splitLeaf(s.leaf, s.side, panel);
+            self.removeFromLeaf(source_leaf, panel);
+        },
+    }
+}
+
+/// Detaches `panel` into a new floating leaf at `rect`.
+pub fn floatPanel(self: *DockLayout, panel: PanelId, rect: dvui.Rect) !void {
+    const source_leaf = self.findPanel(panel);
+
+    const idx = try self.allocNode();
+    var tabs: std.ArrayList(PanelId) = .empty;
+    try tabs.append(self.allocator, panel);
+    self.nodes.items[idx] = .{ .leaf = .{ .tabs = tabs, .active = 0 } };
+    try self.floats.append(self.allocator, .{ .leaf = idx, .rect = rect });
+
+    if (source_leaf) |sl| self.removeFromLeaf(sl, panel);
+}
+
+pub fn apply(self: *DockLayout, m: Mutation) !void {
+    switch (m) {
+        .move => |mv| try self.movePanel(mv.panel, mv.target),
+        .remove => |p| self.removePanel(p),
+        .set_active => |sa| self.setActive(sa.leaf, sa.index),
+        .float => |f| try self.floatPanel(f.panel, f.rect),
+    }
+}
+
+test "single leaf init and find" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "hierarchy");
+    defer layout.deinit();
+
+    try std.testing.expect(layout.contains("hierarchy"));
+    try std.testing.expect(!layout.contains("inspector"));
+}
+
+test "splitLeaf keeps parent index stable and creates two leaves" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "hierarchy");
+    defer layout.deinit();
+
+    const root = layout.root;
+    try layout.splitLeaf(root, .right, "inspector");
+
+    try std.testing.expect(layout.root == root); // root index unchanged
+    try std.testing.expectEqual(Node.split, std.meta.activeTag(layout.nodes.items[root]));
+    const split = layout.nodes.items[root].split;
+    try std.testing.expectEqual(dvui.enums.Direction.horizontal, split.dir);
+    try std.testing.expect(layout.contains("hierarchy"));
+    try std.testing.expect(layout.contains("inspector"));
+
+    const hier_leaf = layout.findPanel("hierarchy").?;
+    const insp_leaf = layout.findPanel("inspector").?;
+    try std.testing.expect(hier_leaf != insp_leaf);
+    try std.testing.expectEqual(split.first, hier_leaf); // .right => existing moves first
+    try std.testing.expectEqual(split.second, insp_leaf);
+}
+
+test "insertTab adds a tab to an existing leaf" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "hierarchy");
+    defer layout.deinit();
+
+    try layout.insertTab(layout.root, 0, "scene");
+    const leaf = layout.nodes.items[layout.root].leaf;
+    try std.testing.expectEqual(@as(usize, 2), leaf.tabs.items.len);
+    try std.testing.expectEqualStrings("scene", leaf.tabs.items[0]);
+    try std.testing.expectEqual(@as(usize, 0), leaf.active);
+}
+
+test "removePanel collapses single-child split, preserving parent index" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "hierarchy");
+    defer layout.deinit();
+    const root = layout.root;
+    try layout.splitLeaf(root, .right, "inspector");
+
+    layout.removePanel("inspector");
+
+    try std.testing.expect(layout.root == root);
+    try std.testing.expectEqual(Node.leaf, std.meta.activeTag(layout.nodes.items[root]));
+    try std.testing.expect(layout.contains("hierarchy"));
+    try std.testing.expect(!layout.contains("inspector"));
+}
+
+test "remove last panel leaves an empty root leaf" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "hierarchy");
+    defer layout.deinit();
+
+    layout.removePanel("hierarchy");
+
+    try std.testing.expectEqual(Node.leaf, std.meta.activeTag(layout.nodes.items[layout.root]));
+    try std.testing.expectEqual(@as(usize, 0), layout.nodes.items[layout.root].leaf.tabs.items.len);
+}
+
+test "removing the active tab activates the previous index, not 0" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "a");
+    defer layout.deinit();
+    try layout.insertTab(layout.root, 1, "b");
+    try layout.insertTab(layout.root, 2, "c"); // active = 2 ("c")
+
+    layout.removePanel("c");
+
+    const leaf = layout.nodes.items[layout.root].leaf;
+    try std.testing.expectEqualStrings("b", leaf.tabs.items[leaf.active]);
+}
+
+test "movePanel .tab moves panel between leaves and collapses source" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "hierarchy");
+    defer layout.deinit();
+    const root = layout.root;
+    try layout.splitLeaf(root, .right, "inspector");
+    const insp_leaf = layout.findPanel("inspector").?;
+    const hier_leaf = layout.findPanel("hierarchy").?;
+
+    try layout.movePanel("hierarchy", .{ .tab = .{ .leaf = insp_leaf, .index = 0 } });
+
+    try std.testing.expect(layout.root == root);
+    try std.testing.expectEqual(Node.leaf, std.meta.activeTag(layout.nodes.items[root]));
+    const leaf = layout.nodes.items[root].leaf;
+    try std.testing.expectEqual(@as(usize, 2), leaf.tabs.items.len);
+    try std.testing.expectEqualStrings("hierarchy", leaf.tabs.items[0]);
+    _ = hier_leaf;
+}
+
+test "movePanel .split onto sibling leaf (adjacent collapse) does not corrupt tree" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "a");
+    defer layout.deinit();
+    const root = layout.root;
+    try layout.splitLeaf(root, .right, "b"); // root: split(a | b)
+    const b_leaf = layout.findPanel("b").?;
+
+    // Drag the only tab ("a") into "b"'s leaf as a new split (adjacent sibling).
+    try layout.movePanel("a", .{ .split = .{ .leaf = b_leaf, .side = .bottom } });
+
+    try std.testing.expect(layout.contains("a"));
+    try std.testing.expect(layout.contains("b"));
+    try std.testing.expect(layout.root == root);
+}
+
+test "movePanel .split onto self is a no-op when it is the only tab" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "a");
+    defer layout.deinit();
+    const root = layout.root;
+
+    try layout.movePanel("a", .{ .split = .{ .leaf = root, .side = .right } });
+
+    try std.testing.expectEqual(Node.leaf, std.meta.activeTag(layout.nodes.items[root]));
+    try std.testing.expectEqual(@as(usize, 1), layout.nodes.items[root].leaf.tabs.items.len);
+}
+
+test "movePanel .split on own leaf with other tabs splits off the dragged one" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "a");
+    defer layout.deinit();
+    try layout.insertTab(layout.root, 1, "b");
+    const root = layout.root;
+
+    try layout.movePanel("a", .{ .split = .{ .leaf = root, .side = .right } });
+
+    try std.testing.expect(layout.root == root);
+    try std.testing.expectEqual(Node.split, std.meta.activeTag(layout.nodes.items[root]));
+    try std.testing.expect(layout.contains("a"));
+    try std.testing.expect(layout.contains("b"));
+}
+
+test "floatPanel detaches a panel and freeNode/free-list is reused" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "a");
+    defer layout.deinit();
+    try layout.insertTab(layout.root, 1, "b");
+    const node_count_before = layout.nodes.items.len;
+
+    try layout.floatPanel("b", .{ .x = 10, .y = 10, .w = 200, .h = 200 });
+
+    try std.testing.expectEqual(@as(usize, 1), layout.floats.items.len);
+    try std.testing.expect(!layout.contains("b") or layout.isFloat(layout.findPanel("b").?));
+    try std.testing.expectEqual(@as(usize, 1), layout.nodes.items[layout.root].leaf.tabs.items.len);
+
+    // Float back out (last tab of the float leaf) -> float entry removed and its slot recycled.
+    const float_leaf = layout.findPanel("b").?;
+    layout.removePanel("b");
+    try std.testing.expectEqual(@as(usize, 0), layout.floats.items.len);
+    try std.testing.expectEqual(layout.free_head.?, float_leaf);
+    try std.testing.expectEqual(node_count_before + 1, layout.nodes.items.len);
+}
+
+test "collectActivePanels walks tree and floats" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "a");
+    defer layout.deinit();
+    try layout.splitLeaf(layout.root, .right, "b");
+    try layout.floatPanel("b", .{ .x = 0, .y = 0, .w = 100, .h = 100 });
+
+    var list: std.ArrayList(PanelId) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try layout.collectActivePanels(&list, std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), list.items.len);
+}
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/widgets/DockingWidget/Layout.zig
+++ b/src/widgets/DockingWidget/Layout.zig
@@ -370,6 +370,217 @@ pub fn apply(self: *DockLayout, m: Mutation) !void {
     }
 }
 
+/// Schema:
+/// ```json
+/// { "version": 1,
+///   "root": { "split": { "dir": "horizontal", "ratio": 0.5,
+///     "first": { "leaf": { "tabs": ["a"], "active": 0 } },
+///     "second": { "leaf": { "tabs": ["b"], "active": 0 } } } },
+///   "floats": [ { "rect": [x,y,w,h], "leaf": { "tabs": ["c"], "active": 0 } } ] }
+/// ```
+/// No dvui dependency beyond `std.json` and the plain data types already
+/// used elsewhere in this file.
+pub fn writeJson(self: *const DockLayout, writer: *std.Io.Writer) !void {
+    var s: std.json.Stringify = .{ .writer = writer };
+    try s.beginObject();
+
+    try s.objectField("version");
+    try s.write(1);
+
+    try s.objectField("root");
+    try self.writeNodeJson(&s, self.root);
+
+    try s.objectField("floats");
+    try s.beginArray();
+    for (self.floats.items) |f| {
+        try s.beginObject();
+        try s.objectField("rect");
+        try s.beginArray();
+        try s.write(f.rect.x);
+        try s.write(f.rect.y);
+        try s.write(f.rect.w);
+        try s.write(f.rect.h);
+        try s.endArray();
+        try s.objectField("leaf");
+        try writeLeafJson(&s, self.nodes.items[f.leaf].leaf);
+        try s.endObject();
+    }
+    try s.endArray();
+
+    try s.endObject();
+}
+
+fn writeNodeJson(self: *const DockLayout, s: *std.json.Stringify, idx: NodeIndex) !void {
+    switch (self.nodes.items[idx]) {
+        .split => |sp| {
+            try s.beginObject();
+            try s.objectField("split");
+            try s.beginObject();
+            try s.objectField("dir");
+            try s.write(@tagName(sp.dir));
+            try s.objectField("ratio");
+            try s.write(sp.ratio);
+            try s.objectField("first");
+            try self.writeNodeJson(s, sp.first);
+            try s.objectField("second");
+            try self.writeNodeJson(s, sp.second);
+            try s.endObject();
+            try s.endObject();
+        },
+        .leaf => |l| {
+            try s.beginObject();
+            try s.objectField("leaf");
+            try writeLeafJson(s, l);
+            try s.endObject();
+        },
+        .free => unreachable,
+    }
+}
+
+fn writeLeafJson(s: *std.json.Stringify, l: Node.Leaf) !void {
+    try s.beginObject();
+    try s.objectField("tabs");
+    try s.beginArray();
+    for (l.tabs.items) |t| try s.write(t);
+    try s.endArray();
+    try s.objectField("active");
+    try s.write(l.active);
+    try s.endObject();
+}
+
+/// Deserializes a layout written by `writeJson`. `version` is required and
+/// must be `1`; any structural problem fails the whole parse (forward-fail —
+/// callers should catch, log, and fall back to a default layout rather than
+/// trying to salvage a partial tree).
+///
+/// Panel slug strings are duplicated with `allocator` (the `PanelId` contract
+/// elsewhere in this file — layout never dupes/frees — assumes app-owned
+/// static strings, which a parsed file can't provide). `DockLayout.deinit`
+/// only frees the per-leaf tab list containers, not the strings themselves,
+/// so pass an arena as `allocator` if you want one `arena.deinit()` to free
+/// both the layout and these slug copies together.
+pub fn parseJson(allocator: std.mem.Allocator, slice: []const u8) !DockLayout {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, slice, .{});
+    defer parsed.deinit();
+
+    const root_obj = switch (parsed.value) {
+        .object => |o| o,
+        else => return error.InvalidFormat,
+    };
+
+    const version = switch (root_obj.get("version") orelse return error.InvalidVersion) {
+        .integer => |i| i,
+        else => return error.InvalidVersion,
+    };
+    if (version != 1) return error.InvalidVersion;
+
+    var self = DockLayout.init(allocator);
+    errdefer self.deinit();
+
+    self.root = try parseNode(&self, root_obj.get("root") orelse return error.InvalidFormat);
+
+    if (root_obj.get("floats")) |floats_v| {
+        const floats_arr = switch (floats_v) {
+            .array => |a| a,
+            else => return error.InvalidFormat,
+        };
+        for (floats_arr.items) |fv| {
+            const fo = switch (fv) {
+                .object => |o| o,
+                else => return error.InvalidFormat,
+            };
+            const rect_arr = switch (fo.get("rect") orelse return error.InvalidFormat) {
+                .array => |a| a,
+                else => return error.InvalidFormat,
+            };
+            if (rect_arr.items.len != 4) return error.InvalidFormat;
+            const rect: dvui.Rect = .{
+                .x = try jsonNumber(rect_arr.items[0]),
+                .y = try jsonNumber(rect_arr.items[1]),
+                .w = try jsonNumber(rect_arr.items[2]),
+                .h = try jsonNumber(rect_arr.items[3]),
+            };
+            const leaf = try parseLeaf(&self, fo.get("leaf") orelse return error.InvalidFormat);
+            const idx = try self.allocNode();
+            self.nodes.items[idx] = .{ .leaf = leaf };
+            try self.floats.append(allocator, .{ .leaf = idx, .rect = rect });
+        }
+    }
+
+    return self;
+}
+
+fn jsonNumber(v: std.json.Value) !f32 {
+    return switch (v) {
+        .integer => |i| @floatFromInt(i),
+        .float => |f| @floatCast(f),
+        else => error.InvalidFormat,
+    };
+}
+
+fn parseLeaf(self: *DockLayout, v: std.json.Value) !Node.Leaf {
+    const obj = switch (v) {
+        .object => |o| o,
+        else => return error.InvalidFormat,
+    };
+    const tabs_arr = switch (obj.get("tabs") orelse return error.InvalidFormat) {
+        .array => |a| a,
+        else => return error.InvalidFormat,
+    };
+
+    var tabs: std.ArrayList(PanelId) = .empty;
+    for (tabs_arr.items) |tv| {
+        const str = switch (tv) {
+            .string => |str| str,
+            else => return error.InvalidFormat,
+        };
+        try tabs.append(self.allocator, try self.allocator.dupe(u8, str));
+    }
+
+    const active_raw: i64 = switch (obj.get("active") orelse std.json.Value{ .integer = 0 }) {
+        .integer => |i| i,
+        else => 0,
+    };
+    const active: usize = if (tabs.items.len == 0) 0 else @intCast(std.math.clamp(active_raw, 0, @as(i64, @intCast(tabs.items.len - 1))));
+
+    return .{ .tabs = tabs, .active = active };
+}
+
+fn parseNode(self: *DockLayout, v: std.json.Value) !NodeIndex {
+    const obj = switch (v) {
+        .object => |o| o,
+        else => return error.InvalidFormat,
+    };
+
+    if (obj.get("split")) |split_v| {
+        const so = switch (split_v) {
+            .object => |o| o,
+            else => return error.InvalidFormat,
+        };
+        const dir_str = switch (so.get("dir") orelse return error.InvalidFormat) {
+            .string => |str| str,
+            else => return error.InvalidFormat,
+        };
+        const dir = std.meta.stringToEnum(dvui.enums.Direction, dir_str) orelse return error.InvalidFormat;
+        const ratio = try jsonNumber(so.get("ratio") orelse std.json.Value{ .float = 0.5 });
+        const first = try parseNode(self, so.get("first") orelse return error.InvalidFormat);
+        const second = try parseNode(self, so.get("second") orelse return error.InvalidFormat);
+
+        const idx = try self.allocNode();
+        self.nodes.items[idx] = .{ .split = .{ .dir = dir, .ratio = ratio, .first = first, .second = second } };
+        return idx;
+    }
+
+    if (obj.get("leaf")) |leaf_v| {
+        const leaf = try parseLeaf(self, leaf_v);
+        const idx = try self.allocNode();
+        self.nodes.items[idx] = .{ .leaf = leaf };
+        return idx;
+    }
+
+    return error.InvalidFormat;
+}
+
 test "single leaf init and find" {
     var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "hierarchy");
     defer layout.deinit();
@@ -561,6 +772,46 @@ test "collectActivePanels walks tree and floats" {
     try layout.collectActivePanels(&list, std.testing.allocator);
 
     try std.testing.expectEqual(@as(usize, 2), list.items.len);
+}
+
+test "writeJson/parseJson round-trip preserves tree, tabs, and floats" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "a");
+    defer layout.deinit();
+    try layout.splitLeaf(layout.root, .right, "b");
+    try layout.insertTab(layout.findPanel("b").?, 1, "c");
+    try layout.floatPanel("c", .{ .x = 10, .y = 20, .w = 300, .h = 200 });
+
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+    try layout.writeJson(&out.writer);
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var loaded = try DockLayout.parseJson(arena.allocator(), out.written());
+    defer loaded.deinit();
+
+    try std.testing.expect(loaded.contains("a"));
+    try std.testing.expect(loaded.contains("b"));
+    try std.testing.expect(loaded.contains("c"));
+    try std.testing.expect(loaded.isFloat(loaded.findPanel("c").?));
+    try std.testing.expectEqual(Node.split, std.meta.activeTag(loaded.nodes.items[loaded.root]));
+
+    const b_float = loaded.floats.items[0];
+    try std.testing.expectApproxEqAbs(@as(f32, 10), b_float.rect.x, 0.01);
+    try std.testing.expectApproxEqAbs(@as(f32, 300), b_float.rect.w, 0.01);
+}
+
+test "parseJson forward-fails on missing or wrong version" {
+    try std.testing.expectError(error.InvalidVersion, DockLayout.parseJson(std.testing.allocator, "{}"));
+    try std.testing.expectError(error.InvalidVersion, DockLayout.parseJson(std.testing.allocator,
+        \\{"version": 2, "root": {"leaf": {"tabs": ["a"], "active": 0}}}
+    ));
+}
+
+test "parseJson forward-fails on malformed root" {
+    try std.testing.expectError(error.InvalidFormat, DockLayout.parseJson(std.testing.allocator,
+        \\{"version": 1, "root": {"nonsense": true}}
+    ));
 }
 
 test {

--- a/src/widgets/DockingWidget/Layout.zig
+++ b/src/widgets/DockingWidget/Layout.zig
@@ -42,6 +42,9 @@ pub const Float = struct {
 pub const MoveTarget = union(enum) {
     tab: struct { leaf: NodeIndex, index: usize },
     split: struct { leaf: NodeIndex, side: Side },
+    /// Splits the whole tree (root-edge drop zones), regardless of whether
+    /// `root` currently holds a leaf or a split.
+    split_root: Side,
 };
 
 pub const Mutation = union(enum) {
@@ -203,6 +206,33 @@ pub fn splitLeaf(self: *DockLayout, leaf_idx: NodeIndex, side: Side, panel: Pane
     self.nodes.items[leaf_idx] = .{ .split = .{ .dir = dir, .ratio = 0.5, .first = first, .second = second } };
 }
 
+/// Wraps the whole tree in a new split (root-edge drop zones): `root`'s
+/// current content (leaf or split) moves to one side, unchanged, and a fresh
+/// single-tab leaf holding `panel` goes on the other side. `root` itself
+/// keeps its index (now holding the new split), same trick as `splitLeaf`.
+pub fn splitRoot(self: *DockLayout, side: Side, panel: PanelId) !void {
+    const old_root = self.nodes.items[self.root];
+
+    const moved_idx = try self.allocNode();
+    self.nodes.items[moved_idx] = old_root;
+
+    const new_idx = try self.allocNode();
+    var new_tabs: std.ArrayList(PanelId) = .empty;
+    try new_tabs.append(self.allocator, panel);
+    self.nodes.items[new_idx] = .{ .leaf = .{ .tabs = new_tabs, .active = 0 } };
+
+    const dir: dvui.enums.Direction = switch (side) {
+        .left, .right => .horizontal,
+        .top, .bottom => .vertical,
+    };
+    const first, const second = switch (side) {
+        .left, .top => .{ new_idx, moved_idx },
+        .right, .bottom => .{ moved_idx, new_idx },
+    };
+
+    self.nodes.items[self.root] = .{ .split = .{ .dir = dir, .ratio = 0.5, .first = first, .second = second } };
+}
+
 /// Inserts `panel` as a new tab in `leaf_idx` at `tab_idx` (clamped) and activates it.
 pub fn insertTab(self: *DockLayout, leaf_idx: NodeIndex, tab_idx: usize, panel: PanelId) !void {
     const leaf = &self.nodes.items[leaf_idx].leaf;
@@ -302,6 +332,17 @@ pub fn movePanel(self: *DockLayout, panel: PanelId, target: MoveTarget) !void {
                 return;
             }
             try self.splitLeaf(s.leaf, s.side, panel);
+            self.removeFromLeaf(source_leaf, panel);
+        },
+        .split_root => |side| {
+            if (source_leaf == self.root) {
+                const tabs_len = self.nodes.items[source_leaf].leaf.tabs.items.len;
+                if (tabs_len <= 1) return; // only tab in the whole tree: nothing to split against
+                self.removeFromLeaf(source_leaf, panel);
+                try self.splitRoot(side, panel);
+                return;
+            }
+            try self.splitRoot(side, panel);
             self.removeFromLeaf(source_leaf, panel);
         },
     }
@@ -461,6 +502,32 @@ test "movePanel .split on own leaf with other tabs splits off the dragged one" {
     try std.testing.expectEqual(Node.split, std.meta.activeTag(layout.nodes.items[root]));
     try std.testing.expect(layout.contains("a"));
     try std.testing.expect(layout.contains("b"));
+}
+
+test "movePanel .split_root wraps a multi-panel tree, keeping root index stable" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "a");
+    defer layout.deinit();
+    try layout.splitLeaf(layout.root, .right, "b");
+    const root = layout.root;
+
+    try layout.movePanel("a", .{ .split_root = .bottom });
+
+    try std.testing.expect(layout.root == root);
+    try std.testing.expectEqual(Node.split, std.meta.activeTag(layout.nodes.items[root]));
+    try std.testing.expectEqual(dvui.enums.Direction.vertical, layout.nodes.items[root].split.dir);
+    try std.testing.expect(layout.contains("a"));
+    try std.testing.expect(layout.contains("b"));
+}
+
+test "movePanel .split_root onto self is a no-op when it is the only tab in the whole tree" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "a");
+    defer layout.deinit();
+    const root = layout.root;
+
+    try layout.movePanel("a", .{ .split_root = .left });
+
+    try std.testing.expect(layout.root == root);
+    try std.testing.expectEqual(Node.leaf, std.meta.activeTag(layout.nodes.items[root]));
 }
 
 test "floatPanel detaches a panel and freeNode/free-list is reused" {

--- a/src/widgets/DockingWidget/Layout.zig
+++ b/src/widgets/DockingWidget/Layout.zig
@@ -61,11 +61,10 @@ nodes: std.ArrayList(Node) = .empty,
 free_head: ?NodeIndex = null,
 root: NodeIndex = 0,
 floats: std.ArrayList(Float) = .empty,
-/// Set by `parseJson`: unlike the normal live-tree contract (app-owned
-/// static `PanelId` strings), a parsed file has no other stable source for
-/// the slugs, so `parseJson` duplicates them with `allocator` and `deinit`
-/// frees those copies. Don't set this yourself unless you also allocated
-/// every current and future `PanelId` you hand this layout with `allocator`.
+/// When set, this layout owns its tab slug strings: `deinit`/`removePanel`
+/// free them with `allocator`. `fromSnapshot` sets it (a loaded layout has no
+/// other stable source for the slugs). Don't set it yourself unless every
+/// `PanelId` you hand this layout is `allocator`-owned.
 owns_panel_ids: bool = false,
 
 pub fn init(allocator: std.mem.Allocator) DockLayout {
@@ -94,8 +93,8 @@ pub fn deinit(self: *DockLayout) void {
     self.* = undefined;
 }
 
-/// Frees the tab slug strings too when `owns_panel_ids` (set by `parseJson`),
-/// then the tab list container itself either way.
+/// Frees the tab slug strings too when `owns_panel_ids`, then the tab list
+/// container itself either way.
 fn freeLeafTabs(self: *DockLayout, l: *Node.Leaf) void {
     if (self.owns_panel_ids) {
         for (l.tabs.items) |t| self.allocator.free(t);
@@ -256,12 +255,10 @@ pub fn insertTab(self: *DockLayout, leaf_idx: NodeIndex, tab_idx: usize, panel: 
     leaf.active = idx;
 }
 
-/// Like `insertTab`, but safe to call with a borrowed/static `panel` string
-/// regardless of `owns_panel_ids`: duplicates it first when set, since
-/// `deinit`/`removePanel` will otherwise try to free a string they don't
-/// own (this is how a static id from an app's panel registry — e.g. a "show
-/// this panel again" menu action — safely ends up in a layout that was
-/// loaded from `parseJson`).
+/// Like `insertTab`, but duplicates `panel` when `owns_panel_ids` is set, so a
+/// borrowed/static id (e.g. from an app's panel registry) can be safely added
+/// to a layout that owns its ids — `deinit`/`removePanel` would otherwise try
+/// to free a string they don't own.
 pub fn insertTabOwned(self: *DockLayout, leaf_idx: NodeIndex, tab_idx: usize, panel: PanelId) !void {
     const id = if (self.owns_panel_ids) try self.allocator.dupe(u8, panel) else panel;
     errdefer if (self.owns_panel_ids) self.allocator.free(id);
@@ -280,14 +277,12 @@ fn reorderTab(self: *DockLayout, leaf_idx: NodeIndex, panel: PanelId, new_index:
     leaf.active = idx;
 }
 
-/// Removes `panel` from `leaf_idx` (must currently contain it), fixing up
-/// `active` and collapsing the tree/floats if the leaf becomes empty.
-/// Removal of the active tab activates the previous tab index, not 0.
-/// Removes `panel` from `leaf_idx` and returns the removed `PanelId` (the
-/// same string that was stored — still alive, just no longer in the tree),
-/// or null if it wasn't there. Callers relocating the panel elsewhere should
-/// ignore the return value; only a true deletion (`removePanel`) should free
-/// it (and only when `owns_panel_ids`).
+/// Removes `panel` from `leaf_idx`, fixing up `active` (removing the active tab
+/// activates the previous index, not 0) and collapsing the tree/floats if the
+/// leaf empties. Returns the removed `PanelId` — the same string, still alive,
+/// just no longer in the tree — or null if it wasn't there. Callers relocating
+/// the panel should ignore it; only `removePanel` frees it (and only when
+/// `owns_panel_ids`).
 fn removeFromLeaf(self: *DockLayout, leaf_idx: NodeIndex, panel: PanelId) ?PanelId {
     const leaf = &self.nodes.items[leaf_idx].leaf;
     const removed_idx = for (leaf.tabs.items, 0..) |t, i| {
@@ -406,219 +401,152 @@ pub fn apply(self: *DockLayout, m: Mutation) !void {
     }
 }
 
-/// Schema:
-/// ```json
-/// { "version": 1,
-///   "root": { "split": { "dir": "horizontal", "ratio": 0.5,
-///     "first": { "leaf": { "tabs": ["a"], "active": 0 } },
-///     "second": { "leaf": { "tabs": ["b"], "active": 0 } } } },
-///   "floats": [ { "rect": [x,y,w,h], "leaf": { "tabs": ["c"], "active": 0 } } ] }
-/// ```
-/// No dvui dependency beyond `std.json` and the plain data types already
-/// used elsewhere in this file.
-pub fn writeJson(self: *const DockLayout, writer: *std.Io.Writer) !void {
-    var s: std.json.Stringify = .{ .writer = writer };
-    try s.beginObject();
+/// Serialization-facing description of a whole layout: a recursive tree of
+/// splits and tabbed leaves plus the floating leaves. Holds only plain values
+/// (enums, floats, slices, tagged unions), so callers can (de)serialize it in
+/// whatever format they like — the widget never picks one. `snapshot` builds
+/// one from a live layout; `fromSnapshot` rebuilds a layout from one.
+pub const Snapshot = struct {
+    root: Tree,
+    floats: []const FloatNode = &.{},
 
-    try s.objectField("version");
-    try s.write(1);
+    pub const Tree = union(enum) {
+        split: Split,
+        leaf: Leaf,
 
-    try s.objectField("root");
-    try self.writeNodeJson(&s, self.root);
+        pub const Split = struct {
+            dir: dvui.enums.Direction,
+            ratio: f32 = 0.5,
+            first: *const Tree,
+            second: *const Tree,
+        };
 
-    try s.objectField("floats");
-    try s.beginArray();
-    for (self.floats.items) |f| {
-        try s.beginObject();
-        try s.objectField("rect");
-        try s.beginArray();
-        try s.write(f.rect.x);
-        try s.write(f.rect.y);
-        try s.write(f.rect.w);
-        try s.write(f.rect.h);
-        try s.endArray();
-        try s.objectField("leaf");
-        try writeLeafJson(&s, self.nodes.items[f.leaf].leaf);
-        try s.endObject();
+        pub const Leaf = struct {
+            tabs: []const PanelId,
+            active: usize = 0,
+        };
+    };
+
+    pub const FloatNode = struct {
+        rect: dvui.Rect,
+        leaf: Tree.Leaf,
+    };
+
+    /// Frees what `snapshot` allocated. Only valid on a `Snapshot` that
+    /// `snapshot` returned, not one deserialized or built by other means.
+    pub fn deinit(self: Snapshot, allocator: std.mem.Allocator) void {
+        freeTree(self.root, allocator);
+        for (self.floats) |f| allocator.free(f.leaf.tabs);
+        allocator.free(self.floats);
     }
-    try s.endArray();
 
-    try s.endObject();
+    fn freeTree(node: Tree, allocator: std.mem.Allocator) void {
+        switch (node) {
+            .split => |s| {
+                freeTree(s.first.*, allocator);
+                freeTree(s.second.*, allocator);
+                allocator.destroy(s.first);
+                allocator.destroy(s.second);
+            },
+            .leaf => |l| allocator.free(l.tabs),
+        }
+    }
+};
+
+/// Builds a `Snapshot` of the current layout. Tree nodes and tab arrays are
+/// allocated with `allocator`; the panel-id strings are borrowed from the live
+/// layout (valid until it next changes). Free with `Snapshot.deinit`.
+pub fn snapshot(self: *const DockLayout, allocator: std.mem.Allocator) !Snapshot {
+    const root = try self.snapshotNode(self.root, allocator);
+    errdefer Snapshot.freeTree(root, allocator);
+
+    var floats: std.ArrayList(Snapshot.FloatNode) = .empty;
+    errdefer {
+        for (floats.items) |f| allocator.free(f.leaf.tabs);
+        floats.deinit(allocator);
+    }
+    for (self.floats.items) |f| {
+        const leaf = try snapshotLeaf(self.nodes.items[f.leaf].leaf, allocator);
+        errdefer allocator.free(leaf.tabs);
+        try floats.append(allocator, .{ .rect = f.rect, .leaf = leaf });
+    }
+
+    return .{ .root = root, .floats = try floats.toOwnedSlice(allocator) };
 }
 
-fn writeNodeJson(self: *const DockLayout, s: *std.json.Stringify, idx: NodeIndex) !void {
+fn snapshotNode(self: *const DockLayout, idx: NodeIndex, allocator: std.mem.Allocator) !Snapshot.Tree {
     switch (self.nodes.items[idx]) {
         .split => |sp| {
-            try s.beginObject();
-            try s.objectField("split");
-            try s.beginObject();
-            try s.objectField("dir");
-            try s.write(@tagName(sp.dir));
-            try s.objectField("ratio");
-            try s.write(sp.ratio);
-            try s.objectField("first");
-            try self.writeNodeJson(s, sp.first);
-            try s.objectField("second");
-            try self.writeNodeJson(s, sp.second);
-            try s.endObject();
-            try s.endObject();
+            const first = try allocator.create(Snapshot.Tree);
+            errdefer allocator.destroy(first);
+            first.* = try self.snapshotNode(sp.first, allocator);
+            errdefer Snapshot.freeTree(first.*, allocator);
+
+            const second = try allocator.create(Snapshot.Tree);
+            errdefer allocator.destroy(second);
+            second.* = try self.snapshotNode(sp.second, allocator);
+
+            return .{ .split = .{ .dir = sp.dir, .ratio = sp.ratio, .first = first, .second = second } };
         },
-        .leaf => |l| {
-            try s.beginObject();
-            try s.objectField("leaf");
-            try writeLeafJson(s, l);
-            try s.endObject();
-        },
+        .leaf => |l| return .{ .leaf = try snapshotLeaf(l, allocator) },
         .free => unreachable,
     }
 }
 
-fn writeLeafJson(s: *std.json.Stringify, l: Node.Leaf) !void {
-    try s.beginObject();
-    try s.objectField("tabs");
-    try s.beginArray();
-    for (l.tabs.items) |t| try s.write(t);
-    try s.endArray();
-    try s.objectField("active");
-    try s.write(l.active);
-    try s.endObject();
+fn snapshotLeaf(l: Node.Leaf, allocator: std.mem.Allocator) !Snapshot.Tree.Leaf {
+    return .{ .tabs = try allocator.dupe(PanelId, l.tabs.items), .active = l.active };
 }
 
-/// Deserializes a layout written by `writeJson`. `version` is required and
-/// must be `1`; any structural problem fails the whole parse (forward-fail —
-/// callers should catch, log, and fall back to a default layout rather than
-/// trying to salvage a partial tree).
-///
-/// Panel slug strings are duplicated with `allocator` (the `PanelId` contract
-/// elsewhere in this file — layout never dupes/frees — assumes app-owned
-/// static strings, which a parsed file can't provide). This sets
-/// `owns_panel_ids`, so a plain `deinit()` frees those slug copies too, same
-/// as any other allocation this layout owns — no arena required. If you
-/// reconcile the parsed slugs against your own static registry (dropping
-/// unknown ones, say), do that before relying on `owns_panel_ids`-driven
-/// freeing, since it frees whatever strings are still in the tree at
-/// `deinit()`, not specifically "the ones parseJson allocated".
-pub fn parseJson(allocator: std.mem.Allocator, slice: []const u8) !DockLayout {
-    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, slice, .{});
-    defer parsed.deinit();
-
-    const root_obj = switch (parsed.value) {
-        .object => |o| o,
-        else => return error.InvalidFormat,
-    };
-
-    const version = switch (root_obj.get("version") orelse return error.InvalidVersion) {
-        .integer => |i| i,
-        else => return error.InvalidVersion,
-    };
-    if (version != 1) return error.InvalidVersion;
-
+/// Rebuilds a live layout from `snap` (typically freshly deserialized). Panel
+/// ids are duplicated with `allocator` and owned by the result
+/// (`owns_panel_ids`), so `snap` and its backing bytes may be freed right
+/// after. Any well-formed `Snapshot` yields a valid layout.
+pub fn fromSnapshot(allocator: std.mem.Allocator, snap: Snapshot) !DockLayout {
     var self = DockLayout.init(allocator);
     self.owns_panel_ids = true;
     errdefer self.deinit();
 
-    self.root = try parseNode(&self, root_obj.get("root") orelse return error.InvalidFormat);
-
-    if (root_obj.get("floats")) |floats_v| {
-        const floats_arr = switch (floats_v) {
-            .array => |a| a,
-            else => return error.InvalidFormat,
-        };
-        for (floats_arr.items) |fv| {
-            const fo = switch (fv) {
-                .object => |o| o,
-                else => return error.InvalidFormat,
-            };
-            const rect_arr = switch (fo.get("rect") orelse return error.InvalidFormat) {
-                .array => |a| a,
-                else => return error.InvalidFormat,
-            };
-            if (rect_arr.items.len != 4) return error.InvalidFormat;
-            const rect: dvui.Rect = .{
-                .x = try jsonNumber(rect_arr.items[0]),
-                .y = try jsonNumber(rect_arr.items[1]),
-                .w = try jsonNumber(rect_arr.items[2]),
-                .h = try jsonNumber(rect_arr.items[3]),
-            };
-            const leaf = try parseLeaf(&self, fo.get("leaf") orelse return error.InvalidFormat);
-            const idx = try self.allocNode();
-            self.nodes.items[idx] = .{ .leaf = leaf };
-            try self.floats.append(allocator, .{ .leaf = idx, .rect = rect });
-        }
+    self.root = try self.buildNode(snap.root);
+    for (snap.floats) |f| {
+        const idx = try self.allocNode();
+        self.nodes.items[idx] = .{ .leaf = try self.buildLeaf(f.leaf) };
+        try self.floats.append(allocator, .{ .leaf = idx, .rect = f.rect });
     }
-
     return self;
 }
 
-fn jsonNumber(v: std.json.Value) !f32 {
-    return switch (v) {
-        .integer => |i| @floatFromInt(i),
-        .float => |f| @floatCast(f),
-        else => error.InvalidFormat,
-    };
+fn buildNode(self: *DockLayout, node: Snapshot.Tree) !NodeIndex {
+    switch (node) {
+        .split => |sp| {
+            const first = try self.buildNode(sp.first.*);
+            const second = try self.buildNode(sp.second.*);
+            const idx = try self.allocNode();
+            self.nodes.items[idx] = .{ .split = .{ .dir = sp.dir, .ratio = sp.ratio, .first = first, .second = second } };
+            return idx;
+        },
+        .leaf => |l| {
+            const idx = try self.allocNode();
+            self.nodes.items[idx] = .{ .leaf = try self.buildLeaf(l) };
+            return idx;
+        },
+    }
 }
 
-fn parseLeaf(self: *DockLayout, v: std.json.Value) !Node.Leaf {
-    const obj = switch (v) {
-        .object => |o| o,
-        else => return error.InvalidFormat,
-    };
-    const tabs_arr = switch (obj.get("tabs") orelse return error.InvalidFormat) {
-        .array => |a| a,
-        else => return error.InvalidFormat,
-    };
-
+fn buildLeaf(self: *DockLayout, l: Snapshot.Tree.Leaf) !Node.Leaf {
     var tabs: std.ArrayList(PanelId) = .empty;
-    for (tabs_arr.items) |tv| {
-        const str = switch (tv) {
-            .string => |str| str,
-            else => return error.InvalidFormat,
-        };
-        try tabs.append(self.allocator, try self.allocator.dupe(u8, str));
+    errdefer {
+        for (tabs.items) |t| self.allocator.free(t);
+        tabs.deinit(self.allocator);
     }
-
-    const active_raw: i64 = switch (obj.get("active") orelse std.json.Value{ .integer = 0 }) {
-        .integer => |i| i,
-        else => 0,
-    };
-    const active: usize = if (tabs.items.len == 0) 0 else @intCast(std.math.clamp(active_raw, 0, @as(i64, @intCast(tabs.items.len - 1))));
-
+    for (l.tabs) |t| {
+        const dup = try self.allocator.dupe(u8, t);
+        tabs.append(self.allocator, dup) catch |e| {
+            self.allocator.free(dup);
+            return e;
+        };
+    }
+    const active: usize = if (tabs.items.len == 0) 0 else @min(l.active, tabs.items.len - 1);
     return .{ .tabs = tabs, .active = active };
-}
-
-fn parseNode(self: *DockLayout, v: std.json.Value) !NodeIndex {
-    const obj = switch (v) {
-        .object => |o| o,
-        else => return error.InvalidFormat,
-    };
-
-    if (obj.get("split")) |split_v| {
-        const so = switch (split_v) {
-            .object => |o| o,
-            else => return error.InvalidFormat,
-        };
-        const dir_str = switch (so.get("dir") orelse return error.InvalidFormat) {
-            .string => |str| str,
-            else => return error.InvalidFormat,
-        };
-        const dir = std.meta.stringToEnum(dvui.enums.Direction, dir_str) orelse return error.InvalidFormat;
-        const ratio = try jsonNumber(so.get("ratio") orelse std.json.Value{ .float = 0.5 });
-        const first = try parseNode(self, so.get("first") orelse return error.InvalidFormat);
-        const second = try parseNode(self, so.get("second") orelse return error.InvalidFormat);
-
-        const idx = try self.allocNode();
-        self.nodes.items[idx] = .{ .split = .{ .dir = dir, .ratio = ratio, .first = first, .second = second } };
-        return idx;
-    }
-
-    if (obj.get("leaf")) |leaf_v| {
-        const leaf = try parseLeaf(self, leaf_v);
-        const idx = try self.allocNode();
-        self.nodes.items[idx] = .{ .leaf = leaf };
-        return idx;
-    }
-
-    return error.InvalidFormat;
 }
 
 test "single leaf init and find" {
@@ -781,13 +709,13 @@ test "movePanel .split_root onto self is a no-op when it is the only tab in the 
     try std.testing.expectEqual(Node.leaf, std.meta.activeTag(layout.nodes.items[root]));
 }
 
-test "insertTabOwned: a borrowed static id in an owning (parseJson'd) layout doesn't crash on deinit" {
-    // A real parseJson'd layout has every string duped from the start (never
-    // a mix); "a" here stands in for that, so deinit freeing it afterward is valid.
+test "insertTabOwned: a borrowed static id in an owning layout doesn't crash on deinit" {
+    // An owning layout has every string duped from the start (never a mix);
+    // "a" here stands in for that, so deinit freeing it afterward is valid.
     const owned_a = try std.testing.allocator.dupe(u8, "a");
     var layout = try DockLayout.initSingleLeaf(std.testing.allocator, owned_a);
     defer layout.deinit();
-    layout.owns_panel_ids = true; // simulates a layout loaded via parseJson
+    layout.owns_panel_ids = true; // simulates a layout loaded via fromSnapshot
 
     const static_id: PanelId = "profiler"; // NOT allocated by layout.allocator
     try layout.insertTabOwned(layout.root, 1, static_id);
@@ -841,21 +769,20 @@ test "collectActivePanels walks tree and floats" {
     try std.testing.expectEqual(@as(usize, 2), list.items.len);
 }
 
-test "writeJson/parseJson round-trip preserves tree, tabs, and floats" {
+test "snapshot/fromSnapshot round-trip preserves tree, tabs, and floats" {
     var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "a");
     defer layout.deinit();
     try layout.splitLeaf(layout.root, .right, "b");
     try layout.insertTab(layout.findPanel("b").?, 1, "c");
     try layout.floatPanel("c", .{ .x = 10, .y = 20, .w = 300, .h = 200 });
 
-    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
-    defer out.deinit();
-    try layout.writeJson(&out.writer);
+    const snap = try layout.snapshot(std.testing.allocator);
+    defer snap.deinit(std.testing.allocator);
 
     // Plain `std.testing.allocator` (no arena): exercises that `deinit`
-    // actually frees the slug strings `parseJson` duplicated, not just the
+    // actually frees the slug strings `fromSnapshot` duplicated, not just the
     // node/tab-list containers — `owns_panel_ids` is what makes that safe.
-    var loaded = try DockLayout.parseJson(std.testing.allocator, out.written());
+    var loaded = try DockLayout.fromSnapshot(std.testing.allocator, snap);
     defer loaded.deinit();
 
     try std.testing.expect(loaded.owns_panel_ids);
@@ -872,19 +799,6 @@ test "writeJson/parseJson round-trip preserves tree, tabs, and floats" {
     // Also exercise removePanel actually freeing an owned slug (not just deinit).
     loaded.removePanel("c");
     try std.testing.expect(!loaded.contains("c"));
-}
-
-test "parseJson forward-fails on missing or wrong version" {
-    try std.testing.expectError(error.InvalidVersion, DockLayout.parseJson(std.testing.allocator, "{}"));
-    try std.testing.expectError(error.InvalidVersion, DockLayout.parseJson(std.testing.allocator,
-        \\{"version": 2, "root": {"leaf": {"tabs": ["a"], "active": 0}}}
-    ));
-}
-
-test "parseJson forward-fails on malformed root" {
-    try std.testing.expectError(error.InvalidFormat, DockLayout.parseJson(std.testing.allocator,
-        \\{"version": 1, "root": {"nonsense": true}}
-    ));
 }
 
 test {

--- a/src/widgets/DockingWidget/Layout.zig
+++ b/src/widgets/DockingWidget/Layout.zig
@@ -256,6 +256,18 @@ pub fn insertTab(self: *DockLayout, leaf_idx: NodeIndex, tab_idx: usize, panel: 
     leaf.active = idx;
 }
 
+/// Like `insertTab`, but safe to call with a borrowed/static `panel` string
+/// regardless of `owns_panel_ids`: duplicates it first when set, since
+/// `deinit`/`removePanel` will otherwise try to free a string they don't
+/// own (this is how a static id from an app's panel registry — e.g. a "show
+/// this panel again" menu action — safely ends up in a layout that was
+/// loaded from `parseJson`).
+pub fn insertTabOwned(self: *DockLayout, leaf_idx: NodeIndex, tab_idx: usize, panel: PanelId) !void {
+    const id = if (self.owns_panel_ids) try self.allocator.dupe(u8, panel) else panel;
+    errdefer if (self.owns_panel_ids) self.allocator.free(id);
+    try self.insertTab(leaf_idx, tab_idx, id);
+}
+
 /// Reorders `panel` (already in `leaf_idx`) to `new_index` within the same leaf.
 fn reorderTab(self: *DockLayout, leaf_idx: NodeIndex, panel: PanelId, new_index: usize) void {
     const leaf = &self.nodes.items[leaf_idx].leaf;
@@ -767,6 +779,33 @@ test "movePanel .split_root onto self is a no-op when it is the only tab in the 
 
     try std.testing.expect(layout.root == root);
     try std.testing.expectEqual(Node.leaf, std.meta.activeTag(layout.nodes.items[root]));
+}
+
+test "insertTabOwned: a borrowed static id in an owning (parseJson'd) layout doesn't crash on deinit" {
+    // A real parseJson'd layout has every string duped from the start (never
+    // a mix); "a" here stands in for that, so deinit freeing it afterward is valid.
+    const owned_a = try std.testing.allocator.dupe(u8, "a");
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, owned_a);
+    defer layout.deinit();
+    layout.owns_panel_ids = true; // simulates a layout loaded via parseJson
+
+    const static_id: PanelId = "profiler"; // NOT allocated by layout.allocator
+    try layout.insertTabOwned(layout.root, 1, static_id);
+
+    try std.testing.expect(layout.contains("profiler"));
+    // Removing it exercises the free path too (not just deinit's).
+    layout.removePanel("profiler");
+    try std.testing.expect(!layout.contains("profiler"));
+}
+
+test "insertTabOwned: leaves a borrowed id borrowed when the layout doesn't own its ids" {
+    var layout = try DockLayout.initSingleLeaf(std.testing.allocator, "a");
+    defer layout.deinit();
+
+    const static_id: PanelId = "profiler";
+    try layout.insertTabOwned(layout.root, 1, static_id);
+
+    try std.testing.expectEqual(static_id.ptr, layout.nodes.items[layout.root].leaf.tabs.items[1].ptr);
 }
 
 test "floatPanel detaches a panel and freeNode/free-list is reused" {

--- a/src/widgets/FloatingTooltipWidget.zig
+++ b/src/widgets/FloatingTooltipWidget.zig
@@ -98,6 +98,13 @@ pub fn init(self: *FloatingTooltipWidget, src: std.builtin.SourceLocation, init_
             // rectFor/minSizeForChild which is important because we are outside
             // normal layout
             .rect = opts_in.rect orelse .{},
+            // Identity only — the rest of `opts_in` styles the *content* (see
+            // `self.options` below) and must not reach layout here. Without
+            // these, every tooltip sharing a source location shares an id, so
+            // one of them showing makes all of them show (`_showing` is keyed
+            // by id) and they collide in `subwindowAdd`.
+            .id_extra = opts_in.id_extra,
+            .tag = opts_in.tag,
         })),
         // get scale from parent
         .scale_val = init_opts.scale orelse (dvui.parentGet().screenRectScale(Rect{}).s / dvui.windowNaturalScale()),


### PR DESCRIPTION
dvui has no way to let users rearrange panels — split, tab together, float, drag between areas — the way VSCode, Unreal, or Unity do.

A brief technical how-to:

- `DockLayout` is a pure-data binary tree of splits and tabbed leaves, with stable node slots (free-list, never compacted) so a `split_ratio` pointer or a panel's scroll state survives the tree being rearranged around it.
- `dvui.dockspace()` walks that tree, opening a `PanedWidget` per split and a tabbed header + content box per leaf, exposed to the caller as a simple pull loop (`while (dock.panel()) |p|`).
- Dragging a tab computes drop zones (center = new tab in same zone, edges = split that side) live against the mouse and resolves on release; everything (clicks, drags, closes) is queued as a mutation and applied once per frame so the tree stays immutable for the whole walk.
- Floating panels reuse `FloatingWindowWidget`.
- Persistence is a thin `writeJson`/`parseJson` pair on plain `std.json` — no opinion on *how* an app should save it, just a stable schema.

Potential missing features: no OS-level window detachment and no undo for layout changes.

We might adjust API based on review