### PR TITLE
Add hover fading (helper + menu and button)

### DIFF
--- a/src/Examples/styling.zig
+++ b/src/Examples/styling.zig
@@ -19,7 +19,13 @@ pub fn styling() void {
     }
 
     {
-        dvui.label(@src(), "Styling Buttons", .{}, .{});
+        {
+            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+            defer hbox.deinit();
+
+            dvui.label(@src(), "Styling Buttons", .{}, .{});
+            _ = dvui.sliderEntry(@src(), "hover fade: {d:0.2}", .{ .value = &dvui.hover_fade_secs, .min = 0, .max = 1.0, .interval = 0.01 }, .{ .min_size_content = .width(200) });
+        }
 
         var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
         defer hbox.deinit();

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1975,18 +1975,17 @@ pub var hover_fade_secs: f32 = 0.12;
 /// Only valid between `Window.begin` and `Window.end`.
 pub fn hoverFade(id: Id, hovered: bool) f32 {
     const target: f32 = if (hovered) 1 else 0;
-    if (reduce_motion) return target;
+    if (reduce_motion or hover_fade_secs == 0.0) return target;
     // Default 0 (instead of target) so a widget with the first frame already hovered
     // (e.g. a context-menu item that pops up under the cursor) fades in rather
     // than starting fully lit.
-    var cur = dataGetDefault(null, id, "_hover_fade", f32, 0);
-    if (cur != target) {
+    const cur = dataGetPtrDefault(null, id, "__hover_fade", f32, 0);
+    if (cur.* != target) {
         const step = currentWindow().secs_since_last_frame / hover_fade_secs;
-        cur = if (cur < target) @min(target, cur + step) else @max(target, cur - step);
-        dataSet(null, id, "_hover_fade", cur);
+        cur.* = if (cur.* < target) @min(target, cur.* + step) else @max(target, cur.* - step);
         refresh(null, @src(), id);
     }
-    return cur;
+    return cur.*;
 }
 
 /// Add a timer for id that will be `timerDone` on the first frame after micros

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1966,6 +1966,29 @@ pub fn animationGet(id: Id, key: []const u8) ?Animation {
     return currentWindow().animations.get(h);
 }
 
+/// How long a hover fade (see `hoverFade`) takes to reach full intensity.
+pub var hover_fade_secs: f32 = 0.12;
+
+/// Lets a hover wash fade in and out (instead of snapping the frame at once).
+/// Call at most once per widget per frame.
+///
+/// Only valid between `Window.begin` and `Window.end`.
+pub fn hoverFade(id: Id, hovered: bool) f32 {
+    const target: f32 = if (hovered) 1 else 0;
+    if (reduce_motion) return target;
+    // Default 0 (instead of target) so a widget with the first frame already hovered
+    // (e.g. a context-menu item that pops up under the cursor) fades in rather
+    // than starting fully lit.
+    var cur = dataGetDefault(null, id, "_hover_fade", f32, 0);
+    if (cur != target) {
+        const step = currentWindow().secs_since_last_frame / hover_fade_secs;
+        cur = if (cur < target) @min(target, cur + step) else @max(target, cur - step);
+        dataSet(null, id, "_hover_fade", cur);
+        refresh(null, @src(), id);
+    }
+    return cur;
+}
+
 /// Add a timer for id that will be `timerDone` on the first frame after micros
 /// has passed.
 ///

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -108,12 +108,13 @@ pub fn drawFocus(self: *ButtonWidget) void {
 /// Returns an `Options` struct with color/style overrides for the hover and press state
 pub fn style(self: *ButtonWidget) Options {
     var opts = self.data().options.styleOnly();
+    const t = dvui.hoverFade(self.data().id, self.hover);
     if (dvui.captured(self.data().id)) {
         opts.color_fill = self.data().options.color(.fill_press);
         opts.color_text = self.data().options.color(.text_press);
-    } else if (self.hover) {
-        opts.color_fill = self.data().options.color(.fill_hover);
-        opts.color_text = self.data().options.color(.text_hover);
+    } else if (t > 0) {
+        opts.color_fill = self.data().options.color(.fill).lerp(self.data().options.color(.fill_hover), t);
+        opts.color_text = self.data().options.color(.text).lerp(self.data().options.color(.text_hover), t);
     }
     return opts;
 }

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -116,13 +116,12 @@ pub fn style(self: *MenuItemWidget) Options {
     var opts: Options = self.data().options.styleOnly();
     if (self.show_active and !self.init_opts.focus_as_outline) {
         const rest_fill = opts.color(.fill);
-        const rest_text = opts.color(.text);
         opts.style = .highlight;
         const active_fill = opts.color_fill_hover orelse opts.color(.fill);
         const active_text = opts.color_text_hover orelse opts.color(.text_hover);
         if (self.highlight) {
             opts.color_fill = rest_fill.lerp(active_fill, self.hover_t);
-            opts.color_text = rest_text.lerp(active_text, self.hover_t);
+            opts.color_text = active_text;
         } else {
             opts.color_fill = active_fill;
             opts.color_text = active_text;

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -36,6 +36,7 @@ init_opts: InitOptions,
 activated: bool = false,
 show_active: bool = false,
 mouse_over: bool = false,
+hover_t: f32 = 0,
 
 /// It's expected to call this when `self` is `undefined`
 pub fn init(self: *MenuItemWidget, src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) void {
@@ -61,6 +62,8 @@ pub fn init(self: *MenuItemWidget, src: std.builtin.SourceLocation, init_opts: I
 }
 
 pub fn drawBackground(self: *MenuItemWidget) void {
+    self.hover_t = dvui.hoverFade(self.data().id, self.highlight);
+
     var focused: bool = self.data().id == dvui.focusedWidgetId();
 
     if (self.data().id == dvui.focusedWidgetIdInCurrentSubwindow()) {
@@ -100,7 +103,7 @@ pub fn drawBackground(self: *MenuItemWidget) void {
             } else {
                 rs.r.fill(cr, .{ .color = cols.color(.fill), .fade = 1.0 });
             }
-        } else if ((self.data().id == dvui.focusedWidgetIdInCurrentSubwindow()) or self.highlight) {
+        } else if ((self.data().id == dvui.focusedWidgetIdInCurrentSubwindow()) or self.highlight or self.hover_t > 0) {
             rs.r.fill(cr, .{ .color = cols.color(.fill), .fade = 1.0 });
         } else if (self.data().options.backgroundGet()) {
             rs.r.fill(cr, .{ .color = cols.color(.fill), .fade = 1.0 });
@@ -115,10 +118,10 @@ pub fn style(self: *MenuItemWidget) Options {
         opts.style = .highlight;
         opts.color_fill = opts.color_fill_hover orelse opts.color(.fill);
         opts.color_text = opts.color_text_hover orelse opts.color(.text_hover);
-    } else if (self.highlight) {
-        // mouse is over us
-        opts.color_fill = opts.color_fill_hover orelse opts.color(.fill_hover);
-        opts.color_text = opts.color_text_hover orelse opts.color(.text_hover);
+    } else if (self.hover_t > 0) {
+        // mouse is over us (or just left us)
+        opts.color_fill = opts.color(.fill).lerp(opts.color_fill_hover orelse opts.color(.fill_hover), self.hover_t);
+        opts.color_text = opts.color(.text).lerp(opts.color_text_hover orelse opts.color(.text_hover), self.hover_t);
     }
 
     return opts;

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -115,9 +115,18 @@ pub fn drawBackground(self: *MenuItemWidget) void {
 pub fn style(self: *MenuItemWidget) Options {
     var opts: Options = self.data().options.styleOnly();
     if (self.show_active and !self.init_opts.focus_as_outline) {
+        const rest_fill = opts.color(.fill);
+        const rest_text = opts.color(.text);
         opts.style = .highlight;
-        opts.color_fill = opts.color_fill_hover orelse opts.color(.fill);
-        opts.color_text = opts.color_text_hover orelse opts.color(.text_hover);
+        const active_fill = opts.color_fill_hover orelse opts.color(.fill);
+        const active_text = opts.color_text_hover orelse opts.color(.text_hover);
+        if (self.highlight) {
+            opts.color_fill = rest_fill.lerp(active_fill, self.hover_t);
+            opts.color_text = rest_text.lerp(active_text, self.hover_t);
+        } else {
+            opts.color_fill = active_fill;
+            opts.color_text = active_text;
+        }
     } else if (self.hover_t > 0) {
         // mouse is over us (or just left us)
         opts.color_fill = opts.color(.fill).lerp(opts.color_fill_hover orelse opts.color(.fill_hover), self.hover_t);


### PR DESCRIPTION
(I know this isn't fully complete - other widgets didn't get it, but I needed just this for now, so this is what I implemented. If you want me to implement for others, I can. I figured I'll submit it meanwhile.)

This introduces the ability to have hover fade helper, and I added hover fade ability for both ButtonWidget and MenuItemWidget. The commits have a better description.

It respects `reduce_motion` too.