### PR TITLE
fix: specify opengl internal texture format as rgba8

### DIFF
--- a/src/backends/render/opengl.zig
+++ b/src/backends/render/opengl.zig
@@ -295,7 +295,7 @@ pub fn renderTarget(self: *@This(), maybe_texture: ?dvui.TextureTarget) !void {
 }
 
 fn createTexture(pixels: ?[*]const u8, options: dvui.Texture.CreateOptions) !u32 {
-    if (options.format != .rgba_32) {
+    if (options.format != .RGBA_32) {
         log.err("unsupported texture format", .{});
         return dvui.Backend.TextureError.TextureCreate;
     }
@@ -303,7 +303,7 @@ fn createTexture(pixels: ?[*]const u8, options: dvui.Texture.CreateOptions) !u32
     var texture: u32 = undefined;
     gl.genTextures(1, &texture);
     gl.bindTexture(gl.TEXTURE_2D, texture);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, @bitCast(options.width), @bitCast(options.height), 0, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, @bitCast(options.width), @bitCast(options.height), 0, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
 
     switch (options.wrap_u) {
         .clamp => gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE),

--- a/src/backends/render/opengl.zig
+++ b/src/backends/render/opengl.zig
@@ -295,7 +295,7 @@ pub fn renderTarget(self: *@This(), maybe_texture: ?dvui.TextureTarget) !void {
 }
 
 fn createTexture(pixels: ?[*]const u8, options: dvui.Texture.CreateOptions) !u32 {
-    if (options.format != .RGBA_32) {
+    if (options.format != .rgba_32) {
         log.err("unsupported texture format", .{});
         return dvui.Backend.TextureError.TextureCreate;
     }


### PR DESCRIPTION
this fixes issues for anyone attempting to use more modern opengl features on dvui textures. we already use u8 arrays, so this matches current behavior