### PR TITLE
Attempt to remove performance drops on very long single lines

### DIFF
--- a/src/Font.zig
+++ b/src/Font.zig
@@ -355,6 +355,10 @@ pub const Cache = struct {
     database: std.ArrayList(Source) = .empty,
     cache: dvui.TrackingAutoHashMap(u64, Entry, .get_and_put, void) = .empty,
 
+    /// Most recent `getOrCreate` hit, to skip hashing and probing for the very common case of
+    /// asking for the same font over and over.
+    last: ?struct { font: Font, entry: *Entry } = null,
+
     pub fn deinit(self: *Cache, gpa: std.mem.Allocator, backend: Backend) void {
         defer self.* = undefined;
         var it = self.cache.iterator();
@@ -372,11 +376,21 @@ pub const Cache = struct {
     }
 
     pub fn reset(self: *Cache, gpa: std.mem.Allocator, backend: Backend) void {
+        self.last = null;
         var it = self.cache.iterator();
         while (it.next_resetting()) |kv| {
             var fce = kv.value;
             fce.deinit(gpa, backend);
         }
+    }
+
+    /// Whether two fonts resolve to the same entry, the same fields the hash covers.
+    /// `line_height_factor`/`underline`/`strike` are deliberately excluded..
+    fn sameEntry(a: Font, b: Font) bool {
+        return a.size == b.size and
+            a.weight == b.weight and
+            a.style == b.style and
+            std.mem.eql(u8, &a.family, &b.family);
     }
 
     pub fn findSource(self: *Cache, font: Font) struct { ?Source, ?Source } {
@@ -405,8 +419,21 @@ pub const Cache = struct {
     }
 
     pub fn getOrCreate(self: *Cache, gpa: std.mem.Allocator, font: Font) std.mem.Allocator.Error!*Entry {
+        if (self.last) |l| {
+            if (sameEntry(l.font, font)) {
+                // Still has to mark the entry used, or `reset` (every frame) would evict a font
+                // that is being asked for constantly
+                @TypeOf(self.cache).setUsed(l.entry, true);
+                return l.entry;
+            }
+        }
+
         const entry = try self.cache.getOrPut(gpa, font.hash());
-        if (entry.found_existing) return entry.value_ptr;
+        if (entry.found_existing) {
+            self.last = .{ .font = font, .entry = entry.value_ptr };
+            return entry.value_ptr;
+        }
+        self.last = null;
 
         const fname = font.name(gpa);
         defer gpa.free(fname);
@@ -447,10 +474,16 @@ pub const Cache = struct {
         em_height: f32, // height of M
         glyph_info: std.AutoHashMapUnmanaged(u32, GlyphInfo) = .empty,
         glyph_info_ascii: [ascii_size - ascii_start]GlyphInfo,
+        /// Kerning between two printable ASCII characters, filled on first use. Measuring text asks
+        /// for kerning once per character pair, and asking the font means a binary search of its character
+        /// map for each of the two codepoints plus one of its kerning table, so a 200k-character line
+        /// is 600k binary searches for what is, in ASCII text, at most a few thousand distinct answers.
+        kern_ascii: [ascii_size - ascii_start][ascii_size - ascii_start]f32 = @splat(@splat(kern_unknown)),
         texture_atlas_cache: ?Texture = null,
 
         const ascii_size = 127;
         const ascii_start = 32;
+        const kern_unknown = std.math.nan(f32);
 
         const GlyphInfo = struct {
             advance: f32, // horizontal distance to move the pen
@@ -822,6 +855,20 @@ pub const Cache = struct {
         }
 
         pub fn kern(fce: *Entry, codepoint1: u32, codepoint2: u32) f32 {
+            const cache_slot: ?*f32 = blk: {
+                if (codepoint1 < ascii_start or codepoint1 >= ascii_size) break :blk null;
+                if (codepoint2 < ascii_start or codepoint2 >= ascii_size) break :blk null;
+                const slot = &fce.kern_ascii[codepoint1 - ascii_start][codepoint2 - ascii_start];
+                if (!std.math.isNan(slot.*)) return slot.*;
+                break :blk slot;
+            };
+
+            const k = fce.kernUncached(codepoint1, codepoint2);
+            if (cache_slot) |slot| slot.* = k;
+            return k;
+        }
+
+        fn kernUncached(fce: *Entry, codepoint1: u32, codepoint2: u32) f32 {
             if (impl == .FreeType) {
                 const index1 = c.FT_Get_Char_Index(fce.face, codepoint1);
                 const index2 = c.FT_Get_Char_Index(fce.face, codepoint2);

--- a/src/render.zig
+++ b/src/render.zig
@@ -241,6 +241,8 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
         next_kern_idx += 1;
     }
 
+    const clip = dvui.clipGet();
+
     var i: usize = 0;
     while (i < opts.text.len) {
         const cplen = std.unicode.utf8ByteSequenceLength(opts.text[i]) catch unreachable;
@@ -311,8 +313,16 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
             }
         }
 
+        // Glyphs that land entirely outside the clip rect horizontally can't produce a visible
+        // pixel, and a single unwrapped line can be enormous (minified JSON on one line), where
+        // four vertices per glyph runs out of `Vertex.Index` long before any of them would have
+        // been drawn. Everything above still runs, so x, kerning and selection bookkeeping stay
+        // exact; only the quads are dropped. Rotation can swing an off-clip glyph back into
+        // view, so it opts out.
+        const off_clip = opts.rotation == 0 and (leftx > clip.x + clip.w or nextx < clip.x);
+
         // don't output triangles for a zero-width glyph (space seems to be the only one)
-        if (gi.w > 0) {
+        if (gi.w > 0 and !off_clip) {
             const vtx_offset: dvui.Vertex.Index = @intCast(builder.vertexes.items.len);
             var v: Vertex = undefined;
 

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -490,6 +490,11 @@ pub fn drawAfterText(self: *TextEntryWidget) void {
 }
 
 pub fn drawCursor(self: *TextEntryWidget) void {
+    // The caret is somewhere off the right edge that we declined to measure, so there is no
+    // position to draw it at. `scrollClip` below is wider than the text's own clip, so drawing
+    // the pinned position would put a caret on the edge instead of off screen.
+    if (self.textLayout.cursor_offscreen) return;
+
     var sel = self.textLayout.selectionGet(self.len);
     if (sel.empty()) {
         // the cursor can be slightly outside the textLayout clip

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -248,6 +248,11 @@ cache_layout: bool = false,
 cache_layout_bytes: ?bytesNeededReturn = null,
 cache_layout_bytes_seen: usize = 0,
 byte_height_ready: ?ByteHeight = null,
+/// Bytes that produced visible pixels this frame narrowed further by which
+/// parts of each line fell inside the clip rect horizontally
+visible_ranges: VisibleRanges = .{},
+visible_ranges_last: ?VisibleRanges = null,
+
 byte_heights: []ByteHeight = &.{}, // from last frame
 byte_heights_new: std.ArrayList(ByteHeight) = .empty, // creating this frame
 byte_height_after_idx: ?usize = null,
@@ -289,6 +294,7 @@ pub fn init(self: *TextLayoutWidget, src: std.builtin.SourceLocation, init_opts:
     if (dvui.dataGet(null, self.wd.id, "_click_num", u8)) |val| self.click_num = val;
     if (dvui.dataGet(null, self.wd.id, "_click_num_pt", dvui.Point.Physical)) |val| self.click_num_pt = val;
     if (dvui.dataGetSlice(null, self.wd.id, "_byte_heights", []ByteHeight)) |bh| self.byte_heights = bh;
+    if (dvui.dataGet(null, self.wd.id, "_visible_ranges", VisibleRanges)) |vr| self.visible_ranges_last = vr;
     if (dvui.dataGetSlice(null, self.wd.id, "__line_ascents", []LineAscent)) |la| self.line_ascents = la;
 
     if (dvui.dataGet(null, self.wd.id, "_scroll_to_cursor", bool) orelse false) {
@@ -1066,6 +1072,54 @@ fn cursorSeen(self: *TextLayoutWidget) void {
     }
 }
 
+pub const ByteRange = struct { start: usize, end: usize };
+
+/// The bytes that produced visible pixels, as a handful of runs rather than one range: a line
+/// wider than the viewport is laid out only up to the right edge (see `horizontalCull`), so the
+/// bytes on screen above it and below it are separated by a gap of bytes that aren't. Reporting
+/// that as a single span would put the whole off-screen middle back in, which is the entire point
+/// of the gap.
+pub const VisibleRanges = struct {
+    /// Enough for a few long lines in one viewport; past this, the smallest gaps are given up
+    /// rather than dropping ranges, so the result stays a superset of what's visible.
+    pub const max = 8;
+
+    /// A gap only pays for itself if what it saves a consumer beats the fixed cost of handling
+    /// another range, so don't split for a few off-screen characters at the end of a line.
+    const min_gap = 512;
+
+    buf: [max]ByteRange = @splat(.{ .start = 0, .end = 0 }),
+    count: usize = 0,
+
+    pub fn slice(self: *const VisibleRanges) []const ByteRange {
+        return self.buf[0..self.count];
+    }
+
+    /// `r` must start at or after the last added range — layout only ever moves forward.
+    fn add(self: *VisibleRanges, r: ByteRange) void {
+        if (self.count > 0) {
+            const last = &self.buf[self.count - 1];
+            if (r.start <= last.end + min_gap or self.count == max) {
+                last.end = @max(last.end, r.end);
+                return;
+            }
+        }
+        self.buf[self.count] = r;
+        self.count += 1;
+    }
+};
+
+/// What was visible on the previous frame.
+///
+/// Useful to callers that generate the text (a syntax highlighter) and can do less work for
+/// bytes that won't be seen: this widget already declines to lay out what it can, but it only
+/// knows the answer after laying out, so a caller deciding up front has to go on the previous
+/// frame.
+pub fn visibleBytesLastFrame(self: *const TextLayoutWidget) []const ByteRange {
+    if (self.visible_ranges_last) |*vr| return vr.slice();
+    return &.{};
+}
+
 pub const ByteHeight = struct {
     pub const dist: f32 = 200.0; // record byte/height every this many logical pixels
 
@@ -1227,6 +1281,38 @@ fn checkAscent(self: *TextLayoutWidget) void {
     }
 }
 
+/// Left/right edges of the region that can produce visible pixels, or null when this frame must
+/// lay out every byte regardless of where it lands horizontally.
+///
+/// Only offered when `cache_layout` is on, for the same reason `cache_layout` exists at all:
+/// declining to measure text means `min_size.w` no longer sees it, and `bytesNeeded` is what
+/// carries the width forward from the frame that did measure it all.
+fn horizontalCull(self: *TextLayoutWidget, clip_logical: Rect) ?struct { left: f32, right: f32 } {
+    if (!self.cache_layout) return null;
+    if (self.break_lines) return null; // wrapped text never extends past the right edge anyway
+    return .{ .left = clip_logical.x, .right = clip_logical.x + clip_logical.w };
+}
+
+/// Whether this frame needs the exact position of bytes up to `end` even where they land off
+/// screen. Anything that answers "where is byte N" (a caret or selection edge to draw, a
+/// clipboard copy, an accessibility text run) or "which byte is at point P" (a click, a drag,
+/// a home/end motion) has no answer for text we declined to measure, so those frames pay for
+/// the full line. They're all transient — the steady state of a document just sitting on screen
+/// is none of them.
+fn needsExactPositions(self: *TextLayoutWidget, end: usize) bool {
+    if (self.copy_sel != null) return true;
+    if (self.sel_move != .none) return true;
+    if (self.sel_pts[0] != null or self.sel_pts[1] != null) return true;
+    if (!self.cursor_seen and self.selection.cursor <= end) return true;
+    // A selection edge inside the skipped run would leave `sel_start_r`/`sel_end_r` (the touch
+    // draggables) pointing at a stale position. `selectAll` parks `end` at maxInt, which is
+    // past everything and so never counts as inside.
+    if (self.selection.start >= self.bytes_seen and self.selection.start <= end) return true;
+    if (self.selection.end >= self.bytes_seen and self.selection.end <= end) return true;
+    if (dvui.accesskit_enabled and dvui.currentWindow().accesskit.text_run_parent != null) return true;
+    return false;
+}
+
 pub fn cacheLayoutBytes(self: *TextLayoutWidget) ?bytesNeededReturn {
     if (self.cache_layout_bytes == null) self.cache_layout_bytes = self.bytesNeeded(std.math.maxInt(usize), 0, 0);
     return self.cache_layout_bytes;
@@ -1264,6 +1350,26 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
         }
     }
 
+    // Horizontal culling. `cacheLayoutBytes` above narrowed us to the visible lines, but a
+    // single line can be far wider than the viewport, and everything below (shaping, glyph
+    // quads) costs per byte. If the pen already sits right of the clip rect, none of the bytes
+    // up to the next newline can produce a visible pixel, so skip the whole chunk without
+    // measuring it, since a syntax-highlighted long line arrives as
+    // thousands of one-token chunks. Chunks containing a newline fall through to the loop,
+    // which skips up to the newline and then lays the newline out normally so all the
+    // end-of-line bookkeeping keeps running in one place.
+    const clip_logical = self.data().contentRectScale().rectFromPhysical(dvui.clipGet());
+    const cull = self.horizontalCull(clip_logical);
+    if (cull) |c| {
+        if (self.insert_pt.x > c.right and
+            std.mem.indexOfScalar(u8, visible_chunk, '\n') == null and
+            !self.needsExactPositions(self.bytes_seen + visible_chunk.len))
+        {
+            self.bytes_seen += visible_chunk.len;
+            return null;
+        }
+    }
+
     var txt = dvui.toUtf8(cw.lifo(), visible_chunk) catch |err| blk: {
         dvui.logError(@src(), err, "Failed to convert to utf8", .{});
         break :blk visible_chunk;
@@ -1293,6 +1399,19 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
             //std.debug.print("byte_height_new append {d} {d}\n", .{ bhr.byte, bhr.height });
             self.byte_heights_new.append(cw.arena(), bhr) catch {};
             self.byte_height_ready = null;
+        }
+
+        // Rest of this line is off the right edge — see `horizontalCull`. Stop before the
+        // newline so the iteration after this one takes the normal path with `newline` set.
+        if (cull) |c| {
+            if (self.insert_pt.x > c.right) {
+                const skip = std.mem.indexOfScalar(u8, txt, '\n') orelse txt.len;
+                if (skip > 0 and !self.needsExactPositions(self.bytes_seen + skip)) {
+                    self.bytes_seen += skip;
+                    txt = txt[skip..];
+                    continue :text_loop;
+                }
+            }
         }
 
         self.current_line_height = @max(self.current_line_height, line_height);
@@ -1335,11 +1454,25 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
 
         var kern_buf: [10]u32 = @splat(0);
 
+        // Unwrapped text is measured to the newline no matter how far past the right edge that
+        // is, which is the whole cost of a 200k-character line. Stop at the edge instead and
+        // let the next iteration skip the remainder. Only the part of
+        // the run we don't need positions for can be dropped, so a caret or selection edge
+        // still ahead of us forces the full measure.
+        var max_width: ?f32 = if (self.break_lines) width else null;
+        if (max_width == null) {
+            if (cull) |c| {
+                if (!self.needsExactPositions(self.bytes_seen + txt.len)) {
+                    max_width = c.right - self.insert_pt.x + msize.w;
+                }
+            }
+        }
+
         // get slice of text that fits within width or ends with newline
         var ascent: f32 = undefined;
         var s = font.textSizeEx(txt, .{
             .kerning = self.kerning,
-            .max_width = if (self.break_lines) width else null,
+            .max_width = max_width,
             .end_idx = &end,
             .kern_out = &kern_buf,
             .ascent_out = &ascent,
@@ -1352,6 +1485,8 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
         }
 
         self.newline = (txt[end - 1] == '\n');
+
+        const cull_truncated = !self.break_lines and max_width != null and end < txt.len and !self.newline;
 
         //std.debug.print("{d} 1 txt to {d} \"{s}\"\n", .{ container_width, end, txt[0..end] });
 
@@ -1593,6 +1728,10 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
             };
         }
 
+        if (self.insert_pt.x <= clip_logical.x + clip_logical.w and self.insert_pt.x + s.w >= clip_logical.x) {
+            self.visible_ranges.add(.{ .start = self.bytes_seen, .end = self.bytes_seen + end });
+        }
+
         // Even if we don't actually render (might be outside clipping region),
         // need to update insert_pt and minSize like we did because our parent
         // might size based on that (might be in a scroll area)
@@ -1646,7 +1785,7 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
         }
 
         // move insert_pt to next line if we have more text
-        if (self.newline or txt.len > 0) {
+        if (!cull_truncated and (self.newline or txt.len > 0)) {
             self.checkAscent();
             self.line += 1;
             self.insert_pt.y += self.current_line_height;
@@ -2348,6 +2487,11 @@ pub fn deinit(self: *TextLayoutWidget) void {
     dvui.dataSet(null, self.data().id, "_sel_end_r", self.sel_end_r);
     dvui.dataSet(null, self.data().id, "_selection", self.selection.*);
     dvui.dataSetSlice(null, self.data().id, "_byte_heights", self.byte_heights_new.items);
+    if (self.visible_ranges.count > 0) {
+        dvui.dataSet(null, self.data().id, "_visible_ranges", self.visible_ranges);
+    } else {
+        dvui.dataRemove(null, self.data().id, "_visible_ranges");
+    }
     dvui.dataSetSlice(null, self.data().id, "__line_ascents", self.line_ascents_new.items);
 
     if (self.scroll_to_cursor_next_frame) {

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -226,6 +226,9 @@ sel_pts: [2]?Point = [2]?Point{ null, null },
 cursor_seen: bool = false,
 /// SAFETY: Set in `textAddEx`
 cursor_rect: Rect = undefined,
+/// The cursor landed in bytes horizontal culling skipped, so `cursor_rect` is pinned to the
+/// right edge rather than measured (see `cursorSkipped`). Don't paint a caret at it.
+cursor_offscreen: bool = false,
 scroll_to_cursor: bool = false,
 scroll_to_cursor_next_frame: bool = false,
 
@@ -1303,14 +1306,43 @@ fn needsExactPositions(self: *TextLayoutWidget, end: usize) bool {
     if (self.copy_sel != null) return true;
     if (self.sel_move != .none) return true;
     if (self.sel_pts[0] != null or self.sel_pts[1] != null) return true;
-    if (!self.cursor_seen and self.selection.cursor <= end) return true;
-    // A selection edge inside the skipped run would leave `sel_start_r`/`sel_end_r` (the touch
-    // draggables) pointing at a stale position. `selectAll` parks `end` at maxInt, which is
-    // past everything and so never counts as inside.
-    if (self.selection.start >= self.bytes_seen and self.selection.start <= end) return true;
-    if (self.selection.end >= self.bytes_seen and self.selection.end <= end) return true;
+    // The caret being inside the skipped run is not by itself a reason to measure it: the caret
+    // is off the right edge there, so drawing it is a no-op after clipping, and `cursorSkipped`
+    // pins it to the edge. Scrolling to it is the one thing that needs its real position. This
+    // matters because a caret sitting on a long line (byte 0 of a one-line JSON file, say) is a
+    // steady state, not a transient one, and forcing the full measure on it would give the line
+    // back its full cost on every frame.
+    if (self.scroll_to_cursor and !self.cursor_seen and self.selection.cursor <= end) return true;
+    // A selection edge inside the skipped run would leave `sel_start_r`/`sel_end_r` pointing at
+    // a stale position. Those only place the touch draggables, so only touch editing pays for
+    // it — same reasoning as the caret above, and select-all on a long line is just as much a
+    // steady state. `selectAll` parks `end` at maxInt, which is past everything and so never
+    // counts as inside.
+    if (self.touch_editing) {
+        if (self.selection.start >= self.bytes_seen and self.selection.start <= end) return true;
+        if (self.selection.end >= self.bytes_seen and self.selection.end <= end) return true;
+    }
     if (dvui.accesskit_enabled and dvui.currentWindow().accesskit.text_run_parent != null) return true;
     return false;
+}
+
+/// Horizontal culling is about to skip bytes ending at `skip_end`, which may be where the caret
+/// is. Nothing else this frame will fill in `cursor_rect` for it, and leaving `cursor_seen`
+/// false is worse than not knowing where the caret is: `needsExactPositions` would then put
+/// every later line back on the full-measure path.
+///
+/// The skipped bytes are all off the right edge, so pin the caret there and flag it as a
+/// position we didn't actually measure — `cursor_offscreen` is what keeps a caret from being
+/// painted at the edge it was pinned to. The frames that need its true position
+/// (`scroll_to_cursor`, any `sel_move`) never reach here.
+///
+/// Mirrors what `bytesNeeded` does when vertical culling starts below the caret.
+fn cursorSkipped(self: *TextLayoutWidget, skip_end: usize, right: f32) void {
+    if (self.cursor_seen) return;
+    if (self.selection.cursor > skip_end) return;
+    self.cursor_rect = .{ .x = right, .y = self.insert_pt.y, .w = 1, .h = self.current_line_height };
+    self.cursor_offscreen = true;
+    self.cursorSeen();
 }
 
 pub fn cacheLayoutBytes(self: *TextLayoutWidget) ?bytesNeededReturn {
@@ -1365,6 +1397,7 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
             std.mem.indexOfScalar(u8, visible_chunk, '\n') == null and
             !self.needsExactPositions(self.bytes_seen + visible_chunk.len))
         {
+            self.cursorSkipped(self.bytes_seen + visible_chunk.len, c.right);
             self.bytes_seen += visible_chunk.len;
             return null;
         }
@@ -1407,6 +1440,7 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
             if (self.insert_pt.x > c.right) {
                 const skip = std.mem.indexOfScalar(u8, txt, '\n') orelse txt.len;
                 if (skip > 0 and !self.needsExactPositions(self.bytes_seen + skip)) {
+                    self.cursorSkipped(self.bytes_seen + skip, c.right);
                     self.bytes_seen += skip;
                     txt = txt[skip..];
                     continue :text_loop;
@@ -2536,4 +2570,122 @@ fn textRunSrc() std.builtin.SourceLocation {
 
 test {
     @import("std").testing.refAllDecls(@This());
+}
+
+test "horizontal cull with the caret on the long line" {
+    // One enormous line, no newline anywhere: unformatted JSON. The caret defaults to byte 0,
+    // which is on screen, so this must not fall back to measuring the whole line
+    var text: [20000]u8 = @splat('a');
+
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 400, .h = 300 } });
+    defer t.deinit();
+
+    const Temp = struct {
+        var ranges: VisibleRanges = .{};
+        var cursor_seen: bool = false;
+        var cursor_offscreen: bool = false;
+        var content: []const u8 = undefined;
+        var put_cursor_at: ?usize = null;
+
+        fn frame() !dvui.App.Result {
+            var tl = dvui.textLayout(@src(), .{ .cache_layout = true, .break_lines = false }, .{ .expand = .both });
+            if (put_cursor_at) |c| tl.selection.moveCursor(c, false);
+            tl.addText(content, .{});
+            ranges = tl.visible_ranges;
+            cursor_seen = tl.cursor_seen;
+            cursor_offscreen = tl.cursor_offscreen;
+            tl.deinit();
+            return .ok;
+        }
+    };
+    Temp.content = &text;
+
+    try dvui.testing.settle(Temp.frame);
+
+    const ranges = Temp.ranges.slice();
+    try std.testing.expectEqual(1, ranges.len);
+    try std.testing.expectEqual(0, ranges[0].start);
+    try std.testing.expect(ranges[0].end < 500);
+    // The caret is inside the measured part here, but either way the frame has to end with it
+    // resolved or every later line pays for it.
+    try std.testing.expect(Temp.cursor_seen);
+    try std.testing.expect(!Temp.cursor_offscreen);
+
+    // Same line, caret now way off the right edge. Still no reason to measure up to it: nothing
+    // this frame is going to draw or scroll to it, so it gets pinned and flagged instead.
+    Temp.put_cursor_at = text.len - 1;
+    try dvui.testing.settle(Temp.frame);
+
+    const ranges2 = Temp.ranges.slice();
+    try std.testing.expectEqual(1, ranges2.len);
+    try std.testing.expect(ranges2[0].end < 500);
+    try std.testing.expect(Temp.cursor_seen);
+    try std.testing.expect(Temp.cursor_offscreen);
+}
+
+test "horizontal cull visible ranges, many overflowing lines" {
+    // Several lines that each run well past the right edge. Every line contributes a visible
+    // run followed by a gap (the off-screen tail), so this is the case where `VisibleRanges`
+    // runs out of slots: past `VisibleRanges.max` the remaining gaps are folded into the last
+    // range. The result must stay a superset of what's on screen, and must still be far less
+    // than the whole text, which is the point of culling.
+    const line_count = 10;
+    const line_len = 2000; // tail off screen is way past VisibleRanges.min_gap
+
+    var text: [line_count * (line_len + 1)]u8 = @splat('a');
+    for (0..line_count) |i| text[i * (line_len + 1) + line_len] = '\n';
+
+    var t = try dvui.testing.init(.{ .window_size = .{ .w = 400, .h = 300 } });
+    defer t.deinit();
+
+    const Temp = struct {
+        var ranges: VisibleRanges = .{};
+        var content: []const u8 = undefined;
+
+        fn frame() !dvui.App.Result {
+            var tl = dvui.textLayout(@src(), .{ .cache_layout = true, .break_lines = false }, .{ .expand = .both });
+            tl.addText(content, .{});
+
+            // Grab it before deinit stores it, so we're looking at this frame's answer.
+            ranges = tl.visible_ranges;
+
+            tl.deinit();
+            return .ok;
+        }
+    };
+    Temp.content = &text;
+
+    try dvui.testing.settle(Temp.frame);
+
+    const ranges = Temp.ranges.slice();
+    // More overflowing lines than there are slots, so the count saturates and the gaps in the
+    // tail get folded into the last range rather than dropped.
+    try std.testing.expectEqual(VisibleRanges.max, ranges.len);
+
+    var covered: usize = 0;
+    var prev_end: usize = 0;
+    for (ranges) |r| {
+        try std.testing.expect(r.start <= r.end);
+        try std.testing.expect(r.start >= prev_end); // sorted and non-overlapping
+        prev_end = r.end;
+        covered += r.end - r.start;
+    }
+
+    // Every line has visible bytes at its start, so each line start must be inside some range,
+    // even the lines whose gaps got folded away.
+    for (0..line_count) |i| {
+        const line_start = i * (line_len + 1);
+        var found = false;
+        for (ranges) |r| {
+            if (line_start >= r.start and line_start < r.end) found = true;
+        }
+        if (!found) {
+            std.debug.print("line {d} (byte {d}) not covered by {any}\n", .{ i, line_start, ranges });
+            return error.LineNotCovered;
+        }
+    }
+
+    // The off-screen tails dominate: culling has to have dropped most of the text even with
+    // the slots exhausted.
+    try std.testing.expect(covered < text.len / 2);
 }


### PR DESCRIPTION
Hi! 

This PR exists to try to tackle performance issues using TextLayoutWidget with very long single lines. Until now, it seems the performance work was handled per-line, so very long single lines (such as unformatted JSON, etc) end up causing performance issues quickly.

This PR implements two attempts to increase performance:

1. Horizontal culling
2. Avoid hashing font where possible (lots of asks for the same font)

Below are some benchmark results through fizzy:

ReleaseFast, `zig build bench-text` (on fizzy), ms/frame (lower is better).

**200,000-char line** (204 KB file)

| Build | Idle | Caret mid-line | Idle, no highlighting |
| --- | ---: | ---: | ---: |
| **Current (both fixes)** | **1.52** | **4.49** | **0.02** |
| Horizontal culling off | 22.48 | 23.27 | 3.77 |
| Font/kern cache off | 1.58 | 13.17 | 0.03 |

**Scaling with line length** (idle, ms/frame)

| Line length | Culling on | Culling off |
| --- | ---: | ---: |
| 2,000 chars | 0.42 | 0.58 |
| 20,000 chars | 1.51 | 2.31 |
| 200,000 chars | 1.52 | 22.48 |

Please let me know if you'd like me to remove comments or make any other changes, or if this is a wrong approach, I initially just tried to make things clearer to understand.