### PR TITLE
Add pugl backend

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1063,6 +1063,43 @@ pub fn buildBackend(
                 _ = addExample("wio-ontop", b.path("examples/wio-ontop.zig"), true, example_opts, dvui_opts);
             }
         },
+        .pugl => {
+            dvui_opts.setDefaults(.{ .libc = true, .freetype = true, .tiny_file_dialogs = true, .stb_image = true, .tree_sitter = true });
+
+            if (dvui_opts.render_backend == .default) {
+                dvui_opts.render_backend = .opengl;
+            }
+
+            const pugl_backend_mod = b.addModule("pugl", .{
+                .root_source_file = b.path("src/backends/pugl.zig"),
+                .target = target,
+                .optimize = optimize,
+            });
+            dvui_opts.addChecks(pugl_backend_mod, "pugl-backend");
+            dvui_opts.addTests(pugl_backend_mod, "pugl-backend");
+
+            if (b.lazyDependency("pugl", .{
+                .target = target,
+                .optimize = optimize,
+                .opengl = true,
+            })) |pugl| {
+                pugl_backend_mod.addImport("pugl", pugl.module("pugl"));
+                pugl_backend_mod.addImport("pugl-opengl", pugl.module("backend_opengl"));
+            }
+
+            const dvui_pugl = addDvuiModule("dvui_pugl", dvui_opts);
+            dvui_opts.addChecks(dvui_pugl, "dvui_pugl");
+            if (test_dvui_and_app)
+                dvui_opts.addTests(dvui_pugl, "dvui_pugl");
+
+            linkBackend(dvui_pugl, pugl_backend_mod);
+
+            _ = addExample("pugl-standalone", b.path("examples/pugl-standalone.zig"), true, .{
+                .dvui_mod = dvui_pugl,
+                .backend_name = "pugl-backend",
+                .backend_mod = pugl_backend_mod,
+            }, dvui_opts);
+        },
     }
 }
 

--- a/build.zig
+++ b/build.zig
@@ -1094,11 +1094,14 @@ pub fn buildBackend(
 
             linkBackend(dvui_pugl, pugl_backend_mod);
 
-            _ = addExample("pugl-standalone", b.path("examples/pugl-standalone.zig"), true, .{
+            const example_opts: ExampleOptions = .{
                 .dvui_mod = dvui_pugl,
                 .backend_name = "pugl-backend",
                 .backend_mod = pugl_backend_mod,
-            }, dvui_opts);
+            };
+
+            _ = addExample("pugl-standalone", b.path("examples/pugl-standalone.zig"), true, example_opts, dvui_opts);
+            _ = addExample("pugl-app", b.path("examples/app.zig"), test_dvui_and_app, example_opts, dvui_opts);
         },
     }
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -115,5 +115,10 @@
             .hash = "zgl-1.1.0-p_NpAJNECgCzUGx0aF5KFsmD5VOwfw8LaOsN0fcoU2bi",
             .lazy = true,
         },
+        .pugl = .{
+            .url = "git+https://github.com/bandithedoge/pugl.zig.git#fd9e92f4d8924add632d795c9aee08792d57a8f6",
+            .hash = "pugl-0.1.0-CUvtThRZAQCrKftq12FsCfgQfo2rRT3Y_bhxiuH1-Esi",
+            .lazy = true,
+        },
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -116,8 +116,8 @@
             .lazy = true,
         },
         .pugl = .{
-            .url = "git+https://github.com/bandithedoge/pugl.zig.git#fd9e92f4d8924add632d795c9aee08792d57a8f6",
-            .hash = "pugl-0.1.0-CUvtThRZAQCrKftq12FsCfgQfo2rRT3Y_bhxiuH1-Esi",
+            .url = "git+https://github.com/bandithedoge/pugl.zig.git#421f838133e081c6d23edd61c1545bdfc3ebe1ad",
+            .hash = "pugl-0.1.0-CUvtTm5dAQB7DY_J0RHTxDGSz1JNul6YlBpt_bp38kMe",
             .lazy = true,
         },
     },

--- a/examples/pugl-standalone.zig
+++ b/examples/pugl-standalone.zig
@@ -1,0 +1,147 @@
+const std = @import("std");
+const dvui = @import("dvui");
+const PuglBackend = @import("pugl-backend");
+const pugl = PuglBackend.pugl;
+
+comptime {
+    std.debug.assert(@hasDecl(PuglBackend, "pugl"));
+}
+
+const State = struct {
+    backend: *PuglBackend,
+    window: *dvui.Window,
+    io: std.Io,
+    run: bool = true,
+    scale: f32 = 1,
+    end_us: ?u32 = 0,
+    wait_us: u32 = 0,
+
+    pub fn guiFrame(self: *State) bool {
+        {
+            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .style = .window, .background = true, .expand = .horizontal, .name = "main" });
+            defer hbox.deinit();
+
+            var m = dvui.menu(@src(), .horizontal, .{});
+            defer m.deinit();
+
+            if (dvui.menuItemLabel(@src(), "File", .{ .submenu = true }, .{})) |r| {
+                var fw = dvui.floatingMenu(@src(), .{ .from = r }, .{});
+                defer fw.deinit();
+
+                if (dvui.menuItemLabel(@src(), "Close Menu", .{}, .{ .expand = .horizontal }) != null) {
+                    m.close();
+                }
+
+                if (dvui.menuItemLabel(@src(), "Exit", .{}, .{ .expand = .horizontal }) != null) {
+                    return false;
+                }
+            }
+        }
+
+        var scroll = dvui.scrollArea(@src(), .{}, .{ .expand = .both });
+        defer scroll.deinit();
+
+        var tl = dvui.textLayout(@src(), .{}, .{ .expand = .horizontal, .font = .theme(.title) });
+        tl.addText("This example shows how to use dvui with the pugl backend in a normal application.", .{});
+        tl.deinit();
+
+        const label = if (dvui.Examples.show_demo_window) "Hide Demo Window" else "Show Demo Window";
+        if (dvui.button(@src(), label, .{}, .{})) {
+            dvui.Examples.show_demo_window = !dvui.Examples.show_demo_window;
+        }
+
+        if (dvui.button(@src(), "Debug Window", .{}, .{})) {
+            dvui.toggleDebugWindow();
+        }
+
+        {
+            var scaler = dvui.scale(@src(), .{ .scale = &self.scale }, .{ .expand = .horizontal });
+            defer scaler.deinit();
+
+            var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+            defer hbox.deinit();
+
+            if (dvui.button(@src(), "Zoom In", .{}, .{})) {
+                self.scale = @round(dvui.themeGet().font_body.size * self.scale + 1.0) / dvui.themeGet().font_body.size;
+            }
+
+            if (dvui.button(@src(), "Zoom Out", .{}, .{})) {
+                self.scale = @round(dvui.themeGet().font_body.size * self.scale - 1.0) / dvui.themeGet().font_body.size;
+            }
+        }
+
+        // only shows the demo if dvui.Examples.show_demo_window is true
+        dvui.Examples.demo(.full);
+
+        return true;
+    }
+};
+
+pub fn main(init: std.process.Init) !void {
+    dvui.Examples.show_demo_window = true;
+
+    const world = try pugl.World.init(.program, .{});
+    defer world.deinit();
+
+    const view = try pugl.View.init(&world);
+    defer view.deinit();
+
+    try view.setBoolHint(.context_debug, true);
+
+    try view.setSizeHint(.default, .{ .width = 800, .height = 600 });
+    try view.setStringHint(.window_title, "DVUI pugl example");
+    try view.setBoolHint(.resizable, true);
+
+    try view.setEventFunc(onEvent);
+
+    var state: State = .{
+        .backend = undefined,
+        .window = undefined,
+        .io = init.io,
+    };
+
+    view.setHandle(&state);
+
+    var backend = try PuglBackend.init(.{
+        .io = init.io,
+        .gpa = init.gpa,
+        .view = view,
+    });
+    defer backend.deinit();
+    state.backend = &backend;
+
+    var window = try dvui.Window.init(@src(), init.gpa, backend.backend(), .{});
+    defer window.deinit();
+    state.window = &window;
+
+    try view.show(.raise);
+
+    while (state.run) {
+        state.backend.waitEventTimeout(state.wait_us);
+        state.wait_us = state.window.waitTime(state.end_us);
+    }
+}
+
+fn onEvent(view: *const pugl.View, event: pugl.event.Event) pugl.Error!void {
+    const state: *State = @ptrCast(@alignCast(view.getHandle()));
+    try state.backend.handleEvent(event, state.window);
+
+    switch (event) {
+        .expose => {
+            const nstime = state.window.beginWait(true);
+            state.window.begin(nstime) catch return error.BackendFailed;
+
+            state.backend.renderer.clear();
+            if (!state.guiFrame()) {
+                state.run = false;
+                return;
+            }
+
+            state.end_us = state.window.end(.{}) catch return error.BackendFailed;
+        },
+        .update => if (state.end_us != null) try view.obscure(),
+        .close => state.run = false,
+        .configure, .realize, .unrealize => {},
+        else => try view.obscure(),
+    }
+}

--- a/examples/pugl-standalone.zig
+++ b/examples/pugl-standalone.zig
@@ -86,8 +86,6 @@ pub fn main(init: std.process.Init) !void {
     const view = try pugl.View.init(&world);
     defer view.deinit();
 
-    try view.setBoolHint(.context_debug, true);
-
     try view.setSizeHint(.default, .{ .width = 800, .height = 600 });
     try view.setStringHint(.window_title, "DVUI pugl example");
     try view.setBoolHint(.resizable, true);

--- a/src/Examples/animations.zig
+++ b/src/Examples/animations.zig
@@ -209,7 +209,7 @@ pub fn animations() void {
             .web => dvui.label(@src(), "web: updated when not interrupted by event", .{}, .{}),
             .raylib, .raylib_zig => dvui.label(@src(), "raylib: updated when not interrupted by event", .{}, .{}),
             .dx11 => dvui.label(@src(), "dx11: only updated if non-null passed to waitTime", .{}, .{}),
-            .sdl, .custom, .testing, .proxy, .glfw, .wio => {},
+            .sdl, .custom, .testing, .proxy, .glfw, .wio, .pugl => {},
         }
     }
 

--- a/src/backends/pugl.zig
+++ b/src/backends/pugl.zig
@@ -1,0 +1,355 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const dvui = @import("dvui");
+pub const pugl = @import("pugl");
+pub const OpenGlBackend = @import("pugl-opengl");
+
+pub const kind = dvui.enums.Backend.pugl;
+
+io: std.Io,
+gpa: std.mem.Allocator,
+view: pugl.View,
+// SAFETY: assigned in begin
+arena: std.mem.Allocator = undefined,
+opengl_backend: OpenGlBackend,
+renderer: dvui.render_backend,
+
+pub fn backend(self: *@This()) dvui.Backend {
+    return .init(self, &self.renderer);
+}
+
+pub const InitOptions = struct {
+    io: std.Io,
+    gpa: std.mem.Allocator,
+    view: pugl.View,
+};
+
+/// This function will immediately call `pugl.View.realize` on `options.view`, so make sure it's properly configured
+/// before. Its graphics API hints and pugl render backend will be overwritten.
+pub fn init(options: InitOptions) !@This() {
+    dvui.io = options.io;
+
+    try options.view.setContextApi(.opengl);
+    try options.view.setIntHint(.context_version_major, 3);
+    try options.view.setIntHint(.context_version_minor, 2);
+    try options.view.setContextProfile(.core);
+
+    const opengl_backend = OpenGlBackend.init(options.view);
+    try options.view.setBackend(opengl_backend.backend);
+
+    try options.view.realize();
+
+    try opengl_backend.enterContext();
+
+    var ret: @This() = .{
+        .io = options.io,
+        .gpa = options.gpa,
+        .view = options.view,
+        .opengl_backend = opengl_backend,
+        .renderer = try .init(options.gpa, getProcAddress, "330"),
+    };
+
+    errdefer ret.deinit();
+
+    try opengl_backend.leaveContext();
+
+    return ret;
+}
+
+pub fn deinit(self: *@This()) void {
+    self.renderer.deinit();
+}
+
+pub fn nanoTime(self: *@This()) i128 {
+    return std.Io.Clock.awake.now(self.io).toNanoseconds();
+}
+
+pub fn sleep(self: *@This(), ns: u64) void {
+    self.io.sleep(.fromNanoseconds(ns), .awake) catch {};
+}
+
+pub fn begin(self: *@This(), arena: std.mem.Allocator) !void {
+    self.arena = arena;
+}
+
+pub fn end(_: *@This()) !void {}
+
+pub fn pixelSize(self: *const @This()) dvui.Size.Physical {
+    const size = self.view.getSizeHint(.current);
+    return .{
+        .w = @floatFromInt(size.width),
+        .h = @floatFromInt(size.height),
+    };
+}
+
+pub fn windowSize(self: *const @This()) dvui.Size.Natural {
+    // HACK: pugl size hints are only physical
+    const size = self.view.getSizeHint(.current);
+    const scale: f32 = @floatCast(self.view.getScaleFactor());
+    return .{
+        .w = @as(f32, @floatFromInt(size.width)) / scale,
+        .h = @as(f32, @floatFromInt(size.height)) / scale,
+    };
+}
+
+pub fn contentScale(self: *const @This()) f32 {
+    return @floatCast(self.view.getScaleFactor());
+}
+
+pub fn clipboardText(self: *@This()) dvui.Backend.GenericError![]const u8 {
+    // HACK: pugl doesn't let us directly read the contents of the system clipboard,
+    // so we have to request a DataOffer event and "paste" the received text later
+    self.view.paste() catch return error.BackendError;
+    return "";
+}
+
+pub fn clipboardTextSet(self: *@This(), text: []const u8) dvui.Backend.GenericError!void {
+    self.view.setClipboard(u8, .general, "text/plain", text) catch return error.BackendError;
+}
+
+pub fn openURL(_: *@This(), _: []const u8, _: bool) !void {}
+
+pub fn preferredColorScheme(self: *@This()) ?dvui.enums.ColorScheme {
+    return if (self.view.getBoolHint(.dark_frame)) |dark|
+        if (dark) .dark else .light
+    else
+        null;
+}
+
+pub fn prefersReducedMotion(_: *@This()) bool {
+    return false;
+}
+
+pub fn refresh(self: *@This()) void {
+    self.view.obscure() catch |e| dvui.log.err("failed to refresh window: {}", .{e});
+}
+
+pub fn native(self: *@This(), _: *dvui.Window) dvui.Window.Native {
+    const handle = self.view.getNativeView();
+    return switch (builtin.os.tag) {
+        .windows => .{ .hwnd = @ptrFromInt(handle) },
+        .macos => .{ .cocoa_window = @ptrFromInt(handle) },
+        else => {},
+    };
+}
+
+pub fn title(self: *@This(), _: *dvui.Window, new_title: []const u8) void {
+    const new_title_sentinel = self.gpa.dupeSentinel(u8, new_title, 0) catch {
+        dvui.log.err("out of memory", .{});
+        return;
+    };
+    defer self.gpa.free(new_title_sentinel);
+    self.view.setStringHint(.window_title, new_title_sentinel) catch |e| dvui.log.err("failed to set window title: {}", .{e});
+}
+
+pub fn windowStateSet(self: *@This(), _: *dvui.Window, state: dvui.enums.WindowState) void {
+    var style = self.view.getViewStyle();
+
+    switch (state) {
+        .normal => {
+            style.tall = false;
+            style.wide = false;
+            style.fullscreen = false;
+        },
+        .fullscreen => {
+            style.tall = false;
+            style.wide = false;
+            style.fullscreen = true;
+        },
+        .maximize => {
+            style.tall = true;
+            style.wide = true;
+            style.fullscreen = false;
+        },
+    }
+
+    self.view.setViewStyle(style) catch |e| dvui.log.err("failed to set window state '{}': {}", .{ state, e });
+}
+
+pub fn waitEventTimeout(self: *@This(), timeout_us: u32) void {
+    const world = self.view.getWorld();
+    (if (timeout_us == std.math.maxInt(@TypeOf(timeout_us)))
+        world.update(-1)
+    else
+        world.update(@as(f64, @floatFromInt(timeout_us)) / std.time.us_per_s)) catch |e|
+        dvui.log.err("waitEventTimeout failed: {}", .{e});
+}
+
+pub fn renderPresent(_: *@This()) void {}
+
+pub fn textInputRect(_: *@This(), _: ?dvui.Rect.Natural) void {}
+
+pub fn setCursor(self: *@This(), cursor: dvui.enums.Cursor) void {
+    self.view.setCursor(switch (cursor) {
+        .ibeam => .caret,
+        .arrow_nw_se => .up_left_down_right,
+        .arrow_ne_sw => .up_right_down_left,
+        .arrow_w_e => .left_right,
+        .arrow_n_s => .up_down,
+        .arrow_all => .all_scroll,
+        .bad => .no,
+        .wait, .wait_arrow, .hidden => .arrow,
+        inline else => |c| @field(pugl.View.Cursor, @tagName(c)),
+    }) catch |e|
+        dvui.log.err("failed to set cursor: {}", .{e});
+}
+
+pub fn handleEvent(self: *@This(), event: pugl.event.Event, window: *dvui.Window) pugl.Error!void {
+    switch (event) {
+        .close => try window.addEventWindow(.{ .action = .close }),
+        .key_press, .key_release => |key| _ =
+            try window.addEventKey(puglKeyToDvui(key.key, key.state, @enumFromInt(@intFromEnum(key.type)))),
+        .text => |text| {
+            if (window.textInputRequested() != null and !(text.state.ctrl or text.state.alt or text.state.super))
+                _ = try window.addEventText(.{
+                    .text = &text.string,
+                });
+        },
+        .pointer_in => _ = try window.addEventPointer(.{
+            .action = .focus,
+            .button = .none,
+        }),
+        .button_press => |button| _ = try window.addEventMouseButton(
+            std.enums.fromInt(dvui.enums.Button, button.button + 1) orelse return,
+            .press,
+        ),
+        .button_release => |button| _ = try window.addEventMouseButton(
+            std.enums.fromInt(dvui.enums.Button, button.button + 1) orelse return,
+            .release,
+        ),
+        .motion => |motion| _ = try window.addEventMouseMotion(.{
+            .pt = .{
+                .x = @floatCast(motion.x),
+                .y = @floatCast(motion.y),
+            },
+        }),
+        .scroll => |scroll| switch (scroll.direction) {
+            .up, .down => {
+                const ticks: f32 = @floatCast(scroll.dy);
+                _ = try window.addEventMouseWheel(
+                    ticks * dvui.scroll_speed,
+                    .vertical,
+                    dvui.Window.mouseTypeGLFW(window.mouseWheelBatch(.vertical, ticks)),
+                );
+            },
+            .left, .right => {
+                const ticks: f32 = @floatCast(scroll.dx);
+                _ = try window.addEventMouseWheel(
+                    ticks * dvui.scroll_speed,
+                    .horizontal,
+                    dvui.Window.mouseTypeGLFW(window.mouseWheelBatch(.horizontal, ticks)),
+                );
+            },
+            .smooth => {
+                if (scroll.dx != 0)
+                    _ = try window.addEventMouseWheel(@floatCast(scroll.dx), .horizontal, null);
+                if (scroll.dy != 0)
+                    _ = try window.addEventMouseWheel(@floatCast(scroll.dy), .vertical, null);
+            },
+        },
+        .data_offer => |offer| {
+            var type_index: ?u32 = null;
+
+            // accept text/plain, fallback to first text/*
+            for (0..self.view.getNumClipboardTypes(.general)) |i| {
+                const mime = self.view.getClipboardType(.general, @intCast(i));
+
+                if (std.mem.startsWith(u8, mime, "text/plain")) {
+                    type_index = @intCast(i);
+                    break;
+                }
+
+                if (std.mem.startsWith(u8, mime, "text/"))
+                    type_index = @intCast(i);
+            }
+
+            if (type_index) |i|
+                try self.view.acceptOffer(&offer, i, .copy, .{ .x = 0, .y = 0 }, .{ .width = 0, .height = 0 });
+        },
+        .data => |data| {
+            if (window.textInputRequested() != null) {
+                if (self.view.getClipboard(u8, .general, data.type_index)) |content|
+                    // simulate pasting
+                    _ = try window.addEventText(.{ .text = content });
+            }
+        },
+        else => {},
+    }
+}
+
+fn puglKeyToDvui(key: u32, state: pugl.event.Mods, e_type: pugl.event.Type) dvui.Event.Key {
+    return .{
+        .code = if (std.enums.fromInt(pugl.Keycode, key)) |code|
+            switch (code) {
+                .none => .unknown,
+                .print_screen => .print,
+                .shift_l => .left_shift,
+                .shift_r => .right_shift,
+                .ctrl_l => .left_control,
+                .ctrl_r => .right_control,
+                .alt_l => .left_alt,
+                .alt_r => .right_alt,
+                .super_l => .left_command,
+                .super_r => .right_command,
+                .keypad_0 => .kp_0,
+                .keypad_1 => .kp_1,
+                .keypad_2 => .kp_2,
+                .keypad_3 => .kp_3,
+                .keypad_4 => .kp_4,
+                .keypad_5 => .kp_5,
+                .keypad_6 => .kp_6,
+                .keypad_7 => .kp_7,
+                .keypad_8 => .kp_8,
+                .keypad_9 => .kp_9,
+                .keypad_enter => .kp_enter,
+                .keypad_page_up => .page_up,
+                .keypad_page_down => .page_down,
+                .keypad_end => .end,
+                .keypad_home => .home,
+                .keypad_left => .left,
+                .keypad_up => .up,
+                .keypad_right => .right,
+                .keypad_down => .down,
+                .keypad_insert => .insert,
+                .keypad_delete => .delete,
+                .keypad_equal => .kp_equal,
+                .keypad_multiply => .kp_multiply,
+                .keypad_add => .kp_add,
+                .keypad_separator => .kp_decimal,
+                .keypad_subtract => .kp_subtract,
+                .keypad_decimal => .kp_decimal,
+                .keypad_divide => .kp_divide,
+
+                .keypad_clear => .unknown,
+                inline else => |c| @field(dvui.enums.Key, @tagName(c)),
+            }
+        else switch (key) {
+            // 0-9
+            48...57 => |n| @enumFromInt(@intFromEnum(dvui.enums.Key.zero) + n - 48),
+            // a-z
+            97...122 => |n| @enumFromInt(@intFromEnum(dvui.enums.Key.a) + n - 97),
+            else => .unknown,
+        },
+        .action = switch (e_type) {
+            .key_press => .down,
+            .key_release => .up,
+            else => unreachable,
+        },
+        .mod = blk: {
+            var mod = dvui.enums.Mod.none;
+            if (state.shift)
+                mod.combine(.lshift);
+            if (state.ctrl)
+                mod.combine(.lcontrol);
+            if (state.alt)
+                mod.combine(.lalt);
+            if (state.super)
+                mod.combine(.lcommand);
+            break :blk mod;
+        },
+    };
+}
+
+fn getProcAddress(name: [*:0]const u8) ?*const anyopaque {
+    return OpenGlBackend.getProcAddress(std.mem.span(name));
+}

--- a/src/backends/pugl.zig
+++ b/src/backends/pugl.zig
@@ -6,6 +6,8 @@ pub const OpenGlBackend = @import("pugl-opengl");
 
 pub const kind = dvui.enums.Backend.pugl;
 
+const PuglBackend = @This();
+
 io: std.Io,
 gpa: std.mem.Allocator,
 view: pugl.View,
@@ -14,7 +16,7 @@ arena: std.mem.Allocator = undefined,
 opengl_backend: OpenGlBackend,
 renderer: dvui.render_backend,
 
-pub fn backend(self: *@This()) dvui.Backend {
+pub fn backend(self: *PuglBackend) dvui.Backend {
     return .init(self, &self.renderer);
 }
 
@@ -26,7 +28,7 @@ pub const InitOptions = struct {
 
 /// This function will immediately call `pugl.View.realize` on `options.view`, so make sure it's properly configured
 /// before. Its graphics API hints and pugl render backend will be overwritten.
-pub fn init(options: InitOptions) !@This() {
+pub fn init(options: InitOptions) !PuglBackend {
     dvui.io = options.io;
 
     try options.view.setContextApi(.opengl);
@@ -41,7 +43,7 @@ pub fn init(options: InitOptions) !@This() {
 
     try opengl_backend.enterContext();
 
-    var ret: @This() = .{
+    var ret: PuglBackend = .{
         .io = options.io,
         .gpa = options.gpa,
         .view = options.view,
@@ -56,25 +58,25 @@ pub fn init(options: InitOptions) !@This() {
     return ret;
 }
 
-pub fn deinit(self: *@This()) void {
+pub fn deinit(self: *PuglBackend) void {
     self.renderer.deinit();
 }
 
-pub fn nanoTime(self: *@This()) i128 {
+pub fn nanoTime(self: *PuglBackend) i128 {
     return std.Io.Clock.awake.now(self.io).toNanoseconds();
 }
 
-pub fn sleep(self: *@This(), ns: u64) void {
+pub fn sleep(self: *PuglBackend, ns: u64) void {
     self.io.sleep(.fromNanoseconds(ns), .awake) catch {};
 }
 
-pub fn begin(self: *@This(), arena: std.mem.Allocator) !void {
+pub fn begin(self: *PuglBackend, arena: std.mem.Allocator) !void {
     self.arena = arena;
 }
 
-pub fn end(_: *@This()) !void {}
+pub fn end(_: *PuglBackend) !void {}
 
-pub fn pixelSize(self: *const @This()) dvui.Size.Physical {
+pub fn pixelSize(self: *const PuglBackend) dvui.Size.Physical {
     const size = self.view.getSizeHint(.current);
     return .{
         .w = @floatFromInt(size.width),
@@ -82,7 +84,7 @@ pub fn pixelSize(self: *const @This()) dvui.Size.Physical {
     };
 }
 
-pub fn windowSize(self: *const @This()) dvui.Size.Natural {
+pub fn windowSize(self: *const PuglBackend) dvui.Size.Natural {
     // HACK: pugl size hints are only physical
     const size = self.view.getSizeHint(.current);
     const scale: f32 = @floatCast(self.view.getScaleFactor());
@@ -92,39 +94,39 @@ pub fn windowSize(self: *const @This()) dvui.Size.Natural {
     };
 }
 
-pub fn contentScale(self: *const @This()) f32 {
+pub fn contentScale(self: *const PuglBackend) f32 {
     return @floatCast(self.view.getScaleFactor());
 }
 
-pub fn clipboardText(self: *@This()) dvui.Backend.GenericError![]const u8 {
+pub fn clipboardText(self: *PuglBackend) dvui.Backend.GenericError![]const u8 {
     // HACK: pugl doesn't let us directly read the contents of the system clipboard,
     // so we have to request a DataOffer event and "paste" the received text later
     self.view.paste() catch return error.BackendError;
     return "";
 }
 
-pub fn clipboardTextSet(self: *@This(), text: []const u8) dvui.Backend.GenericError!void {
+pub fn clipboardTextSet(self: *PuglBackend, text: []const u8) dvui.Backend.GenericError!void {
     self.view.setClipboard(u8, .general, "text/plain", text) catch return error.BackendError;
 }
 
-pub fn openURL(_: *@This(), _: []const u8, _: bool) !void {}
+pub fn openURL(_: *PuglBackend, _: []const u8, _: bool) !void {}
 
-pub fn preferredColorScheme(self: *@This()) ?dvui.enums.ColorScheme {
+pub fn preferredColorScheme(self: *PuglBackend) ?dvui.enums.ColorScheme {
     return if (self.view.getBoolHint(.dark_frame)) |dark|
         if (dark) .dark else .light
     else
         null;
 }
 
-pub fn prefersReducedMotion(_: *@This()) bool {
+pub fn prefersReducedMotion(_: *PuglBackend) bool {
     return false;
 }
 
-pub fn refresh(self: *@This()) void {
+pub fn refresh(self: *PuglBackend) void {
     self.view.obscure() catch |e| dvui.log.err("failed to refresh window: {}", .{e});
 }
 
-pub fn native(self: *@This(), _: *dvui.Window) dvui.Window.Native {
+pub fn native(self: *PuglBackend, _: *dvui.Window) dvui.Window.Native {
     const handle = self.view.getNativeView();
     return switch (builtin.os.tag) {
         .windows => .{ .hwnd = @ptrFromInt(handle) },
@@ -133,7 +135,7 @@ pub fn native(self: *@This(), _: *dvui.Window) dvui.Window.Native {
     };
 }
 
-pub fn title(self: *@This(), _: *dvui.Window, new_title: []const u8) void {
+pub fn title(self: *PuglBackend, _: *dvui.Window, new_title: []const u8) void {
     const new_title_sentinel = self.gpa.dupeSentinel(u8, new_title, 0) catch {
         dvui.log.err("out of memory", .{});
         return;
@@ -142,7 +144,7 @@ pub fn title(self: *@This(), _: *dvui.Window, new_title: []const u8) void {
     self.view.setStringHint(.window_title, new_title_sentinel) catch |e| dvui.log.err("failed to set window title: {}", .{e});
 }
 
-pub fn windowStateSet(self: *@This(), _: *dvui.Window, state: dvui.enums.WindowState) void {
+pub fn windowStateSet(self: *PuglBackend, _: *dvui.Window, state: dvui.enums.WindowState) void {
     var style = self.view.getViewStyle();
 
     switch (state) {
@@ -166,7 +168,7 @@ pub fn windowStateSet(self: *@This(), _: *dvui.Window, state: dvui.enums.WindowS
     self.view.setViewStyle(style) catch |e| dvui.log.err("failed to set window state '{}': {}", .{ state, e });
 }
 
-pub fn waitEventTimeout(self: *@This(), timeout_us: u32) void {
+pub fn waitEventTimeout(self: *PuglBackend, timeout_us: u32) void {
     const world = self.view.getWorld();
     (if (timeout_us == std.math.maxInt(@TypeOf(timeout_us)))
         world.update(-1)
@@ -175,11 +177,11 @@ pub fn waitEventTimeout(self: *@This(), timeout_us: u32) void {
         dvui.log.err("waitEventTimeout failed: {}", .{e});
 }
 
-pub fn renderPresent(_: *@This()) void {}
+pub fn renderPresent(_: *PuglBackend) void {}
 
-pub fn textInputRect(_: *@This(), _: ?dvui.Rect.Natural) void {}
+pub fn textInputRect(_: *PuglBackend, _: ?dvui.Rect.Natural) void {}
 
-pub fn setCursor(self: *@This(), cursor: dvui.enums.Cursor) void {
+pub fn setCursor(self: *PuglBackend, cursor: dvui.enums.Cursor) void {
     self.view.setCursor(switch (cursor) {
         .ibeam => .caret,
         .arrow_nw_se => .up_left_down_right,
@@ -194,7 +196,7 @@ pub fn setCursor(self: *@This(), cursor: dvui.enums.Cursor) void {
         dvui.log.err("failed to set cursor: {}", .{e});
 }
 
-pub fn handleEvent(self: *@This(), event: pugl.event.Event, window: *dvui.Window) pugl.Error!void {
+pub fn handleEvent(self: *PuglBackend, event: pugl.event.Event, window: *dvui.Window) pugl.Error!void {
     switch (event) {
         .close => try window.addEventWindow(.{ .action = .close }),
         .key_press, .key_release => |key| _ =
@@ -352,4 +354,101 @@ fn puglKeyToDvui(key: u32, state: pugl.event.Mods, e_type: pugl.event.Type) dvui
 
 fn getProcAddress(name: [*:0]const u8) ?*const anyopaque {
     return OpenGlBackend.getProcAddress(std.mem.span(name));
+}
+
+const AppState = struct {
+    backend: PuglBackend,
+    window: dvui.Window,
+    run: bool = true,
+    end_us: ?u32 = 0,
+    wait_us: u32 = 0,
+};
+
+pub fn main(main_init: std.process.Init) !void {
+    var state: AppState = .{
+        .backend = undefined,
+        .window = undefined,
+    };
+
+    dvui.App.main_init = main_init;
+
+    const app = dvui.App.get() orelse return error.DvuiAppNotDefined;
+    const config = app.config.get();
+
+    const gpa = config.gpa orelse main_init.gpa;
+    const io = config.io orelse main_init.io;
+
+    const world = try pugl.World.init(.program, .{});
+    defer world.deinit();
+
+    const view = try pugl.View.init(&world);
+    defer view.deinit();
+
+    try view.setSizeHint(.default, .{
+        .width = @trunc(config.size.w),
+        .height = @trunc(config.size.h),
+    });
+    if (config.min_size) |min_size|
+        try view.setSizeHint(.minimum, .{
+            .width = @trunc(min_size.w),
+            .height = @trunc(min_size.h),
+        });
+    if (config.max_size) |max_size|
+        try view.setSizeHint(.maximum, .{
+            .width = @trunc(max_size.w),
+            .height = @trunc(max_size.h),
+        });
+
+    try view.setStringHint(.window_title, config.title);
+    try view.setBoolHint(.resizable, true);
+
+    view.setHandle(&state);
+    try view.setEventFunc(appOnEvent);
+
+    state.backend = try init(.{ .gpa = gpa, .io = io, .view = view });
+    defer state.backend.deinit();
+
+    state.window = try dvui.Window.init(@src(), gpa, state.backend.backend(), config.window_init_options);
+    defer state.window.deinit();
+
+    try view.show(.raise);
+
+    if (app.initFn) |initFn| {
+        try state.window.begin(state.window.frame_time_ns);
+        try initFn(&state.window);
+        _ = try state.window.end(.{});
+    }
+    defer if (app.deinitFn) |deinitFn| deinitFn(&state.window);
+
+    while (state.run) {
+        state.backend.waitEventTimeout(state.wait_us);
+        state.wait_us = state.window.waitTime(state.end_us);
+    }
+}
+
+fn appOnEvent(view: *const pugl.View, event: pugl.event.Event) pugl.Error!void {
+    const state: *AppState = @ptrCast(@alignCast(view.getHandle()));
+    const app = dvui.App.get().?;
+    try state.backend.handleEvent(event, &state.window);
+
+    switch (event) {
+        .expose => {
+            const nstime = state.window.beginWait(true);
+            state.window.begin(nstime) catch return error.BackendFailed;
+
+            state.backend.renderer.clear();
+            const res = app.frameFn() catch |e| blk: {
+                dvui.log.err("{}", .{e});
+                state.run = false;
+                break :blk .close;
+            };
+
+            state.end_us = state.window.end(.{}) catch return error.BackendFailed;
+            if (res != .ok) state.run = false;
+        },
+        .update => if (state.end_us != null) try view.obscure(),
+        .close => state.run = false,
+        .configure, .realize, .unrealize => {},
+        else => try view.obscure(),
+    }
 }

--- a/src/enums_backend.zig
+++ b/src/enums_backend.zig
@@ -15,6 +15,7 @@ pub const Backend = enum {
     glfw,
     web,
     wio,
+    pugl,
     /// Does no rendering!
     testing,
     /// Forwards rendering to a host-injected bridge (plugin dylibs).


### PR DESCRIPTION
As discussed on Discord (sorry it took so long btw), here's a backend that uses [pugl](https://gitlab.com/lv2/pugl) via [pugl.zig](https://github.com/bandithedoge/pugl.zig), primarily intended for use with audio plugins. Most of it is based on the wio backend and [my previous attempt](https://codeberg.org/bandithedoge/dvui-pugl).

Some decisions stemming from the design of pugl may be questionable:

- Because pugl's OpenGL backend requires a little extra setup, the DVUI render backend is set up in `init()` and mutates the user's pugl view. Is it better to delegate it to the user and have them match the configuration?
- Driving the event loop for variable framerate is a bit unintuitive (see pugl examples for the idiomatic way). The constant framerate case is more obvious, I'll document it later.
- You can only get clipboard content via a pugl view by requesting a DataOffer event, see HACK comment.

If the above is acceptable, I will carry on with writing more examples and implementing `dvui.App` support.