### PR TITLE
widgets: always feather rounded-corner fills/borders

### DIFF
--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -198,7 +198,8 @@ pub fn visible(self: *const WidgetData) bool {
 pub fn borderAndBackground(self: *const WidgetData, opts: struct {
     fill_color: ?Color = null,
     ninepatch: ?*const Ninepatch = null,
-    /// If null, 0.0 if natural scale >= 2, otherwise 1.0
+    /// If null, 1.0 (0.0 when drawing a ninepatch, which already has its
+    /// own baked edges).
     fade: ?f32 = null,
 }) void {
     if (!self.visible()) {
@@ -233,7 +234,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct {
 
             var rs = self.borderRectScale();
             if (!rs.r.empty()) {
-                const fade: f32 = opts.fade orelse (if (dvui.windowNaturalScale() >= 2.0) 0.0 else 1.0);
+                const fade: f32 = opts.fade orelse 1.0;
                 if (fade > 0) {
                     // if any border is zero, inset by half the fade so it doesn't bleed out
                     var inset: Rect.Physical = .{};
@@ -259,7 +260,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct {
             const fill = opts.fill_color orelse self.options.color(.fill);
             rs.r.fill(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{
                 .color = fill,
-                .fade = opts.fade orelse (if (ninepatch != null or dvui.windowNaturalScale() >= 2.0) 0.0 else 1.0),
+                .fade = opts.fade orelse (if (ninepatch != null) 0.0 else 1.0),
             });
         }
     }

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -392,10 +392,7 @@ pub const CellWidget = struct {
             const rs = self.data().backgroundRectScale();
             if (!rs.r.empty()) {
                 const fill = (dvui.themeGet().text_select orelse dvui.themeGet().color(.highlight, .fill)).opacity(0.75);
-                rs.r.fill(self.data().options.cornersGet().scale(rs.s, dvui.CornerRect.Physical), .{
-                    .color = fill,
-                    .fade = if (dvui.windowNaturalScale() >= 2.0) 0.0 else 1.0,
-                });
+                rs.r.fill(self.data().options.cornersGet().scale(rs.s, dvui.CornerRect.Physical), .{ .color = fill });
             }
         }
     }


### PR DESCRIPTION
Drop the windowNaturalScale() >= 2.0 heuristic that skipped edge fade on hi-dpi displays.
<img width="326" height="484" alt="image" src="https://github.com/user-attachments/assets/124513d3-abe8-443a-8a88-553c8e7607ee" />
closes #950 