### PR TITLE
web: extract shared code into web-common.js

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1615,6 +1615,8 @@ fn addWebExample(
     compile_step.dependOn(&b.addInstallFileWithDir(output, install_dir, "index.html").step);
     const web_js = b.path("src/backends/web.js");
     compile_step.dependOn(&b.addInstallFileWithDir(web_js, install_dir, "web.js").step);
+    const web_common = b.path("src/backends/web-common.js");
+    compile_step.dependOn(&b.addInstallFileWithDir(web_common, install_dir, "web-common.js").step);
     b.addNamedLazyPath("web.js", web_js);
     compile_step.dependOn(&install_wasm.step);
     compile_step.dependOn(&install_noto.step);

--- a/src/backends/web-common.js
+++ b/src/backends/web-common.js
@@ -1,0 +1,1059 @@
+/**
+ * Fetch a url and return its body as bytes.
+ * @param {string} url
+ * @returns {Promise<Uint8Array>}
+ */
+export async function dvui_fetch(url) {
+    let x = await fetch(url);
+    let blob = await x.blob();
+    //console.log("dvui_fetch: " + blob.size);
+    return new Uint8Array(await blob.arrayBuffer());
+}
+
+export const vertexShaderSource_webgl = `
+    precision mediump float;
+
+    attribute vec4 aVertexPosition;
+    attribute vec4 aVertexColor;
+    attribute vec2 aTextureCoord;
+
+    uniform mat4 uMatrix;
+
+    varying vec4 vColor;
+    varying vec2 vTextureCoord;
+
+    void main() {
+      gl_Position = uMatrix * aVertexPosition;
+      vColor = aVertexColor / 255.0;  // normalize u8 colors to 0-1
+      vTextureCoord = aTextureCoord;
+    }
+`;
+
+export const vertexShaderSource_webgl2 = `# version 300 es
+
+    precision mediump float;
+
+    in vec4 aVertexPosition;
+    in vec4 aVertexColor;
+    in vec2 aTextureCoord;
+
+    uniform mat4 uMatrix;
+
+    out vec4 vColor;
+    out vec2 vTextureCoord;
+
+    void main() {
+      gl_Position = uMatrix * aVertexPosition;
+      vColor = aVertexColor / 255.0;  // normalize u8 colors to 0-1
+      vTextureCoord = aTextureCoord;
+    }
+`;
+
+export const fragmentShaderSource_webgl = `
+    precision mediump float;
+
+    varying vec4 vColor;
+    varying vec2 vTextureCoord;
+
+    uniform sampler2D uSampler;
+    uniform bool useTex;
+
+    void main() {
+        if (useTex) {
+            gl_FragColor = texture2D(uSampler, vTextureCoord) * vColor;
+        }
+        else {
+            gl_FragColor = vColor;
+        }
+    }
+`;
+
+export const fragmentShaderSource_webgl2 = `# version 300 es
+
+    precision mediump float;
+
+    in vec4 vColor;
+    in vec2 vTextureCoord;
+
+    uniform sampler2D uSampler;
+    uniform bool useTex;
+
+    out vec4 fragColor;
+
+    void main() {
+        if (useTex) {
+            fragColor = texture(uSampler, vTextureCoord) * vColor;
+        }
+        else {
+            fragColor = vColor;
+        }
+    }
+`;
+
+export const utf8decoder = new TextDecoder();
+export const utf8encoder = new TextEncoder();
+
+/**
+ * Encode modifier keys into a 4-bit value.
+ * @param {KeyboardEvent | MouseEvent} ev
+ * @returns {number}
+ */
+export function encodeModifiers(ev) {
+    return (ev.metaKey << 3) + (ev.altKey << 2) + (ev.ctrlKey << 1) + (ev.shiftKey << 0);
+}
+
+/**
+ * Return the existing touch index for pointerId, allocating a new one if needed.
+ * @param {[number, number][]} touches
+ * @param {number} pointerId
+ * @returns {number}
+ */
+export function touchIndex(touches, pointerId) {
+    let idx = touches.findIndex((e) => e[0] === pointerId);
+    if (idx < 0) {
+        idx = touches.length;
+        touches.push([pointerId, idx]);
+    }
+    return idx;
+}
+
+/**
+ * Tracks wheel/touchpad scroll deltas and produces normalized tick values.
+ */
+export class WheelHandler {
+    /** The lowest deltaX/Y seen, used to determine the delta for touchpads
+     *
+     * The first number is x and second is y
+     * @type {[number, number]} */
+    scrollLowest = [99999, 99999];
+    /** The lowest deltaX/Y seen in this batch (resets if none in 1s).  Used to
+     * determine if we think a touchpad is being used and also as the delta for
+     * mouse wheels.
+     *
+     * The first number is x and second is y
+     * @type {[number, number]} */
+    scrollLowestBatch = [99999, 99999];
+    scrollLastMs = Date.now();
+    touchpadAdj = 0.025;
+
+    /**
+     * Process a WheelEvent and return scroll actions.
+     * @param {WheelEvent} ev
+     * @returns {{axis: number, ticks: number, trackpad: number}[]}
+     */
+    processWheelEvent(ev) {
+        const actions = [];
+
+        if ((Date.now() - this.scrollLastMs) > 1000) {
+            this.scrollLowestBatch[0] = 99999;
+            this.scrollLowestBatch[1] = 99999;
+        }
+        this.scrollLastMs = Date.now();
+
+        if (ev.deltaX !== 0) {
+            const result = this._processAxis(0, ev.deltaX, ev.deltaMode);
+            if (result) actions.push({ axis: 0, ...result });
+        }
+        if (ev.deltaY !== 0) {
+            const result = this._processAxis(1, ev.deltaY, ev.deltaMode);
+            if (result) actions.push({ axis: 1, ...result });
+        }
+
+        return actions;
+    }
+
+    _processAxis(index, delta, deltaMode) {
+        const absDelta = Math.abs(delta);
+        this.scrollLowest[index] = Math.min(absDelta, this.scrollLowest[index]);
+        this.scrollLowestBatch[index] = Math.min(absDelta, this.scrollLowestBatch[index]);
+
+        let ticks = -delta;
+        let trackpad = 0;
+
+        if (deltaMode !== 0) {
+            // only mouse wheels produce non-pixel deltas, so this is definitive without
+            // needing the magnitude heuristic.
+            ticks /= this.scrollLowestBatch[index];
+        } else if (
+            this.scrollLowestBatch[index] >= 100 || // most wheels
+            this.scrollLowestBatch[index] === 16 || // mac firefox
+            (index === 0 && (
+                this.scrollLowestBatch[index] === 9 || // mac firefox holding shift
+                this.scrollLowestBatch[index] === 40 // mac safari/chrome holding shift
+            )) ||
+            this.scrollLowestBatch[index] === 4.000244140625 // mac safari/chrome
+        ) {
+            // assume this is a mouse wheel
+            ticks /= this.scrollLowestBatch[index];
+            if (this.scrollLowestBatch[index] === 4.000244140625) {
+                ticks *= this.touchpadAdj; // mac safari/chrome scale wheel like touchpad
+            }
+        } else {
+            // assume touchpad
+            trackpad = 1;
+            ticks = (ticks / this.scrollLowest[index]) * this.touchpadAdj;
+        }
+
+        return { ticks, trackpad };
+    }
+}
+
+//let par = document.createElement("p");
+//document.body.prepend(par);
+
+/**
+ * Manages a hidden input element for IME / on-screen keyboard support.
+ */
+export class HiddenInputManager {
+    /** @type {HTMLInputElement} */
+    hiddenInput;
+    /**
+     * x y w h of on screen keyboard editing position, or empty if none
+     *
+     * @type {[number, number, number, number] | []} */
+    textInputRect = [];
+    /** @type {HTMLElement} */
+    target;
+
+    /**
+     * @param {HTMLElement} target - Element to position relative to (typically canvas)
+     */
+    constructor(target) {
+        this.target = target;
+        this.hiddenInput = document.createElement("input");
+        this.hiddenInput.setAttribute("autocapitalize", "none");
+        this.hiddenInput.style.position = "absolute";
+        this.hiddenInput.style.left = "0";
+        this.hiddenInput.style.top = "0";
+        // remove extra size so input doesn't cause overflow
+        this.hiddenInput.style.padding = "0";
+        this.hiddenInput.style.border = "0";
+        this.hiddenInput.style.margin = "0";
+        this.hiddenInput.style.opacity = "0";
+        this.hiddenInput.style.zIndex = "-1";
+        document.body.prepend(this.hiddenInput);
+    }
+
+    /**
+     * Set the on screen keyboard editing position, or empty if none.
+     * @param {[number, number, number, number] | []} rect - x y w h
+     */
+    setRect(rect) {
+        if (rect.length === 4 && rect[2] > 0 && rect[3] > 0) {
+            this.textInputRect = rect;
+        } else {
+            this.textInputRect = [];
+        }
+    }
+
+    // This does 2 things:
+    // * on desktop it's needed for us to get text events (not just char down/up)
+    // * on touch it's needed to show the on screen keyboard
+    check() {
+        if (this.textInputRect.length === 0) {
+            this.target.focus();
+        } else {
+            const rect = this.target.getBoundingClientRect();
+            const left = window.scrollX + rect.left + this.textInputRect[0];
+            const top = window.scrollY + rect.top + this.textInputRect[1];
+            // limit the width and height to prevent overflow
+            const width = Math.max(0, Math.min(this.textInputRect[2], this.target.clientWidth - this.textInputRect[0]));
+            const height = Math.max(0, Math.min(this.textInputRect[3], this.target.clientHeight - this.textInputRect[1]));
+            this.hiddenInput.style.left = left + "px";
+            this.hiddenInput.style.top = top + "px";
+            this.hiddenInput.style.width = width + "px";
+            this.hiddenInput.style.height = height + "px";
+            this.hiddenInput.focus();
+            //par.textContent = hiddenInput.style.left + " " + hiddenInput.style.top + " " + hiddenInput.style.width + " " + hiddenInput.style.height;
+        }
+    }
+}
+
+/**
+ * Normalize touch coordinates relative to an element's bounding rect.
+ * @param {Touch} touch
+ * @param {DOMRect} rect
+ * @returns {[number, number]}
+ */
+export function getTouchCoords(touch, rect) {
+    return [
+        (touch.clientX - rect.left) / (rect.right - rect.left),
+        (touch.clientY - rect.top) / (rect.bottom - rect.top),
+    ];
+}
+
+export class WebRenderer {
+    /** @type {WebGL2RenderingContext | WebGLRenderingContext | null} */
+    gl = null;
+    /** @type {WebGLBuffer | null} */
+    indexBuffer = null;
+    /** @type {WebGLBuffer | null} */
+    vertexBuffer = null;
+    /** @type {WebGLProgram | null} */
+    shaderProgram = null;
+    /** @type {{ attribLocations: { vertexPosition: number;
+            vertexColor: number;
+            textureCoord: number;
+        };
+        uniformLocations: {
+            matrix: WebGLUniformLocation | null;
+            uSampler: WebGLUniformLocation | null;
+            useTex: WebGLUniformLocation | null;
+        };
+    } | null} */
+    programInfo = null;
+    /** @type {Map<number, [WebGLTexture, number, number]>} */
+    textures = new Map();
+    newTextureId = 1;
+
+    /** @returns {[WebGLTexture, number, number] | null} */
+    textureEntry(id) {
+        if (id === 0) return null;
+        return this.textures.get(id) ?? null;
+    }
+    
+    using_fb = false;
+    /** @type {WebGLFramebuffer | null} */
+    frame_buffer = null;
+    /** @type {[number, number]} */
+    renderTargetSize = [0, 0];
+
+    /** @type {WebAssembly.Instance | null} */
+    instance = null;
+
+    console_string = "";
+
+    get webgl2() {
+        return this.gl instanceof WebGL2RenderingContext;
+    }
+
+    /**
+     * @param {DVUI.AllocatorFunction} allocFn
+     * @param {number} len
+     * @returns {[pointer: number, slice: Uint8Array]}
+     */
+    genericAlloc(allocFn, len) {
+        const pointer = allocFn(len);
+        const slice = new Uint8Array(
+            this.instance.exports.memory.buffer, 
+            pointer, 
+            len);
+        return [pointer, slice];
+    }
+
+    /**
+     * @param {DVUI.AllocatorFunction} allocFn
+     * @param {ArrayLike<number>} bytes
+     * @returns {number} pointer
+     */
+    allocBuffer(allocFn, bytes) {
+        const [pointer, slice] = this.genericAlloc(allocFn, bytes.length);
+        slice.set(bytes);
+        return pointer;
+    }
+
+    /**
+     * @param {DVUI.AllocatorFunction} allocFn
+     * @param {ArrayLike<number>} bytes
+     * @param {number} sentinel
+     * @returns {number} pointer
+     */
+    allocBufferZ(allocFn, bytes, sentinel = 0) {
+        const [pointer, slice] = this.genericAlloc(allocFn, bytes.length + 1);
+        slice.set(bytes);
+        slice[bytes.length] = sentinel;
+        return pointer;
+    }
+
+    /**
+     * @param {DVUI.AllocatorFunction} allocFn
+     * @param {string} string
+     * @returns {number} pointer
+     */
+    allocString(allocFn, string) {
+        const buffer = utf8encoder.encode(string);
+        return this.allocBuffer(allocFn, buffer);
+    }
+
+    /**
+     * @param {DVUI.AllocatorFunction} allocFn
+     * @param {string} string
+     * @param {number} sentinel
+     * @returns {number} pointer
+     */
+    allocStringZ(allocFn, string, sentinel = 0) {
+        const buffer = utf8encoder.encode(string);
+        return this.allocBufferZ(allocFn, buffer, sentinel);
+    }
+
+    /**
+     * @param {number} ptr
+     * @param {number} length
+     * @returns {string}
+     */
+    stringFromPointer(ptr, length) {
+        return utf8decoder.decode(this.bytesFromPointer(ptr, length));
+    }
+
+    /**
+     * @param {number} ptr
+     * @param {number} length
+     * @returns {Uint8Array}
+     */
+    bytesFromPointer(ptr, length) {
+        return new Uint8Array(this.instance.exports.memory.buffer, ptr, length);
+    }
+
+    buildImports() {
+        const names = [
+            "wasm_about_webgl2",
+            "wasm_console_drain",
+            "wasm_console_flush",
+            "wasm_now",
+            "wasm_frame_buffer",
+            "wasm_pixel_width",
+            "wasm_pixel_height",
+            "wasm_canvas_width",
+            "wasm_canvas_height",
+            "wasm_textureCreate",
+            "wasm_textureCreateTarget",
+            "wasm_textureClearTarget",
+            "wasm_textureRead",
+            "wasm_renderTarget",
+            "wasm_textureDestroy",
+            "wasm_renderGeometry",
+            "wasm_download_data",
+            "wasm_panic",
+            "wasm_sleep",
+            "wasm_refresh",
+            "wasm_cursor",
+            "wasm_text_input",
+            "wasm_open_url",
+            "wasm_preferred_color_scheme",
+            "wasm_prefers_reduced_motion",
+            "wasm_open_file_picker",
+            "wasm_get_file_size",
+            "wasm_get_file_name",
+            "wasm_read_file_data",
+            "wasm_get_number_of_files_available",
+            "wasm_clipboardTextSet",
+            "wasm_add_noto_font",
+            "wasm_canvas_info",
+            "wasm_wait_event",
+            "wasm_send_offscreencanvas_bitmap",
+        ];
+        const imports = {};
+        for (const name of names) {
+            imports[name] = (...args) => this[name](...args);
+        }
+        return imports;
+    }
+
+    setInstance(instance) {
+        this.instance = instance;
+    }
+
+    /**
+     * @param {HTMLCanvasElement | OffscreenCanvas} canvas
+     * @returns {WebGLProgram | null}
+     */
+    setupWebGL(canvas) {
+        this.gl = canvas.getContext("webgl2", { alpha: true, antialias: false });
+        if (this.gl === null) {
+            this.gl = canvas.getContext("webgl", { alpha: true, antialias: false });
+        }
+        if (this.gl === null) {
+            console.error("Unable to initialize WebGL.");
+            return null;
+        }
+
+        this.frame_buffer = this.gl.createFramebuffer();
+
+        const gl = this.gl;
+        const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+        gl.shaderSource(vertexShader, this.webgl2 ? vertexShaderSource_webgl2 : vertexShaderSource_webgl);
+        gl.compileShader(vertexShader);
+        if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
+            console.error("Vertex shader error:", gl.getShaderInfoLog(vertexShader));
+            return null;
+        }
+
+        const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+        gl.shaderSource(fragmentShader, this.webgl2 ? fragmentShaderSource_webgl2 : fragmentShaderSource_webgl);
+        gl.compileShader(fragmentShader);
+        if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
+            console.error("Fragment shader error:", gl.getShaderInfoLog(fragmentShader));
+            return null;
+        }
+
+        this.shaderProgram = gl.createProgram();
+        gl.attachShader(this.shaderProgram, vertexShader);
+        gl.attachShader(this.shaderProgram, fragmentShader);
+        gl.linkProgram(this.shaderProgram);
+        if (!gl.getProgramParameter(this.shaderProgram, gl.LINK_STATUS)) {
+            console.error("Shader link error:", gl.getProgramInfoLog(this.shaderProgram));
+            return null;
+        }
+
+        this.programInfo = {
+            attribLocations: {
+                vertexPosition: gl.getAttribLocation(this.shaderProgram, "aVertexPosition"),
+                vertexColor: gl.getAttribLocation(this.shaderProgram, "aVertexColor"),
+                textureCoord: gl.getAttribLocation(this.shaderProgram, "aTextureCoord"),
+            },
+            uniformLocations: {
+                matrix: gl.getUniformLocation(this.shaderProgram, "uMatrix"),
+                uSampler: gl.getUniformLocation(this.shaderProgram, "uSampler"),
+                useTex: gl.getUniformLocation(this.shaderProgram, "useTex"),
+            },
+        };
+
+        this.indexBuffer = gl.createBuffer();
+        this.vertexBuffer = gl.createBuffer();
+
+        gl.enable(gl.BLEND);
+        gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+        gl.enable(gl.SCISSOR_TEST);
+        return this.shaderProgram;
+    }
+
+    wasm_about_webgl2() {
+        if (this.webgl2) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    wasm_panic(ptr, len) {
+        const msg = this.stringFromPointer(ptr, len);
+        console.error("PANIC:", msg);
+    }
+
+    wasm_console_drain(ptr, len) {
+        this.console_string += this.stringFromPointer(ptr, len);
+    }
+
+    wasm_console_flush(level) {
+        switch (level) {
+            case 9:
+                console.error(this.console_string);
+                break;
+            case 7:
+                console.warn(this.console_string);
+                break;
+            case 5:
+                console.info(this.console_string);
+                break;
+            case 3:
+                console.debug(this.console_string);
+                break;
+            default:
+                console.log(this.console_string);
+                break;
+        }
+        this.console_string = "";
+    }
+
+    wasm_now() {
+        return performance.now();
+    }
+
+    wasm_sleep(_ms) { }
+
+    wasm_refresh() { }
+
+    wasm_pixel_width() {
+        return this.gl.drawingBufferWidth;
+    }
+
+    wasm_pixel_height() {
+        return this.gl.drawingBufferHeight;
+    }
+
+    wasm_frame_buffer() {
+        if (this.using_fb) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    wasm_canvas_width() {
+        return this.gl.canvas.clientWidth;
+    }
+
+    wasm_canvas_height() {
+        return this.gl.canvas.clientHeight;
+    }
+
+    wasm_textureCreate(pixels, width, height, interp, wrap_u, wrap_v) {
+        const pixelData = this.bytesFromPointer(pixels, width * height * 4);
+
+        const texture = this.gl.createTexture();
+        const id = this.newTextureId;
+        //console.log("creating texture " + id);
+        this.newTextureId += 1;
+        this.textures.set(id, [texture, width, height]);
+
+        this.gl.bindTexture(this.gl.TEXTURE_2D, texture);
+
+        this.gl.texImage2D(
+            this.gl.TEXTURE_2D,
+            0,
+            this.gl.RGBA,
+            width,
+            height,
+            0,
+            this.gl.RGBA,
+            this.gl.UNSIGNED_BYTE,
+            pixelData,
+        );
+
+        if (this.webgl2) {
+            this.gl.generateMipmap(this.gl.TEXTURE_2D);
+        }
+
+        if (interp == 0) {
+            this.gl.texParameteri(
+                this.gl.TEXTURE_2D,
+                this.gl.TEXTURE_MIN_FILTER,
+                this.gl.NEAREST,
+            );
+            this.gl.texParameteri(
+                this.gl.TEXTURE_2D,
+                this.gl.TEXTURE_MAG_FILTER,
+                this.gl.NEAREST,
+            );
+        } else {
+            this.gl.texParameteri(
+                this.gl.TEXTURE_2D,
+                this.gl.TEXTURE_MIN_FILTER,
+                this.gl.LINEAR,
+            );
+            this.gl.texParameteri(
+                this.gl.TEXTURE_2D,
+                this.gl.TEXTURE_MAG_FILTER,
+                this.gl.LINEAR,
+            );
+        }
+        if (wrap_u === 1) {
+            this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.REPEAT);
+        } else {
+            this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
+        }
+        if (wrap_v === 1) {
+            this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.REPEAT);
+        } else {
+            this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
+        }
+
+        this.gl.bindTexture(this.gl.TEXTURE_2D, null);
+
+        return id;
+    }
+
+    wasm_textureCreateTarget(width, height, interp, wrap_u, wrap_v) {
+        const texture = this.gl.createTexture();
+        const id = this.newTextureId;
+        //console.log("creating texture " + id);
+        this.newTextureId += 1;
+        this.textures.set(id, [texture, width, height]);
+
+        this.gl.bindTexture(this.gl.TEXTURE_2D, texture);
+
+        this.gl.texImage2D(
+            this.gl.TEXTURE_2D,
+            0,
+            this.gl.RGBA,
+            width,
+            height,
+            0,
+            this.gl.RGBA,
+            this.gl.UNSIGNED_BYTE,
+            null,
+        );
+
+        if (interp == 0) {
+            this.gl.texParameteri(
+                this.gl.TEXTURE_2D,
+                this.gl.TEXTURE_MIN_FILTER,
+                this.gl.NEAREST,
+            );
+            this.gl.texParameteri(
+                this.gl.TEXTURE_2D,
+                this.gl.TEXTURE_MAG_FILTER,
+                this.gl.NEAREST,
+            );
+        } else {
+            this.gl.texParameteri(
+                this.gl.TEXTURE_2D,
+                this.gl.TEXTURE_MIN_FILTER,
+                this.gl.LINEAR,
+            );
+            this.gl.texParameteri(
+                this.gl.TEXTURE_2D,
+                this.gl.TEXTURE_MAG_FILTER,
+                this.gl.LINEAR,
+            );
+        }
+        if (wrap_u === 1) {
+            this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.REPEAT);
+        } else {
+            this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
+        }
+        if (wrap_v === 1) {
+            this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.REPEAT);
+        } else {
+            this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
+        }
+
+        this.gl.bindTexture(this.gl.TEXTURE_2D, null);
+
+        this.wasm_textureClearTarget(id);
+
+        return id;
+    }
+
+    wasm_textureClearTarget(textureId) {
+        this.wasm_renderTarget(textureId);
+        this.gl.clearColor(0.0, 0.0, 0.0, 0.0); // fully transparent
+        this.gl.clear(this.gl.COLOR_BUFFER_BIT);
+        this.wasm_renderTarget(0);
+    }
+
+    wasm_textureRead(textureId, pixels_out, width, height) {
+        //console.log("textureRead " + textureId);
+        const entry = this.textureEntry(textureId);
+        if (entry === null) {
+            console.warn(
+                `wasm_textureRead: missing texture id ${textureId}`,
+            );
+            return;
+        }
+        const texture = entry[0];
+
+        this.gl.bindFramebuffer(
+            this.gl.FRAMEBUFFER,
+            this.frame_buffer,
+        );
+        this.gl.framebufferTexture2D(
+            this.gl.FRAMEBUFFER,
+            this.gl.COLOR_ATTACHMENT0,
+            this.gl.TEXTURE_2D,
+            texture,
+            0,
+        );
+
+        var dest = this.bytesFromPointer(pixels_out, width * height * 4);
+        this.gl.readPixels(
+            0,
+            0,
+            width,
+            height,
+            this.gl.RGBA,
+            this.gl.UNSIGNED_BYTE,
+            dest,
+            0,
+        );
+
+        this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, null);
+    }
+
+    wasm_renderTarget(id) {
+        //console.log("renderTarget " + id);
+        if (id === 0) {
+            this.using_fb = false;
+            this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, null);
+            this.renderTargetSize = [
+                this.gl.drawingBufferWidth,
+                this.gl.drawingBufferHeight,
+            ];
+            this.gl.viewport(
+                0,
+                0,
+                this.renderTargetSize[0],
+                this.renderTargetSize[1],
+            );
+            this.gl.scissor(
+                0,
+                0,
+                this.renderTargetSize[0],
+                this.renderTargetSize[1],
+            );
+        } else {
+            this.using_fb = true;
+            this.gl.bindFramebuffer(
+                this.gl.FRAMEBUFFER,
+                this.frame_buffer,
+            );
+
+            const rt = this.textureEntry(id);
+            if (rt === null) {
+                console.warn(
+                    `wasm_renderTarget: missing texture id ${id}`,
+                );
+                this.using_fb = false;
+                this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, null);
+                this.renderTargetSize = [
+                    this.gl.drawingBufferWidth,
+                    this.gl.drawingBufferHeight,
+                ];
+            } else {
+                this.gl.framebufferTexture2D(
+                    this.gl.FRAMEBUFFER,
+                    this.gl.COLOR_ATTACHMENT0,
+                    this.gl.TEXTURE_2D,
+                    rt[0],
+                    0,
+                );
+                this.renderTargetSize = [rt[1], rt[2]];
+            }
+            this.gl.viewport(
+                0,
+                0,
+                this.renderTargetSize[0],
+                this.renderTargetSize[1],
+            );
+            this.gl.scissor(
+                0,
+                0,
+                this.renderTargetSize[0],
+                this.renderTargetSize[1],
+            );
+        }
+    }
+
+    wasm_textureDestroy(id) {
+        //console.log("deleting texture " + id);
+        const entry = this.textureEntry(id);
+        if (entry === null) return;
+        this.textures.delete(id);
+        this.gl.deleteTexture(entry[0]);
+    }
+
+    buildOrthoMatrix() {
+        const matrix = new Float32Array(16);
+        matrix[0] = 2.0 / this.renderTargetSize[0];
+        matrix[1] = 0.0;
+        matrix[2] = 0.0;
+        matrix[3] = 0.0;
+        matrix[4] = 0.0;
+        if (this.using_fb) {
+            matrix[5] = 2.0 / this.renderTargetSize[1];
+        } else {
+            matrix[5] = -2.0 / this.renderTargetSize[1];
+        }
+        matrix[6] = 0.0;
+        matrix[7] = 0.0;
+        matrix[8] = 0.0;
+        matrix[9] = 0.0;
+        matrix[10] = 1.0;
+        matrix[11] = 0.0;
+        matrix[12] = -1.0;
+        if (this.using_fb) {
+            matrix[13] = -1.0;
+        } else {
+            matrix[13] = 1.0;
+        }
+        matrix[14] = 0.0;
+        matrix[15] = 1.0;
+        return matrix;
+    }
+
+    wasm_renderGeometry(
+        textureId,
+        index_ptr,
+        index_len,
+        vertex_ptr,
+        vertex_len,
+        sizeof_vertex,
+        offset_pos,
+        offset_col,
+        offset_uv,
+        clip,
+        x,
+        y,
+        w,
+        h,
+    ) {
+        //console.log("drawClippedTriangles " + textureId + " sizeof " + sizeof_vertex + " pos " + offset_pos + " col " + offset_col + " uv " + offset_uv);
+
+        //let old_scissor;
+        if (clip === 1) {
+            // just calling getParameter here is quite slow (5-10 ms per frame according to chrome)
+            //old_scissor = gl.getParameter(gl.SCISSOR_BOX);
+            this.gl.scissor(x, y, w, h);
+        }
+
+        this.gl.bindBuffer(
+            this.gl.ELEMENT_ARRAY_BUFFER,
+            this.indexBuffer,
+        );
+        const indices = new Uint16Array(
+            this.instance.exports.memory.buffer,
+            index_ptr,
+            index_len / 2,
+        );
+        this.gl.bufferData(
+            this.gl.ELEMENT_ARRAY_BUFFER,
+            indices,
+            this.gl.DYNAMIC_DRAW,
+        );
+
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+        const vertexes = this.bytesFromPointer(vertex_ptr, vertex_len)
+        this.gl.bufferData(
+            this.gl.ARRAY_BUFFER,
+            vertexes,
+            this.gl.DYNAMIC_DRAW,
+        );
+
+        let matrix = this.buildOrthoMatrix();
+
+        // vertex
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+        this.gl.vertexAttribPointer(
+            this.programInfo.attribLocations.vertexPosition,
+            2, // num components
+            this.gl.FLOAT,
+            false, // don't normalize
+            sizeof_vertex, // stride
+            offset_pos, // offset
+        );
+        this.gl.enableVertexAttribArray(
+            this.programInfo.attribLocations.vertexPosition,
+        );
+
+        // color
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+        this.gl.vertexAttribPointer(
+            this.programInfo.attribLocations.vertexColor,
+            4, // num components
+            this.gl.UNSIGNED_BYTE,
+            false, // don't normalize
+            sizeof_vertex, // stride
+            offset_col, // offset
+        );
+        this.gl.enableVertexAttribArray(
+            this.programInfo.attribLocations.vertexColor,
+        );
+
+        // texture
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+        this.gl.vertexAttribPointer(
+            this.programInfo.attribLocations.textureCoord,
+            2, // num components
+            this.gl.FLOAT,
+            false, // don't normalize
+            sizeof_vertex, // stride
+            offset_uv, // offset
+        );
+        this.gl.enableVertexAttribArray(
+            this.programInfo.attribLocations.textureCoord,
+        );
+
+        // Tell WebGL to use our program when drawing
+        this.gl.useProgram(this.shaderProgram);
+
+        // Set the shader uniforms
+        this.gl.uniformMatrix4fv(
+            this.programInfo.uniformLocations.matrix,
+            false,
+            matrix,
+        );
+
+        if (textureId != 0) {
+            const tex = this.textureEntry(textureId);
+            if (tex !== null) {
+                this.gl.activeTexture(this.gl.TEXTURE0);
+                this.gl.bindTexture(this.gl.TEXTURE_2D, tex[0]);
+                this.gl.uniform1i(
+                    this.programInfo.uniformLocations.useTex,
+                    1,
+                );
+            } else {
+                console.warn(
+                    `wasm_renderGeometry: missing texture id ${textureId}`,
+                );
+                this.gl.bindTexture(this.gl.TEXTURE_2D, null);
+                this.gl.uniform1i(
+                    this.programInfo.uniformLocations.useTex,
+                    0,
+                );
+            }
+        } else {
+            this.gl.bindTexture(this.gl.TEXTURE_2D, null);
+            this.gl.uniform1i(
+                this.programInfo.uniformLocations.useTex,
+                0,
+            );
+        }
+
+        this.gl.uniform1i(
+            this.programInfo.uniformLocations.uSampler,
+            0,
+        );
+
+        //console.log("drawElements " + textureId);
+        this.gl.drawElements(
+            this.gl.TRIANGLES,
+            indices.length,
+            this.gl.UNSIGNED_SHORT,
+            0,
+        );
+
+        if (clip === 1) {
+            //gl.scissor(old_scissor[0], old_scissor[1], old_scissor[2], old_scissor[3]);
+            this.gl.scissor(
+                0,
+                0,
+                this.renderTargetSize[0],
+                this.renderTargetSize[1],
+            );
+        }
+    }
+
+    wasm_cursor(_name_ptr, _name_len) { }
+
+    wasm_text_input(_x, _y, _w, _h) { }
+
+    wasm_open_url(_ptr, _len, _new_win) { }
+
+    wasm_preferred_color_scheme() { return 0; }
+
+    wasm_prefers_reduced_motion() { return 0; }
+
+    wasm_download_data(name_ptr, name_len, data_ptr, data_len) {
+        const name = this.stringFromPointer(name_ptr, name_len);
+        const data = this.bytesFromPointer(data_ptr, data_len);
+        const blob = new Blob([data], { type: "application/octet-stream" });
+        const fileURL = URL.createObjectURL(blob);
+        const dl = document.createElement("a");
+        dl.href = fileURL;
+        dl.download = name;
+        dl.click();
+        dl.remove();
+        URL.revokeObjectURL(fileURL);
+    }
+
+    wasm_open_file_picker(_id, _accept_ptr, _accept_len, _multiple) { }
+
+    wasm_get_file_size(_id, _file_index) { return -1; }
+
+    wasm_get_file_name(_id, _file_index) { return 0; }
+
+    wasm_read_file_data(_id, _file_index, _data) { }
+
+    wasm_get_number_of_files_available(_id) { return 0; }
+
+    wasm_clipboardTextSet(_ptr, _len) { }
+
+    wasm_add_noto_font() { }
+
+    wasm_canvas_info(_out_pw, _out_ph, _out_cw, _out_ch) { }
+
+    wasm_wait_event(_timeout_ms) { return 0; }
+
+    wasm_send_offscreencanvas_bitmap() { }
+}

--- a/src/backends/web.js
+++ b/src/backends/web.js
@@ -2,16 +2,7 @@
 
 /**@typedef {BigInt} Id */
 
-/**
- * @param {string} url
- * @returns {Promise<Uint8Array>}
- */
-async function dvui_fetch(url) {
-    let x = await fetch(url);
-    let blob = await x.blob();
-    //console.log("dvui_fetch: " + blob.size);
-    return new Uint8Array(await blob.arrayBuffer());
-}
+import { WebRenderer, encodeModifiers, touchIndex, WheelHandler, HiddenInputManager, utf8encoder, getTouchCoords, dvui_fetch } from "./web-common.js";
 
 /**
  * @param {string} accept Maps to the accept attribute of the file input element
@@ -46,86 +37,6 @@ async function dvui_open_file_picker(accept, multiple) {
     });
 }
 
-const vertexShaderSource_webgl = `
-    precision mediump float;
-
-    attribute vec4 aVertexPosition;
-    attribute vec4 aVertexColor;
-    attribute vec2 aTextureCoord;
-
-    uniform mat4 uMatrix;
-
-    varying vec4 vColor;
-    varying vec2 vTextureCoord;
-
-    void main() {
-      gl_Position = uMatrix * aVertexPosition;
-      vColor = aVertexColor / 255.0;  // normalize u8 colors to 0-1
-      vTextureCoord = aTextureCoord;
-    }
-`;
-
-const vertexShaderSource_webgl2 = `# version 300 es
-
-    precision mediump float;
-
-    in vec4 aVertexPosition;
-    in vec4 aVertexColor;
-    in vec2 aTextureCoord;
-
-    uniform mat4 uMatrix;
-
-    out vec4 vColor;
-    out vec2 vTextureCoord;
-
-    void main() {
-      gl_Position = uMatrix * aVertexPosition;
-      vColor = aVertexColor / 255.0;  // normalize u8 colors to 0-1
-      vTextureCoord = aTextureCoord;
-    }
-`;
-
-const fragmentShaderSource_webgl = `
-    precision mediump float;
-
-    varying vec4 vColor;
-    varying vec2 vTextureCoord;
-
-    uniform sampler2D uSampler;
-    uniform bool useTex;
-
-    void main() {
-        if (useTex) {
-            gl_FragColor = texture2D(uSampler, vTextureCoord) * vColor;
-        }
-        else {
-            gl_FragColor = vColor;
-        }
-    }
-`;
-
-const fragmentShaderSource_webgl2 = `# version 300 es
-
-    precision mediump float;
-
-    in vec4 vColor;
-    in vec2 vTextureCoord;
-
-    uniform sampler2D uSampler;
-    uniform bool useTex;
-
-    out vec4 fragColor;
-
-    void main() {
-        if (useTex) {
-            fragColor = texture(uSampler, vTextureCoord) * vColor;
-        }
-        else {
-            fragColor = vColor;
-        }
-    }
-`;
-
 /**
  * @param {string | HTMLCanvasElement} canvas - A canvas element or string id of one
  * @param {DVUI.WasmArg} wasmRef - The url to the wasm file, to be used in `fetch`
@@ -144,850 +55,30 @@ export function dvui(canvas, wasmRef) {
     });
 }
 
-const utf8decoder = new TextDecoder();
-const utf8encoder = new TextEncoder();
-
-export class Dvui {
-    /** @type {WebGL2RenderingContext | WebGLRenderingContext} */
-    gl;
-    /** @type {WebGLBuffer} */
-    indexBuffer;
-    /** @type {WebGLBuffer} */
-    vertexBuffer;
-    /** @type {WebGLProgram} */
-    shaderProgram;
-    /** @type {{ attribLocations: { vertexPosition: number;
-            vertexColor: number;
-            textureCoord: number;
-        };
-        uniformLocations: {
-            matrix: WebGLUniformLocation | null;
-            uSampler: WebGLUniformLocation | null;
-            useTex: WebGLUniformLocation | null;
-        };
-    }} */
-    programInfo;
-    /** @type {Map<number, [WebGLTexture, number, number]>} */
-    textures = new Map();
-    newTextureId = 1;
-
-    /** @returns {[WebGLTexture, number, number] | null} */
-    textureEntry(id) {
-        if (id === 0) return null;
-        return this.textures.get(id) ?? null;
-    }
-    using_fb = false;
-    /** @type {WebGLFramebuffer | null} */
-    frame_buffer = null;
-    /** @type {[number, number]} */
-    renderTargetSize = [0, 0];
-
+export class Dvui extends WebRenderer {
     renderRequested = false;
     renderTimeoutId = 0;
 
     /** @type {WebAssembly.ModuleImports} */
     imports;
 
-    /** @type {WebAssembly.Instance} */
-    instance;
     stopped = false;
-    console_string = "";
-    /** @type {HTMLInputElement} */
-    hidden_input;
+    /** @type {HiddenInputManager | null} */
+    hiddenInputMgr = null;
     /**
      * list of tuple (touch identifier, initial index)
      * @type {[number, number][]} */
     touches = [];
-    /** The lowest deltaX/Y seen, used to determine the delta for touchpads
-     *
-     * The first number is x and second is y
-     * @type {[number, number]} */
-    scroll_lowest = [99999, 99999];
-    /** The lowest deltaX/Y seen in this batch (resets if none in 1s).  Used to
-     * determine if we think a touchpad is being used and also as the delta for
-     * mouse wheels.
-     *
-     * The first number is x and second is y
-     * @type {[number, number]} */
-    scroll_lowest_batch = [99999, 99999];
-    scroll_last_ms = Date.now();
-    /**
-     * x y w h of on screen keyboard editing position, or empty if none
-     *
-     * @type {[number, number, number, number] | []} */
-    textInputRect = [];
+    wheelHandler = new WheelHandler();
 
     // Used for file uploads. Only valid for one frame
     filesCacheModified = false;
     /** @type {Map<Id, FileList>} */
     filesCache = new Map();
 
-    //let par = document.createElement("p");
-    //document.body.prepend(par);
-
-    get webgl2() {
-        return this.gl instanceof WebGL2RenderingContext;
-    }
-
-    // This does 2 things:
-    // * on desktop it's needed for us to get text events (not just char down/up)
-    // * on touch it's needed to show the on screen keyboard
-    oskCheck() {
-        if (this.textInputRect.length == 0) {
-            this.gl.canvas.focus();
-        } else {
-            const rect = this.gl.canvas.getBoundingClientRect();
-            const left = window.scrollX + rect.left + this.textInputRect[0];
-            const top = window.scrollY + rect.top + this.textInputRect[1];
-            // limit the width and height to prevent overflow
-            const width = Math.max(
-                0,
-                Math.min(
-                    this.textInputRect[2],
-                    this.gl.canvas.clientWidth - left,
-                ),
-            );
-            const height = Math.max(
-                0,
-                Math.min(
-                    this.textInputRect[2],
-                    this.gl.canvas.clientHeight - top,
-                ),
-            );
-            this.hidden_input.style.left = left + "px";
-            this.hidden_input.style.top = top + "px";
-            this.hidden_input.style.width = width + "px";
-            this.hidden_input.style.height = height + "px";
-            this.hidden_input.focus();
-            //par.textContent = hidden_input.style.left + " " + hidden_input.style.top + " " + hidden_input.style.width + " " + hidden_input.style.height;
-        }
-    }
-
-    touchIndex(pointerId) {
-        let idx = this.touches.findIndex((e) => e[0] === pointerId);
-        if (idx < 0) {
-            idx = this.touches.length;
-            this.touches.push([pointerId, idx]);
-        }
-
-        return idx;
-    }
-
-    /**
-     * @param {DVUI.AllocatorFunction} allocFn 
-     * @param {number} len 
-     * @returns {[pointer: number, slice: Uint8Array]}
-     */
-    genericAlloc(allocFn, len) {
-        const pointer = allocFn(len);
-        const slice = new Uint8Array(
-            this.instance.exports.memory.buffer,
-            pointer,
-            len
-        );
-
-        return [pointer, slice];
-    }
-
-    /**
-     * @param {DVUI.AllocatorFunction} allocFn 
-     * @param {ArrayLike<number>} bytes 
-     * @returns {number} pointer
-     */
-    allocBuffer(allocFn, bytes) {
-        const [pointer, slice] = this.genericAlloc(allocFn, bytes.length);
-        slice.set(bytes);
-        return pointer;
-    }
-
-    /**
-     * @param {DVUI.AllocatorFunction} allocFn 
-     * @param {ArrayLike<number>} bytes 
-     * @param {number} sentinel 
-     * @returns {number} pointer
-     */
-    allocBufferZ(allocFn, bytes, sentinel = 0) {
-        const [pointer, slice] = this.genericAlloc(allocFn, bytes.length + 1);
-        slice.set(bytes);
-        slice[bytes.length] = sentinel;
-        return pointer;
-    }
-
-    /**
-     * @param {DVUI.AllocatorFunction} allocFn 
-     * @param {string} string 
-     * @returns 
-     */
-    allocString(allocFn, string) {
-        const buffer = utf8encoder.encode(string);
-        return this.allocBuffer(allocFn, buffer);
-    };
-
-    /**
-     * @param {DVUI.AllocatorFunction} allocFn 
-     * @param {string} string 
-     * @param {number} sentinel 
-     * @returns {number} pointer
-     */
-    allocStringZ(allocFn, string, sentinel) {
-        const buffer = utf8encoder.encode(string);
-        return this.allocBufferZ(allocFn, buffer, sentinel);
-    };
-
-    /**
-     * @param {number} ptr 
-     * @param {number} length 
-     * @returns {string}
-     */
-    stringFromPointer(ptr, length) {
-        return utf8decoder.decode(this.bytesFromPointer(ptr, length));
-    }
-
-    /**
-     * @param {number} ptr 
-     * @param {number} length 
-     * @returns {Uint8Array}
-     */
-    bytesFromPointer(ptr, length) {
-        return new Uint8Array(this.instance.exports.memory.buffer, ptr, length)
-    }
-
     constructor() {
-        this.hidden_input = document.createElement("input");
-        this.hidden_input.setAttribute("autocapitalize", "none");
-        this.hidden_input.style.position = "absolute";
-        this.hidden_input.style.left = 0;
-        this.hidden_input.style.top = 0;
-        // remove extra size so input doesn't cause overflow
-        this.hidden_input.style.padding = 0;
-        this.hidden_input.style.border = 0;
-        this.hidden_input.style.margin = 0;
-        this.hidden_input.style.opacity = 0;
-        this.hidden_input.style.zIndex = -1;
-        document.body.prepend(this.hidden_input);
-
-        this.imports = {
-            wasm_about_webgl2: () => {
-                if (this.webgl2) {
-                    return 1;
-                } else {
-                    return 0;
-                }
-            },
-            wasm_panic: (ptr, len) => {
-                this.stop();
-                const msg = this.stringFromPointer(ptr, len);
-                console.error("PANIC:", msg);
-                alert(msg);
-            },
-            wasm_console_drain: (ptr, len) => {
-                this.console_string += this.stringFromPointer(ptr, len);
-            },
-            wasm_console_flush: (level) => {
-                switch (level) {
-                    case 9:
-                        console.error(this.console_string);
-                        break;
-                    case 7:
-                        console.warn(this.console_string);
-                        break;
-                    case 5:
-                        console.info(this.console_string);
-                        break;
-                    case 3:
-                        console.debug(this.console_string);
-                        break;
-                    default:
-                        console.log(this.console_string);
-                        break;
-                }
-                this.console_string = "";
-            },
-            wasm_now: () => {
-                return performance.now();
-            },
-            wasm_sleep: (ms) => {
-                const end = Date.now() + ms;
-                while (Date.now() < end) {
-                    // block because the point is to limit the framerate
-                }
-            },
-            wasm_refresh: () => {
-                this.requestRender();
-            },
-            wasm_pixel_width: () => {
-                return this.gl.drawingBufferWidth;
-            },
-            wasm_pixel_height: () => {
-                return this.gl.drawingBufferHeight;
-            },
-            wasm_frame_buffer: () => {
-                if (this.using_fb) {
-                    return 1;
-                } else {
-                    return 0;
-                }
-            },
-            wasm_canvas_width: () => {
-                return this.gl.canvas.clientWidth;
-            },
-            wasm_canvas_height: () => {
-                return this.gl.canvas.clientHeight;
-            },
-            wasm_textureCreate: (pixels, width, height, interp, wrap_u, wrap_v) => {
-                const pixelData = this.bytesFromPointer(pixels, width * height * 4);
-
-                const texture = this.gl.createTexture();
-                const id = this.newTextureId;
-                //console.log("creating texture " + id);
-                this.newTextureId += 1;
-                this.textures.set(id, [texture, width, height]);
-
-                this.gl.bindTexture(this.gl.TEXTURE_2D, texture);
-
-                this.gl.texImage2D(
-                    this.gl.TEXTURE_2D,
-                    0,
-                    this.gl.RGBA,
-                    width,
-                    height,
-                    0,
-                    this.gl.RGBA,
-                    this.gl.UNSIGNED_BYTE,
-                    pixelData,
-                );
-
-                if (this.webgl2) {
-                    this.gl.generateMipmap(this.gl.TEXTURE_2D);
-                }
-
-                if (interp == 0) {
-                    this.gl.texParameteri(
-                        this.gl.TEXTURE_2D,
-                        this.gl.TEXTURE_MIN_FILTER,
-                        this.gl.NEAREST,
-                    );
-                    this.gl.texParameteri(
-                        this.gl.TEXTURE_2D,
-                        this.gl.TEXTURE_MAG_FILTER,
-                        this.gl.NEAREST,
-                    );
-                } else {
-                    this.gl.texParameteri(
-                        this.gl.TEXTURE_2D,
-                        this.gl.TEXTURE_MIN_FILTER,
-                        this.gl.LINEAR,
-                    );
-                    this.gl.texParameteri(
-                        this.gl.TEXTURE_2D,
-                        this.gl.TEXTURE_MAG_FILTER,
-                        this.gl.LINEAR,
-                    );
-                }
-                if (wrap_u === 1) {
-                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.REPEAT);
-                } else {
-                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
-                }
-                if (wrap_v === 1) {
-                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.REPEAT);
-                } else {
-                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
-                }
-
-                this.gl.bindTexture(this.gl.TEXTURE_2D, null);
-
-                return id;
-            },
-            wasm_textureCreateTarget: (width, height, interp, wrap_u, wrap_v) => {
-                const texture = this.gl.createTexture();
-                const id = this.newTextureId;
-                //console.log("creating texture " + id);
-                this.newTextureId += 1;
-                this.textures.set(id, [texture, width, height]);
-
-                this.gl.bindTexture(this.gl.TEXTURE_2D, texture);
-
-                this.gl.texImage2D(
-                    this.gl.TEXTURE_2D,
-                    0,
-                    this.gl.RGBA,
-                    width,
-                    height,
-                    0,
-                    this.gl.RGBA,
-                    this.gl.UNSIGNED_BYTE,
-                    null,
-                );
-
-                if (interp == 0) {
-                    this.gl.texParameteri(
-                        this.gl.TEXTURE_2D,
-                        this.gl.TEXTURE_MIN_FILTER,
-                        this.gl.NEAREST,
-                    );
-                    this.gl.texParameteri(
-                        this.gl.TEXTURE_2D,
-                        this.gl.TEXTURE_MAG_FILTER,
-                        this.gl.NEAREST,
-                    );
-                } else {
-                    this.gl.texParameteri(
-                        this.gl.TEXTURE_2D,
-                        this.gl.TEXTURE_MIN_FILTER,
-                        this.gl.LINEAR,
-                    );
-                    this.gl.texParameteri(
-                        this.gl.TEXTURE_2D,
-                        this.gl.TEXTURE_MAG_FILTER,
-                        this.gl.LINEAR,
-                    );
-                }
-                if (wrap_u === 1) {
-                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.REPEAT);
-                } else {
-                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
-                }
-                if (wrap_v === 1) {
-                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.REPEAT);
-                } else {
-                    this.gl.texParameteri( this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
-                }
-
-                this.gl.bindTexture(this.gl.TEXTURE_2D, null);
-
-                this.imports.wasm_textureClearTarget(id);
-
-                return id;
-            },
-            wasm_textureClearTarget: (textureId) => {
-                this.imports.wasm_renderTarget(textureId);
-                this.gl.clearColor(0.0, 0.0, 0.0, 0.0); // fully transparent
-                this.gl.clear(this.gl.COLOR_BUFFER_BIT);
-                this.imports.wasm_renderTarget(0);
-            },
-            wasm_textureRead: (textureId, pixels_out, width, height) => {
-                //console.log("textureRead " + textureId);
-                const entry = this.textureEntry(textureId);
-                if (entry === null) {
-                    console.warn(
-                        `wasm_textureRead: missing texture id ${textureId}`,
-                    );
-                    return;
-                }
-                const texture = entry[0];
-
-                this.gl.bindFramebuffer(
-                    this.gl.FRAMEBUFFER,
-                    this.frame_buffer,
-                );
-                this.gl.framebufferTexture2D(
-                    this.gl.FRAMEBUFFER,
-                    this.gl.COLOR_ATTACHMENT0,
-                    this.gl.TEXTURE_2D,
-                    texture,
-                    0,
-                );
-
-                var dest = this.bytesFromPointer(pixels_out, width * height * 4);
-                this.gl.readPixels(
-                    0,
-                    0,
-                    width,
-                    height,
-                    this.gl.RGBA,
-                    this.gl.UNSIGNED_BYTE,
-                    dest,
-                    0,
-                );
-
-                this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, null);
-            },
-            wasm_renderTarget: (id) => {
-                //console.log("renderTarget " + id);
-                if (id === 0) {
-                    this.using_fb = false;
-                    this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, null);
-                    this.renderTargetSize = [
-                        this.gl.drawingBufferWidth,
-                        this.gl.drawingBufferHeight,
-                    ];
-                    this.gl.viewport(
-                        0,
-                        0,
-                        this.renderTargetSize[0],
-                        this.renderTargetSize[1],
-                    );
-                    this.gl.scissor(
-                        0,
-                        0,
-                        this.renderTargetSize[0],
-                        this.renderTargetSize[1],
-                    );
-                } else {
-                    this.using_fb = true;
-                    this.gl.bindFramebuffer(
-                        this.gl.FRAMEBUFFER,
-                        this.frame_buffer,
-                    );
-
-                    const rt = this.textureEntry(id);
-                    if (rt === null) {
-                        console.warn(
-                            `wasm_renderTarget: missing texture id ${id}`,
-                        );
-                        this.using_fb = false;
-                        this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, null);
-                        this.renderTargetSize = [
-                            this.gl.drawingBufferWidth,
-                            this.gl.drawingBufferHeight,
-                        ];
-                    } else {
-                        this.gl.framebufferTexture2D(
-                            this.gl.FRAMEBUFFER,
-                            this.gl.COLOR_ATTACHMENT0,
-                            this.gl.TEXTURE_2D,
-                            rt[0],
-                            0,
-                        );
-                        this.renderTargetSize = [rt[1], rt[2]];
-                    }
-                    this.gl.viewport(
-                        0,
-                        0,
-                        this.renderTargetSize[0],
-                        this.renderTargetSize[1],
-                    );
-                    this.gl.scissor(
-                        0,
-                        0,
-                        this.renderTargetSize[0],
-                        this.renderTargetSize[1],
-                    );
-                }
-            },
-            wasm_textureDestroy: (id) => {
-                //console.log("deleting texture " + id);
-                const entry = this.textureEntry(id);
-                if (entry === null) return;
-                this.textures.delete(id);
-                this.gl.deleteTexture(entry[0]);
-            },
-            wasm_renderGeometry: (
-                textureId,
-                index_ptr,
-                index_len,
-                vertex_ptr,
-                vertex_len,
-                sizeof_vertex,
-                offset_pos,
-                offset_col,
-                offset_uv,
-                clip,
-                x,
-                y,
-                w,
-                h,
-            ) => {
-                //console.log("drawClippedTriangles " + textureId + " sizeof " + sizeof_vertex + " pos " + offset_pos + " col " + offset_col + " uv " + offset_uv);
-
-                //let old_scissor;
-                if (clip === 1) {
-                    // just calling getParameter here is quite slow (5-10 ms per frame according to chrome)
-                    //old_scissor = gl.getParameter(gl.SCISSOR_BOX);
-                    this.gl.scissor(x, y, w, h);
-                }
-
-                this.gl.bindBuffer(
-                    this.gl.ELEMENT_ARRAY_BUFFER,
-                    this.indexBuffer,
-                );
-                const indices = new Uint16Array(
-                    this.instance.exports.memory.buffer,
-                    index_ptr,
-                    index_len / 2,
-                );
-                this.gl.bufferData(
-                    this.gl.ELEMENT_ARRAY_BUFFER,
-                    indices,
-                    this.gl.DYNAMIC_DRAW,
-                );
-
-                this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
-                const vertexes = this.bytesFromPointer(vertex_ptr, vertex_len)
-                this.gl.bufferData(
-                    this.gl.ARRAY_BUFFER,
-                    vertexes,
-                    this.gl.DYNAMIC_DRAW,
-                );
-
-                let matrix = new Float32Array(16);
-                matrix[0] = 2.0 / this.renderTargetSize[0];
-                matrix[1] = 0.0;
-                matrix[2] = 0.0;
-                matrix[3] = 0.0;
-                matrix[4] = 0.0;
-                if (this.using_fb) {
-                    matrix[5] = 2.0 / this.renderTargetSize[1];
-                } else {
-                    matrix[5] = -2.0 / this.renderTargetSize[1];
-                }
-                matrix[6] = 0.0;
-                matrix[7] = 0.0;
-                matrix[8] = 0.0;
-                matrix[9] = 0.0;
-                matrix[10] = 1.0;
-                matrix[11] = 0.0;
-                matrix[12] = -1.0;
-                if (this.using_fb) {
-                    matrix[13] = -1.0;
-                } else {
-                    matrix[13] = 1.0;
-                }
-                matrix[14] = 0.0;
-                matrix[15] = 1.0;
-
-                // vertex
-                this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
-                this.gl.vertexAttribPointer(
-                    this.programInfo.attribLocations.vertexPosition,
-                    2, // num components
-                    this.gl.FLOAT,
-                    false, // don't normalize
-                    sizeof_vertex, // stride
-                    offset_pos, // offset
-                );
-                this.gl.enableVertexAttribArray(
-                    this.programInfo.attribLocations.vertexPosition,
-                );
-
-                // color
-                this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
-                this.gl.vertexAttribPointer(
-                    this.programInfo.attribLocations.vertexColor,
-                    4, // num components
-                    this.gl.UNSIGNED_BYTE,
-                    false, // don't normalize
-                    sizeof_vertex, // stride
-                    offset_col, // offset
-                );
-                this.gl.enableVertexAttribArray(
-                    this.programInfo.attribLocations.vertexColor,
-                );
-
-                // texture
-                this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
-                this.gl.vertexAttribPointer(
-                    this.programInfo.attribLocations.textureCoord,
-                    2, // num components
-                    this.gl.FLOAT,
-                    false, // don't normalize
-                    sizeof_vertex, // stride
-                    offset_uv, // offset
-                );
-                this.gl.enableVertexAttribArray(
-                    this.programInfo.attribLocations.textureCoord,
-                );
-
-                // Tell WebGL to use our program when drawing
-                this.gl.useProgram(this.shaderProgram);
-
-                // Set the shader uniforms
-                this.gl.uniformMatrix4fv(
-                    this.programInfo.uniformLocations.matrix,
-                    false,
-                    matrix,
-                );
-
-                if (textureId != 0) {
-                    const tex = this.textureEntry(textureId);
-                    if (tex !== null) {
-                        this.gl.activeTexture(this.gl.TEXTURE0);
-                        this.gl.bindTexture(this.gl.TEXTURE_2D, tex[0]);
-                        this.gl.uniform1i(
-                            this.programInfo.uniformLocations.useTex,
-                            1,
-                        );
-                    } else {
-                        console.warn(
-                            `wasm_renderGeometry: missing texture id ${textureId}`,
-                        );
-                        this.gl.bindTexture(this.gl.TEXTURE_2D, null);
-                        this.gl.uniform1i(
-                            this.programInfo.uniformLocations.useTex,
-                            0,
-                        );
-                    }
-                } else {
-                    this.gl.bindTexture(this.gl.TEXTURE_2D, null);
-                    this.gl.uniform1i(
-                        this.programInfo.uniformLocations.useTex,
-                        0,
-                    );
-                }
-
-                this.gl.uniform1i(
-                    this.programInfo.uniformLocations.uSampler,
-                    0,
-                );
-
-                //console.log("drawElements " + textureId);
-                this.gl.drawElements(
-                    this.gl.TRIANGLES,
-                    indices.length,
-                    this.gl.UNSIGNED_SHORT,
-                    0,
-                );
-
-                if (clip === 1) {
-                    //gl.scissor(old_scissor[0], old_scissor[1], old_scissor[2], old_scissor[3]);
-                    this.gl.scissor(
-                        0,
-                        0,
-                        this.renderTargetSize[0],
-                        this.renderTargetSize[1],
-                    );
-                }
-            },
-            wasm_cursor: (name_ptr, name_len) => {
-                const cursor_name = this.stringFromPointer(name_ptr, name_len);
-                this.gl.canvas.style.cursor = cursor_name;
-            },
-            wasm_text_input: (x, y, w, h) => {
-                if (w > 0 && h > 0) {
-                    this.textInputRect = [x, y, w, h];
-                } else {
-                    this.textInputRect = [];
-                }
-            },
-            wasm_open_url: (ptr, len, new_win) => {
-                const url = this.stringFromPointer(ptr, len);
-
-                if (new_win) {
-                    window.open(url);
-                } else {
-                    window.location.href = url;
-                }
-            },
-            wasm_preferred_color_scheme: () => {
-                if (
-                    window.matchMedia("(prefers-color-scheme: dark)").matches
-                ) {
-                    return 1;
-                }
-                if (
-                    window.matchMedia("(prefers-color-scheme: light)").matches
-                ) {
-                    return 2;
-                }
-                return 0;
-            },
-            wasm_prefers_reduced_motion: () => {
-                if (
-                    window.matchMedia("(prefers-reduced-motion: no-preference)").matches
-                ) {
-                    return 0;
-                }
-                if (
-                    window.matchMedia("(prefers-reduced-motion: reduce)").matches
-                ) {
-                    return 1;
-                }
-                return 0;
-            },
-            wasm_download_data: (
-                name_ptr,
-                name_len,
-                data_ptr,
-                data_len,
-            ) => {
-                const name = this.stringFromPointer(name_ptr, name_len);
-                const data = this.bytesFromPointer(data_ptr, data_len);
-                const blob = new Blob([data], { type: "application/octet-stream" });
-                const fileURL = URL.createObjectURL(blob);
-                const dl = document.createElement("a");
-                dl.href = fileURL;
-                dl.download = name;
-                dl.click();
-                dl.remove();
-                URL.revokeObjectURL(fileURL);
-            },
-            wasm_open_file_picker: (id, accept_ptr, accept_len, multiple) => {
-                const accept = this.stringFromPointer(accept_ptr, accept_len);
-                // console.log("Open picker", accept_ptr, accept_len, accept, multiple);
-                dvui_open_file_picker(accept, multiple).then((filelist) => {
-                    let files = [];
-                    let data = [];
-                    for (let i = 0; i < filelist.length; i++) {
-                        const file = filelist.item(i);
-                        files.push(file);
-                        data.push(file.arrayBuffer());
-                    }
-                    Promise.all(data).then((data) => {
-                        this.filesCacheModified = true;
-                        this.filesCache.set(id, { files, data });
-                        this.requestRender();
-                    });
-                }).catch(() => {
-                    console.debug(
-                        "Filepicker canceled: This is currently not detectable from within dvui",
-                    );
-                    this.requestRender();
-                });
-            },
-            wasm_get_file_size: (id, file_index) => {
-                const cached = this.filesCache.get(id);
-                if (!cached || cached.files.length <= file_index) return;
-                const size = cached.files[file_index].size;
-                return size;
-            },
-            wasm_get_file_name: (id, file_index) => {
-                const cached = this.filesCache.get(id);
-                if (!cached || cached.files.length <= file_index) return;
-
-                return this.allocStringZ(this.instance.exports.arena_u8, cached.files[file_index].name);
-            },
-            wasm_read_file_data: (id, file_index, data_ptr) => {
-                const cached = this.filesCache.get(id);
-                if (!cached || cached.files.length <= file_index) return;
-                var dest = new Uint8Array(
-                    this.instance.exports.memory.buffer,
-                    data_ptr,
-                );
-                dest.set(new Uint8Array(cached.data[file_index]));
-            },
-            wasm_get_number_of_files_available: (id) => {
-                const cached = this.filesCache.get(id);
-                if (!cached) return 0;
-                return cached.files.length;
-            },
-            wasm_clipboardTextSet: (ptr, len) => {
-                if (len == 0) {
-                    return;
-                }
-
-                const msg = this.stringFromPointer(ptr, len)
-                if (navigator.clipboard) {
-                    navigator.clipboard.writeText(msg);
-                } else {
-                    this.hidden_input.value = msg;
-                    this.hidden_input.focus();
-                    this.hidden_input.select();
-                    document.execCommand("copy");
-                    this.hidden_input.value = "";
-                }
-            },
-            wasm_add_noto_font: () => {
-                dvui_fetch("NotoSansKR-Regular.ttf").then((bytes) => {
-                    //console.log("bytes len " + bytes.length);
-                    const ptr = this.allocBuffer(this.instance.exports.gpa_u8, bytes)
-                    this.instance.exports.new_font(
-                        ptr,
-                        bytes.length,
-                    );
-                });
-            },
-        };
+        super();
+        this.imports = this.buildImports();
     }
 
     setInstance(instance) {
@@ -1015,130 +106,191 @@ export class Dvui {
             );
         }
 
-        // We do our own edge fades with triangles. If we leave antialias on
-        // then you can get a faint brightness on the edge of a filled square.
-        // Right on the edge you get the blended combination of both triangles
-        // that share that edge.
-        // It's not easy to notice, but to reproduce:
-        // * turn antialias on
-        // * use the builtin Adwaita Dark theme
-        // * put a small filled (.background = true) box in a larger filled box
-        // * screenshot it
-        // * the edge of the small box will be brighter than the fill color
-        this.gl = canvas.getContext("webgl2", { alpha: true, antialias: false });
-        if (this.gl === null) {
-            this.gl = canvas.getContext("webgl", { alpha: true, antialias: false });
-        }
-
-        if (this.gl === null) {
-            alert("Unable to initialize WebGL.");
+        if (!this.setupWebGL(canvas)) {
             return;
         }
 
+        this.hiddenInputMgr = new HiddenInputManager(canvas);
+    }
+
+    setupWebGL(canvas) {
+        const program = super.setupWebGL(canvas);
+        if (!program) {
+            alert("Unable to initialize WebGL.");
+            return null;
+        }
         if (!this.webgl2) {
             const ext = this.gl.getExtension("OES_element_index_uint");
             if (ext === null) {
                 alert("WebGL doesn't support OES_element_index_uint.");
-                return;
+                return null;
             }
         }
-        this.frame_buffer = this.gl.createFramebuffer();
+        return program;
+    }
 
-        const vertexShader = this.gl.createShader(this.gl.VERTEX_SHADER);
-        if (this.webgl2) {
-            this.gl.shaderSource(vertexShader, vertexShaderSource_webgl2);
+    wasm_panic(ptr, len) {
+        this.stop();
+        const msg = this.stringFromPointer(ptr, len);
+        console.error("PANIC:", msg);
+        alert(msg);
+    }
+
+    wasm_sleep(ms) {
+        const end = Date.now() + ms;
+        while (Date.now() < end) {
+            // block because the point is to limit the framerate
+        }
+    }
+
+    wasm_refresh() {
+        this.requestRender();
+    }
+
+    wasm_pixel_width() {
+        return this.gl.drawingBufferWidth;
+    }
+
+    wasm_pixel_height() {
+        return this.gl.drawingBufferHeight;
+    }
+
+    wasm_canvas_width() {
+        return this.gl.canvas.clientWidth;
+    }
+
+    wasm_canvas_height() {
+        return this.gl.canvas.clientHeight;
+    }
+
+    wasm_cursor(name_ptr, name_len) {
+        const cursor_name = this.stringFromPointer(name_ptr, name_len);
+        this.gl.canvas.style.cursor = cursor_name;
+    }
+
+    wasm_text_input(x, y, w, h) {
+        this.hiddenInputMgr.setRect([x, y, w, h]);
+    }
+
+    wasm_open_url(ptr, len, new_win) {
+        const url = this.stringFromPointer(ptr, len);
+
+        if (new_win) {
+            window.open(url);
         } else {
-            this.gl.shaderSource(vertexShader, vertexShaderSource_webgl);
+            window.location.href = url;
         }
-        this.gl.compileShader(vertexShader);
-        if (!this.gl.getShaderParameter(vertexShader, this.gl.COMPILE_STATUS)) {
-            alert(
-                `Error compiling vertex shader: ${this.gl.getShaderInfoLog(vertexShader)
-                }`,
-            );
-            this.gl.deleteShader(vertexShader);
-            return null;
-        }
+    }
 
-        const fragmentShader = this.gl.createShader(this.gl.FRAGMENT_SHADER);
-        if (this.webgl2) {
-            this.gl.shaderSource(fragmentShader, fragmentShaderSource_webgl2);
-        } else {
-            this.gl.shaderSource(fragmentShader, fragmentShaderSource_webgl);
-        }
-        this.gl.compileShader(fragmentShader);
+    wasm_preferred_color_scheme() {
         if (
-            !this.gl.getShaderParameter(fragmentShader, this.gl.COMPILE_STATUS)
+            window.matchMedia("(prefers-color-scheme: dark)").matches
         ) {
-            alert(
-                `Error compiling fragment shader: ${this.gl.getShaderInfoLog(fragmentShader)
-                }`,
-            );
-            this.gl.deleteShader(fragmentShader);
-            return null;
+            return 1;
         }
-
-        this.shaderProgram = this.gl.createProgram();
-        this.gl.attachShader(this.shaderProgram, vertexShader);
-        this.gl.attachShader(this.shaderProgram, fragmentShader);
-        this.gl.linkProgram(this.shaderProgram);
-
         if (
-            !this.gl.getProgramParameter(
-                this.shaderProgram,
-                this.gl.LINK_STATUS,
-            )
+            window.matchMedia("(prefers-color-scheme: light)").matches
         ) {
-            alert(
-                `Error initializing shader program: ${this.gl.getProgramInfoLog(this.shaderProgram)
-                }`,
-            );
-            return null;
+            return 2;
         }
+        return 0;
+    }
 
-        this.programInfo = {
-            attribLocations: {
-                vertexPosition: this.gl.getAttribLocation(
-                    this.shaderProgram,
-                    "aVertexPosition",
-                ),
-                vertexColor: this.gl.getAttribLocation(
-                    this.shaderProgram,
-                    "aVertexColor",
-                ),
-                textureCoord: this.gl.getAttribLocation(
-                    this.shaderProgram,
-                    "aTextureCoord",
-                ),
-            },
-            uniformLocations: {
-                matrix: this.gl.getUniformLocation(
-                    this.shaderProgram,
-                    "uMatrix",
-                ),
-                uSampler: this.gl.getUniformLocation(
-                    this.shaderProgram,
-                    "uSampler",
-                ),
-                useTex: this.gl.getUniformLocation(
-                    this.shaderProgram,
-                    "useTex",
-                ),
-            },
-        };
+    wasm_prefers_reduced_motion() {
+        if (
+            window.matchMedia("(prefers-reduced-motion: no-preference)").matches
+        ) {
+            return 0;
+        }
+        if (
+            window.matchMedia("(prefers-reduced-motion: reduce)").matches
+        ) {
+            return 1;
+        }
+        return 0;
+    }
 
-        this.indexBuffer = this.gl.createBuffer();
-        this.vertexBuffer = this.gl.createBuffer();
+    wasm_open_file_picker(id, accept_ptr, accept_len, multiple) {
+        const accept = this.stringFromPointer(accept_ptr, accept_len);
+        // console.log("Open picker", accept_ptr, accept_len, accept, multiple);
+        dvui_open_file_picker(accept, multiple).then((filelist) => {
+            let files = [];
+            let data = [];
+            for (let i = 0; i < filelist.length; i++) {
+                const file = filelist.item(i);
+                files.push(file);
+                data.push(file.arrayBuffer());
+            }
+            Promise.all(data).then((data) => {
+                this.filesCacheModified = true;
+                this.filesCache.set(id, { files, data });
+                this.requestRender();
+            });
+        }).catch(() => {
+            console.debug(
+                "Filepicker canceled: This is currently not detectable from within dvui",
+            );
+            this.requestRender();
+        });
+    }
 
-        this.gl.enable(this.gl.BLEND);
-        this.gl.blendFunc(this.gl.ONE, this.gl.ONE_MINUS_SRC_ALPHA);
-        this.gl.enable(this.gl.SCISSOR_TEST);
-        this.gl.scissor(
-            0,
-            0,
-            this.gl.canvas.clientWidth,
-            this.gl.canvas.clientHeight,
+    wasm_get_file_size(id, file_index) {
+        const cached = this.filesCache.get(id);
+        if (!cached || cached.files.length <= file_index) return;
+        const size = cached.files[file_index].size;
+        return size;
+    }
+
+    wasm_get_file_name(id, file_index) {
+        const cached = this.filesCache.get(id);
+        if (!cached || cached.files.length <= file_index) return;
+
+        return this.allocStringZ(this.instance.exports.arena_u8, cached.files[file_index].name);
+    }
+
+    wasm_read_file_data(id, file_index, data_ptr) {
+        const cached = this.filesCache.get(id);
+        if (!cached || cached.files.length <= file_index) return;
+        var dest = new Uint8Array(
+            this.instance.exports.memory.buffer,
+            data_ptr,
         );
+        dest.set(new Uint8Array(cached.data[file_index]));
+    }
+
+    wasm_get_number_of_files_available(id) {
+        const cached = this.filesCache.get(id);
+        if (!cached) return 0;
+        return cached.files.length;
+    }
+
+    wasm_clipboardTextSet(ptr, len) {
+        if (len == 0) {
+            return;
+        }
+
+        const msg = this.stringFromPointer(ptr, len)
+        if (navigator.clipboard) {
+            navigator.clipboard.writeText(msg);
+        } else {
+            const hiddenInput = this.hiddenInputMgr.hiddenInput;
+            hiddenInput.value = msg;
+            hiddenInput.focus();
+            hiddenInput.select();
+            document.execCommand("copy");
+            hiddenInput.value = "";
+        }
+    }
+
+    wasm_add_noto_font() {
+        dvui_fetch("NotoSansKR-Regular.ttf").then((bytes) => {
+            //console.log("bytes len " + bytes.length);
+            const ptr = this.allocBuffer(this.instance.exports.gpa_u8, bytes)
+            this.instance.exports.new_font(
+                ptr,
+                bytes.length,
+            );
+        });
     }
 
     init() {
@@ -1235,9 +387,9 @@ export class Dvui {
 
         let millis_to_wait = this.instance.exports.dvui_update();
 
-        // This oskCheck is for desktop to get text events.  Touch devices will
+        // This check is for desktop to get text events.  Touch devices will
         // show/hide the keyboard (but not all, see touchend handler).
-        this.oskCheck();
+        this.hiddenInputMgr.check();
 
         if (!this.filesCacheModified) {
             // Only clear if we didn't add anything this frame. Async could add items after they were requested
@@ -1311,90 +463,12 @@ export class Dvui {
             if (this.stopped) return;
             ev.preventDefault();
 
-            // If we haven't gotten a wheel event in a second, reset our first
-            // because the user might have switched between mouse and touchpad.
-            if ((Date.now() - this.scroll_last_ms) > 1000) {
-                this.scroll_lowest_batch = [99999, 99999];
-            }
-            this.scroll_last_ms = Date.now();
-
-            const touchpad_adj = 0.025;
-
-            if (ev.deltaX != 0) {
-                this.scroll_lowest[0] = Math.min(
-                    Math.abs(ev.deltaX),
-                    this.scroll_lowest[0],
-                );
-                this.scroll_lowest_batch[0] = Math.min(
-                    Math.abs(ev.deltaX),
-                    this.scroll_lowest_batch[0],
-                );
-                var ticks = -ev.deltaX;
-                var trackpad = 0;
-                if (ev.deltaMode !== 0) {
-                    // only mouse wheels produce non-pixel deltas, so this is definitive without
-                    // needing the magnitude heuristic.
-                    ticks /= this.scroll_lowest_batch[0];
-                } else if ((this.scroll_lowest_batch[0] >= 100) || // most wheels
-                    (this.scroll_lowest_batch[0] === 16) || // mac firefox
-                    (this.scroll_lowest_batch[0] === 9) || // mac firefox holding shift
-                    (this.scroll_lowest_batch[0] === 40) || // mac safari/chrome holding shift
-                    (this.scroll_lowest_batch[0] === 4.000244140625)) { // mac safari/chrome
-                    // assume this is a mouse wheel
-                    ticks /= this.scroll_lowest_batch[0];
-                    if (this.scroll_lowest_batch[0] === 4.000244140625) {
-                        ticks *= touchpad_adj; // mac safari/chrome scale wheel like touchpad
-                    }
-                    //console.log("wheelX -deltaX " + -ev.deltaX + " ticks " + ticks);
-                } else {
-                    // assume touchpad
-                    trackpad = 1;
-                    ticks = ticks / this.scroll_lowest[0] * touchpad_adj;
-                    //console.log("touchpadX -deltaX " + -ev.deltaX + " ticks " + ticks);
-                }
+            for (const action of this.wheelHandler.processWheelEvent(ev)) {
                 this.instance.exports.add_event(
                     4,
-                    0,
-                    trackpad,
-                    ticks,
-                    0,
-                );
-            }
-            if (ev.deltaY != 0) {
-                //console.log("deltaMode: " + ev.deltaMode + " deltaY: " + ev.deltaY);
-                this.scroll_lowest[1] = Math.min(
-                    Math.abs(ev.deltaY),
-                    this.scroll_lowest[1],
-                );
-                this.scroll_lowest_batch[1] = Math.min(
-                    Math.abs(ev.deltaY),
-                    this.scroll_lowest_batch[1],
-                );
-                var ticks = -ev.deltaY;
-                var trackpad = 0;
-                if (ev.deltaMode !== 0) {
-                    // only mouse wheels produce non-pixel deltas
-                    ticks /= this.scroll_lowest_batch[1];
-                } else if ((this.scroll_lowest_batch[1] >= 100) || // most wheels
-                    (this.scroll_lowest_batch[1] === 16) || // mac firefox
-                    (this.scroll_lowest_batch[1] === 4.000244140625)) { // mac safari/chrome
-                    // assume this is a mouse wheel
-                    ticks /= this.scroll_lowest_batch[1];
-                    if (this.scroll_lowest_batch[1] === 4.000244140625) {
-                        ticks *= touchpad_adj; // mac safari/chrome scale wheel like touchpad
-                    }
-                    //console.log("wheelY -deltaY " + -ev.deltaY + " ticks " + ticks);
-                } else {
-                    // assume touchpad
-                    trackpad = 1;
-                    ticks = ticks / this.scroll_lowest[1] * touchpad_adj;
-                    //console.log("touchpadY -deltaY " + -ev.deltaY + " ticks " + ticks);
-                }
-                this.instance.exports.add_event(
-                    4,
-                    1,
-                    trackpad,
-                    ticks,
+                    action.axis,
+                    action.trackpad,
+                    action.ticks,
                     0,
                 );
             }
@@ -1423,14 +497,13 @@ export class Dvui {
                     ptr,
                     str.length,
                     ev.repeat,
-                    (ev.metaKey << 3) + (ev.altKey << 2) +
-                    (ev.ctrlKey << 1) + (ev.shiftKey << 0),
+                    encodeModifiers(ev),
                 );
                 this.requestRender();
             }
         };
         this.gl.canvas.addEventListener("keydown", keydown.bind(this));
-        this.hidden_input.addEventListener("keydown", keydown.bind(this));
+        this.hiddenInputMgr.hiddenInput.addEventListener("keydown", keydown.bind(this));
 
         let keyup = (ev) => {
             if (this.stopped) return;
@@ -1441,15 +514,14 @@ export class Dvui {
                 ptr,
                 str.length,
                 0,
-                (ev.metaKey << 3) + (ev.altKey << 2) + (ev.ctrlKey << 1) +
-                (ev.shiftKey << 0),
+                encodeModifiers(ev),
             );
             this.requestRender();
         };
         this.gl.canvas.addEventListener("keyup", keyup.bind(this));
-        this.hidden_input.addEventListener("keyup", keyup.bind(this));
+        this.hiddenInputMgr.hiddenInput.addEventListener("keyup", keyup.bind(this));
 
-        this.hidden_input.addEventListener("beforeinput", (ev) => {
+        this.hiddenInputMgr.hiddenInput.addEventListener("beforeinput", (ev) => {
             if (this.stopped) return;
             ev.preventDefault();
             if (ev.data && !ev.isComposing) {
@@ -1465,7 +537,7 @@ export class Dvui {
                 this.requestRender();
             }
         });
-        this.hidden_input.addEventListener("compositionend", (ev) => {
+        this.hiddenInputMgr.hiddenInput.addEventListener("compositionend", (ev) => {
             if (this.stopped) return;
             if (ev.data) {
                 const str = utf8encoder.encode(ev.data);
@@ -1488,11 +560,8 @@ export class Dvui {
             let rect = this.gl.canvas.getBoundingClientRect();
             for (let i = 0; i < ev.changedTouches.length; i++) {
                 let touch = ev.changedTouches[i];
-                let x = (touch.clientX - rect.left) /
-                    (rect.right - rect.left);
-                let y = (touch.clientY - rect.top) /
-                    (rect.bottom - rect.top);
-                let tidx = this.touchIndex(touch.identifier);
+                let [x, y] = getTouchCoords(touch, rect);
+                let tidx = touchIndex(this.touches, touch.identifier);
                 this.instance.exports.add_event(
                     8,
                     this.touches[tidx][1],
@@ -1509,11 +578,8 @@ export class Dvui {
             let rect = this.gl.canvas.getBoundingClientRect();
             for (let i = 0; i < ev.changedTouches.length; i++) {
                 let touch = ev.changedTouches[i];
-                let x = (touch.clientX - rect.left) /
-                    (rect.right - rect.left);
-                let y = (touch.clientY - rect.top) /
-                    (rect.bottom - rect.top);
-                let tidx = this.touchIndex(touch.identifier);
+                let [x, y] = getTouchCoords(touch, rect);
+                let tidx = touchIndex(this.touches, touch.identifier);
                 this.instance.exports.add_event(
                     9,
                     this.touches[tidx][1],
@@ -1523,10 +589,10 @@ export class Dvui {
                 );
                 this.touches.splice(tidx, 1);
             }
-            // This oskCheck is for some platforms (iphone) where showing
+            // This check is for some platforms (iphone) where showing
             // the keyboard has to be done inside an event handler.
             // https://stackoverflow.com/a/6837575
-            this.oskCheck();
+            this.hiddenInputMgr.check();
             this.requestRender();
         });
         this.gl.canvas.addEventListener("touchmove", (ev) => {
@@ -1535,11 +601,8 @@ export class Dvui {
             let rect = this.gl.canvas.getBoundingClientRect();
             for (let i = 0; i < ev.changedTouches.length; i++) {
                 let touch = ev.changedTouches[i];
-                let x = (touch.clientX - rect.left) /
-                    (rect.right - rect.left);
-                let y = (touch.clientY - rect.top) /
-                    (rect.bottom - rect.top);
-                let tidx = this.touchIndex(touch.identifier);
+                let [x, y] = getTouchCoords(touch, rect);
+                let tidx = touchIndex(this.touches, touch.identifier);
                 this.instance.exports.add_event(
                     10,
                     this.touches[tidx][1],


### PR DESCRIPTION
## This refactor is the prerequisite for #962 
Moves all code shared between the in-page backend (`web.js`) and the upcoming Worker backend into a new ES module `web-common.js` (~1060 lines): shaders, `WebRenderer` base class (GL setup, textures, render geometry, import-object builder), and event helpers (`encodeModifiers`, `touchIndex`, `WheelHandler`, `HiddenInputManager`, `getTouchCoords`, `dvui_fetch`). `web.js` shrinks from ~1300 to ~620 lines and now just holds the app-specific `Dvui` subclass.

## Review guide

- [`web-common.js:1-95`](https://github.com/david-vanderson/dvui/blob/58394dda17a7b2fe7616e9cf6d12c698da803a46/src/backends/web-common.js#L1-L95) — shader sources + `dvui_fetch`, moved verbatim; check no drift vs. old `web.js`.
- [`web-common.js:96-150`](https://github.com/david-vanderson/dvui/blob/58394dda17a7b2fe7616e9cf6d12c698da803a46/src/backends/web-common.js#L96-L150) — string/UTF helpers and `encodeModifiers`/`touchIndex`.
- [`web-common.js:400-550`](https://github.com/david-vanderson/dvui/blob/58394dda17a7b2fe7616e9cf6d12c698da803a46/src/backends/web-common.js#L400-L550) — `WebRenderer` class; [`buildImports()`](https://github.com/david-vanderson/dvui/blob/58394dda17a7b2fe7616e9cf6d12c698da803a46/src/backends/web-common.js#L442-L476) — verify the import list is the union both backends need.
- [`web-common.js:1050-1085`](https://github.com/david-vanderson/dvui/blob/58394dda17a7b2fe7616e9cf6d12c698da803a46/src/backends/web-common.js#L1050-L1085) — default no-op host functions; `web.js` overrides the ones it implements.
- [`web.js:5`](https://github.com/david-vanderson/dvui/blob/58394dda17a7b2fe7616e9cf6d12c698da803a46/src/backends/web.js#L5) — imports from `./web-common.js`; [`web.js:58`](https://github.com/david-vanderson/dvui/blob/58394dda17a7b2fe7616e9cf6d12c698da803a46/src/backends/web.js#L58) — `class Dvui extends WebRenderer`. Everything below should be override-only; confirm no duplicated logic remains.
- [`build.zig:1641-1642`](https://github.com/david-vanderson/dvui/blob/58394dda17a7b2fe7616e9cf6d12c698da803a46/build.zig#L1641-L1642) — `web-common.js` added to install set for `web-test`/`web-app`.
- Verify: `zig build web-app` still serves and renders identically (pure refactor, no behavior change intended).