### PR TITLE
Fix C based backends in 0.17.x branch

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -501,6 +501,7 @@ pub fn buildBackend(
                 .c_source_file = b.path("src/backends/sdl2-c.h"),
                 .target = target,
                 .optimize = optimize,
+                .default_init = true,
             });
             const sdl_mod = b.addModule("sdl2", .{
                 .root_source_file = b.path("src/backends/sdl.zig"),
@@ -602,6 +603,7 @@ pub fn buildBackend(
                 .c_source_file = b.path("src/backends/sdl3-c.h"),
                 .target = target,
                 .optimize = optimize,
+                .default_init = true,
             });
             const sdl_mod = b.addModule("sdl3gpu", .{
                 .root_source_file = b.path("src/backends/sdl3gpu.zig"),
@@ -653,6 +655,7 @@ pub fn buildBackend(
                 .c_source_file = b.path("src/backends/sdl3-c.h"),
                 .target = target,
                 .optimize = optimize,
+                .default_init = true,
             });
 
             if (b.systemIntegrationOption("sdl3", .{})) {
@@ -755,6 +758,7 @@ pub fn buildBackend(
                 .c_source_file = b.path("src/backends/raylib-c.h"),
                 .target = target,
                 .optimize = optimize,
+                .default_init = true,
             });
             const raylib_backend_mod = b.addModule("raylib", .{
                 .root_source_file = b.path("src/backends/raylib-c.zig"),


### PR DESCRIPTION
fix regression from #958
Old translate c inited C fields to 0s by default. Some of examples and backends relied on this behavior by omitting some of fields.
I didn't check all examples but it fixed sdl3gpu-standalone at least.

I didn't set dvui.h to use default_init since it doesn't really have much of structs in it.