### PR TITLE
Support fade in for floating windows

### DIFF
--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -278,8 +278,9 @@ pub fn focusBorder(self: *const WidgetData) void {
     if (self.visible()) {
         const rs = self.borderRectScale();
         const thick = 2 * rs.s;
+        const t = dvui.stateFade(self.id, "__focus_fade", true, dvui.hover_fade_secs);
 
-        rs.r.stroke(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{ .thickness = thick, .color = self.options.themeGet().focus, .after = true });
+        rs.r.stroke(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{ .thickness = thick, .color = self.options.themeGet().focus.opacity(t), .after = true });
     }
 }
 

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1944,8 +1944,9 @@ pub fn animationGet(id: Id, key: []const u8) ?Animation {
 /// How long a hover fade (see `hoverFade`) takes to reach full intensity.
 pub var hover_fade_secs: f32 = 0.12;
 
-/// Lets a hover wash fade in and out (instead of snapping the frame at once).
-/// Call at most once per widget per frame.
+/// The longest a single `stateFade` step may count for.
+const state_fade_max_step_secs: f32 = 1.0 / 30.0;
+
 ///
 /// Only valid between `Window.begin` and `Window.end`.
 pub fn stateFade(id: Id, key: []const u8, on: bool, secs: f32) f32 {
@@ -1956,7 +1957,8 @@ pub fn stateFade(id: Id, key: []const u8, on: bool, secs: f32) f32 {
     // in rather than starting fully lit.
     const cur = dataGetPtrDefault(null, id, key, f32, 0);
     if (cur.* != target) {
-        const step = currentWindow().secs_since_last_frame / hover_fade_secs;
+        const dt = @min(currentWindow().secs_since_last_frame, state_fade_max_step_secs);
+        const step = dt / secs;
         cur.* = if (cur.* < target) @min(target, cur.* + step) else @max(target, cur.* - step);
         refresh(null, @src(), id);
     }

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1941,7 +1941,7 @@ pub fn animationGet(id: Id, key: []const u8) ?Animation {
     return currentWindow().animations.get(h);
 }
 
-/// How long a hover fade (see `hoverFade`) takes to reach full intensity.
+/// How long a state fade (see `stateFade`) takes to reach full intensity.
 pub var hover_fade_secs: f32 = 0.12;
 
 /// The longest a single `stateFade` step may count for.

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -1948,19 +1948,23 @@ pub var hover_fade_secs: f32 = 0.12;
 /// Call at most once per widget per frame.
 ///
 /// Only valid between `Window.begin` and `Window.end`.
-pub fn hoverFade(id: Id, hovered: bool) f32 {
-    const target: f32 = if (hovered) 1 else 0;
-    if (reduce_motion or hover_fade_secs == 0.0) return target;
-    // Default 0 (instead of target) so a widget with the first frame already hovered
-    // (e.g. a context-menu item that pops up under the cursor) fades in rather
-    // than starting fully lit.
-    const cur = dataGetPtrDefault(null, id, "__hover_fade", f32, 0);
+pub fn stateFade(id: Id, key: []const u8, on: bool, secs: f32) f32 {
+    const target: f32 = if (on) 1 else 0;
+    if (reduce_motion or secs <= 0.0) return target;
+    // Default 0 (instead of target) so a widget with the first frame already in
+    // the state (e.g. a context-menu item that pops up under the cursor) fades
+    // in rather than starting fully lit.
+    const cur = dataGetPtrDefault(null, id, key, f32, 0);
     if (cur.* != target) {
         const step = currentWindow().secs_since_last_frame / hover_fade_secs;
         cur.* = if (cur.* < target) @min(target, cur.* + step) else @max(target, cur.* - step);
         refresh(null, @src(), id);
     }
     return cur.*;
+}
+
+pub fn hoverFade(id: Id, hovered: bool) f32 {
+    return stateFade(id, "__hover_fade", hovered, hover_fade_secs);
 }
 
 /// Add a timer for id that will be `timerDone` on the first frame after micros

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -37,6 +37,9 @@ pub const InitOptions = struct {
     center_on: ?Rect.Natural = null,
     open_flag: ?*bool = null,
 
+    /// 0 is opens full opacity.
+    fade_in_secs: f32 = 0,
+
     /// Whether to allow resizing the window by dragging the edges/corners.
     resize: Resize = .all,
     process_events_in_deinit: bool = true,
@@ -97,6 +100,8 @@ auto_size: bool = false,
 auto_size_refresh_prev_value: ?u8 = null,
 drag_part: ?DragPart = null,
 drag_area: Rect.Physical = undefined,
+// Null while window is opaque (every frame once the fade has finished).
+prev_alpha: ?f32 = null,
 
 pub fn init(self: *FloatingWindowWidget, src: std.builtin.SourceLocation, init_opts: InitOptions, opts: Options) void {
     const options = defaults.override(opts);
@@ -272,6 +277,14 @@ pub fn init(self: *FloatingWindowWidget, src: std.builtin.SourceLocation, init_o
         else
             AccessKit.nodeClearModal(ak_node);
         AccessKit.nodeAddAction(ak_node, AccessKit.Action.focus);
+    }
+
+    if (self.init_options.fade_in_secs > 0) {
+        const t = if (dvui.firstFrame(self.data().id))
+            0
+        else
+            dvui.stateFade(self.data().id, "__fade_in", true, self.init_options.fade_in_secs);
+        if (t < 1) self.prev_alpha = dvui.alpha(t);
     }
 
     dvui.toastsShow(self.data().id, .cast(self.data().rect));
@@ -558,6 +571,7 @@ pub fn minSizeForChild(self: *FloatingWindowWidget, s: Size) void {
 pub fn deinit(self: *FloatingWindowWidget) void {
     defer if (dvui.widgetIsAllocated(self)) dvui.widgetFree(self);
     defer self.* = undefined;
+    defer if (self.prev_alpha) |a| dvui.alphaSet(a);
     if (self.layout) |*l| l.deinit();
 
     if (self.auto_size_refresh_prev_value) |pv| {


### PR DESCRIPTION
Assumes on #965.

Allows `FloatingWindowWidget` to set fade in from invisible. It reinstates whatever the user had it set to before.

I needed this to avoid an abrupt dialog open on an app.

This has to be inside the widget rather than in calling code, because `dvui.floatingWindow()` paints the modal dimming and the window background during setup, before the caller gets the widget back.

The first frame of a new window is the throwaway one used to measure and centre it, so the fade starts on the second frame, the first one that is actually on screen.

I put this info in the commit too.