### PR TITLE
Feature/Gradient Support

### DIFF
--- a/examples/raylib-ontop.zig
+++ b/examples/raylib-ontop.zig
@@ -115,7 +115,7 @@ fn colorPicker(result: *dvui.Color) void {
         defer hbox.deinit();
 
         dvui.labelNoFmt(@src(), &color_hex, .{}, .{
-            .color_text = result.*,
+            .color_text = .{ .color = result.* },
             .gravity_y = 0.5,
         });
 

--- a/examples/raylib-zig-ontop.zig
+++ b/examples/raylib-zig-ontop.zig
@@ -124,7 +124,7 @@ fn colorPicker(result: *dvui.Color) void {
         defer hbox.deinit();
 
         dvui.labelNoFmt(@src(), &color_hex, .{}, .{
-            .color_text = result.*,
+            .color_text = .{ .color = result.* },
             .gravity_y = 0.5,
         });
 

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -252,9 +252,9 @@ pub fn captureWidget(self: *Debug, gpa: std.mem.Allocator, wd: *const dvui.Widge
         .subwindow_id = dvui.subwindowCurrentId(),
         .background = wd.options.backgroundGet(),
         .style = wd.options.styleGet(),
-        .color_fill = wd.options.textColor(.fill).toColor(),
-        .color_text = wd.options.textColor(.text).toColor(),
-        .color_border = wd.options.textColor(.border).toColor(),
+        .color_fill = wd.options.color(.fill).toColor(),
+        .color_text = wd.options.color(.text).toColor(),
+        .color_border = wd.options.color(.border).toColor(),
         .font = wd.options.fontGet(),
         .focused = wd.id == dvui.focusedWidgetId(),
         .active = dvui.captured(wd.id),
@@ -700,7 +700,7 @@ pub fn show(self: *Debug) void {
         if (self.widget_id == .zero) {
             // blend text and control colors
             const opts: Options = .{};
-            color = .{ .color = .average(opts.textColor(.text).toColor(), opts.textColor(.fill).toColor()) };
+            color = .{ .color = .average(opts.color(.text).toColor(), opts.color(.fill).toColor()) };
         }
 
         if (dvui.button(@src(), "Edit Options", .{}, .{ .gravity_x = 1, .color_text = color })) {
@@ -867,7 +867,7 @@ pub fn show(self: *Debug) void {
                 const opts: Options = .{};
                 const stack = dvui.box(@src(), .{}, .{
                     .expand = .both,
-                    .color_fill = if (button.pressed()) opts.textColor(.fill_press) else null,
+                    .color_fill = if (button.pressed()) opts.color(.fill_press) else null,
                 });
                 defer stack.deinit();
 
@@ -1355,7 +1355,7 @@ fn stylePage(self: *Options, id: dvui.Id) bool {
 
                 var label_opts = tab.data().options.strip();
                 if (dvui.captured(tab.data().id)) {
-                    label_opts.color_text = label_opts.textColor(.text_press);
+                    label_opts.color_text = label_opts.color(.text_press);
                 }
 
                 const field = "color_" ++ @tagName(color_ask);
@@ -1388,7 +1388,7 @@ fn stylePage(self: *Options, id: dvui.Id) bool {
             // produce a flat `.color`.
             const default: dvui.Color, const current: ?dvui.Color = switch (active_color.*) {
                 inline else => |c| .{
-                    self.textColor(@field(dvui.Options.ColorAsk, @tagName(c))).toColor(),
+                    self.color(@field(dvui.Options.ColorAsk, @tagName(c))).toColor(),
                     if (@field(self, "color_" ++ @tagName(c))) |cog| cog.toColor() else null,
                 },
             };

--- a/src/Debug.zig
+++ b/src/Debug.zig
@@ -252,9 +252,9 @@ pub fn captureWidget(self: *Debug, gpa: std.mem.Allocator, wd: *const dvui.Widge
         .subwindow_id = dvui.subwindowCurrentId(),
         .background = wd.options.backgroundGet(),
         .style = wd.options.styleGet(),
-        .color_fill = wd.options.color(.fill),
-        .color_text = wd.options.color(.text),
-        .color_border = wd.options.color(.border),
+        .color_fill = wd.options.textColor(.fill).toColor(),
+        .color_text = wd.options.textColor(.text).toColor(),
+        .color_border = wd.options.textColor(.border).toColor(),
         .font = wd.options.fontGet(),
         .focused = wd.id == dvui.focusedWidgetId(),
         .active = dvui.captured(wd.id),
@@ -696,11 +696,11 @@ pub fn show(self: *Debug) void {
         var corner_box = dvui.box(@src(), .{}, .{ .gravity_x = 1, .margin = .all(8) });
         defer corner_box.deinit();
 
-        var color: ?dvui.Color = null;
+        var color: ?dvui.ColorOrGradient = null;
         if (self.widget_id == .zero) {
             // blend text and control colors
             const opts: Options = .{};
-            color = .average(opts.color(.text), opts.color(.fill));
+            color = .{ .color = .average(opts.textColor(.text).toColor(), opts.textColor(.fill).toColor()) };
         }
 
         if (dvui.button(@src(), "Edit Options", .{}, .{ .gravity_x = 1, .color_text = color })) {
@@ -867,7 +867,7 @@ pub fn show(self: *Debug) void {
                 const opts: Options = .{};
                 const stack = dvui.box(@src(), .{}, .{
                     .expand = .both,
-                    .color_fill = if (button.pressed()) opts.color(.fill_press) else null,
+                    .color_fill = if (button.pressed()) opts.textColor(.fill_press) else null,
                 });
                 defer stack.deinit();
 
@@ -1355,7 +1355,7 @@ fn stylePage(self: *Options, id: dvui.Id) bool {
 
                 var label_opts = tab.data().options.strip();
                 if (dvui.captured(tab.data().id)) {
-                    label_opts.color_text = label_opts.color(.text_press);
+                    label_opts.color_text = label_opts.textColor(.text_press);
                 }
 
                 const field = "color_" ++ @tagName(color_ask);
@@ -1382,21 +1382,29 @@ fn stylePage(self: *Options, id: dvui.Id) bool {
             var vbox = dvui.box(@src(), .{}, .{});
             defer vbox.deinit();
 
-            const field: *?dvui.Color, const default: dvui.Color = switch (active_color.*) {
+            // All `color_*` fields are `?ColorOrGradient` -- this picker only
+            // edits flat colors, so gradient fields collapse to a
+            // representative color (via `toColor`) and writes always
+            // produce a flat `.color`.
+            const default: dvui.Color, const current: ?dvui.Color = switch (active_color.*) {
                 inline else => |c| .{
-                    &@field(self, "color_" ++ @tagName(c)),
-                    self.color(std.meta.stringToEnum(dvui.Options.ColorAsk, @tagName(c)) orelse unreachable),
+                    self.textColor(@field(dvui.Options.ColorAsk, @tagName(c))).toColor(),
+                    if (@field(self, "color_" ++ @tagName(c))) |cog| cog.toColor() else null,
                 },
             };
-            var hsv = dvui.Color.HSV.fromColor(field.* orelse default);
+            var hsv = dvui.Color.HSV.fromColor(current orelse default);
             if (dvui.colorPicker(@src(), .{ .hsv = &hsv, .dir = .horizontal }, .{})) {
                 changed = true;
-                field.* = hsv.toColor();
+                switch (active_color.*) {
+                    inline else => |c| @field(self, "color_" ++ @tagName(c)) = .{ .color = hsv.toColor() },
+                }
             }
 
-            if (field.* != null and dvui.button(@src(), "Set to null", .{}, .{})) {
+            if (current != null and dvui.button(@src(), "Set to null", .{}, .{})) {
                 changed = true;
-                field.* = null;
+                switch (active_color.*) {
+                    inline else => |c| @field(self, "color_" ++ @tagName(c)) = null,
+                }
             }
         }
     }
@@ -1645,8 +1653,14 @@ pub fn ZigCodeFormatter(comptime T: type) type {
                         },
                         .c, .many, .slice => if (ptr.child == u8)
                             try writer.print("\"{s}\"", .{self.value})
-                        else
-                            @compileError("Cannot write non string many item pointer"),
+                        else {
+                            try writer.writeAll("&.{ ");
+                            for (self.value) |v| {
+                                try writer.print("{f}", .{asZigCode(v)});
+                                try writer.writeAll(", ");
+                            }
+                            try writer.writeAll("}");
+                        },
                     }
                 },
                 .array => |array| if (array.child == u8) {

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -193,7 +193,7 @@ pub fn demo(comptime include: DemoInclude) void {
                 defer box.deinit();
 
                 var options: dvui.Options = .{ .gravity_x = 0.5, .gravity_y = 1.0 };
-                if (dvui.captured(bw.data().id)) options = options.override(.{ .color_text = options.color(.text_press) });
+                if (dvui.captured(bw.data().id)) options = options.override(.{ .color_text = options.textColor(.text_press) });
 
                 dvui.label(@src(), "{s}", .{e.name()}, options);
 
@@ -256,7 +256,7 @@ pub fn demo(comptime include: DemoInclude) void {
 
             dvui.label(@src(), "{s}", .{demo_active.name()}, .{ .font = dvui.Font.theme(.title), .gravity_y = 0.5 });
             if (include == .full) {
-                if (dvui.labelClick(@src(), "View source code", .{}, .{}, .{ .gravity_x = 1.0, .gravity_y = 0.5, .color_text = dvui.themeGet().focus })) {
+                if (dvui.labelClick(@src(), "View source code", .{}, .{}, .{ .gravity_x = 1.0, .gravity_y = 0.5, .color_text = .{ .color = dvui.themeGet().focus } })) {
                     const window_rect = dvui.currentWindow().data().contentRect();
                     source_code_rect = .{ .x = window_rect.x + window_rect.w / 2, .y = window_rect.y, .h = window_rect.h, .w = window_rect.w / 2 };
                     source_code_show = true;
@@ -302,7 +302,7 @@ pub fn demo(comptime include: DemoInclude) void {
     }
 
     if (icon_browser_show) {
-        iconBrowser(@src(), &icon_browser_show, "entypo", entypo);
+        iconBrowser(@src(), &icon_browser_show, "entypo", entypo, null);
     }
 
     if (stroke_test_show) {
@@ -454,7 +454,7 @@ pub fn show_stroke_test_window() void {
     const fill_color = dvui.Color{ .r = 200, .g = 200, .b = 200, .a = 255 };
     for (points.items, 0..) |p, i| {
         const rect: dvui.Rect = .{ .x = p.x - 10, .y = p.y - 10, .w = 20, .h = 20 };
-        rs.rectToPhysical(rect).fill(.round(1), .{ .color = fill_color, .fade = 1.0 });
+        rs.rectToPhysical(rect).fill(.round(1), .{ .color = .{ .color = fill_color }, .fade = 1.0 });
 
         _ = i;
         //_ = dvui.button(@src(), i, "Floating", .{}, .{ .rect = dvui.Rect.fromPoint(p) });
@@ -463,7 +463,7 @@ pub fn show_stroke_test_window() void {
     var builder: dvui.Path.Builder = .init(dvui.currentWindow().arena());
     for (points.items) |p| builder.addPoint(rs.pointToPhysical(p));
     const stroke_color = dvui.Color{ .r = 0, .g = 0, .b = 255, .a = 150 };
-    builder.build().stroke(.{ .thickness = rs.s * thickness.*, .color = stroke_color, .closed = closed.*, .endcap_style = endcap.* });
+    builder.build().stroke(.{ .thickness = rs.s * thickness.*, .color = .{ .color = stroke_color }, .closed = closed.*, .endcap_style = endcap.* });
 
     for (dvui.events()) |*e| {
         if (!dvui.eventMatchSimple(e, st.data())) continue;

--- a/src/Examples.zig
+++ b/src/Examples.zig
@@ -193,7 +193,7 @@ pub fn demo(comptime include: DemoInclude) void {
                 defer box.deinit();
 
                 var options: dvui.Options = .{ .gravity_x = 0.5, .gravity_y = 1.0 };
-                if (dvui.captured(bw.data().id)) options = options.override(.{ .color_text = options.textColor(.text_press) });
+                if (dvui.captured(bw.data().id)) options = options.override(.{ .color_text = options.color(.text_press) });
 
                 dvui.label(@src(), "{s}", .{e.name()}, options);
 

--- a/src/Examples/animations.zig
+++ b/src/Examples/animations.zig
@@ -182,7 +182,7 @@ pub fn animations() void {
 
     if (dvui.expander(@src(), "Spinner", .{}, .{ .expand = .horizontal })) {
         dvui.labelNoFmt(@src(), "Spinner maxes out frame rate", .{}, .{});
-        dvui.spinner(@src(), .{ .color_text = .{ .r = 100, .g = 200, .b = 100 } });
+        dvui.spinner(@src(), .{ .color_text = .{ .color = .{ .r = 100, .g = 200, .b = 100 } } });
     }
 
     if (dvui.expander(@src(), "Clock", .{}, .{ .expand = .horizontal })) {

--- a/src/Examples/applets.zig
+++ b/src/Examples/applets.zig
@@ -589,7 +589,7 @@ fn checkerboard() void {
                 .id_extra = row * 1000 + col,
                 .rect = .{ .x = x, .y = y, .w = cell, .h = cell },
                 .background = true,
-                .color_fill = if (on) swatches[col % swatches.len] else .black,
+                .color_fill = .{ .color = if (on) swatches[col % swatches.len] else .black },
             });
             b.deinit();
             col += 1;

--- a/src/Examples/applets.zig
+++ b/src/Examples/applets.zig
@@ -245,7 +245,7 @@ pub fn draw() void {
 
     for (points.items) |p| {
         dvui.Path.stroke(.{ .points = &.{rs.pointToPhysical(p)} }, .{
-            .color = dvui.Color{ .b = 120, .g = 12, .r = 212 },
+            .color = .{ .color = .{ .b = 120, .g = 12, .r = 212 } },
             .thickness = 5 * rs.s,
         });
     }

--- a/src/Examples/grid.zig
+++ b/src/Examples/grid.zig
@@ -135,10 +135,10 @@ pub fn gridStyling() void {
         }
         for (start_row..end_row) |row| {
             for (0..@trunc(cols.*)) |col| {
-                const fill = switch (local.banding) {
+                const fill: ?dvui.ColorOrGradient = switch (local.banding) {
                     .none => null,
-                    .rows => if (row % 2 == 1) dvui.themeGet().color(.control, .fill_press) else null,
-                    .cols => if (col % 2 == 1) dvui.themeGet().color(.control, .fill_press) else null,
+                    .rows => if (row % 2 == 1) .{ .color = dvui.themeGet().color(.control, .fill_press) } else null,
+                    .cols => if (col % 2 == 1) .{ .color = dvui.themeGet().color(.control, .fill_press) } else null,
                 };
 
                 var cell = grid.cell(.{ .col = col, .row = row }, .{
@@ -484,7 +484,7 @@ pub fn gridSelection() void {
         var opts: dvui.Options = .{};
         if (cell_hovered) |cell| {
             if (cell.row == row) {
-                opts.color_fill = dvui.themeGet().color(.control, .fill_press);
+                opts.color_fill = .{ .color = dvui.themeGet().color(.control, .fill_press) };
                 opts.background = true;
             }
         }
@@ -537,7 +537,7 @@ pub fn gridSelection() void {
                 .Fair => dvui.Color.fromHex("#d3b95f"),
                 .Poor => dvui.Color.fromHex("#c96b6b"),
             };
-            dvui.labelNoFmt(@src(), @tagName(car.condition), .{}, .{ .color_text = col });
+            dvui.labelNoFmt(@src(), @tagName(car.condition), .{}, .{ .color_text = .{ .color = col } });
         }
         // Description
         {

--- a/src/Examples/icon_browser.zig
+++ b/src/Examples/icon_browser.zig
@@ -1,5 +1,11 @@
+/// An icon chosen out of `iconBrowser`'s `selected` out-param.
+pub const IconChoice = struct { name: []const u8 = "", tvg_bytes: []const u8 = "" };
+
 /// ![image](Examples-iconBrowser.png)
-pub fn iconBrowser(src: std.builtin.SourceLocation, show_flag: *bool, comptime icon_decl_name: []const u8, comptime icon_decl: type) void {
+///
+/// If `selected` is non-null, clicking an icon stores it there and closes
+/// the browser (picker mode) instead of the default copy-to-clipboard.
+pub fn iconBrowser(src: std.builtin.SourceLocation, show_flag: *bool, comptime icon_decl_name: []const u8, comptime icon_decl: type, selected: ?*IconChoice) void {
     const num_icons = @typeInfo(icon_decl).@"struct".decls.len;
     const Settings = struct {
         icon_size: f32 = 20,
@@ -78,13 +84,20 @@ pub fn iconBrowser(src: std.builtin.SourceLocation, show_flag: *bool, comptime i
                 .{},
                 .{
                     .min_size_content = .{ .h = settings.icon_size },
-                    .color_text = settings.icon_rgb,
+                    .color_text = .{ .color = settings.icon_rgb },
                 },
             )) {
-                dvui.clipboardTextSet(text);
-                var buf2: [100]u8 = undefined;
-                const toast_text = std.fmt.bufPrint(&buf2, "Copied \"{s}\"", .{text}) catch "Copied <Too much text>";
-                dvui.toast(@src(), .{ .message = toast_text, .timeout = 1_000_000 });
+                if (selected) |sel| {
+                    // `name` is a comptime-known decl name (stable storage),
+                    // unlike `text` which points into this frame's stack buffer.
+                    sel.* = .{ .name = name, .tvg_bytes = field };
+                    show_flag.* = false;
+                } else {
+                    dvui.clipboardTextSet(text);
+                    var buf2: [100]u8 = undefined;
+                    const toast_text = std.fmt.bufPrint(&buf2, "Copied \"{s}\"", .{text}) catch "Copied <Too much text>";
+                    dvui.toast(@src(), .{ .message = toast_text, .timeout = 1_000_000 });
+                }
             }
             dvui.labelNoFmt(@src(), text, .{}, .{ .gravity_y = 0.5 });
 
@@ -112,7 +125,7 @@ test "DOCIMG iconBrowser" {
             var box = dvui.box(@src(), .{}, .{ .expand = .both, .background = true, .style = .window });
             defer box.deinit();
             var show_flag: bool = true;
-            iconBrowser(@src(), &show_flag, "entypo", dvui.entypo);
+            iconBrowser(@src(), &show_flag, "entypo", dvui.entypo, null);
             return .ok;
         }
     }.frame;

--- a/src/Examples/layout.zig
+++ b/src/Examples/layout.zig
@@ -204,7 +204,7 @@ pub fn layout() void {
                     .{
                         .min_size_content = Static.size,
                         .background = Static.background,
-                        .color_fill = options.textColor(.text),
+                        .color_fill = options.color(.text),
                         .border = if (Static.border) Rect.all(1) else null,
                         .label = .{ .text = "zig favicon" },
                     },

--- a/src/Examples/layout.zig
+++ b/src/Examples/layout.zig
@@ -204,7 +204,7 @@ pub fn layout() void {
                     .{
                         .min_size_content = Static.size,
                         .background = Static.background,
-                        .color_fill = options.color(.text),
+                        .color_fill = options.textColor(.text),
                         .border = if (Static.border) Rect.all(1) else null,
                         .label = .{ .text = "zig favicon" },
                     },

--- a/src/Examples/menus.zig
+++ b/src/Examples/menus.zig
@@ -196,7 +196,7 @@ pub fn menus() void {
 
                     var label_opts = tab.data().options.strip();
                     if (dvui.captured(tab.data().id)) {
-                        label_opts.color_text = (dvui.Options{}).textColor(.text_press);
+                        label_opts.color_text = (dvui.Options{}).color(.text_press);
                     }
 
                     dvui.labelNoFmt(@src(), tabname, .{}, label_opts);

--- a/src/Examples/menus.zig
+++ b/src/Examples/menus.zig
@@ -196,7 +196,7 @@ pub fn menus() void {
 
                     var label_opts = tab.data().options.strip();
                     if (dvui.captured(tab.data().id)) {
-                        label_opts.color_text = (dvui.Options{}).color(.text_press);
+                        label_opts.color_text = (dvui.Options{}).textColor(.text_press);
                     }
 
                     dvui.labelNoFmt(@src(), tabname, .{}, label_opts);
@@ -354,7 +354,7 @@ pub fn focus() void {
 
             if (e.evt == .mouse and e.evt.mouse.action == .position) {
                 hbox.data().options.background = true;
-                hbox.data().options.color_fill = dvui.themeGet().color(.content, .fill_hover);
+                hbox.data().options.color_fill = .{ .color = dvui.themeGet().color(.content, .fill_hover) };
             }
         }
         hbox.drawBackground();

--- a/src/Examples/reorder_tree.zig
+++ b/src/Examples/reorder_tree.zig
@@ -114,13 +114,13 @@ pub fn reorderLists() void {
 
             if (dvui.dragName("tree_drag")) {
                 label_opts.background = true;
-                label_opts.color_fill = dvui.themeGet().color(.content, .fill_hover);
+                label_opts.color_fill = .{ .color = dvui.themeGet().color(.content, .fill_hover) };
 
                 for (dvui.events()) |*e| {
                     if (!dvui.eventMatch(e, .{ .id = vbox.data().id, .r = vbox.data().borderRectScale().r, .drag_name = "tree_drag" })) continue;
 
                     if (e.evt == .mouse and e.evt.mouse.action == .position) {
-                        label_opts.color_fill = dvui.themeGet().color(.content, .fill_press);
+                        label_opts.color_fill = .{ .color = dvui.themeGet().color(.content, .fill_press) };
                     }
 
                     if (e.evt == .mouse and e.evt.mouse.action == .release and e.evt.mouse.button.pointer()) {
@@ -612,7 +612,7 @@ fn exampleFileTreeSearch(directory: []const u8, base_entries: *MutableTreeEntry.
                 @src(),
                 "FolderIcon",
                 dvui.entypo.folder,
-                .{ .fill_color = color },
+                .{ .fill_color = .{ .color = color } },
                 .{
                     .gravity_y = 0.5,
                 },
@@ -624,7 +624,7 @@ fn exampleFileTreeSearch(directory: []const u8, base_entries: *MutableTreeEntry.
                 @src(),
                 "DropIcon",
                 if (branch.expanded) dvui.entypo.triangle_down else dvui.entypo.triangle_right,
-                .{ .fill_color = color },
+                .{ .fill_color = .{ .color = color } },
                 .{
                     .gravity_y = 0.5,
                     .gravity_x = 1.0,
@@ -633,7 +633,7 @@ fn exampleFileTreeSearch(directory: []const u8, base_entries: *MutableTreeEntry.
 
             var expander_opts_override = dvui.Options{
                 .margin = .{ .x = 14 },
-                .color_border = color,
+                .color_border = .{ .color = color },
                 .background = if (expander_options.border != null) true else false,
                 .expand = .horizontal,
             };
@@ -661,7 +661,7 @@ fn exampleFileTreeSearch(directory: []const u8, base_entries: *MutableTreeEntry.
 
             color_id.* = color_id.* + 1;
         } else {
-            dvui.icon(@src(), "FileIcon", dvui.entypo.text_document, .{ .fill_color = color }, .{
+            dvui.icon(@src(), "FileIcon", dvui.entypo.text_document, .{ .fill_color = .{ .color = color } }, .{
                 .gravity_y = 0.5,
             });
 
@@ -820,7 +820,7 @@ fn recurseFiles(root_directory: []const u8, outer_tree: *dvui.TreeWidget, unique
                             @src(),
                             "FileIcon",
                             icon,
-                            .{ .fill_color = icon_color },
+                            .{ .fill_color = .{ .color = icon_color } },
                             .{
                                 .gravity_y = 0.5,
                                 .padding = padding,
@@ -831,7 +831,7 @@ fn recurseFiles(root_directory: []const u8, outer_tree: *dvui.TreeWidget, unique
                             "{s}",
                             .{entry.name},
                             .{
-                                .color_text = text_color,
+                                .color_text = .{ .color = text_color },
                                 .padding = padding,
                             },
                         );
@@ -849,7 +849,7 @@ fn recurseFiles(root_directory: []const u8, outer_tree: *dvui.TreeWidget, unique
                             "FolderIcon",
                             dvui.entypo.folder,
                             .{
-                                .fill_color = icon_color,
+                                .fill_color = .{ .color = icon_color },
                             },
                             .{
                                 .gravity_y = 0.5,
@@ -857,14 +857,14 @@ fn recurseFiles(root_directory: []const u8, outer_tree: *dvui.TreeWidget, unique
                             },
                         );
                         dvui.label(@src(), "{s}", .{folder_name}, .{
-                            .color_text = dvui.themeGet().color(.control, .text),
+                            .color_text = .{ .color = dvui.themeGet().color(.control, .text) },
                             .padding = padding,
                         });
                         _ = dvui.icon(
                             @src(),
                             "DropIcon",
                             if (branch.expanded) dvui.entypo.triangle_down else dvui.entypo.triangle_right,
-                            .{ .fill_color = icon_color },
+                            .{ .fill_color = .{ .color = icon_color } },
                             .{
                                 .gravity_y = 0.5,
                                 .gravity_x = 1.0,
@@ -874,7 +874,7 @@ fn recurseFiles(root_directory: []const u8, outer_tree: *dvui.TreeWidget, unique
 
                         var expander_opts_override = dvui.Options{
                             .margin = .{ .x = 14 },
-                            .color_border = color,
+                            .color_border = .{ .color = color },
                             .expand = .horizontal,
                         };
 
@@ -912,7 +912,7 @@ fn recurseFiles(root_directory: []const u8, outer_tree: *dvui.TreeWidget, unique
         "FolderIcon",
         dvui.entypo.folder,
         .{
-            .fill_color = tree_palette[0],
+            .fill_color = .{ .color = tree_palette[0] },
         },
         .{
             .gravity_y = 0.5,
@@ -922,14 +922,14 @@ fn recurseFiles(root_directory: []const u8, outer_tree: *dvui.TreeWidget, unique
 
     const folder_name = std.Io.Dir.path.basename(root_directory);
     dvui.label(@src(), "{s}", .{folder_name}, .{
-        .color_text = dvui.themeGet().color(.control, .text),
+        .color_text = .{ .color = dvui.themeGet().color(.control, .text) },
         .padding = dvui.Rect.all(10),
     });
     dvui.icon(
         @src(),
         "DropIcon",
         if (root_branch.expanded) dvui.entypo.triangle_down else dvui.entypo.triangle_right,
-        .{ .fill_color = tree_palette[0] },
+        .{ .fill_color = .{ .color = tree_palette[0] } },
         .{
             .gravity_y = 0.5,
             .gravity_x = 1.0,
@@ -938,8 +938,8 @@ fn recurseFiles(root_directory: []const u8, outer_tree: *dvui.TreeWidget, unique
     );
 
     if (root_branch.expander(@src(), .{ .indent = 14.0 }, .{
-        .color_fill = dvui.themeGet().color(.window, .fill),
-        .color_border = tree_palette[0],
+        .color_fill = .{ .color = dvui.themeGet().color(.window, .fill) },
+        .color_border = .{ .color = tree_palette[0] },
         .expand = .horizontal,
         .corners = root_branch.button.wd.options.corners,
         .background = true,

--- a/src/Examples/scroll_canvas.zig
+++ b/src/Examples/scroll_canvas.zig
@@ -53,12 +53,12 @@ pub fn scrollCanvas() void {
     dvui.Path.stroke(.{ .points = &.{
         dataRectScale.pointToPhysical(.{ .x = -10 }),
         dataRectScale.pointToPhysical(.{ .x = 10 }),
-    } }, .{ .thickness = 1, .color = dvui.themeGet().color(.control, .text) });
+    } }, .{ .thickness = 1, .color = .{ .color = dvui.themeGet().color(.control, .text) } });
 
     dvui.Path.stroke(.{ .points = &.{
         dataRectScale.pointToPhysical(.{ .y = -10 }),
         dataRectScale.pointToPhysical(.{ .y = 10 }),
-    } }, .{ .thickness = 1, .color = dvui.themeGet().color(.control, .text) });
+    } }, .{ .thickness = 1, .color = .{ .color = dvui.themeGet().color(.control, .text) } });
 
     // keep record of bounding box
     var mbbox: ?Rect.Physical = null;
@@ -75,7 +75,7 @@ pub fn scrollCanvas() void {
 
         const mouse_point = dvui.currentWindow().mouse_pt.toNatural().diff(.{ .x = 10, .y = 10 });
         var fw: dvui.FloatingWidget = undefined;
-        fw.init(@src(), .{ .mouse_events = false }, .{ .rect = Rect.fromPoint(.cast(mouse_point)), .min_size_content = .all(20), .background = true, .color_fill = dvui.themeGet().focus.opacity(0.5), .data_out = &fwd });
+        fw.init(@src(), .{ .mouse_events = false }, .{ .rect = Rect.fromPoint(.cast(mouse_point)), .min_size_content = .all(20), .background = true, .color_fill = .{ .color = dvui.themeGet().focus.opacity(0.5) }, .data_out = &fwd });
         fw.deinit();
 
         // We want to get mouse motion events during the drag as if we had
@@ -116,7 +116,7 @@ pub fn scrollCanvas() void {
             .style = .window,
             .border = .{ .h = 1, .w = 1, .x = 1, .y = 1 },
             .corners = .all(5),
-            .color_border = if (dragging_box) dvui.themeGet().focus else null,
+            .color_border = if (dragging_box) .{ .color = dvui.themeGet().focus } else null,
             .box_shadow = .{},
         });
 
@@ -178,7 +178,7 @@ pub fn scrollCanvas() void {
                     _ = dvui.spacer(@src(), .{ .min_size_content = .width(5), .id_extra = k });
                 }
                 const col = if (dragging_this) dvui.Color.lime.opacity(0.5) else dvui.Color.blue;
-                var dbox = dvui.box(@src(), .{}, .{ .id_extra = k, .min_size_content = .{ .w = 20, .h = 20 }, .background = true, .color_fill = col });
+                var dbox = dvui.box(@src(), .{}, .{ .id_extra = k, .min_size_content = .{ .w = 20, .h = 20 }, .background = true, .color_fill = .{ .color = col } });
                 defer dbox.deinit();
 
                 for (evts) |*e| {
@@ -279,7 +279,7 @@ pub fn scrollCanvas() void {
                             dvui.cursorSet(.crosshair);
                             // the drag is hovered above us, draw to indicate that
                             const rs = dragBox.data().contentRectScale();
-                            rs.r.fill(dragBox.data().options.cornersGet().scale(rs.s, CornerRect.Physical), .{ .color = dvui.themeGet().focus.opacity(0.2) });
+                            rs.r.fill(dragBox.data().options.cornersGet().scale(rs.s, CornerRect.Physical), .{ .color = .{ .color = dvui.themeGet().focus.opacity(0.2) } });
                         }
                     },
                     else => {},

--- a/src/Examples/styling.zig
+++ b/src/Examples/styling.zig
@@ -236,73 +236,16 @@ pub fn styling() void {
             var vbox2 = dvui.box(@src(), .{}, .{ .margin = .{ .y = 30 } });
             defer vbox2.deinit();
 
-            const gradient = dvui.dataGetPtrDefault(null, vbox2.data().id, "gradient", usize, 0);
-
-            {
-                var gbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
-                defer gbox.deinit();
-                dvui.label(@src(), "Gradient", .{}, .{ .gravity_y = 0.5 });
-                _ = dvui.dropdown(@src(), &.{ "flat", "horizontal", "vertical", "radial" }, .{ .choice = gradient }, .{}, .{});
-            }
-
-            var drawBox = dvui.box(@src(), .{}, .{ .min_size_content = .{ .w = 200, .h = 100 } });
-            defer drawBox.deinit();
-            const rs = drawBox.data().contentRectScale();
-
-            var path: dvui.Path.Builder = .init(dvui.currentWindow().lifo());
-            defer path.deinit();
-            path.addRect(rs.r, .round(5));
-
-            var triangles = path.build().fillConvexTriangles(dvui.currentWindow().lifo(), .{ .color = .white, .center = rs.r.center() }) catch dvui.Triangles.empty;
-            defer triangles.deinit(dvui.currentWindow().lifo());
-
-            const ca0 = backbox_color;
-            const ca1 = backbox_color.opacity(0);
-
-            switch (gradient.*) {
-                1, 2 => |choice| {
-                    for (triangles.vertexes) |*v| {
-                        const t = if (choice == 1)
-                            (v.pos.x - rs.r.x) / rs.r.w
-                        else
-                            (v.pos.y - rs.r.y) / rs.r.h;
-                        v.col = v.col.multiply(.fromColor(dvui.Color.lerp(ca0, ca1, t)));
-                    }
-                },
-                3 => {
-                    const center = rs.r.center();
-                    const max = rs.r.bottomRight().diff(center).length();
-                    for (triangles.vertexes) |*v| {
-                        const l: f32 = v.pos.diff(center).length();
-                        const t = l / max;
-                        v.col = v.col.multiply(.fromColor(dvui.Color.lerp(ca0, ca1, t)));
-                    }
-                },
-                else => {
-                    triangles.color(ca0);
-                },
-            }
-            dvui.renderTriangles(triangles, null) catch |err| {
-                dvui.logError(@src(), err, "Could not render gradient triangles", .{});
-            };
-        }
-        {
-            var vbox3 = dvui.box(@src(), .{}, .{ .margin = .{ .y = 30 } });
-            defer vbox3.deinit();
-
             dvui.label(@src(), "Options.fill_gradient", .{}, .{});
 
-            const kind = dvui.dataGetPtrDefault(null, vbox3.data().id, "kind", usize, 0);
+            const kind = dvui.dataGetPtrDefault(null, vbox2.data().id, "kind", usize, 0);
             _ = dvui.dropdown(@src(), &.{ "linear", "radial" }, .{ .choice = kind }, .{}, .{});
 
-            const angle = dvui.dataGetPtrDefault(null, vbox3.data().id, "angle", f32, 90);
+            const angle = dvui.dataGetPtrDefault(null, vbox2.data().id, "angle", f32, 90);
             if (kind.* == 0) {
                 _ = dvui.sliderEntry(@src(), "angle: {d:0.0}", .{ .value = angle, .min = 0, .max = 360, .interval = 1 }, .{});
             }
 
-            // Same visual result as the "vertical"/"radial" cases above,
-            // but declared on Options directly instead of hand-building
-            // triangles and lerping vertex colors.
             var gbox = dvui.box(@src(), .{}, .{
                 .min_size_content = .{ .w = 200, .h = 100 },
                 .corners = .all(5),
@@ -314,6 +257,35 @@ pub fn styling() void {
                     .{ .radial = .{ .color2 = backbox_color } },
             });
             defer gbox.deinit();
+        }
+        {
+            var vbox3 = dvui.box(@src(), .{}, .{ .margin = .{ .y = 30 } });
+            defer vbox3.deinit();
+
+            dvui.label(@src(), "Options.border_gradient", .{}, .{});
+
+            const kind = dvui.dataGetPtrDefault(null, vbox3.data().id, "kind", usize, 0);
+            _ = dvui.dropdown(@src(), &.{ "linear", "radial" }, .{ .choice = kind }, .{}, .{});
+
+            const angle = dvui.dataGetPtrDefault(null, vbox3.data().id, "angle", f32, 90);
+            if (kind.* == 0) {
+                _ = dvui.sliderEntry(@src(), "angle: {d:0.0}", .{ .value = angle, .min = 0, .max = 360, .interval = 1 }, .{});
+            }
+
+            const thickness = dvui.dataGetPtrDefault(null, vbox3.data().id, "thickness", f32, 8);
+            _ = dvui.sliderEntry(@src(), "thickness: {d:0.0}", .{ .value = thickness, .min = 1, .max = 20, .interval = 1 }, .{});
+
+            var bbox = dvui.box(@src(), .{}, .{
+                .min_size_content = .{ .w = 200, .h = 100 },
+                .corners = .all(5),
+                .border = dvui.Rect.all(thickness.*),
+                .color_border = .white,
+                .border_gradient = if (kind.* == 0)
+                    .{ .linear = .{ .color2 = backbox_color, .angle_degrees = angle.* } }
+                else
+                    .{ .radial = .{ .color2 = backbox_color } },
+            });
+            defer bbox.deinit();
         }
     }
 

--- a/src/Examples/styling.zig
+++ b/src/Examples/styling.zig
@@ -286,6 +286,27 @@ pub fn styling() void {
                 dvui.logError(@src(), err, "Could not render gradient triangles", .{});
             };
         }
+        {
+            var vbox3 = dvui.box(@src(), .{}, .{ .margin = .{ .y = 30 } });
+            defer vbox3.deinit();
+
+            dvui.label(@src(), "Options.fill_gradient", .{}, .{});
+
+            const angle = dvui.dataGetPtrDefault(null, vbox3.data().id, "angle", f32, 90);
+            _ = dvui.sliderEntry(@src(), "angle: {d:0.0}", .{ .value = angle, .min = 0, .max = 360, .interval = 1 }, .{});
+
+            // Same visual result as the "vertical" case above (at angle 90),
+            // but declared on Options directly instead of hand-building
+            // triangles and lerping vertex colors.
+            var gbox = dvui.box(@src(), .{}, .{
+                .min_size_content = .{ .w = 200, .h = 100 },
+                .corners = .all(5),
+                .background = true,
+                .color_fill = .white,
+                .fill_gradient = .{ .color2 = backbox_color, .angle_degrees = angle.* },
+            });
+            defer gbox.deinit();
+        }
     }
 
     {

--- a/src/Examples/styling.zig
+++ b/src/Examples/styling.zig
@@ -1,6 +1,146 @@
-var hsluv_hsl: dvui.Color.HSLuv = .fromColor(.black);
-var hsv_color: dvui.Color.HSV = .fromColor(.black);
-var backbox_color: dvui.Color = .black;
+const gradient_demo_orange: dvui.Color = .{ .r = 255, .g = 140, .b = 0, .a = 255 };
+var hsluv_hsl: dvui.Color.HSLuv = .fromColor(gradient_demo_orange);
+var hsv_color: dvui.Color.HSV = .fromColor(gradient_demo_orange);
+var backbox_color: dvui.Color = gradient_demo_orange;
+
+/// Shared controls for the gradient showcase below: kind (linear/radial/
+/// scattered), linear angle or radial shape/extent/position or scattered
+/// stop positions, an optional middle stop (linear/radial only), and the
+/// base/stop-2 colors. `parent_id` should be the id of the currently-active
+/// box so each demo's state is independent.
+fn gradientDemoControls(parent_id: dvui.Id) dvui.ColorOrGradient {
+    const kind = dvui.dataGetPtrDefault(null, parent_id, "kind", usize, 0);
+    _ = dvui.dropdown(@src(), &.{ "linear", "radial", "scattered" }, .{ .choice = kind }, .{}, .{});
+
+    const angle = dvui.dataGetPtrDefault(null, parent_id, "angle", f32, 147);
+    const shape = dvui.dataGetPtrDefault(null, parent_id, "shape", usize, 1); // 0=circle, 1=ellipse
+    const extent = dvui.dataGetPtrDefault(null, parent_id, "extent", usize, 3); // matches Gradient.Extent order
+    const pos_x = dvui.dataGetPtrDefault(null, parent_id, "pos_x", f32, 0.5);
+    const pos_y = dvui.dataGetPtrDefault(null, parent_id, "pos_y", f32, 0.5);
+
+    const fixed_size = dvui.dataGetPtrDefault(null, parent_id, "fixed_size", bool, false);
+    const size_x = dvui.dataGetPtrDefault(null, parent_id, "size_x", f32, 40);
+    const size_y = dvui.dataGetPtrDefault(null, parent_id, "size_y", f32, 40);
+    const use_focal = dvui.dataGetPtrDefault(null, parent_id, "use_focal", bool, false);
+    const focal_x = dvui.dataGetPtrDefault(null, parent_id, "focal_x", f32, 0.5);
+    const focal_y = dvui.dataGetPtrDefault(null, parent_id, "focal_y", f32, 0.5);
+    const rotation = dvui.dataGetPtrDefault(null, parent_id, "rotation", f32, 0);
+
+    if (kind.* == 0) {
+        _ = dvui.sliderEntry(@src(), "angle: {d:0.0}", .{ .value = angle, .min = 0, .max = 360, .interval = 1 }, .{});
+    } else if (kind.* == 1) {
+        _ = dvui.dropdown(@src(), &.{ "circle", "ellipse" }, .{ .choice = shape }, .{}, .{});
+        _ = dvui.checkbox(@src(), fixed_size, "fixed pixel size", .{});
+        if (fixed_size.*) {
+            _ = dvui.sliderEntry(@src(), "size x: {d:0.0}", .{ .value = size_x, .min = 1, .max = 150, .interval = 1 }, .{});
+            if (shape.* != 0) _ = dvui.sliderEntry(@src(), "size y: {d:0.0}", .{ .value = size_y, .min = 1, .max = 150, .interval = 1 }, .{});
+        } else {
+            _ = dvui.dropdown(@src(), &.{ "closest_side", "farthest_side", "closest_corner", "farthest_corner" }, .{ .choice = extent }, .{}, .{});
+        }
+        _ = dvui.sliderEntry(@src(), "pos x: {d:0.2}", .{ .value = pos_x, .min = 0, .max = 1, .interval = 0.05 }, .{});
+        _ = dvui.sliderEntry(@src(), "pos y: {d:0.2}", .{ .value = pos_y, .min = 0, .max = 1, .interval = 0.05 }, .{});
+        if (shape.* != 0) _ = dvui.sliderEntry(@src(), "rotation: {d:0.0}", .{ .value = rotation, .min = 0, .max = 360, .interval = 1 }, .{});
+        _ = dvui.checkbox(@src(), use_focal, "focal point", .{});
+        if (use_focal.*) {
+            _ = dvui.sliderEntry(@src(), "focal x: {d:0.2}", .{ .value = focal_x, .min = 0, .max = 1, .interval = 0.05 }, .{});
+            _ = dvui.sliderEntry(@src(), "focal y: {d:0.2}", .{ .value = focal_y, .min = 0, .max = 1, .interval = 0.05 }, .{});
+        }
+    }
+
+    if (kind.* != 2) {
+        const multistop = dvui.dataGetPtrDefault(null, parent_id, "multistop", bool, false);
+        const mid_color = dvui.dataGetPtrDefault(null, parent_id, "mid_color", dvui.Color, .purple);
+        _ = dvui.checkbox(@src(), multistop, "extra middle stop", .{});
+        if (multistop.*) {
+            var midhbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+            defer midhbox.deinit();
+            dvui.label(@src(), "Mid: ", .{}, .{ .gravity_y = 0.5 });
+            _ = dvui.textEntryColor(@src(), .{ .value = mid_color }, .{});
+        }
+
+        const base_color = dvui.dataGetPtrDefault(null, parent_id, "base_color", dvui.Color, .cyan);
+        {
+            var basehbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+            defer basehbox.deinit();
+            dvui.label(@src(), "Base: ", .{}, .{ .gravity_y = 0.5 });
+            _ = dvui.textEntryColor(@src(), .{ .value = base_color }, .{});
+        }
+        {
+            var stop2hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+            defer stop2hbox.deinit();
+            dvui.label(@src(), "Stop 2: ", .{}, .{ .gravity_y = 0.5 });
+            if (dvui.textEntryColor(@src(), .{ .value = &backbox_color }, .{}).changed) {
+                hsluv_hsl = .fromColor(backbox_color);
+                hsv_color = .fromColor(backbox_color);
+            }
+        }
+
+        // Frame-scoped: consumed immediately by the fill/border call below.
+        // Base color is a stop at offset 0 and "Stop 2" at offset 1 -- chosen
+        // for a familiar full-span gradient, not because Gradient.Stop requires
+        // boundary stops (it doesn't: positions outside the stop range just
+        // clamp to the nearest stop's color).
+        const stops: []const dvui.Gradient.Stop = blk: {
+            const n: usize = if (multistop.*) 3 else 2;
+            const s = dvui.currentWindow().arena().alloc(dvui.Gradient.Stop, n) catch break :blk &.{};
+            s[0] = .{ .color = base_color.*, .offset = 0 };
+            if (multistop.*) {
+                s[1] = .{ .color = mid_color.*, .offset = 0.5 };
+                s[2] = .{ .color = backbox_color, .offset = 1 };
+            } else {
+                s[1] = .{ .color = backbox_color, .offset = 1 };
+            }
+            break :blk s;
+        };
+
+        const gradient: dvui.Gradient = if (kind.* == 0)
+            .{ .linear = .{ .angle_degrees = angle.*, .stops = stops } }
+        else
+            .{ .radial = .{
+                .shape = if (shape.* == 0)
+                    .{ .circle = .{ .radius = if (fixed_size.*) size_x.* else null } }
+                else
+                    .{ .ellipse = .{
+                        .size = if (fixed_size.*) .{ .x = size_x.*, .y = size_y.* } else null,
+                        .rotation_degrees = rotation.*,
+                    } },
+                .extent = switch (extent.*) {
+                    0 => .closest_side,
+                    1 => .farthest_side,
+                    2 => .closest_corner,
+                    else => .farthest_corner,
+                },
+                .position = .{ .x = pos_x.*, .y = pos_y.* },
+                .focal = if (use_focal.*) .{ .x = focal_x.*, .y = focal_y.* } else null,
+                .stops = stops,
+            } };
+
+        return .{ .gradient = gradient };
+    }
+
+    // Scattered: a fixed set of freely-positioned color stops instead of a
+    // linear/radial ramp -- each has its own x/y (fraction of the bounding
+    // box) alongside its color.
+    const scatter_stops = dvui.dataGetPtrDefault(null, parent_id, "scatter_stops", [3]dvui.Gradient.ScatterStop, .{
+        .{ .color = .red, .x = 0.1, .y = 0.1 },
+        .{ .color = .lime, .x = 0.9, .y = 0.2 },
+        .{ .color = .blue, .x = 0.4, .y = 0.9 },
+    });
+    for (scatter_stops, 0..) |*stop, i| {
+        var col = dvui.box(@src(), .{}, .{ .id_extra = i });
+        defer col.deinit();
+        {
+            var row = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+            defer row.deinit();
+            dvui.label(@src(), "Stop {d}: ", .{i + 1}, .{ .gravity_y = 0.5 });
+            _ = dvui.textEntryColor(@src(), .{ .value = &stop.color }, .{});
+        }
+        _ = dvui.sliderEntry(@src(), "x: {d:0.2}", .{ .value = &stop.x, .min = 0, .max = 1, .interval = 0.05 }, .{});
+        _ = dvui.sliderEntry(@src(), "y: {d:0.2}", .{ .value = &stop.y, .min = 0, .max = 1, .interval = 0.05 }, .{});
+    }
+
+    return .{ .gradient = .{ .scattered = .{ .stops = scatter_stops } } };
+}
 
 /// ![image](Examples-styling.png)
 pub fn styling() void {
@@ -71,7 +211,7 @@ pub fn styling() void {
         _ = dvui.slider(@src(), .{ .fraction = fraction }, .{ .expand = .horizontal });
         _ = dvui.sliderEntry(@src(), "value: {d:0.2}", .{ .value = value, .min = 0, .max = 1, .interval = 0.01 }, .{});
 
-        var scroll = dvui.scrollArea(@src(), .{ .vertical_bar = .show }, .{ .min_size_content = .{ .w = 180, .h = 100 }, .max_size_content = .{ .w = 180, .h = 100 }, .style = .content, .color_text = dvui.themeGet().focus });
+        var scroll = dvui.scrollArea(@src(), .{ .vertical_bar = .show }, .{ .min_size_content = .{ .w = 180, .h = 100 }, .max_size_content = .{ .w = 180, .h = 100 }, .style = .content, .color_text = .{ .color = dvui.themeGet().focus } });
         defer scroll.deinit();
         for (0..12) |i| {
             dvui.label(@src(), "Scroll item {d}", .{i}, .{ .id_extra = i });
@@ -180,7 +320,7 @@ pub fn styling() void {
             var vbox = dvui.box(@src(), .{}, .{});
             defer vbox.deinit();
 
-            var backbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .min_size_content = .{ .h = 40 }, .expand = .horizontal, .background = true, .color_fill = backbox_color });
+            var backbox = dvui.box(@src(), .{ .dir = .horizontal }, .{ .min_size_content = .{ .h = 40 }, .expand = .horizontal, .background = true, .color_fill = .{ .color = backbox_color } });
             backbox.deinit();
 
             if (dvui.sliderEntry(@src(), "A: {d:0.2}", .{ .value = &hsv_color.a, .min = 0, .max = 1, .interval = 0.01 }, .{ .min_size_content = .{}, .expand = .horizontal })) {
@@ -210,7 +350,7 @@ pub fn styling() void {
     }
 
     {
-        var hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+        var hbox = dvui.flexbox(@src(), .{}, .{ .expand = .horizontal });
         defer hbox.deinit();
 
         const border = dvui.dataGetPtrDefault(null, hbox.data().id, "border", bool, true);
@@ -233,59 +373,138 @@ pub fn styling() void {
             _ = dvui.sliderEntry(@src(), "alpha: {d:0.2}", .{ .value = alpha, .min = 0, .max = 1, .interval = 0.01 }, .{ .gravity_x = 0.5 });
         }
         {
-            var vbox2 = dvui.box(@src(), .{}, .{ .margin = .{ .y = 30 } });
-            defer vbox2.deinit();
+            var showcase_box = dvui.box(@src(), .{}, .{ .margin = .{ .y = 30 } });
+            defer showcase_box.deinit();
+            const showcase_id = showcase_box.data().id;
 
-            dvui.label(@src(), "Options.fill_gradient", .{}, .{});
+            dvui.label(@src(), "Gradient Showcase", .{}, .{});
 
-            const kind = dvui.dataGetPtrDefault(null, vbox2.data().id, "kind", usize, 0);
-            _ = dvui.dropdown(@src(), &.{ "linear", "radial" }, .{ .choice = kind }, .{}, .{});
+            // Controls (left) and demo output (right) are separate columns so
+            // that switching gradient kind -- which changes how many sliders
+            // are visible -- resizes only the controls column instead of
+            // shoving the demo output around underneath it.
+            var showcase_hbox = dvui.box(@src(), .{ .dir = .horizontal }, .{});
+            defer showcase_hbox.deinit();
 
-            const angle = dvui.dataGetPtrDefault(null, vbox2.data().id, "angle", f32, 90);
-            if (kind.* == 0) {
-                _ = dvui.sliderEntry(@src(), "angle: {d:0.0}", .{ .value = angle, .min = 0, .max = 360, .interval = 1 }, .{});
+            var controls_vbox = dvui.box(@src(), .{}, .{ .min_size_content = .{ .w = 220 } });
+            const shape = dvui.dataGetPtrDefault(null, showcase_id, "showcase_target", usize, 4);
+            _ = dvui.dropdown(@src(), &.{ "Box fill", "Box border", "Path.fill (star)", "Thick stroke", "Text", "Icon" }, .{ .choice = shape }, .{}, .{});
+
+            const thickness = dvui.dataGetPtrDefault(null, showcase_id, "thickness", f32, 8);
+            if (shape.* == 1 or shape.* == 3) {
+                _ = dvui.sliderEntry(@src(), "thickness: {d:0.0}", .{ .value = thickness, .min = 1, .max = 20, .interval = 1 }, .{});
             }
 
-            var gbox = dvui.box(@src(), .{}, .{
-                .min_size_content = .{ .w = 200, .h = 100 },
-                .corners = .all(5),
-                .background = true,
-                .color_fill = .white,
-                .fill_gradient = if (kind.* == 0)
-                    .{ .linear = .{ .color2 = backbox_color, .angle_degrees = angle.* } }
-                else
-                    .{ .radial = .{ .color2 = backbox_color } },
+            const text_buf = dvui.dataGetPtrDefault(null, showcase_id, "text_buf", [64:0]u8, blk: {
+                var b: [64:0]u8 = @splat(0);
+                const default_text = "Gradient\nText Demo";
+                @memcpy(b[0..default_text.len], default_text);
+                break :blk b;
             });
-            defer gbox.deinit();
-        }
-        {
-            var vbox3 = dvui.box(@src(), .{}, .{ .margin = .{ .y = 30 } });
-            defer vbox3.deinit();
-
-            dvui.label(@src(), "Options.border_gradient", .{}, .{});
-
-            const kind = dvui.dataGetPtrDefault(null, vbox3.data().id, "kind", usize, 0);
-            _ = dvui.dropdown(@src(), &.{ "linear", "radial" }, .{ .choice = kind }, .{}, .{});
-
-            const angle = dvui.dataGetPtrDefault(null, vbox3.data().id, "angle", f32, 90);
-            if (kind.* == 0) {
-                _ = dvui.sliderEntry(@src(), "angle: {d:0.0}", .{ .value = angle, .min = 0, .max = 360, .interval = 1 }, .{});
+            if (shape.* == 4) {
+                var te = dvui.textEntry(@src(), .{ .text = .{ .buffer = text_buf[0..] }, .multiline = true }, .{ .min_size_content = .{ .w = 200, .h = 40 } });
+                te.deinit();
             }
 
-            const thickness = dvui.dataGetPtrDefault(null, vbox3.data().id, "thickness", f32, 8);
-            _ = dvui.sliderEntry(@src(), "thickness: {d:0.0}", .{ .value = thickness, .min = 1, .max = 20, .interval = 1 }, .{});
+            const icon_choice = dvui.dataGetPtrDefault(null, showcase_id, "icon_choice", icon_browser.IconChoice, .{ .name = "star", .tvg_bytes = dvui.entypo.star });
+            const icon_browser_show = dvui.dataGetPtrDefault(null, showcase_id, "icon_browser_show", bool, false);
+            if (shape.* == 5) {
+                if (dvui.button(@src(), "Choose Icon...", .{}, .{})) icon_browser_show.* = true;
+                if (icon_browser_show.*) {
+                    icon_browser.iconBrowser(@src(), icon_browser_show, "entypo", dvui.entypo, icon_choice);
+                }
+            }
 
-            var bbox = dvui.box(@src(), .{}, .{
-                .min_size_content = .{ .w = 200, .h = 100 },
-                .corners = .all(5),
-                .border = dvui.Rect.all(thickness.*),
-                .color_border = .white,
-                .border_gradient = if (kind.* == 0)
-                    .{ .linear = .{ .color2 = backbox_color, .angle_degrees = angle.* } }
-                else
-                    .{ .radial = .{ .color2 = backbox_color } },
-            });
-            defer bbox.deinit();
+            const demo = gradientDemoControls(showcase_id);
+            controls_vbox.deinit();
+
+            var demo_vbox = dvui.box(@src(), .{}, .{ .min_size_content = .{ .w = 220, .h = 140 }, .gravity_y = 0 });
+            defer demo_vbox.deinit();
+
+            switch (shape.*) {
+                0 => {
+                    var gbox = dvui.box(@src(), .{}, .{
+                        .min_size_content = .{ .w = 200, .h = 100 },
+                        .corners = .all(5),
+                        .background = true,
+                        .color_fill = demo,
+                    });
+                    defer gbox.deinit();
+                },
+                1 => {
+                    var bbox = dvui.box(@src(), .{}, .{
+                        .min_size_content = .{ .w = 200, .h = 100 },
+                        .corners = .all(5),
+                        .border = dvui.Rect.all(thickness.*),
+                        .color_border = demo,
+                    });
+                    defer bbox.deinit();
+                },
+                2 => {
+                    var sbox = dvui.box(@src(), .{}, .{ .min_size_content = .{ .w = 200, .h = 100 } });
+                    defer sbox.deinit();
+
+                    // Star is deliberately concave: it must go through
+                    // earcut-based Path.fillTriangles (via Path.fill), not the
+                    // convex fan path fillConvexTriangles uses.
+                    const rs = sbox.data().contentRectScale();
+                    var builder: dvui.Path.Builder = .init(dvui.currentWindow().arena());
+                    defer builder.deinit();
+                    const cx = 100;
+                    const cy = 50;
+                    const outer = 45;
+                    const inner = 18;
+                    var i: usize = 0;
+                    while (i < 10) : (i += 1) {
+                        const r: f32 = if (i % 2 == 0) outer else inner;
+                        const a = -std.math.pi / 2.0 + @as(f32, @floatFromInt(i)) * std.math.pi / 5.0;
+                        builder.addPoint(rs.pointToPhysical(.{ .x = cx + r * @cos(a), .y = cy + r * @sin(a) }));
+                    }
+                    const star = builder.build();
+
+                    dvui.Path.fill(&.{star}, .{
+                        .color = demo,
+                    });
+                },
+                3 => {
+                    var lbox = dvui.box(@src(), .{}, .{ .min_size_content = .{ .w = 200, .h = 100 } });
+                    defer lbox.deinit();
+
+                    const rs = lbox.data().contentRectScale();
+                    var builder: dvui.Path.Builder = .init(dvui.currentWindow().arena());
+                    defer builder.deinit();
+                    builder.addPoint(rs.pointToPhysical(.{ .x = 10, .y = 10 }));
+                    builder.addPoint(rs.pointToPhysical(.{ .x = 190, .y = 30 }));
+                    builder.addPoint(rs.pointToPhysical(.{ .x = 40, .y = 90 }));
+                    const line = builder.build();
+
+                    line.stroke(.{ .thickness = thickness.*, .color = demo });
+                },
+                4 => {
+                    var tbox = dvui.box(@src(), .{}, .{ .min_size_content = .{ .w = 200, .h = 100 } });
+                    defer tbox.deinit();
+
+                    // Vertex colors are sampled once per glyph corner against this
+                    // label's own rect -- see `render.TextOptions.gradient`'s doc
+                    // comment for why that's fine for text (unlike fills).
+                    dvui.labelNoFmt(@src(), std.mem.sliceTo(text_buf[0..], 0), .{}, .{
+                        .font = dvui.Font.theme(.title),
+                        .color_text = demo,
+                        .gravity_x = 0.5,
+                        .gravity_y = 0.5,
+                    });
+                },
+                else => {
+                    var ibox = dvui.box(@src(), .{}, .{ .min_size_content = .{ .w = 200, .h = 100 }, .gravity_x = 0.5, .gravity_y = 0.5 });
+                    defer ibox.deinit();
+
+                    dvui.icon(@src(), icon_choice.name, icon_choice.tvg_bytes, .{ .fill_color = demo, .stroke_color = demo }, .{
+                        .min_size_content = .{ .h = 80 },
+                        .gravity_x = 0.5,
+                        .gravity_y = 0.5,
+                    });
+                },
+            }
         }
     }
 
@@ -394,6 +613,7 @@ test "DOCIMG styling" {
 const std = @import("std");
 const dvui = @import("../dvui.zig");
 const Examples = @import("../Examples.zig");
+const icon_browser = @import("icon_browser.zig");
 const Options = dvui.Options;
 const Rect = dvui.Rect;
 const CornerRect = dvui.CornerRect;

--- a/src/Examples/styling.zig
+++ b/src/Examples/styling.zig
@@ -292,10 +292,15 @@ pub fn styling() void {
 
             dvui.label(@src(), "Options.fill_gradient", .{}, .{});
 
-            const angle = dvui.dataGetPtrDefault(null, vbox3.data().id, "angle", f32, 90);
-            _ = dvui.sliderEntry(@src(), "angle: {d:0.0}", .{ .value = angle, .min = 0, .max = 360, .interval = 1 }, .{});
+            const kind = dvui.dataGetPtrDefault(null, vbox3.data().id, "kind", usize, 0);
+            _ = dvui.dropdown(@src(), &.{ "linear", "radial" }, .{ .choice = kind }, .{}, .{});
 
-            // Same visual result as the "vertical" case above (at angle 90),
+            const angle = dvui.dataGetPtrDefault(null, vbox3.data().id, "angle", f32, 90);
+            if (kind.* == 0) {
+                _ = dvui.sliderEntry(@src(), "angle: {d:0.0}", .{ .value = angle, .min = 0, .max = 360, .interval = 1 }, .{});
+            }
+
+            // Same visual result as the "vertical"/"radial" cases above,
             // but declared on Options directly instead of hand-building
             // triangles and lerping vertex colors.
             var gbox = dvui.box(@src(), .{}, .{
@@ -303,7 +308,10 @@ pub fn styling() void {
                 .corners = .all(5),
                 .background = true,
                 .color_fill = .white,
-                .fill_gradient = .{ .color2 = backbox_color, .angle_degrees = angle.* },
+                .fill_gradient = if (kind.* == 0)
+                    .{ .linear = .{ .color2 = backbox_color, .angle_degrees = angle.* } }
+                else
+                    .{ .radial = .{ .color2 = backbox_color } },
             });
             defer gbox.deinit();
         }

--- a/src/Examples/text_entry.zig
+++ b/src/Examples/text_entry.zig
@@ -271,7 +271,7 @@ pub fn textEntryWidgets() void {
             la2.spacer(@src(), 0);
 
             const normalOptions: dvui.Options = .{ .margin = dvui.TextEntryWidget.defaults.marginGet().plus(.all(1)) };
-            const errOptions: dvui.Options = .{ .color_border = dvui.themeGet().err.fill orelse .red, .border = dvui.Rect.all(2) };
+            const errOptions: dvui.Options = .{ .color_border = .{ .color = dvui.themeGet().err.fill orelse .red }, .border = dvui.Rect.all(2) };
 
             const name_error = dvui.dataGetPtrDefault(null, hbox2.data().id, "_name_error", bool, false);
             var te_name = dvui.textEntry(@src(), .{}, if (name_error.*) errOptions else normalOptions);

--- a/src/Examples/text_layout.zig
+++ b/src/Examples/text_layout.zig
@@ -167,7 +167,7 @@ pub fn layoutText() void {
         const start = "\nNotice that the text in this box is wrapping around the stuff in the corners.\n\n";
         tl.addText(start, .{ .font = .theme(.title) });
 
-        const col = dvui.Color.average(tl.data().options.textColor(.text).toColor(), tl.data().options.textColor(.fill).toColor());
+        const col = dvui.Color.average(tl.data().options.color(.text).toColor(), tl.data().options.color(.fill).toColor());
         tl.addTextTooltip(@src(), "Hover this for a tooltip.\n\n", "This is some tooltip", .{ .color_text = .{ .color = col } });
 
         tl.format("This line uses zig format strings: {d}\n\n", .{12345}, .{});

--- a/src/Examples/text_layout.zig
+++ b/src/Examples/text_layout.zig
@@ -167,8 +167,8 @@ pub fn layoutText() void {
         const start = "\nNotice that the text in this box is wrapping around the stuff in the corners.\n\n";
         tl.addText(start, .{ .font = .theme(.title) });
 
-        const col = dvui.Color.average(tl.data().options.color(.text), tl.data().options.color(.fill));
-        tl.addTextTooltip(@src(), "Hover this for a tooltip.\n\n", "This is some tooltip", .{ .color_text = col });
+        const col = dvui.Color.average(tl.data().options.textColor(.text).toColor(), tl.data().options.textColor(.fill).toColor());
+        tl.addTextTooltip(@src(), "Hover this for a tooltip.\n\n", "This is some tooltip", .{ .color_text = .{ .color = col } });
 
         tl.format("This line uses zig format strings: {d}\n\n", .{12345}, .{});
 
@@ -191,10 +191,10 @@ pub fn layoutText() void {
             tl.addText("Mono not available (using fallback font)\n", .{ .font = mono_font.larger(2) });
         }
 
-        tl.addText("Here ", .{ .font = dvui.Font.theme(.body).withWeight(.bold).withStyle(.italic).larger(12), .color_text = .{ .r = 100, .b = 100 } });
-        tl.addText("is some ", .{ .font = dvui.Font.theme(.body).larger(6), .color_text = .{ .b = 100, .g = 100 }, .color_fill = .green });
-        tl.addText("ugly text ", .{ .font = dvui.Font.theme(.body).larger(8), .color_text = .{ .r = 100, .g = 100 }, .color_fill = .teal });
-        tl.addText("that shows styling.", .{ .font = dvui.Font.theme(.body).larger(-2), .color_text = .{ .r = 100, .g = 50, .b = 50 } });
+        tl.addText("Here ", .{ .font = dvui.Font.theme(.body).withWeight(.bold).withStyle(.italic).larger(12), .color_text = .{ .color = .{ .r = 100, .b = 100 } } });
+        tl.addText("is some ", .{ .font = dvui.Font.theme(.body).larger(6), .color_text = .{ .color = .{ .b = 100, .g = 100 } }, .color_fill = .green });
+        tl.addText("ugly text ", .{ .font = dvui.Font.theme(.body).larger(8), .color_text = .{ .color = .{ .r = 100, .g = 100 } }, .color_fill = .teal });
+        tl.addText("that shows styling.", .{ .font = dvui.Font.theme(.body).larger(-2), .color_text = .{ .color = .{ .r = 100, .g = 50, .b = 50 } } });
     }
 
     if (dvui.useTreeSitter) {

--- a/src/Examples/theming.zig
+++ b/src/Examples/theming.zig
@@ -302,7 +302,7 @@ fn styles(theme: *Theme) bool {
                 .corners = .all(100),
                 .border = .all(1),
                 .background = true,
-                .color_fill = color,
+                .color_fill = if (color) |c| .{ .color = c } else null,
             });
             dvui.labelNoFmt(@src(), @tagName(color_name), .{}, tab.style().override(.{ .margin = .{ .x = wd.rect.w }, .gravity_y = 0.5 }));
         }

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -2294,7 +2294,7 @@ const DisplayScrollArea = struct {
 
     pub fn layoutWidget() void {
         const box_size = 26;
-        const color_fill = options.textColor(.border).opacity(0.25);
+        const color_fill = options.color(.border).opacity(0.25);
 
         options.min_size_content = if (init_opts.scroll_info == null) null else .{ .w = @floatFromInt(nr_boxes.w * (box_size + 2)), .h = @floatFromInt(nr_boxes.h * (box_size + 2)) };
         init_opts.focus_id = switch (focus_id) {
@@ -2761,7 +2761,7 @@ const DisplayTabs = struct {
 
                     var label_opts = tab.data().options.strip();
                     if (dvui.captured(tab.data().id)) {
-                        label_opts.color_text = (dvui.Options{}).textColor(.text_press);
+                        label_opts.color_text = (dvui.Options{}).color(.text_press);
                     }
 
                     dvui.labelNoFmt(@src(), tabname, .{}, label_opts);

--- a/src/Examples/widgetpedia.zig
+++ b/src/Examples/widgetpedia.zig
@@ -74,7 +74,7 @@ pub fn widgetpedia() void {
         var tree = dvui.TreeWidget.tree(@src(), .{ .enable_reordering = false }, .{});
         defer tree.deinit();
         for (widget_hierarchy, 0..) |widget, i| {
-            const color_fill: ?dvui.Color = blk: {
+            const color_fill: ?dvui.ColorOrGradient = blk: {
                 if (widget.children) |children|
                     for (children) |child| {
                         if (child.displayFn != displayEmpty) break :blk null;
@@ -106,7 +106,7 @@ pub fn widgetpedia() void {
             if (branch.expander(@src(), .{ .indent = 10 }, .{ .expand = .horizontal })) {
                 if (widget.children) |children| {
                     for (children, 0..) |child, j| {
-                        const branch_child = tree.branch(@src(), .{ .expanded = true }, .{ .id_extra = j, .expand = .horizontal, .color_fill = if (child.displayFn == displayEmpty) .gray else null });
+                        const branch_child = tree.branch(@src(), .{ .expanded = true }, .{ .id_extra = j, .expand = .horizontal, .color_fill = if (child.displayFn == displayEmpty) .{ .color = .gray } else null });
                         defer branch_child.deinit();
                         dvui.labelNoFmt(@src(), child.name, .{}, .{ .expand = .horizontal });
                         if (branch_child.button.clicked()) {
@@ -336,7 +336,7 @@ const DisplayAnimate = struct {
 
     pub fn resetWidget() void {
         init_opts = .{ .kind = .alpha, .duration = 5_000_000 };
-        options = .{ .expand = .both, .background = true, .color_fill = .navy };
+        options = .{ .expand = .both, .background = true, .color_fill = .{ .color = .navy } };
         test_options.restart_animation = false;
     }
 
@@ -997,7 +997,7 @@ const DisplayFlexBox = struct {
                 .border = .all(1),
                 .id_extra = i,
                 .expand = test_options.expand,
-                .color_border = options.themeGet().focus,
+                .color_border = .{ .color = options.themeGet().focus },
             });
             b.deinit();
         }
@@ -2244,7 +2244,7 @@ const DisplayScale = struct {
     pub fn layoutWidget() void {
         var scalew = dvui.scale(@src(), init_opts, options.override(.{ .data_out = &wd, .expand = .both }));
         defer scalew.deinit();
-        dvui.labelNoFmt(@src(), "Scalable", .{}, .{ .border = .all(1), .color_border = dvui.themeGet().focus, .gravity_x = 0.5, .gravity_y = 0.5 });
+        dvui.labelNoFmt(@src(), "Scalable", .{}, .{ .border = .all(1), .color_border = .{ .color = dvui.themeGet().focus }, .gravity_x = 0.5, .gravity_y = 0.5 });
     }
 
     pub fn layoutWidgetControls() void {
@@ -2294,7 +2294,7 @@ const DisplayScrollArea = struct {
 
     pub fn layoutWidget() void {
         const box_size = 26;
-        const color_fill = options.color(.border).opacity(0.25);
+        const color_fill = options.textColor(.border).opacity(0.25);
 
         options.min_size_content = if (init_opts.scroll_info == null) null else .{ .w = @floatFromInt(nr_boxes.w * (box_size + 2)), .h = @floatFromInt(nr_boxes.h * (box_size + 2)) };
         init_opts.focus_id = switch (focus_id) {
@@ -2761,7 +2761,7 @@ const DisplayTabs = struct {
 
                     var label_opts = tab.data().options.strip();
                     if (dvui.captured(tab.data().id)) {
-                        label_opts.color_text = (dvui.Options{}).color(.text_press);
+                        label_opts.color_text = (dvui.Options{}).textColor(.text_press);
                     }
 
                     dvui.labelNoFmt(@src(), tabname, .{}, label_opts);
@@ -2839,7 +2839,7 @@ const DisplayTabGroup = struct {
         {
             var tig = dvui.tabIndexGroup(@src(), .{ .tab_index = tab_group_index.@".tab_index (green)" });
             defer tig.deinit();
-            var box = dvui.box(@src(), .{}, .{ .border = .all(2), .margin = .all(1), .color_border = .green, .expand = .horizontal });
+            var box = dvui.box(@src(), .{}, .{ .border = .all(2), .margin = .all(1), .color_border = .{ .color = .green }, .expand = .horizontal });
             defer box.deinit();
             var fg = dvui.focusGroup(@src(), .{ .nav_key_dir = .vertical, .wrap = true }, .{});
             defer fg.deinit();
@@ -3399,7 +3399,7 @@ fn structColorPicker(field_name: []const u8, ptr: *anyopaque, read_only: bool, a
         var color_box = dvui.box(@src(), .{}, .{
             .expand = .both,
             .min_size_content = .{ .h = text_height, .w = text_height },
-            .color_fill = field_value_ptr.*,
+            .color_fill = .{ .color = field_value_ptr.* },
             .background = true,
             .gravity_y = 0.5,
             .margin = .all(6),

--- a/src/Gradient.zig
+++ b/src/Gradient.zig
@@ -1,7 +1,6 @@
-/// Self-contained gradient: every stop carries its own color, so a gradient
-/// fully describes what it looks like without needing a base color from the
-/// caller. Blends across the shape's bounding box.
 pub const Gradient = union(enum) {
+    /// NOTE: stops only need to live as long as the call that hands it to dvui
+    /// all defered rendering should dupe
     linear: struct {
         /// Sorted ascending by `offset`. Must have at least 1 stop.
         /// Positions before the first stop or after the last just take that
@@ -51,7 +50,7 @@ pub const Gradient = union(enum) {
     },
 
     pub const Shape = union(enum) {
-        /// Explicit radius in natural pixels (like `Options.border` etc.,
+        /// radius in natural pixels (like `Options.border` etc.,
         /// scaled to physical by the widget before rendering), overriding
         /// `extent`'s keyword sizing.
         circle: struct { radius: ?f32 = null },
@@ -110,8 +109,7 @@ pub const Gradient = union(enum) {
     /// Scales natural-pixel fields (`radial.shape`'s `circle.radius` /
     /// `ellipse.size`) by `s`, the same way `Options.cornersGet()` and
     /// border thickness get scaled before rendering. `anchor` is left
-    /// alone -- it's already a fully-formed physical rect (e.g. another
-    /// widget's `rectScale().r`), not a natural-space size of this widget.
+    /// alone
     pub fn scale(gradient: Gradient, s: f32) Gradient {
         var g = gradient;
         switch (g) {
@@ -125,6 +123,18 @@ pub const Gradient = union(enum) {
                 },
             },
             .linear, .scattered => {},
+        }
+        return g;
+    }
+
+    /// Copies `stops` into memory owned by `allocator`, returning a
+    /// `Gradient` that no longer depends on the caller's slice. See the
+    pub fn dupe(gradient: Gradient, allocator: std.mem.Allocator) std.mem.Allocator.Error!Gradient {
+        var g = gradient;
+        switch (g) {
+            .linear => |*l| l.stops = try allocator.dupe(Stop, l.stops),
+            .radial => |*r| r.stops = try allocator.dupe(Stop, r.stops),
+            .scattered => |*s| s.stops = try allocator.dupe(ScatterStop, s.stops),
         }
         return g;
     }
@@ -634,9 +644,6 @@ pub const ColorOrGradient = union(enum) {
         };
     }
 
-    /// Multiply the opacity of `self` by `mult` (see `Color.opacity` /
-    /// `Gradient.opacity`), preserving whether it's a flat color or a
-    /// gradient.
     pub fn opacity(self: ColorOrGradient, mult: f32) ColorOrGradient {
         return switch (self) {
             .color => |c| .{ .color = c.opacity(mult) },
@@ -644,8 +651,6 @@ pub const ColorOrGradient = union(enum) {
         };
     }
 
-    /// Scales a gradient's natural-pixel fields by `s` (see `Gradient.scale`);
-    /// a flat color is unaffected.
     pub fn scale(self: ColorOrGradient, s: f32) ColorOrGradient {
         return switch (self) {
             .color => self,
@@ -653,10 +658,17 @@ pub const ColorOrGradient = union(enum) {
         };
     }
 
+    pub fn dupe(self: ColorOrGradient, allocator: std.mem.Allocator) std.mem.Allocator.Error!ColorOrGradient {
+        return switch (self) {
+            .color => self,
+            .gradient => |g| .{ .gradient = try g.dupe(allocator) },
+        };
+    }
+
     /// Blends `a` toward `b` by `t` (0-1). If both are flat colors, this is
     /// a normal color lerp. Otherwise it snaps to `a` (t<0.5) or `b`
-    /// (t>=0.5) rather than blending — gradients don't get an automatic
-    /// hover/press adjustment.
+    /// (t>=0.5) rather than blending —
+    /// gradients don't get an automatic hover/press adjustment.
     pub fn lerp(a: ColorOrGradient, b: ColorOrGradient, t: f32) ColorOrGradient {
         if (a == .color and b == .color) return .{ .color = a.color.lerp(b.color, t) };
         return if (t < 0.5) a else b;
@@ -728,10 +740,6 @@ test "fill gradient" {
     });
     defer triangles.deinit(std.testing.allocator);
 
-    // angle_degrees = 0 is left-to-right: vertexes on the left edge should
-    // have `t` (UV.x, into the ramp texture returned via `triangles.texture`
-    // - see `Gradient.apply`) near 0 (left_color), right edge near 1
-    // (right_color).
     try std.testing.expect(triangles.texture != null);
     for (triangles.vertexes) |v| {
         if (v.pos.x < 1) {
@@ -762,12 +770,6 @@ test "fill gradient radial" {
     });
     defer triangles.deinit(std.testing.allocator);
 
-    // Non-focal radial no longer bakes color into vertexes (see
-    // `Gradient.apply`'s radial branch): color lives in a 2D ramp texture
-    // sampled via UV, so check UV distance from the ellipse center (0.5,0.5
-    // in UV space) instead. The center vertex should be near 0 (close to
-    // `center_color`); the corners (farthest from center) should be near
-    // the ellipse boundary (UV distance ~0.5, close to `edge_color`).
     for (triangles.vertexes) |v| {
         const d = @sqrt((v.uv[0] - 0.5) * (v.uv[0] - 0.5) + (v.uv[1] - 0.5) * (v.uv[1] - 0.5));
         if (v.pos.x == 50 and v.pos.y == 50) {
@@ -792,8 +794,6 @@ test "fill gradient radial defaults center to bounding box" {
     const center_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
     const edge_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
 
-    // No `.center` passed: fillConvexTriangles must add one at the bbox
-    // center itself so the middle still samples near `center_color`.
     var triangles = try square.fillConvexTriangles(std.testing.allocator, .{
         .color = .{ .gradient = .{ .radial = .{ .stops = &.{ .{ .color = center_color, .offset = 0 }, .{ .color = edge_color, .offset = 1 } } } } },
     });
@@ -814,10 +814,6 @@ test "fill gradient radial ellipse reaches all edges of a non-square box" {
     var t = try dvui.testing.init(.{});
     defer t.deinit();
 
-    // Regression test: a plain circle (equal rx/ry) on a wide box doesn't
-    // reach the left/right edges, so far-left/right vertexes stay near
-    // `color` instead of blending toward `color2` like CSS's default
-    // "ellipse farthest-corner" does.
     const wide: Path = .{ .points = &.{
         .{ .x = 0, .y = 0 },
         .{ .x = 0, .y = 100 },
@@ -855,10 +851,6 @@ test "fill gradient radial circle shape stays circular on a non-square box" {
     const center_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
     const edge_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
 
-    // closest-side circle: radius = min(half-width, half-height) = 50, so a
-    // point 50px right of center is right at the edge of the circle, but a
-    // point only 10px right (well inside a circle of radius 50) should
-    // still read close to the center color.
     var triangles = try wide.fillConvexTriangles(std.testing.allocator, .{
         .color = .{ .gradient = .{ .radial = .{ .stops = &.{ .{ .color = center_color, .offset = 0 }, .{ .color = edge_color, .offset = 1 } }, .shape = .{ .circle = .{} }, .extent = .closest_side } } },
         .center = .{ .x = 210, .y = 50 },
@@ -869,9 +861,6 @@ test "fill gradient radial circle shape stays circular on a non-square box" {
     for (triangles.vertexes) |v| {
         if (v.pos.x == 210 and v.pos.y == 50) {
             found = true;
-            // 10px right of a radius-50 circle center: `t` = 10/50 = 0.2, so
-            // UV distance from center is 0.2/2 = 0.1 - just inside the
-            // "close to center" half of the ramp.
             const d = @sqrt((v.uv[0] - 0.5) * (v.uv[0] - 0.5) + (v.uv[1] - 0.5) * (v.uv[1] - 0.5));
             try std.testing.expect(d < 0.15);
         }
@@ -893,9 +882,6 @@ test "fill gradient radial position moves the gradient center off the box center
     const center_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
     const edge_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
 
-    // position at the top-left corner: that corner should read as the
-    // center color, while the opposite (bottom-right) corner -- now the
-    // farthest point from the gradient center -- should read as color2.
     var triangles = try square.fillConvexTriangles(std.testing.allocator, .{
         .color = .{ .gradient = .{ .radial = .{ .stops = &.{ .{ .color = center_color, .offset = 0 }, .{ .color = edge_color, .offset = 1 } }, .position = .{ .x = 0, .y = 0 } } } },
         .center = .{ .x = 0, .y = 0 },
@@ -916,9 +902,6 @@ test "fill gradient radial size gives an explicit pixel radius, ignoring extent"
     var t = try dvui.testing.init(.{});
     defer t.deinit();
 
-    // Box is much bigger than the fixed 20x10 ellipse: a keyword extent
-    // would reach the corners, but `size` should keep the ellipse small so
-    // most of the box reads as color2 regardless of box size.
     const big: Path = .{ .points = &.{
         .{ .x = 0, .y = 0 },
         .{ .x = 0, .y = 200 },
@@ -940,9 +923,6 @@ test "fill gradient radial size gives an explicit pixel radius, ignoring extent"
             const d = @sqrt((v.uv[0] - 0.5) * (v.uv[0] - 0.5) + (v.uv[1] - 0.5) * (v.uv[1] - 0.5));
             try std.testing.expect(d < 0.1);
         } else if (v.pos.x == 0 and v.pos.y == 0) {
-            // Far outside the tiny 20x10 ellipse: UV lands well past the
-            // ellipse boundary, which the ramp texture's clamp-to-edge
-            // sampling reads back as the saturated `edge_color`.
             const d = @sqrt((v.uv[0] - 0.5) * (v.uv[0] - 0.5) + (v.uv[1] - 0.5) * (v.uv[1] - 0.5));
             try std.testing.expect(d > 1.0);
         }
@@ -963,10 +943,6 @@ test "fill gradient radial focal point shifts the 0%-offset point off center" {
     const center_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
     const edge_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
 
-    // Ending shape stays centered on the box, but the focal point (the
-    // 0%-offset point) is shifted to the top-left corner: that corner
-    // should read as the center color even though it's far from the
-    // shape's own center -- something CSS radial-gradient() can't express.
     const gradient: Gradient = .{ .radial = .{ .stops = &.{ .{ .color = center_color, .offset = 0 }, .{ .color = edge_color, .offset = 1 } }, .focal = .{ .x = 0, .y = 0 } } };
     var triangles = try square.fillConvexTriangles(std.testing.allocator, .{
         .color = .{ .gradient = gradient },
@@ -974,9 +950,6 @@ test "fill gradient radial focal point shifts the 0%-offset point off center" {
     });
     defer triangles.deinit(std.testing.allocator);
 
-    // Focal radial no longer bakes color into vertexes either (see
-    // `Gradient.apply`'s radial branch): color lives in a 2D ramp texture
-    // sampled via UV, so check the analytic sample directly instead.
     try std.testing.expect(triangles.texture != null);
     const c = gradient.sample(triangles.bounds, .{ .x = 0, .y = 0 });
     try std.testing.expect(c.r > c.b);
@@ -996,10 +969,6 @@ test "fill gradient radial rotation tilts an off-center ellipse" {
     const center_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
     const edge_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
 
-    // A wide, short fixed-size ellipse rotated 90 degrees becomes tall and
-    // narrow: a point straight above center (far along the un-rotated
-    // major axis) should now read closer to color2 than a point beside
-    // it, since the major axis has swapped to vertical.
     var triangles = try square.fillConvexTriangles(std.testing.allocator, .{
         .color = .{ .gradient = .{ .radial = .{
             .stops = &.{ .{ .color = center_color, .offset = 0 }, .{ .color = edge_color, .offset = 1 } },
@@ -1011,10 +980,8 @@ test "fill gradient radial rotation tilts an off-center ellipse" {
 
     for (triangles.vertexes) |v| {
         if (v.pos.x == 50 and v.pos.y == 0) {
-            // 50px above center: inside the rotated (now-vertical) major axis.
             try std.testing.expect(v.col.r > v.col.b);
         } else if (v.pos.x == 0 and v.pos.y == 50) {
-            // 50px left of center: outside the rotated (now-narrow) minor axis.
             try std.testing.expectEqual(edge_color, v.col.toColor());
         }
     }
@@ -1024,10 +991,6 @@ test "fill gradient anchor lets the gradient span a rect outside the shape's own
     var t = try dvui.testing.init(.{});
     defer t.deinit();
 
-    // A small box positioned at the right edge of a much wider anchor rect:
-    // anchoring the gradient to that wider rect should make the box read
-    // as being near the gradient's far end (near color2), not centered in
-    // its own tiny bounding box.
     const small: Path = .{ .points = &.{
         .{ .x = 190, .y = 0 },
         .{ .x = 190, .y = 20 },
@@ -1048,9 +1011,6 @@ test "fill gradient anchor lets the gradient span a rect outside the shape's own
     });
     defer triangles.deinit(std.testing.allocator);
 
-    // Linear gradients don't bake color into vertexes anymore (see
-    // `Gradient.apply`) - they set UV to the analytic `t` instead, for the
-    // caller to draw with the ramp texture returned by `applyDense`.
     try std.testing.expect(triangles.texture != null);
     for (triangles.vertexes) |v| {
         try std.testing.expect(v.uv[0] > 0.5);
@@ -1072,8 +1032,6 @@ test "fill gradient multi-stop" {
     } };
     const bounds: Rect.Physical = .{ .x = 0, .y = 0, .w = 100, .h = 10 };
 
-    // the middle stop should dominate green near x=50; red/blue should
-    // dominate near the two ends.
     try std.testing.expect(gradient.sample(bounds, .{ .x = 0, .y = 5 }).r > 200);
     const midc = gradient.sample(bounds, .{ .x = 50, .y = 5 });
     try std.testing.expect(midc.g > midc.r and midc.g > midc.b);
@@ -1090,15 +1048,12 @@ test "gradient scattered blends by inverse-distance squared, snapping on exact s
     } } };
     const bounds: Rect.Physical = .{ .x = 0, .y = 0, .w = 100, .h = 100 };
 
-    // Exactly on a stop: snaps to that stop's color, not a blend.
     try std.testing.expectEqual(red, gradient.sample(bounds, .{ .x = 0, .y = 50 }));
     try std.testing.expectEqual(blue, gradient.sample(bounds, .{ .x = 100, .y = 50 }));
 
-    // Equidistant from both stops: roughly an even blend.
     const midc = gradient.sample(bounds, .{ .x = 50, .y = 50 });
     try std.testing.expect(@abs(@as(i32, midc.r) - midc.b) < 10);
 
-    // Closer to red: more red than blue.
     const nearc = gradient.sample(bounds, .{ .x = 10, .y = 50 });
     try std.testing.expect(nearc.r > nearc.b);
 }
@@ -1107,11 +1062,9 @@ test "ColorOrGradient.lerp snaps instead of blending when either side is a gradi
     const red: ColorOrGradient = .{ .color = .{ .r = 255, .g = 0, .b = 0, .a = 255 } };
     const blue: ColorOrGradient = .{ .color = .{ .r = 0, .g = 0, .b = 255, .a = 255 } };
 
-    // Both flat colors: real lerp.
     const half = ColorOrGradient.lerp(red, blue, 0.5);
     try std.testing.expect(half.color.r > 0 and half.color.b > 0);
 
-    // One side is a gradient: snaps rather than blending.
     const gradient: ColorOrGradient = .{ .gradient = .{ .linear = .{ .stops = &.{
         .{ .color = .{ .r = 0, .g = 255, .b = 0, .a = 255 }, .offset = 0 },
     } } } };
@@ -1131,11 +1084,6 @@ test "stroke gradient" {
     const left_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
     const right_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
 
-    // strokeTriangles' vtx/idx counts are worst-case upper bounds (e.g. for
-    // miter joints) that aren't always fully used, so - like all its
-    // production callers - it needs an arena allocator here rather than
-    // `std.testing.allocator`, which asserts free() size exactly matches
-    // the allocation size.
     const lifo = dvui.currentWindow().lifo();
     var triangles = try line.strokeTriangles(lifo, .{
         .thickness = 5,
@@ -1159,13 +1107,6 @@ test "stroke gradient" {
     try std.testing.expect(saw_left and saw_right);
 }
 
-// Not a correctness test (no assertions) — a manual visual-verification
-// tool. Renders each Gradient variant to a PNG so it can be screenshotted
-// side-by-side against the equivalent CSS gradient rendered by a browser.
-// Angle conversion: dvui 0deg = left-to-right, clockwise; CSS 0deg = to
-// top, clockwise. Since dvui's East (0deg) is CSS's "to right" (90deg),
-// css_angle = dvui_angle + 90.
-//
 // Run with (from repo root): zig build test -Dtest-filter="DOCIMG gradient css" -Dimage-dir=/tmp/gradient-compare/dvui
 test "DOCIMG gradient css comparison" {
     const size: dvui.Size = .{ .w = 300, .h = 200 };

--- a/src/Gradient.zig
+++ b/src/Gradient.zig
@@ -386,14 +386,18 @@ pub const Gradient = union(enum) {
     /// Gouraud (vertex-color) interpolation produces visibly wrong results
     /// off the gradient axis. UV interpolation reproduces the affine `t`
     /// exactly, and the texture reproduces `interpolate` exactly.
-    fn rampTexture(stops: []const Stop, alpha: f32) (std.mem.Allocator.Error || dvui.Backend.TextureError)!dvui.Texture {
+    fn linearKey(stops: []const Stop, alpha: f32) dvui.Texture.Cache.Key {
         var hasher = dvui.fnv.init();
         for (stops) |s| {
             hasher.update(std.mem.asBytes(&s.offset));
             hasher.update(std.mem.asBytes(&s.color));
         }
         hasher.update(std.mem.asBytes(&alpha));
-        const key = hasher.final();
+        return hasher.final();
+    }
+
+    fn rampTexture(stops: []const Stop, alpha: f32) (std.mem.Allocator.Error || dvui.Backend.TextureError)!dvui.Texture {
+        const key = linearKey(stops, alpha);
         if (dvui.textureGetCached(key)) |cached| return cached;
 
         var pixels: [ramp_width]Color.PMA = undefined;
@@ -422,7 +426,7 @@ pub const Gradient = union(enum) {
     /// `length >= 1` on that axis, so any `(u,v)` outside `[-1,1]^2` reads
     /// back the same saturated last-stop color `t=1` would - no separate
     /// clamp of `(u,v)` is needed before mapping to texture space.
-    fn rampTexture2D(stops: []const Stop, alpha: f32) (std.mem.Allocator.Error || dvui.Backend.TextureError)!dvui.Texture {
+    fn radialKey(stops: []const Stop, alpha: f32) dvui.Texture.Cache.Key {
         var hasher = dvui.fnv.init();
         hasher.update("radial2d"); // distinguish from `rampTexture`'s 1D cache key
         for (stops) |s| {
@@ -430,7 +434,11 @@ pub const Gradient = union(enum) {
             hasher.update(std.mem.asBytes(&s.color));
         }
         hasher.update(std.mem.asBytes(&alpha));
-        const key = hasher.final();
+        return hasher.final();
+    }
+
+    fn rampTexture2D(stops: []const Stop, alpha: f32) (std.mem.Allocator.Error || dvui.Backend.TextureError)!dvui.Texture {
+        const key = radialKey(stops, alpha);
         if (dvui.textureGetCached(key)) |cached| return cached;
 
         var pixels: [ramp2d_width * ramp2d_width]Color.PMA = undefined;
@@ -452,7 +460,7 @@ pub const Gradient = union(enum) {
     /// `[-1,1]^2`. `(fu,fv)` (the focal point's own `radialUV`) is constant
     /// for a given draw but varies across gradients, so it joins the cache
     /// key alongside the stops.
-    fn rampTextureFocal2D(stops: []const Stop, alpha: f32, fu: f32, fv: f32) (std.mem.Allocator.Error || dvui.Backend.TextureError)!dvui.Texture {
+    fn radialFocalKey(stops: []const Stop, alpha: f32, fu: f32, fv: f32) dvui.Texture.Cache.Key {
         var hasher = dvui.fnv.init();
         hasher.update("radial2dfocal");
         for (stops) |s| {
@@ -462,7 +470,11 @@ pub const Gradient = union(enum) {
         hasher.update(std.mem.asBytes(&alpha));
         hasher.update(std.mem.asBytes(&fu));
         hasher.update(std.mem.asBytes(&fv));
-        const key = hasher.final();
+        return hasher.final();
+    }
+
+    fn rampTextureFocal2D(stops: []const Stop, alpha: f32, fu: f32, fv: f32) (std.mem.Allocator.Error || dvui.Backend.TextureError)!dvui.Texture {
+        const key = radialFocalKey(stops, alpha, fu, fv);
         if (dvui.textureGetCached(key)) |cached| return cached;
 
         var pixels: [ramp2d_width * ramp2d_width]Color.PMA = undefined;
@@ -489,7 +501,7 @@ pub const Gradient = union(enum) {
     /// bounds-aspect-relative rather than physical-pixel: a non-square
     /// shape now gets elliptical (not circular) falloff around each stop,
     /// trading that for cacheability (see `scatteredColorAt`).
-    fn rampTextureScattered2D(stops: []const ScatterStop, alpha: f32) (std.mem.Allocator.Error || dvui.Backend.TextureError)!dvui.Texture {
+    fn scatteredKey(stops: []const ScatterStop, alpha: f32) dvui.Texture.Cache.Key {
         var hasher = dvui.fnv.init();
         hasher.update("scattered2d");
         for (stops) |s| {
@@ -498,7 +510,11 @@ pub const Gradient = union(enum) {
             hasher.update(std.mem.asBytes(&s.color));
         }
         hasher.update(std.mem.asBytes(&alpha));
-        const key = hasher.final();
+        return hasher.final();
+    }
+
+    fn rampTextureScattered2D(stops: []const ScatterStop, alpha: f32) (std.mem.Allocator.Error || dvui.Backend.TextureError)!dvui.Texture {
+        const key = scatteredKey(stops, alpha);
         if (dvui.textureGetCached(key)) |cached| return cached;
 
         var pixels: [ramp2d_width * ramp2d_width]Color.PMA = undefined;
@@ -513,6 +529,30 @@ pub const Gradient = union(enum) {
         const tex = try dvui.Texture.fromPixelsPMA(&pixels, ramp2d_width, ramp2d_width, .linear);
         dvui.textureAddToCache(key, tex);
         return tex;
+    }
+
+    /// The `dvui.textureGetCached`/`textureRetain` key `apply` will use for
+    /// this gradient's ramp texture, computed without touching the texture
+    /// cache. `apply` normally keeps its ramp texture alive by being called
+    /// (and so implicitly re-touching the cache) every frame; a caller that
+    /// instead caches geometry referencing the texture across frames (e.g.
+    /// icon rendering's mesh cache) needs this key to `dvui.textureRetain`/
+    /// `textureRelease` it explicitly so it isn't evicted out from under
+    /// the cached geometry after one unrendered frame.
+    pub fn textureCacheKey(gradient: Gradient, bounds_in: Rect.Physical) dvui.Texture.Cache.Key {
+        return switch (gradient) {
+            .linear => |g| linearKey(g.stops, g.alpha),
+            .radial => |g| blk: {
+                const b = g.anchor orelse bounds_in;
+                if (g.focal) |f| {
+                    const geo = radialGeometry(g, b);
+                    const fuv = if (geo) |gm| radialUV(gm, .{ .x = b.x + f.x * b.w, .y = b.y + f.y * b.h }) else [2]f32{ 0, 0 };
+                    break :blk radialFocalKey(g.stops, g.alpha, fuv[0], fuv[1]);
+                }
+                break :blk radialKey(g.stops, g.alpha);
+            },
+            .scattered => |g| scatteredKey(g.stops, g.alpha),
+        };
     }
 
     /// Post-process pass over already-built triangles.

--- a/src/Gradient.zig
+++ b/src/Gradient.zig
@@ -1,0 +1,1220 @@
+/// Self-contained gradient: every stop carries its own color, so a gradient
+/// fully describes what it looks like without needing a base color from the
+/// caller. Blends across the shape's bounding box.
+pub const Gradient = union(enum) {
+    linear: struct {
+        /// Sorted ascending by `offset`. Must have at least 1 stop.
+        /// Positions before the first stop or after the last just take that
+        /// stop's color (matches CSS/SVG gradients) — no need for stops at
+        /// exactly 0 and 1.
+        stops: []const Stop,
+        /// 0 = left-to-right, 90 = top-to-bottom, clockwise.
+        angle_degrees: f32 = 90,
+        /// Overrides the bounding box the gradient is computed against
+        /// (physical pixels), instead of the shape's own bounds. Lets
+        /// separate widgets share one continuous gradient sweep — pass
+        /// e.g. a parent's rect. CSS gradients are always local to their
+        /// own box and can't do this.
+        anchor: ?Rect.Physical = null,
+        /// Multiplies every stop's alpha (see `Gradient.opacity`).
+        alpha: f32 = 1.0,
+    },
+    radial: struct {
+        /// See `linear.stops`.
+        stops: []const Stop,
+        shape: Shape = .{ .ellipse = .{} },
+        extent: Extent = .farthest_corner,
+        /// Gradient center, as a fraction of the bounding box (0,0 = top-left
+        /// corner, 1,1 = bottom-right corner). Defaults to the box center.
+        position: struct { x: f32 = 0.5, y: f32 = 0.5 } = .{},
+        /// SVG-style focal point (as a fraction of the bounding box, same
+        /// convention as `position`): where the 0%-offset point sits.
+        /// Defaults to `position` (the ending shape's own center) when
+        /// null, matching CSS. Offsetting it from `position` gives a
+        /// sphere/light-source highlight CSS radial-gradient() can't do.
+        focal: ?struct { x: f32, y: f32 } = null,
+        /// See `linear.anchor`.
+        anchor: ?Rect.Physical = null,
+        /// See `linear.alpha`.
+        alpha: f32 = 1.0,
+    },
+    /// Arbitrary 2D-positioned color stops, blended by inverse-distance²
+    /// weighting: `weight_i = 1/distance^2`, snapping to a stop's exact
+    /// color if `pos` lands on it, else
+    /// `color = sum(weight_i*color_i) / sum(weight_i)`.
+    scattered: struct {
+        stops: []const ScatterStop,
+        /// See `linear.anchor`.
+        anchor: ?Rect.Physical = null,
+        /// See `linear.alpha`.
+        alpha: f32 = 1.0,
+    },
+
+    pub const Shape = union(enum) {
+        /// Explicit radius in natural pixels (like `Options.border` etc.,
+        /// scaled to physical by the widget before rendering), overriding
+        /// `extent`'s keyword sizing.
+        circle: struct { radius: ?f32 = null },
+        ellipse: struct {
+            /// Explicit x/y radii in natural pixels (see `circle.radius`),
+            /// overriding `extent`'s keyword sizing (CSS
+            /// `radial-gradient(50px 30px at ...)`).
+            size: ?struct { x: f32, y: f32 } = null,
+            /// Rotates the ending ellipse clockwise by this many degrees.
+            /// CSS radial-gradient() can't rotate its ellipse at all.
+            rotation_degrees: f32 = 0,
+        },
+    };
+
+    /// How far the gradient's ending shape extends before reaching the last
+    /// stop. Mirrors CSS `radial-gradient()`'s `<size>` keywords.
+    pub const Extent = enum { closest_side, farthest_side, closest_corner, farthest_corner };
+
+    pub const Stop = struct { color: Color, offset: f32 };
+
+    /// A `scattered`-gradient stop: `x`/`y` are a fraction [0,1] of the
+    /// bounding box (same convention as `radial.position`).
+    pub const ScatterStop = struct { color: Color, x: f32, y: f32 };
+
+    /// `firstColor`, without the `alpha` multiplier applied. Used
+    /// internally as the placeholder color for antialiasing fade vertexes
+    /// before `apply` resamples them -- `apply`/`sample` apply `alpha`
+    /// themselves, so baking it in here too would double it up.
+    fn firstColorRaw(gradient: Gradient) Color {
+        return switch (gradient) {
+            inline else => |g| g.stops[0].color,
+        };
+    }
+
+    /// The gradient's own first stop (with `alpha` applied), used as a flat
+    /// representative color where a full gradient can't be expressed (see
+    /// `ColorOrGradient.toColor`).
+    pub fn firstColor(gradient: Gradient) Color {
+        return switch (gradient) {
+            inline else => |g| g.stops[0].color.opacity(g.alpha),
+        };
+    }
+
+    /// Multiply the gradient's overall opacity by `mult` (see
+    /// `Color.opacity`), applied on top of every stop's own alpha at sample
+    /// time. Just flips the `alpha` multiplier field -- doesn't touch
+    /// `stops`, which is a caller-owned/shared const slice.
+    pub fn opacity(gradient: Gradient, mult: f32) Gradient {
+        var g = gradient;
+        switch (g) {
+            inline else => |*v| v.alpha *= mult,
+        }
+        return g;
+    }
+
+    /// Scales natural-pixel fields (`radial.shape`'s `circle.radius` /
+    /// `ellipse.size`) by `s`, the same way `Options.cornersGet()` and
+    /// border thickness get scaled before rendering. `anchor` is left
+    /// alone -- it's already a fully-formed physical rect (e.g. another
+    /// widget's `rectScale().r`), not a natural-space size of this widget.
+    pub fn scale(gradient: Gradient, s: f32) Gradient {
+        var g = gradient;
+        switch (g) {
+            .radial => |*r| switch (r.shape) {
+                .circle => |*c| if (c.radius) |*radius| {
+                    radius.* *= s;
+                },
+                .ellipse => |*e| if (e.size) |*sz| {
+                    sz.x *= s;
+                    sz.y *= s;
+                },
+            },
+            .linear, .scattered => {},
+        }
+        return g;
+    }
+
+    /// Interpolates through `stops` at position `t`. Positions before the
+    /// first stop or after the last clamp to that stop's color.
+    fn interpolate(stops: []const Stop, t: f32) Color {
+        if (t <= stops[0].offset) return stops[0].color;
+        var prev = stops[0];
+        for (stops[1..]) |s| {
+            if (t <= s.offset) {
+                const span = s.offset - prev.offset;
+                const local_t = if (span <= 0) 0 else (t - prev.offset) / span;
+                return prev.color.lerp(s.color, std.math.clamp(local_t, 0, 1));
+            }
+            prev = s;
+        }
+        return prev.color;
+    }
+
+    /// The analytic gradient position `t` (0-1) for `linear` at `pos`, or
+    /// `null` if the bounds are degenerate (caller should use `firstColor`).
+    /// Factored out of `sample` so `apply` can assign it directly to a
+    /// vertex's UV instead of baking a color from it.
+    fn linearT(g: anytype, bounds: Rect.Physical, pos: Point.Physical) ?f32 {
+        const cx = bounds.x + bounds.w / 2;
+        const cy = bounds.y + bounds.h / 2;
+        const rad = std.math.degreesToRadians(g.angle_degrees);
+        const dir: Point.Physical = .{ .x = @cos(rad), .y = @sin(rad) };
+        const hx = bounds.w / 2;
+        const hy = bounds.h / 2;
+
+        // Half-extent of the bounding box projected onto dir (distance from
+        // center to the corner furthest along the gradient axis).
+        const half_extent = @abs(dir.x) * hx + @abs(dir.y) * hy;
+        if (half_extent <= 0) return null;
+
+        const proj = (pos.x - cx) * dir.x + (pos.y - cy) * dir.y;
+        return std.math.clamp((proj / half_extent + 1) / 2, 0, 1);
+    }
+
+    /// The ending shape's center, radii, and rotation (sin/cos, identity
+    /// when unrotated) for `radial`, resolved from `shape`/`extent`/
+    /// `position` against `bounds`. Shared by the focal-point solve, the
+    /// non-focal `t = length(nx,ny)` path, and the non-focal ramp-texture UV
+    /// path (`radialUV`) below. `null` if the ending shape is degenerate
+    /// (zero radius).
+    const RadialGeometry = struct { px: f32, py: f32, rx: f32, ry: f32, cs: f32, sn: f32 };
+    fn radialGeometry(g: anytype, bounds: Rect.Physical) ?RadialGeometry {
+        const px = bounds.x + g.position.x * bounds.w;
+        const py = bounds.y + g.position.y * bounds.h;
+
+        // Distances from the gradient center to each side of the box;
+        // can be asymmetric when `position` is off-center.
+        const left = px - bounds.x;
+        const right = (bounds.x + bounds.w) - px;
+        const top = py - bounds.y;
+        const bottom = (bounds.y + bounds.h) - py;
+
+        var rx: f32 = 0;
+        var ry: f32 = 0;
+        switch (g.shape) {
+            .circle => |c| if (c.radius) |r| {
+                rx = r;
+                ry = r;
+            } else {
+                rx = switch (g.extent) {
+                    .closest_side => @min(@min(left, right), @min(top, bottom)),
+                    .farthest_side => @max(@max(left, right), @max(top, bottom)),
+                    .closest_corner, .farthest_corner => blk: {
+                        const closest = g.extent == .closest_corner;
+                        const sx = if (closest) @min(left, right) else @max(left, right);
+                        const sy = if (closest) @min(top, bottom) else @max(top, bottom);
+                        break :blk @sqrt(sx * sx + sy * sy);
+                    },
+                };
+                ry = rx;
+            },
+            .ellipse => |e| if (e.size) |sz| {
+                rx = sz.x;
+                ry = sz.y;
+            } else switch (g.extent) {
+                .closest_side => {
+                    rx = @min(left, right);
+                    ry = @min(top, bottom);
+                },
+                .farthest_side => {
+                    rx = @max(left, right);
+                    ry = @max(top, bottom);
+                },
+                .closest_corner, .farthest_corner => {
+                    // Ellipse sized to pass exactly through the closest/farthest
+                    // corner while keeping the aspect ratio of the corresponding
+                    // *_side extents (matches CSS radial-gradient() sizing).
+                    const closest = g.extent == .closest_corner;
+                    const sx = if (closest) @min(left, right) else @max(left, right);
+                    const sy = if (closest) @min(top, bottom) else @max(top, bottom);
+                    rx = sx * std.math.sqrt2;
+                    ry = sy * std.math.sqrt2;
+                },
+            },
+        }
+        if (rx <= 0 or ry <= 0) return null;
+
+        const rotation_degrees: f32 = if (g.shape == .ellipse) g.shape.ellipse.rotation_degrees else 0;
+        const rot = rotation_degrees != 0;
+        const cs = if (rot) @cos(std.math.degreesToRadians(-rotation_degrees)) else 1;
+        const sn = if (rot) @sin(std.math.degreesToRadians(-rotation_degrees)) else 0;
+        return .{ .px = px, .py = py, .rx = rx, .ry = ry, .cs = cs, .sn = sn };
+    }
+
+    /// Radial `(nx,ny)`: `pos` in the ending shape's local, axis-aligned,
+    /// unit-circle space. For non-focal radial, `length(nx,ny)` is the
+    /// gradient's `t` (clamped to [0,1] by the caller); for focal radial,
+    /// `focalRadialT` turns it (plus the focal point's own `(nx,ny)`) into
+    /// `t`. Either way, unlike `t` itself, `(nx,ny)` is an *affine* function
+    /// of `pos` (rotation/translation/scale, no `sqrt`), so it can be
+    /// assigned directly to a vertex's UV and interpolated exactly by the
+    /// GPU across a plain (non-subdivided) quad - see `apply`'s `radial`
+    /// branch.
+    fn radialUV(geo: RadialGeometry, pos: Point.Physical) [2]f32 {
+        const dx = pos.x - geo.px;
+        const dy = pos.y - geo.py;
+        const rdx = dx * geo.cs - dy * geo.sn;
+        const rdy = dx * geo.sn + dy * geo.cs;
+        return .{ rdx / geo.rx, rdy / geo.ry };
+    }
+
+    /// Focal-point radial gradient's `t` as a function of the *affine* `(u,v)`
+    /// (from `radialUV(geo, pos)`) and the focal point's own affine
+    /// coordinates `(fu,fv)` (from `radialUV(geo, focalPos)`, constant for a
+    /// given draw).
+    ///
+    /// SVG-style focal point: `t` is the fraction of the way from the focal
+    /// point to the ellipse boundary along the ray toward `pos`. Substituting
+    /// `d = (u,v) - (fu,fv)` into the boundary-crossing quadratic
+    /// (`|F + s*d| = 1` for the unit circle `(u,v)` lives in) makes it solely
+    /// a function of `(u,v)` and the constant `(fu,fv)` - despite `t` itself
+    /// not being affine in `pos`, `(u,v)` is, so this can be baked into a 2D
+    /// ramp texture sampled via UV instead of resampled per subdivided
+    /// vertex (mirrors `rampTexture2D`'s trick for non-focal radial).
+    fn focalRadialT(u: f32, v: f32, fu: f32, fv: f32) f32 {
+        const dx = u - fu;
+        const dy = v - fv;
+        const a = dx * dx + dy * dy;
+        if (a <= 0) return 0;
+        const b = 2 * (fu * dx + fv * dy);
+        const c = fu * fu + fv * fv - 1;
+        const disc = b * b - 4 * a * c;
+        if (disc < 0) return 1;
+        const sq = @sqrt(disc);
+        const s = @max((-b + sq) / (2 * a), (-b - sq) / (2 * a));
+        return if (s <= 0) 1 else std.math.clamp(1.0 / s, 0, 1);
+    }
+
+    /// `scattered`'s `(u,v)`: `pos` as a fraction of `bounds` (same
+    /// convention as a stop's `x`/`y`), affine in `pos` like `radialUV`.
+    /// Guards against a degenerate (zero-width/height) axis rather than
+    /// dividing by zero - the numerator is 0 in that case anyway since
+    /// `pos` can't extend along a zero-size axis.
+    fn scatteredUV(bounds: Rect.Physical, pos: Point.Physical) [2]f32 {
+        const bw = if (bounds.w > 0) bounds.w else 1;
+        const bh = if (bounds.h > 0) bounds.h else 1;
+        return .{ (pos.x - bounds.x) / bw, (pos.y - bounds.y) / bh };
+    }
+
+    /// `scattered`'s inverse-distance-squared blend (see the `scattered`
+    /// field doc comment), evaluated at the affine `(u,v)` from
+    /// `scatteredUV` against stops' own `(x,y)` (already bounds fractions).
+    /// Since it's a fixed function of that affine `(u,v)`, it can be baked
+    /// into a 2D ramp texture sampled via UV instead of resampled per
+    /// subdivided vertex, same as `focalRadialT`/`rampTexture2D`. Returns
+    /// `null` if there are no stops (caller should use `firstColor`).
+    fn scatteredColorAt(stops: []const ScatterStop, u: f32, v: f32) ?Color {
+        if (stops.len == 0) return null;
+        var wsum: f32 = 0;
+        var r: f32 = 0;
+        var gg: f32 = 0;
+        var bb: f32 = 0;
+        var aa: f32 = 0;
+        for (stops) |s| {
+            const dx = u - s.x;
+            const dy = v - s.y;
+            const dist2 = dx * dx + dy * dy;
+            if (dist2 == 0) return s.color;
+            const w = 1.0 / dist2;
+            wsum += w;
+            r += w * @as(f32, @floatFromInt(s.color.r));
+            gg += w * @as(f32, @floatFromInt(s.color.g));
+            bb += w * @as(f32, @floatFromInt(s.color.b));
+            aa += w * @as(f32, @floatFromInt(s.color.a));
+        }
+        if (wsum <= 0) return null;
+        return .{
+            .r = @intFromFloat(std.math.clamp(r / wsum, 0, 255)),
+            .g = @intFromFloat(std.math.clamp(gg / wsum, 0, 255)),
+            .b = @intFromFloat(std.math.clamp(bb / wsum, 0, 255)),
+            .a = @intFromFloat(std.math.clamp(aa / wsum, 0, 255)),
+        };
+    }
+
+    /// Samples the gradient's raw color (per-stop alpha, no `alpha`
+    /// multiplier) at `pos`. `sample` wraps this with the `alpha`
+    /// multiplier applied once, uniformly, regardless of which branch below
+    /// produced the color.
+    fn sampleRaw(gradient: Gradient, bounds_in: Rect.Physical, pos: Point.Physical) Color {
+        const bounds = switch (gradient) {
+            inline else => |g| g.anchor orelse bounds_in,
+        };
+        const base = gradient.firstColorRaw();
+        if (bounds.w <= 0 and bounds.h <= 0) return base;
+        switch (gradient) {
+            .linear => |g| {
+                const t = linearT(g, bounds, pos) orelse return base;
+                return interpolate(g.stops, t);
+            },
+            .radial => |g| {
+                const geo = radialGeometry(g, bounds) orelse return base;
+
+                const uv = radialUV(geo, pos);
+                if (g.focal) |f| {
+                    const fuv = radialUV(geo, .{ .x = bounds.x + f.x * bounds.w, .y = bounds.y + f.y * bounds.h });
+                    const t = focalRadialT(uv[0], uv[1], fuv[0], fuv[1]);
+                    return interpolate(g.stops, t);
+                }
+
+                const t = std.math.clamp(@sqrt(uv[0] * uv[0] + uv[1] * uv[1]), 0, 1);
+                return interpolate(g.stops, t);
+            },
+            .scattered => |g| {
+                if (g.stops.len == 0) return base;
+                const uv = scatteredUV(bounds, pos);
+                return scatteredColorAt(g.stops, uv[0], uv[1]) orelse base;
+            },
+        }
+    }
+
+    /// Like `sampleRaw`, with the gradient's `alpha` multiplier applied.
+    /// Public so text rendering can Gouraud-sample it per glyph-quad vertex
+    /// instead of going through `apply`'s ramp-texture trick (see
+    /// `render.renderText`).
+    pub fn sample(gradient: Gradient, bounds_in: Rect.Physical, pos: Point.Physical) Color {
+        const alpha = switch (gradient) {
+            inline else => |g| g.alpha,
+        };
+        return gradient.sampleRaw(bounds_in, pos).opacity(alpha);
+    }
+
+    /// Width of the 1D ramp texture generated for `linear` gradients by
+    /// `rampTexture`.
+    const ramp_width = 256;
+
+    /// Builds (or fetches from the texture cache) a `ramp_width`x1 texture
+    /// holding `interpolate(stops, t)` across its width, keyed by the
+    /// stops' contents. Used so `linear` gradients can be drawn via UV +
+    /// texture sampling instead of baking colors at vertexes: `t` is affine
+    /// in `(x,y)` for a linear gradient, but `interpolate` is only
+    /// piecewise-affine once there are 3+ stops, so composing it with
+    /// Gouraud (vertex-color) interpolation produces visibly wrong results
+    /// off the gradient axis. UV interpolation reproduces the affine `t`
+    /// exactly, and the texture reproduces `interpolate` exactly.
+    fn rampTexture(stops: []const Stop, alpha: f32) (std.mem.Allocator.Error || dvui.Backend.TextureError)!dvui.Texture {
+        var hasher = dvui.fnv.init();
+        for (stops) |s| {
+            hasher.update(std.mem.asBytes(&s.offset));
+            hasher.update(std.mem.asBytes(&s.color));
+        }
+        hasher.update(std.mem.asBytes(&alpha));
+        const key = hasher.final();
+        if (dvui.textureGetCached(key)) |cached| return cached;
+
+        var pixels: [ramp_width]Color.PMA = undefined;
+        for (&pixels, 0..) |*px, i| {
+            const t = @as(f32, @floatFromInt(i)) / @as(f32, @floatFromInt(ramp_width - 1));
+            px.* = .fromColor(interpolate(stops, t).opacity(alpha));
+        }
+        const tex = try dvui.Texture.fromPixelsPMA(&pixels, ramp_width, 1, .linear);
+        dvui.textureAddToCache(key, tex);
+        return tex;
+    }
+
+    /// Side length of the square 2D ramp texture generated for non-focal
+    /// `radial` gradients by `rampTexture2D`.
+    const ramp2d_width = 64;
+
+    /// Builds (or fetches from the texture cache) a `ramp2d_width`^2 texture
+    /// holding `interpolate(stops, clamp(length(u,v), 0, 1))` for `(u,v)`
+    /// covering `[-1,1]^2`, keyed by the stops' contents. Mirrors
+    /// `rampTexture`, but 2D: a non-focal radial gradient's `(nx,ny)` (see
+    /// `radialUV`) is affine in position, but the final `t = length(nx,ny)`
+    /// isn't, so unlike `linear` the nonlinear step has to live in the
+    /// texture rather than the UV itself. Texture sampling clamps to the
+    /// edge texel (`Texture.CreateOptions.wrap_*` defaults to `.clamp`), and
+    /// clamping `(u,v)` per-axis to the last texel still yields
+    /// `length >= 1` on that axis, so any `(u,v)` outside `[-1,1]^2` reads
+    /// back the same saturated last-stop color `t=1` would - no separate
+    /// clamp of `(u,v)` is needed before mapping to texture space.
+    fn rampTexture2D(stops: []const Stop, alpha: f32) (std.mem.Allocator.Error || dvui.Backend.TextureError)!dvui.Texture {
+        var hasher = dvui.fnv.init();
+        hasher.update("radial2d"); // distinguish from `rampTexture`'s 1D cache key
+        for (stops) |s| {
+            hasher.update(std.mem.asBytes(&s.offset));
+            hasher.update(std.mem.asBytes(&s.color));
+        }
+        hasher.update(std.mem.asBytes(&alpha));
+        const key = hasher.final();
+        if (dvui.textureGetCached(key)) |cached| return cached;
+
+        var pixels: [ramp2d_width * ramp2d_width]Color.PMA = undefined;
+        for (0..ramp2d_width) |row| {
+            const v = 2 * (@as(f32, @floatFromInt(row)) / @as(f32, @floatFromInt(ramp2d_width - 1))) - 1;
+            for (0..ramp2d_width) |col| {
+                const u = 2 * (@as(f32, @floatFromInt(col)) / @as(f32, @floatFromInt(ramp2d_width - 1))) - 1;
+                const t = std.math.clamp(@sqrt(u * u + v * v), 0, 1);
+                pixels[row * ramp2d_width + col] = .fromColor(interpolate(stops, t).opacity(alpha));
+            }
+        }
+        const tex = try dvui.Texture.fromPixelsPMA(&pixels, ramp2d_width, ramp2d_width, .linear);
+        dvui.textureAddToCache(key, tex);
+        return tex;
+    }
+
+    /// Like `rampTexture2D`, but for focal radial: holds
+    /// `interpolate(stops, focalRadialT(u, v, fu, fv))` for `(u,v)` covering
+    /// `[-1,1]^2`. `(fu,fv)` (the focal point's own `radialUV`) is constant
+    /// for a given draw but varies across gradients, so it joins the cache
+    /// key alongside the stops.
+    fn rampTextureFocal2D(stops: []const Stop, alpha: f32, fu: f32, fv: f32) (std.mem.Allocator.Error || dvui.Backend.TextureError)!dvui.Texture {
+        var hasher = dvui.fnv.init();
+        hasher.update("radial2dfocal");
+        for (stops) |s| {
+            hasher.update(std.mem.asBytes(&s.offset));
+            hasher.update(std.mem.asBytes(&s.color));
+        }
+        hasher.update(std.mem.asBytes(&alpha));
+        hasher.update(std.mem.asBytes(&fu));
+        hasher.update(std.mem.asBytes(&fv));
+        const key = hasher.final();
+        if (dvui.textureGetCached(key)) |cached| return cached;
+
+        var pixels: [ramp2d_width * ramp2d_width]Color.PMA = undefined;
+        for (0..ramp2d_width) |row| {
+            const v = 2 * (@as(f32, @floatFromInt(row)) / @as(f32, @floatFromInt(ramp2d_width - 1))) - 1;
+            for (0..ramp2d_width) |col| {
+                const u = 2 * (@as(f32, @floatFromInt(col)) / @as(f32, @floatFromInt(ramp2d_width - 1))) - 1;
+                const t = focalRadialT(u, v, fu, fv);
+                pixels[row * ramp2d_width + col] = .fromColor(interpolate(stops, t).opacity(alpha));
+            }
+        }
+        const tex = try dvui.Texture.fromPixelsPMA(&pixels, ramp2d_width, ramp2d_width, .linear);
+        dvui.textureAddToCache(key, tex);
+        return tex;
+    }
+
+    /// Like `rampTexture2D`, but for `scattered`: holds
+    /// `scatteredColorAt(stops, u, v)` for `(u,v)` covering `[0,1]^2`
+    /// (bounds fractions, same convention as a stop's own `x`/`y` - no
+    /// `*2-1` remap needed since `scatteredUV` is already `[0,1]`-based).
+    /// Keyed by the whole stop set (position and color), since - unlike the
+    /// single-scalar-`t` gradients - there's no separate 1D interpolation to
+    /// key on. Note this makes the underlying blend distance-metric
+    /// bounds-aspect-relative rather than physical-pixel: a non-square
+    /// shape now gets elliptical (not circular) falloff around each stop,
+    /// trading that for cacheability (see `scatteredColorAt`).
+    fn rampTextureScattered2D(stops: []const ScatterStop, alpha: f32) (std.mem.Allocator.Error || dvui.Backend.TextureError)!dvui.Texture {
+        var hasher = dvui.fnv.init();
+        hasher.update("scattered2d");
+        for (stops) |s| {
+            hasher.update(std.mem.asBytes(&s.x));
+            hasher.update(std.mem.asBytes(&s.y));
+            hasher.update(std.mem.asBytes(&s.color));
+        }
+        hasher.update(std.mem.asBytes(&alpha));
+        const key = hasher.final();
+        if (dvui.textureGetCached(key)) |cached| return cached;
+
+        var pixels: [ramp2d_width * ramp2d_width]Color.PMA = undefined;
+        for (0..ramp2d_width) |row| {
+            const v = @as(f32, @floatFromInt(row)) / @as(f32, @floatFromInt(ramp2d_width - 1));
+            for (0..ramp2d_width) |col| {
+                const u = @as(f32, @floatFromInt(col)) / @as(f32, @floatFromInt(ramp2d_width - 1));
+                const color = scatteredColorAt(stops, u, v) orelse stops[0].color;
+                pixels[row * ramp2d_width + col] = .fromColor(color.opacity(alpha));
+            }
+        }
+        const tex = try dvui.Texture.fromPixelsPMA(&pixels, ramp2d_width, ramp2d_width, .linear);
+        dvui.textureAddToCache(key, tex);
+        return tex;
+    }
+
+    /// Post-process pass over already-built triangles.
+    ///
+    /// Sets each vertex's UV to the gradient's exact analytic (affine)
+    /// coordinate and returns a ramp texture holding the (possibly
+    /// nonlinear) color function of that coordinate, for the caller to draw
+    /// the triangles with. GPU UV interpolation reproduces the affine
+    /// coordinate exactly everywhere, which baked-vertex-color Gouraud
+    /// interpolation can't do for a nonlinear or multi-stop color function
+    /// (see `rampTexture`'s doc comment) - so vertex color is left alone
+    /// (aside from being turned into a texture-modulation white, preserving
+    /// existing alpha for opacity/antialiasing fade).
+    ///
+    /// `bounds` should be the shape's bounding box, e.g. `Triangles.bounds`.
+    pub fn apply(gradient: Gradient, triangles: *Triangles, bounds: Rect.Physical) (std.mem.Allocator.Error || dvui.Backend.TextureError)!?dvui.Texture {
+        switch (gradient) {
+            .linear => |g| {
+                const tex = try rampTexture(g.stops, g.alpha);
+                const b = g.anchor orelse bounds;
+                for (triangles.vertexes) |*v| {
+                    const t = linearT(g, b, v.pos) orelse 0;
+                    v.uv = .{ t, 0.5 };
+                    // White, premultiplied by the vertex's existing alpha, so the
+                    // ramp texture shows through unmodified while still respecting
+                    // opacity/antialiasing fade already baked into that alpha.
+                    v.col = .{ .r = v.col.a, .g = v.col.a, .b = v.col.a, .a = v.col.a };
+                }
+                return tex;
+            },
+            .radial => |g| {
+                // `(nx,ny)` (`radialUV`) is affine in position for both
+                // focal and non-focal radial, so both can go straight into
+                // the UV and be reproduced exactly by GPU interpolation, no
+                // subdivision needed. The nonlinearity (`length()` for
+                // non-focal, `focalRadialT`'s quadratic solve for focal)
+                // lives in the 2D ramp texture instead.
+                const b = g.anchor orelse bounds;
+                const geo = radialGeometry(g, b);
+                const tex = if (g.focal) |f| blk: {
+                    const fuv = if (geo) |gm| radialUV(gm, .{ .x = b.x + f.x * b.w, .y = b.y + f.y * b.h }) else [2]f32{ 0, 0 };
+                    break :blk try rampTextureFocal2D(g.stops, g.alpha, fuv[0], fuv[1]);
+                } else try rampTexture2D(g.stops, g.alpha);
+                for (triangles.vertexes) |*v| {
+                    const uv = if (geo) |gm| radialUV(gm, v.pos) else [2]f32{ 0, 0 };
+                    v.uv = .{ (uv[0] + 1) / 2, (uv[1] + 1) / 2 };
+                    // White, premultiplied by the vertex's existing alpha - see `linear` above.
+                    v.col = .{ .r = v.col.a, .g = v.col.a, .b = v.col.a, .a = v.col.a };
+                }
+                return tex;
+            },
+            .scattered => |g| {
+                const tex = try rampTextureScattered2D(g.stops, g.alpha);
+                const b = g.anchor orelse bounds;
+                for (triangles.vertexes) |*v| {
+                    const uv = scatteredUV(b, v.pos);
+                    v.uv = .{ uv[0], uv[1] };
+                    v.col = .{ .r = v.col.a, .g = v.col.a, .b = v.col.a, .a = v.col.a };
+                }
+                return tex;
+            },
+        }
+    }
+};
+
+/// Either a flat color or a gradient. Used by `Options.color_fill` and
+/// friends so gradients don't need sibling `_gradient` fields.
+pub const ColorOrGradient = union(enum) {
+    color: Color,
+    gradient: Gradient,
+
+    /// A representative flat color: `.color` as-is, or a gradient's own
+    /// first stop. Used where a full gradient can't be expressed (e.g.
+    /// blending into another flat color for a "grayed out" effect).
+    pub fn toColor(self: ColorOrGradient) Color {
+        return switch (self) {
+            .color => |c| c,
+            .gradient => |g| g.firstColor(),
+        };
+    }
+
+    /// Multiply the opacity of `self` by `mult` (see `Color.opacity` /
+    /// `Gradient.opacity`), preserving whether it's a flat color or a
+    /// gradient.
+    pub fn opacity(self: ColorOrGradient, mult: f32) ColorOrGradient {
+        return switch (self) {
+            .color => |c| .{ .color = c.opacity(mult) },
+            .gradient => |g| .{ .gradient = g.opacity(mult) },
+        };
+    }
+
+    /// Scales a gradient's natural-pixel fields by `s` (see `Gradient.scale`);
+    /// a flat color is unaffected.
+    pub fn scale(self: ColorOrGradient, s: f32) ColorOrGradient {
+        return switch (self) {
+            .color => self,
+            .gradient => |g| .{ .gradient = g.scale(s) },
+        };
+    }
+
+    /// Blends `a` toward `b` by `t` (0-1). If both are flat colors, this is
+    /// a normal color lerp. Otherwise it snaps to `a` (t<0.5) or `b`
+    /// (t>=0.5) rather than blending — gradients don't get an automatic
+    /// hover/press adjustment.
+    pub fn lerp(a: ColorOrGradient, b: ColorOrGradient, t: f32) ColorOrGradient {
+        if (a == .color and b == .color) return .{ .color = a.color.lerp(b.color, t) };
+        return if (t < 0.5) a else b;
+    }
+
+    /// Wrap a flat `Color`. Convenience for call sites that only ever pass
+    /// a flat color into a `ColorOrGradient` field.
+    pub fn fromColor(c: Color) ColorOrGradient {
+        return .{ .color = c };
+    }
+
+    /// Forwards to `Color.fromHex`, wrapped as a flat color.
+    pub fn fromHex(hex_color: []const u8) ColorOrGradient {
+        return .{ .color = Color.fromHex(hex_color) };
+    }
+
+    /// Splits into the `color`/`gradient` pair that `FillConvexOptions`,
+    /// `FillOptions`, and `StrokeOptions` take.
+    pub fn split(self: ColorOrGradient) struct { color: Color, gradient: ?Gradient } {
+        return switch (self) {
+            .color => |c| .{ .color = c, .gradient = null },
+            // Raw (no `alpha` applied) -- this feeds the pre-`apply`
+            // placeholder vertex color; `apply`/`sample` apply `alpha`.
+            .gradient => |g| .{ .color = g.firstColorRaw(), .gradient = g },
+        };
+    }
+    // const aliases (future TODO: should be sync to those in Color, if those change)
+    pub const white: ColorOrGradient = .{ .color = Color.white };
+    pub const silver: ColorOrGradient = .{ .color = Color.silver };
+    pub const gray: ColorOrGradient = .{ .color = Color.gray };
+    pub const black: ColorOrGradient = .{ .color = Color.black };
+    pub const red: ColorOrGradient = .{ .color = Color.red };
+    pub const maroon: ColorOrGradient = .{ .color = Color.maroon };
+    pub const yellow: ColorOrGradient = .{ .color = Color.yellow };
+    pub const olive: ColorOrGradient = .{ .color = Color.olive };
+    pub const lime: ColorOrGradient = .{ .color = Color.lime };
+    pub const green: ColorOrGradient = .{ .color = Color.green };
+    pub const aqua: ColorOrGradient = .{ .color = Color.aqua };
+    pub const teal: ColorOrGradient = .{ .color = Color.teal };
+    pub const blue: ColorOrGradient = .{ .color = Color.blue };
+    pub const navy: ColorOrGradient = .{ .color = Color.navy };
+    pub const fuchsia: ColorOrGradient = .{ .color = Color.fuchsia };
+    pub const purple: ColorOrGradient = .{ .color = Color.purple };
+    pub const transparent: ColorOrGradient = .{ .color = Color.transparent };
+    // Aliases for basic colors that are already defined
+    // https://en.wikipedia.org/wiki/Web_colors#Extended_colors
+    pub const cyan = aqua;
+    pub const magenta = fuchsia;
+    pub const dark_cyan = teal;
+    pub const dark_magenta = purple;
+};
+
+test "fill gradient" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const square: Path = .{ .points = &.{
+        .{ .x = 0, .y = 0 },
+        .{ .x = 0, .y = 100 },
+        .{ .x = 100, .y = 100 },
+        .{ .x = 100, .y = 0 },
+    } };
+
+    const left_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const right_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    var triangles = try square.fillConvexTriangles(std.testing.allocator, .{
+        .color = .{ .gradient = .{ .linear = .{ .stops = &.{ .{ .color = left_color, .offset = 0 }, .{ .color = right_color, .offset = 1 } }, .angle_degrees = 0 } } },
+    });
+    defer triangles.deinit(std.testing.allocator);
+
+    // angle_degrees = 0 is left-to-right: vertexes on the left edge should
+    // have `t` (UV.x, into the ramp texture returned via `triangles.texture`
+    // - see `Gradient.apply`) near 0 (left_color), right edge near 1
+    // (right_color).
+    try std.testing.expect(triangles.texture != null);
+    for (triangles.vertexes) |v| {
+        if (v.pos.x < 1) {
+            try std.testing.expect(v.uv[0] < 0.5);
+        } else if (v.pos.x > 99) {
+            try std.testing.expect(v.uv[0] > 0.5);
+        }
+    }
+}
+
+test "fill gradient radial" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const square: Path = .{ .points = &.{
+        .{ .x = 0, .y = 0 },
+        .{ .x = 0, .y = 100 },
+        .{ .x = 100, .y = 100 },
+        .{ .x = 100, .y = 0 },
+    } };
+
+    const center_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const edge_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    var triangles = try square.fillConvexTriangles(std.testing.allocator, .{
+        .color = .{ .gradient = .{ .radial = .{ .stops = &.{ .{ .color = center_color, .offset = 0 }, .{ .color = edge_color, .offset = 1 } } } } },
+        .center = .{ .x = 50, .y = 50 },
+    });
+    defer triangles.deinit(std.testing.allocator);
+
+    // Non-focal radial no longer bakes color into vertexes (see
+    // `Gradient.apply`'s radial branch): color lives in a 2D ramp texture
+    // sampled via UV, so check UV distance from the ellipse center (0.5,0.5
+    // in UV space) instead. The center vertex should be near 0 (close to
+    // `center_color`); the corners (farthest from center) should be near
+    // the ellipse boundary (UV distance ~0.5, close to `edge_color`).
+    for (triangles.vertexes) |v| {
+        const d = @sqrt((v.uv[0] - 0.5) * (v.uv[0] - 0.5) + (v.uv[1] - 0.5) * (v.uv[1] - 0.5));
+        if (v.pos.x == 50 and v.pos.y == 50) {
+            try std.testing.expect(d < 0.1);
+        } else if ((v.pos.x == 0 or v.pos.x == 100) and (v.pos.y == 0 or v.pos.y == 100)) {
+            try std.testing.expect(d > 0.4);
+        }
+    }
+}
+
+test "fill gradient radial defaults center to bounding box" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const square: Path = .{ .points = &.{
+        .{ .x = 0, .y = 0 },
+        .{ .x = 0, .y = 100 },
+        .{ .x = 100, .y = 100 },
+        .{ .x = 100, .y = 0 },
+    } };
+
+    const center_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const edge_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    // No `.center` passed: fillConvexTriangles must add one at the bbox
+    // center itself so the middle still samples near `center_color`.
+    var triangles = try square.fillConvexTriangles(std.testing.allocator, .{
+        .color = .{ .gradient = .{ .radial = .{ .stops = &.{ .{ .color = center_color, .offset = 0 }, .{ .color = edge_color, .offset = 1 } } } } },
+    });
+    defer triangles.deinit(std.testing.allocator);
+
+    var found_center = false;
+    for (triangles.vertexes) |v| {
+        if (v.pos.x == 50 and v.pos.y == 50) {
+            found_center = true;
+            const d = @sqrt((v.uv[0] - 0.5) * (v.uv[0] - 0.5) + (v.uv[1] - 0.5) * (v.uv[1] - 0.5));
+            try std.testing.expect(d < 0.1);
+        }
+    }
+    try std.testing.expect(found_center);
+}
+
+test "fill gradient radial ellipse reaches all edges of a non-square box" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    // Regression test: a plain circle (equal rx/ry) on a wide box doesn't
+    // reach the left/right edges, so far-left/right vertexes stay near
+    // `color` instead of blending toward `color2` like CSS's default
+    // "ellipse farthest-corner" does.
+    const wide: Path = .{ .points = &.{
+        .{ .x = 0, .y = 0 },
+        .{ .x = 0, .y = 100 },
+        .{ .x = 400, .y = 100 },
+        .{ .x = 400, .y = 0 },
+    } };
+
+    const center_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const edge_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    var triangles = try wide.fillConvexTriangles(std.testing.allocator, .{
+        .color = .{ .gradient = .{ .radial = .{ .stops = &.{ .{ .color = center_color, .offset = 0 }, .{ .color = edge_color, .offset = 1 } }, .extent = .closest_side } } },
+    });
+    defer triangles.deinit(std.testing.allocator);
+
+    for (triangles.vertexes) |v| {
+        if (v.pos.x < 1 or v.pos.x > 399) {
+            const d = @sqrt((v.uv[0] - 0.5) * (v.uv[0] - 0.5) + (v.uv[1] - 0.5) * (v.uv[1] - 0.5));
+            try std.testing.expect(d > 0.4);
+        }
+    }
+}
+
+test "fill gradient radial circle shape stays circular on a non-square box" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const wide: Path = .{ .points = &.{
+        .{ .x = 0, .y = 0 },
+        .{ .x = 0, .y = 100 },
+        .{ .x = 400, .y = 100 },
+        .{ .x = 400, .y = 0 },
+    } };
+
+    const center_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const edge_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    // closest-side circle: radius = min(half-width, half-height) = 50, so a
+    // point 50px right of center is right at the edge of the circle, but a
+    // point only 10px right (well inside a circle of radius 50) should
+    // still read close to the center color.
+    var triangles = try wide.fillConvexTriangles(std.testing.allocator, .{
+        .color = .{ .gradient = .{ .radial = .{ .stops = &.{ .{ .color = center_color, .offset = 0 }, .{ .color = edge_color, .offset = 1 } }, .shape = .{ .circle = .{} }, .extent = .closest_side } } },
+        .center = .{ .x = 210, .y = 50 },
+    });
+    defer triangles.deinit(std.testing.allocator);
+
+    var found = false;
+    for (triangles.vertexes) |v| {
+        if (v.pos.x == 210 and v.pos.y == 50) {
+            found = true;
+            // 10px right of a radius-50 circle center: `t` = 10/50 = 0.2, so
+            // UV distance from center is 0.2/2 = 0.1 - just inside the
+            // "close to center" half of the ramp.
+            const d = @sqrt((v.uv[0] - 0.5) * (v.uv[0] - 0.5) + (v.uv[1] - 0.5) * (v.uv[1] - 0.5));
+            try std.testing.expect(d < 0.15);
+        }
+    }
+    try std.testing.expect(found);
+}
+
+test "fill gradient radial position moves the gradient center off the box center" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const square: Path = .{ .points = &.{
+        .{ .x = 0, .y = 0 },
+        .{ .x = 0, .y = 100 },
+        .{ .x = 100, .y = 100 },
+        .{ .x = 100, .y = 0 },
+    } };
+
+    const center_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const edge_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    // position at the top-left corner: that corner should read as the
+    // center color, while the opposite (bottom-right) corner -- now the
+    // farthest point from the gradient center -- should read as color2.
+    var triangles = try square.fillConvexTriangles(std.testing.allocator, .{
+        .color = .{ .gradient = .{ .radial = .{ .stops = &.{ .{ .color = center_color, .offset = 0 }, .{ .color = edge_color, .offset = 1 } }, .position = .{ .x = 0, .y = 0 } } } },
+        .center = .{ .x = 0, .y = 0 },
+    });
+    defer triangles.deinit(std.testing.allocator);
+
+    for (triangles.vertexes) |v| {
+        const d = @sqrt((v.uv[0] - 0.5) * (v.uv[0] - 0.5) + (v.uv[1] - 0.5) * (v.uv[1] - 0.5));
+        if (v.pos.x == 0 and v.pos.y == 0) {
+            try std.testing.expect(d < 0.1);
+        } else if (v.pos.x == 100 and v.pos.y == 100) {
+            try std.testing.expect(d > 0.4);
+        }
+    }
+}
+
+test "fill gradient radial size gives an explicit pixel radius, ignoring extent" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    // Box is much bigger than the fixed 20x10 ellipse: a keyword extent
+    // would reach the corners, but `size` should keep the ellipse small so
+    // most of the box reads as color2 regardless of box size.
+    const big: Path = .{ .points = &.{
+        .{ .x = 0, .y = 0 },
+        .{ .x = 0, .y = 200 },
+        .{ .x = 200, .y = 200 },
+        .{ .x = 200, .y = 0 },
+    } };
+
+    const center_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const edge_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    var triangles = try big.fillConvexTriangles(std.testing.allocator, .{
+        .color = .{ .gradient = .{ .radial = .{ .stops = &.{ .{ .color = center_color, .offset = 0 }, .{ .color = edge_color, .offset = 1 } }, .shape = .{ .ellipse = .{ .size = .{ .x = 20, .y = 10 } } } } } },
+        .center = .{ .x = 100, .y = 100 },
+    });
+    defer triangles.deinit(std.testing.allocator);
+
+    for (triangles.vertexes) |v| {
+        if (v.pos.x == 100 and v.pos.y == 100) {
+            const d = @sqrt((v.uv[0] - 0.5) * (v.uv[0] - 0.5) + (v.uv[1] - 0.5) * (v.uv[1] - 0.5));
+            try std.testing.expect(d < 0.1);
+        } else if (v.pos.x == 0 and v.pos.y == 0) {
+            // Far outside the tiny 20x10 ellipse: UV lands well past the
+            // ellipse boundary, which the ramp texture's clamp-to-edge
+            // sampling reads back as the saturated `edge_color`.
+            const d = @sqrt((v.uv[0] - 0.5) * (v.uv[0] - 0.5) + (v.uv[1] - 0.5) * (v.uv[1] - 0.5));
+            try std.testing.expect(d > 1.0);
+        }
+    }
+}
+
+test "fill gradient radial focal point shifts the 0%-offset point off center" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const square: Path = .{ .points = &.{
+        .{ .x = 0, .y = 0 },
+        .{ .x = 0, .y = 100 },
+        .{ .x = 100, .y = 100 },
+        .{ .x = 100, .y = 0 },
+    } };
+
+    const center_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const edge_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    // Ending shape stays centered on the box, but the focal point (the
+    // 0%-offset point) is shifted to the top-left corner: that corner
+    // should read as the center color even though it's far from the
+    // shape's own center -- something CSS radial-gradient() can't express.
+    const gradient: Gradient = .{ .radial = .{ .stops = &.{ .{ .color = center_color, .offset = 0 }, .{ .color = edge_color, .offset = 1 } }, .focal = .{ .x = 0, .y = 0 } } };
+    var triangles = try square.fillConvexTriangles(std.testing.allocator, .{
+        .color = .{ .gradient = gradient },
+        .center = .{ .x = 0, .y = 0 },
+    });
+    defer triangles.deinit(std.testing.allocator);
+
+    // Focal radial no longer bakes color into vertexes either (see
+    // `Gradient.apply`'s radial branch): color lives in a 2D ramp texture
+    // sampled via UV, so check the analytic sample directly instead.
+    try std.testing.expect(triangles.texture != null);
+    const c = gradient.sample(triangles.bounds, .{ .x = 0, .y = 0 });
+    try std.testing.expect(c.r > c.b);
+}
+
+test "fill gradient radial rotation tilts an off-center ellipse" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const square: Path = .{ .points = &.{
+        .{ .x = 0, .y = 0 },
+        .{ .x = 0, .y = 100 },
+        .{ .x = 100, .y = 100 },
+        .{ .x = 100, .y = 0 },
+    } };
+
+    const center_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const edge_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    // A wide, short fixed-size ellipse rotated 90 degrees becomes tall and
+    // narrow: a point straight above center (far along the un-rotated
+    // major axis) should now read closer to color2 than a point beside
+    // it, since the major axis has swapped to vertical.
+    var triangles = try square.fillConvexTriangles(std.testing.allocator, .{
+        .color = .{ .gradient = .{ .radial = .{
+            .stops = &.{ .{ .color = center_color, .offset = 0 }, .{ .color = edge_color, .offset = 1 } },
+            .shape = .{ .ellipse = .{ .size = .{ .x = 200, .y = 10 }, .rotation_degrees = 90 } },
+        } } },
+        .center = .{ .x = 50, .y = 50 },
+    });
+    defer triangles.deinit(std.testing.allocator);
+
+    for (triangles.vertexes) |v| {
+        if (v.pos.x == 50 and v.pos.y == 0) {
+            // 50px above center: inside the rotated (now-vertical) major axis.
+            try std.testing.expect(v.col.r > v.col.b);
+        } else if (v.pos.x == 0 and v.pos.y == 50) {
+            // 50px left of center: outside the rotated (now-narrow) minor axis.
+            try std.testing.expectEqual(edge_color, v.col.toColor());
+        }
+    }
+}
+
+test "fill gradient anchor lets the gradient span a rect outside the shape's own bounds" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    // A small box positioned at the right edge of a much wider anchor rect:
+    // anchoring the gradient to that wider rect should make the box read
+    // as being near the gradient's far end (near color2), not centered in
+    // its own tiny bounding box.
+    const small: Path = .{ .points = &.{
+        .{ .x = 190, .y = 0 },
+        .{ .x = 190, .y = 20 },
+        .{ .x = 200, .y = 20 },
+        .{ .x = 200, .y = 0 },
+    } };
+
+    const left_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const right_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    var triangles = try small.fillConvexTriangles(std.testing.allocator, .{
+        .color = .{ .gradient = .{ .linear = .{
+            .stops = &.{ .{ .color = left_color, .offset = 0 }, .{ .color = right_color, .offset = 1 } },
+            .angle_degrees = 0,
+            .anchor = .{ .x = 0, .y = 0, .w = 200, .h = 20 },
+        } } },
+        .center = .{ .x = 195, .y = 10 },
+    });
+    defer triangles.deinit(std.testing.allocator);
+
+    // Linear gradients don't bake color into vertexes anymore (see
+    // `Gradient.apply`) - they set UV to the analytic `t` instead, for the
+    // caller to draw with the ramp texture returned by `applyDense`.
+    try std.testing.expect(triangles.texture != null);
+    for (triangles.vertexes) |v| {
+        try std.testing.expect(v.uv[0] > 0.5);
+    }
+}
+
+test "fill gradient multi-stop" {
+    const start: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const mid: Color = .{ .r = 0, .g = 255, .b = 0, .a = 255 };
+    const end: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    const gradient: Gradient = .{ .linear = .{
+        .angle_degrees = 0,
+        .stops = &.{
+            .{ .color = start, .offset = 0 },
+            .{ .color = mid, .offset = 0.5 },
+            .{ .color = end, .offset = 1 },
+        },
+    } };
+    const bounds: Rect.Physical = .{ .x = 0, .y = 0, .w = 100, .h = 10 };
+
+    // the middle stop should dominate green near x=50; red/blue should
+    // dominate near the two ends.
+    try std.testing.expect(gradient.sample(bounds, .{ .x = 0, .y = 5 }).r > 200);
+    const midc = gradient.sample(bounds, .{ .x = 50, .y = 5 });
+    try std.testing.expect(midc.g > midc.r and midc.g > midc.b);
+    try std.testing.expect(gradient.sample(bounds, .{ .x = 100, .y = 5 }).b > 200);
+}
+
+test "gradient scattered blends by inverse-distance squared, snapping on exact stops" {
+    const red: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const blue: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    const gradient: Gradient = .{ .scattered = .{ .stops = &.{
+        .{ .color = red, .x = 0, .y = 0.5 },
+        .{ .color = blue, .x = 1, .y = 0.5 },
+    } } };
+    const bounds: Rect.Physical = .{ .x = 0, .y = 0, .w = 100, .h = 100 };
+
+    // Exactly on a stop: snaps to that stop's color, not a blend.
+    try std.testing.expectEqual(red, gradient.sample(bounds, .{ .x = 0, .y = 50 }));
+    try std.testing.expectEqual(blue, gradient.sample(bounds, .{ .x = 100, .y = 50 }));
+
+    // Equidistant from both stops: roughly an even blend.
+    const midc = gradient.sample(bounds, .{ .x = 50, .y = 50 });
+    try std.testing.expect(@abs(@as(i32, midc.r) - midc.b) < 10);
+
+    // Closer to red: more red than blue.
+    const nearc = gradient.sample(bounds, .{ .x = 10, .y = 50 });
+    try std.testing.expect(nearc.r > nearc.b);
+}
+
+test "ColorOrGradient.lerp snaps instead of blending when either side is a gradient" {
+    const red: ColorOrGradient = .{ .color = .{ .r = 255, .g = 0, .b = 0, .a = 255 } };
+    const blue: ColorOrGradient = .{ .color = .{ .r = 0, .g = 0, .b = 255, .a = 255 } };
+
+    // Both flat colors: real lerp.
+    const half = ColorOrGradient.lerp(red, blue, 0.5);
+    try std.testing.expect(half.color.r > 0 and half.color.b > 0);
+
+    // One side is a gradient: snaps rather than blending.
+    const gradient: ColorOrGradient = .{ .gradient = .{ .linear = .{ .stops = &.{
+        .{ .color = .{ .r = 0, .g = 255, .b = 0, .a = 255 }, .offset = 0 },
+    } } } };
+    try std.testing.expectEqual(red, ColorOrGradient.lerp(red, gradient, 0.25));
+    try std.testing.expectEqual(.gradient, std.meta.activeTag(ColorOrGradient.lerp(red, gradient, 0.75)));
+}
+
+test "stroke gradient" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const line: Path = .{ .points = &.{
+        .{ .x = 0, .y = 50 },
+        .{ .x = 100, .y = 50 },
+    } };
+
+    const left_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const right_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    // strokeTriangles' vtx/idx counts are worst-case upper bounds (e.g. for
+    // miter joints) that aren't always fully used, so - like all its
+    // production callers - it needs an arena allocator here rather than
+    // `std.testing.allocator`, which asserts free() size exactly matches
+    // the allocation size.
+    const lifo = dvui.currentWindow().lifo();
+    var triangles = try line.strokeTriangles(lifo, .{
+        .thickness = 5,
+        .color = .{ .gradient = .{ .linear = .{ .stops = &.{ .{ .color = left_color, .offset = 0 }, .{ .color = right_color, .offset = 1 } }, .angle_degrees = 0 } } },
+    });
+    defer triangles.deinit(lifo);
+
+    try std.testing.expect(triangles.texture != null);
+    var saw_left = false;
+    var saw_right = false;
+    for (triangles.vertexes) |v| {
+        if (v.col.a != 255) continue; // skip aa-fade edge vertexes
+        if (v.pos.x < 1) {
+            try std.testing.expect(v.uv[0] < 0.5);
+            saw_left = true;
+        } else if (v.pos.x > 99) {
+            try std.testing.expect(v.uv[0] > 0.5);
+            saw_right = true;
+        }
+    }
+    try std.testing.expect(saw_left and saw_right);
+}
+
+// Not a correctness test (no assertions) — a manual visual-verification
+// tool. Renders each Gradient variant to a PNG so it can be screenshotted
+// side-by-side against the equivalent CSS gradient rendered by a browser.
+// Angle conversion: dvui 0deg = left-to-right, clockwise; CSS 0deg = to
+// top, clockwise. Since dvui's East (0deg) is CSS's "to right" (90deg),
+// css_angle = dvui_angle + 90.
+//
+// Run with (from repo root): zig build test -Dtest-filter="DOCIMG gradient css" -Dimage-dir=/tmp/gradient-compare/dvui
+test "DOCIMG gradient css comparison" {
+    const size: dvui.Size = .{ .w = 300, .h = 200 };
+    var t = try dvui.testing.init(.{ .window_size = size });
+    defer t.deinit();
+
+    const red: Color = .{ .r = 255, .g = 80, .b = 80, .a = 255 };
+    const blue: Color = .{ .r = 80, .g = 120, .b = 255, .a = 255 };
+    const yellow: Color = .{ .r = 255, .g = 220, .b = 80, .a = 255 };
+
+    const Sample = struct {
+        var gradient: Gradient = undefined;
+
+        fn frame() !dvui.App.Result {
+            var box = dvui.box(@src(), .{}, .{
+                .expand = .both,
+                .background = true,
+                .color_fill = .{ .gradient = gradient },
+            });
+            defer box.deinit();
+            return .ok;
+        }
+    };
+
+    Sample.gradient = .{
+        .linear = .{
+            .angle_degrees = 0, // css: linear-gradient(90deg, ...)
+            .stops = &.{ .{ .color = red, .offset = 0 }, .{ .color = blue, .offset = 1 } },
+        },
+    };
+    try t.saveImage(Sample.frame, null, "linear-basic.png");
+
+    Sample.gradient = .{
+        .linear = .{
+            .angle_degrees = 45, // css: linear-gradient(135deg, ...)
+            .stops = &.{ .{ .color = red, .offset = 0 }, .{ .color = yellow, .offset = 0.5 }, .{ .color = blue, .offset = 1 } },
+        },
+    };
+    try t.saveImage(Sample.frame, null, "linear-diagonal-3stop.png");
+
+    Sample.gradient = .{
+        .radial = .{
+            .shape = .{ .circle = .{} },
+            .extent = .farthest_corner,
+            // css: radial-gradient(circle farthest-corner at 50% 50%, ...)
+            .stops = &.{ .{ .color = red, .offset = 0 }, .{ .color = blue, .offset = 1 } },
+        },
+    };
+    try t.saveImage(Sample.frame, null, "radial-circle-farthest-corner.png");
+
+    Sample.gradient = .{
+        .radial = .{
+            .shape = .{ .ellipse = .{} },
+            .extent = .closest_side,
+            .position = .{ .x = 0.25, .y = 0.25 },
+            // css: radial-gradient(ellipse closest-side at 25% 25%, ...)
+            .stops = &.{ .{ .color = red, .offset = 0 }, .{ .color = blue, .offset = 1 } },
+        },
+    };
+    try t.saveImage(Sample.frame, null, "radial-ellipse-closest-side-offcenter.png");
+
+    Sample.gradient = .{
+        .radial = .{
+            .shape = .{ .ellipse = .{} },
+            .extent = .farthest_corner,
+            .position = .{ .x = 0.7, .y = 0.3 },
+            // css: radial-gradient(ellipse farthest-corner at 70% 30%, ...)
+            .stops = &.{ .{ .color = red, .offset = 0 }, .{ .color = yellow, .offset = 0.5 }, .{ .color = blue, .offset = 1 } },
+        },
+    };
+    try t.saveImage(Sample.frame, null, "radial-ellipse-farthest-corner-3stop.png");
+
+    Sample.gradient = .{
+        .radial = .{
+            .shape = .{ .ellipse = .{ .size = .{ .x = 60, .y = 40 } } },
+            // css: radial-gradient(60px 40px at 50% 50%, ...)
+            .stops = &.{ .{ .color = red, .offset = 0 }, .{ .color = blue, .offset = 1 } },
+        },
+    };
+    try t.saveImage(Sample.frame, null, "radial-ellipse-fixed-size.png");
+}
+
+const std = @import("std");
+const dvui = @import("dvui.zig");
+
+const math = dvui.math;
+const Color = dvui.Color;
+
+const Rect = dvui.Rect;
+const Path = dvui.Path;
+const Point = dvui.Point;
+const Triangles = dvui.Triangles;

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -66,7 +66,7 @@ color_text_hover: ?Color = null,
 color_text_press: ?Color = null,
 color_border: ?Color = null,
 
-/// 2-stop linear gradient for the background fill (`color_fill` -> `color2`),
+/// 2-stop gradient for the background fill (`color_fill` -> `color2`),
 /// drawn in `WidgetData.borderAndBackground`. Only affects the background
 /// rect, not text/border/box_shadow.
 fill_gradient: ?FillGradient = null,

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -66,6 +66,11 @@ color_text_hover: ?Color = null,
 color_text_press: ?Color = null,
 color_border: ?Color = null,
 
+/// 2-stop linear gradient for the background fill (`color_fill` -> `color2`),
+/// drawn in `WidgetData.borderAndBackground`. Only affects the background
+/// rect, not text/border/box_shadow.
+fill_gradient: ?FillGradient = null,
+
 ninepatch_fill: ?*const Ninepatch = null,
 ninepatch_hover: ?*const Ninepatch = null,
 ninepatch_press: ?*const Ninepatch = null,
@@ -108,6 +113,12 @@ background: ?bool = null,
 
 /// Render a box shadow in `WidgetData.borderAndBackground`.
 box_shadow: ?BoxShadow = null,
+
+pub const FillGradient = struct {
+    color2: Color,
+    /// 0 = left-to-right, 90 = top-to-bottom, measured clockwise.
+    angle_degrees: f32 = 90,
+};
 
 pub const LabelOpts = union(enum) {
     /// Use the label from a different widget.  This is preferred if there is a
@@ -335,6 +346,7 @@ pub fn styleOnly(self: *const Options) Options {
         .color_text_hover = self.color_text_hover,
         .color_text_press = self.color_text_press,
         .color_border = self.color_border,
+        .fill_gradient = self.fill_gradient,
 
         .font = self.font,
     };
@@ -399,6 +411,7 @@ pub fn strip(self: *const Options) Options {
         .color_text_hover = self.color_text_hover,
         .color_text_press = self.color_text_press,
         .color_border = self.color_border,
+        .fill_gradient = self.fill_gradient,
 
         .font = self.font,
 
@@ -462,6 +475,7 @@ pub fn hash(self: *const Options) u64 {
     if (self.color_text_hover) |col| hasher.update(asBytes(&col));
     if (self.color_text_press) |col| hasher.update(asBytes(&col));
     if (self.color_border) |col| hasher.update(asBytes(&col));
+    if (self.fill_gradient) |g| hasher.update(asBytes(&g));
 
     const font = self.fontGet();
     hasher.update(asBytes(&font.hash()));

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -71,6 +71,10 @@ color_border: ?Color = null,
 /// rect, not text/border/box_shadow.
 fill_gradient: ?FillGradient = null,
 
+/// 2-stop gradient for the border (`color_border` -> `color2`), drawn in
+/// `WidgetData.borderAndBackground`. Only affects the border.
+border_gradient: ?FillGradient = null,
+
 ninepatch_fill: ?*const Ninepatch = null,
 ninepatch_hover: ?*const Ninepatch = null,
 ninepatch_press: ?*const Ninepatch = null,
@@ -343,6 +347,7 @@ pub fn styleOnly(self: *const Options) Options {
         .color_text_press = self.color_text_press,
         .color_border = self.color_border,
         .fill_gradient = self.fill_gradient,
+        .border_gradient = self.border_gradient,
 
         .font = self.font,
     };
@@ -408,6 +413,7 @@ pub fn strip(self: *const Options) Options {
         .color_text_press = self.color_text_press,
         .color_border = self.color_border,
         .fill_gradient = self.fill_gradient,
+        .border_gradient = self.border_gradient,
 
         .font = self.font,
 
@@ -472,6 +478,7 @@ pub fn hash(self: *const Options) u64 {
     if (self.color_text_press) |col| hasher.update(asBytes(&col));
     if (self.color_border) |col| hasher.update(asBytes(&col));
     if (self.fill_gradient) |g| hasher.update(asBytes(&g));
+    if (self.border_gradient) |g| hasher.update(asBytes(&g));
 
     const font = self.fontGet();
     hasher.update(asBytes(&font.hash()));

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -114,11 +114,7 @@ background: ?bool = null,
 /// Render a box shadow in `WidgetData.borderAndBackground`.
 box_shadow: ?BoxShadow = null,
 
-pub const FillGradient = struct {
-    color2: Color,
-    /// 0 = left-to-right, 90 = top-to-bottom, measured clockwise.
-    angle_degrees: f32 = 90,
-};
+pub const FillGradient = dvui.Path.Gradient;
 
 pub const LabelOpts = union(enum) {
     /// Use the label from a different widget.  This is preferred if there is a

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -57,23 +57,15 @@ gravity_y: ?f32 = null,
 /// * 0 disables (cannot focus via keyboard navigation)
 tab_index: ?u16 = null,
 
-// Used to override the style/theme.
-color_fill: ?Color = null,
-color_fill_hover: ?Color = null,
-color_fill_press: ?Color = null,
-color_text: ?Color = null,
-color_text_hover: ?Color = null,
-color_text_press: ?Color = null,
-color_border: ?Color = null,
-
-/// 2-stop gradient for the background fill (`color_fill` -> `color2`),
-/// drawn in `WidgetData.borderAndBackground`. Only affects the background
-/// rect, not text/border/box_shadow.
-fill_gradient: ?FillGradient = null,
-
-/// 2-stop gradient for the border (`color_border` -> `color2`), drawn in
-/// `WidgetData.borderAndBackground`. Only affects the border.
-border_gradient: ?FillGradient = null,
+// Used to override the style/theme. `color_fill*`/`color_text*`/`color_border`
+// can each be a flat color or a gradient (see `ColorOrGradient`).
+color_fill: ?ColorOrGradient = null,
+color_fill_hover: ?ColorOrGradient = null,
+color_fill_press: ?ColorOrGradient = null,
+color_text: ?ColorOrGradient = null,
+color_text_hover: ?ColorOrGradient = null,
+color_text_press: ?ColorOrGradient = null,
+color_border: ?ColorOrGradient = null,
 
 ninepatch_fill: ?*const Ninepatch = null,
 ninepatch_hover: ?*const Ninepatch = null,
@@ -118,7 +110,7 @@ background: ?bool = null,
 /// Render a box shadow in `WidgetData.borderAndBackground`.
 box_shadow: ?BoxShadow = null,
 
-pub const FillGradient = dvui.Path.Gradient;
+const ColorOrGradient = dvui.ColorOrGradient;
 
 pub const LabelOpts = union(enum) {
     /// Use the label from a different widget.  This is preferred if there is a
@@ -230,19 +222,29 @@ pub const ColorAsk = enum {
     border,
 };
 
-/// Get a color from this Options or fallback to theme colors.
+/// Get a color (or gradient) from this Options or fallback to theme colors.
+/// Hover/press auto-adjustment (see `Theme.adjustColorForState`) only
+/// applies when the fallback source is a flat color -- gradients don't get
+/// an automatic hover/press adjustment.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn color(self: *const Options, ask: ColorAsk) Color {
+pub fn textColor(self: *const Options, ask: ColorAsk) ColorOrGradient {
     return switch (ask) {
         .border => self.color_border,
         .fill => self.color_fill,
-        .fill_hover => self.color_fill_hover orelse if (self.color_fill) |col| self.themeGet().adjustColorForState(col, ask) else null,
-        .fill_press => self.color_fill_press orelse if (self.color_fill) |col| self.themeGet().adjustColorForState(col, ask) else null,
+        .fill_hover => self.color_fill_hover orelse if (self.color_fill) |cog| adjustColorOrGradientForState(self, cog, ask) else null,
+        .fill_press => self.color_fill_press orelse if (self.color_fill) |cog| adjustColorOrGradientForState(self, cog, ask) else null,
         .text => self.color_text,
-        .text_hover => self.color_text_hover orelse self.color_text,
-        .text_press => self.color_text_press orelse self.color_text,
-    } orelse self.themeGet().color(self.styleGet(), ask);
+        .text_hover => self.color_text_hover orelse if (self.color_text) |cog| adjustColorOrGradientForState(self, cog, ask) else null,
+        .text_press => self.color_text_press orelse if (self.color_text) |cog| adjustColorOrGradientForState(self, cog, ask) else null,
+    } orelse ColorOrGradient{ .color = self.themeGet().color(self.styleGet(), ask) };
+}
+
+fn adjustColorOrGradientForState(self: *const Options, cog: ColorOrGradient, ask: ColorAsk) ColorOrGradient {
+    return switch (cog) {
+        .color => |c| .{ .color = self.themeGet().adjustColorForState(c, ask) },
+        .gradient => cog,
+    };
 }
 
 /// Kinds of Ninepatch you can ask Options for.
@@ -346,8 +348,6 @@ pub fn styleOnly(self: *const Options) Options {
         .color_text_hover = self.color_text_hover,
         .color_text_press = self.color_text_press,
         .color_border = self.color_border,
-        .fill_gradient = self.fill_gradient,
-        .border_gradient = self.border_gradient,
 
         .font = self.font,
     };
@@ -412,8 +412,6 @@ pub fn strip(self: *const Options) Options {
         .color_text_hover = self.color_text_hover,
         .color_text_press = self.color_text_press,
         .color_border = self.color_border,
-        .fill_gradient = self.fill_gradient,
-        .border_gradient = self.border_gradient,
 
         .font = self.font,
 
@@ -477,8 +475,6 @@ pub fn hash(self: *const Options) u64 {
     if (self.color_text_hover) |col| hasher.update(asBytes(&col));
     if (self.color_text_press) |col| hasher.update(asBytes(&col));
     if (self.color_border) |col| hasher.update(asBytes(&col));
-    if (self.fill_gradient) |g| hasher.update(asBytes(&g));
-    if (self.border_gradient) |g| hasher.update(asBytes(&g));
 
     const font = self.fontGet();
     hasher.update(asBytes(&font.hash()));

--- a/src/Options.zig
+++ b/src/Options.zig
@@ -228,7 +228,7 @@ pub const ColorAsk = enum {
 /// an automatic hover/press adjustment.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn textColor(self: *const Options, ask: ColorAsk) ColorOrGradient {
+pub fn color(self: *const Options, ask: ColorAsk) ColorOrGradient {
     return switch (ask) {
         .border => self.color_border,
         .fill => self.color_fill,

--- a/src/Path.zig
+++ b/src/Path.zig
@@ -348,7 +348,42 @@ pub const FillConvexOptions = struct {
     /// If >1, then starts a half-pixel inside and the rest outside.
     fade: f32 = 0.0,
     center: ?Point.Physical = null,
+
+    /// Optional 2-stop linear gradient: blends from `color` to `gradient.color2`
+    /// across the fill's bounding box along `gradient.angle_degrees`.
+    gradient: ?Gradient = null,
+
+    pub const Gradient = struct {
+        color2: Color,
+        /// 0 = left-to-right, 90 = top-to-bottom, measured clockwise.
+        angle_degrees: f32 = 90,
+    };
 };
+
+/// Per-vertex color for a fill: `opts.color`, or interpolated toward
+/// `opts.gradient.color2` by how far `pos` sits along the gradient's axis
+/// across `bounds` (the shape's bounding box).
+fn fillVertexColor(opts: FillConvexOptions, bounds: Rect.Physical, pos: Point.Physical) Color {
+    const g = opts.gradient orelse return opts.color;
+    if (bounds.w <= 0 and bounds.h <= 0) return opts.color;
+
+    const rad = std.math.degreesToRadians(g.angle_degrees);
+    const dir: Point.Physical = .{ .x = @sin(rad), .y = -@cos(rad) };
+
+    const cx = bounds.x + bounds.w / 2;
+    const cy = bounds.y + bounds.h / 2;
+    const hx = bounds.w / 2;
+    const hy = bounds.h / 2;
+
+    // Half-extent of the bounding box projected onto dir (distance from
+    // center to the corner furthest along the gradient axis).
+    const half_extent = @abs(dir.x) * hx + @abs(dir.y) * hy;
+    if (half_extent <= 0) return opts.color;
+
+    const proj = (pos.x - cx) * dir.x + (pos.y - cy) * dir.y;
+    const t = std.math.clamp((proj / half_extent + 1) / 2, 0, 1);
+    return opts.color.lerp(g.color2, t);
+}
 
 /// Fill path (must be convex) with `color` (or `Theme.color_fill`).  See `Rect.fill`.
 ///
@@ -410,7 +445,18 @@ pub fn fillConvexTriangles(path: Path, allocator: std.mem.Allocator, opts: FillC
     var builder = try Triangles.Builder.init(allocator, vtx_count, idx_count);
     errdefer comptime unreachable; // No errors from this point on
 
-    const col: Color.PMA = .fromColor(opts.color);
+    const flat_col: Color.PMA = .fromColor(opts.color);
+    var bounds: Rect.Physical = .{ .x = math.floatMax(f32), .y = math.floatMax(f32), .w = -math.floatMax(f32), .h = -math.floatMax(f32) };
+    if (opts.gradient != null) {
+        for (path.points) |p| {
+            bounds.x = @min(bounds.x, p.x);
+            bounds.y = @min(bounds.y, p.y);
+            bounds.w = @max(bounds.w, p.x);
+            bounds.h = @max(bounds.h, p.y);
+        }
+        bounds.w -= bounds.x;
+        bounds.h -= bounds.y;
+    }
 
     var i: usize = 0;
     while (i < path.points.len) : (i += 1) {
@@ -428,12 +474,13 @@ pub fn fillConvexTriangles(path: Path, allocator: std.mem.Allocator, opts: FillC
 
         // inner vertex
         const inside_len = @min(0.5, opts.fade / 2);
+        const vpos: Point.Physical = .{
+            .x = bb.x - norm.x * inside_len,
+            .y = bb.y - norm.y * inside_len,
+        };
         builder.appendVertex(.{
-            .pos = .{
-                .x = bb.x - norm.x * inside_len,
-                .y = bb.y - norm.y * inside_len,
-            },
-            .col = col,
+            .pos = vpos,
+            .col = if (opts.gradient != null) .fromColor(fillVertexColor(opts, bounds, vpos)) else flat_col,
         });
 
         const idx_ai = if (opts.fade > 0) ai * 2 else ai;
@@ -484,7 +531,7 @@ pub fn fillConvexTriangles(path: Path, allocator: std.mem.Allocator, opts: FillC
     if (opts.center) |center| {
         builder.appendVertex(.{
             .pos = center,
-            .col = col,
+            .col = if (opts.gradient != null) .fromColor(fillVertexColor(opts, bounds, center)) else flat_col,
         });
     }
 

--- a/src/Path.zig
+++ b/src/Path.zig
@@ -341,13 +341,67 @@ pub fn dupe(path: Path, allocator: std.mem.Allocator) std.mem.Allocator.Error!Pa
     return .{ .points = try allocator.dupe(Point.Physical, path.points) };
 }
 
-/// 2-stop linear gradient: blends from a fill's base color to `color2`
-/// across the shape's bounding box along `angle_degrees`. Shared by
-/// `FillConvexOptions.gradient` and `Options.fill_gradient`.
-pub const Gradient = struct {
-    color2: Color,
-    /// 0 = left-to-right, 90 = top-to-bottom, measured clockwise.
-    angle_degrees: f32 = 90,
+/// 2-stop gradient: blends from a fill's base color to `color2` across the
+/// shape's bounding box. Shared by `FillConvexOptions.gradient`,
+/// `FillOptions.gradient`, `StrokeOptions.gradient` and `Options.fill_gradient`.
+///
+/// Only 2-stop linear/radial gradients are supported; add variants here if
+/// more are needed later.
+pub const Gradient = union(enum) {
+    linear: struct {
+        color2: Color,
+        /// 0 = left-to-right, 90 = top-to-bottom, measured clockwise.
+        angle_degrees: f32 = 90,
+    },
+    radial: struct {
+        color2: Color,
+    },
+
+    fn sample(gradient: Gradient, base: Color, bounds: Rect.Physical, pos: Point.Physical) Color {
+        if (bounds.w <= 0 and bounds.h <= 0) return base;
+        const cx = bounds.x + bounds.w / 2;
+        const cy = bounds.y + bounds.h / 2;
+        switch (gradient) {
+            .linear => |g| {
+                const rad = std.math.degreesToRadians(g.angle_degrees);
+                const dir: Point.Physical = .{ .x = @cos(rad), .y = @sin(rad) };
+                const hx = bounds.w / 2;
+                const hy = bounds.h / 2;
+
+                // Half-extent of the bounding box projected onto dir (distance from
+                // center to the corner furthest along the gradient axis).
+                const half_extent = @abs(dir.x) * hx + @abs(dir.y) * hy;
+                if (half_extent <= 0) return base;
+
+                const proj = (pos.x - cx) * dir.x + (pos.y - cy) * dir.y;
+                const t = std.math.clamp((proj / half_extent + 1) / 2, 0, 1);
+                return base.lerp(g.color2, t);
+            },
+            .radial => |g| {
+                const max_dist = (Point.Physical{ .x = bounds.w / 2, .y = bounds.h / 2 }).length();
+                if (max_dist <= 0) return base;
+
+                const dist = (Point.Physical{ .x = pos.x - cx, .y = pos.y - cy }).length();
+                const t = std.math.clamp(dist / max_dist, 0, 1);
+                return base.lerp(g.color2, t);
+            },
+        }
+    }
+
+    /// Post-process pass over already-built triangles: any vertex colored
+    /// exactly `base` (a fill/stroke's flat color) is replaced by the
+    /// gradient-sampled color at that vertex's position. Vertexes with any
+    /// other color (e.g. faded to transparent at an edge) are left as-is.
+    ///
+    /// `bounds` should be the shape's bounding box, e.g. `Triangles.bounds`.
+    pub fn apply(gradient: Gradient, triangles: *Triangles, base: Color, bounds: Rect.Physical) void {
+        const flat: Color.PMA = .fromColor(base);
+        for (triangles.vertexes) |*v| {
+            if (std.meta.eql(v.col, flat)) {
+                v.col = .fromColor(gradient.sample(base, bounds, v.pos));
+            }
+        }
+    }
 };
 
 pub const FillConvexOptions = struct {
@@ -358,35 +412,10 @@ pub const FillConvexOptions = struct {
     fade: f32 = 0.0,
     center: ?Point.Physical = null,
 
-    /// Optional 2-stop linear gradient: blends from `color` to `gradient.color2`
-    /// across the fill's bounding box along `gradient.angle_degrees`.
+    /// Optional 2-stop gradient: blends from `color` to `gradient`'s
+    /// `color2` across the fill's bounding box. See `Gradient`.
     gradient: ?Gradient = null,
 };
-
-/// Per-vertex color for a fill: `opts.color`, or interpolated toward
-/// `opts.gradient.color2` by how far `pos` sits along the gradient's axis
-/// across `bounds` (the shape's bounding box).
-fn fillVertexColor(opts: FillConvexOptions, bounds: Rect.Physical, pos: Point.Physical) Color {
-    const g = opts.gradient orelse return opts.color;
-    if (bounds.w <= 0 and bounds.h <= 0) return opts.color;
-
-    const rad = std.math.degreesToRadians(g.angle_degrees);
-    const dir: Point.Physical = .{ .x = @cos(rad), .y = @sin(rad) };
-
-    const cx = bounds.x + bounds.w / 2;
-    const cy = bounds.y + bounds.h / 2;
-    const hx = bounds.w / 2;
-    const hy = bounds.h / 2;
-
-    // Half-extent of the bounding box projected onto dir (distance from
-    // center to the corner furthest along the gradient axis).
-    const half_extent = @abs(dir.x) * hx + @abs(dir.y) * hy;
-    if (half_extent <= 0) return opts.color;
-
-    const proj = (pos.x - cx) * dir.x + (pos.y - cy) * dir.y;
-    const t = std.math.clamp((proj / half_extent + 1) / 2, 0, 1);
-    return opts.color.lerp(g.color2, t);
-}
 
 /// Fill path (must be convex) with `color` (or `Theme.color_fill`).  See `Rect.fill`.
 ///
@@ -449,17 +478,6 @@ pub fn fillConvexTriangles(path: Path, allocator: std.mem.Allocator, opts: FillC
     errdefer comptime unreachable; // No errors from this point on
 
     const flat_col: Color.PMA = .fromColor(opts.color);
-    var bounds: Rect.Physical = .{ .x = math.floatMax(f32), .y = math.floatMax(f32), .w = -math.floatMax(f32), .h = -math.floatMax(f32) };
-    if (opts.gradient != null) {
-        for (path.points) |p| {
-            bounds.x = @min(bounds.x, p.x);
-            bounds.y = @min(bounds.y, p.y);
-            bounds.w = @max(bounds.w, p.x);
-            bounds.h = @max(bounds.h, p.y);
-        }
-        bounds.w -= bounds.x;
-        bounds.h -= bounds.y;
-    }
 
     var i: usize = 0;
     while (i < path.points.len) : (i += 1) {
@@ -483,7 +501,7 @@ pub fn fillConvexTriangles(path: Path, allocator: std.mem.Allocator, opts: FillC
         };
         builder.appendVertex(.{
             .pos = vpos,
-            .col = if (opts.gradient != null) .fromColor(fillVertexColor(opts, bounds, vpos)) else flat_col,
+            .col = flat_col,
         });
 
         const idx_ai = if (opts.fade > 0) ai * 2 else ai;
@@ -534,11 +552,13 @@ pub fn fillConvexTriangles(path: Path, allocator: std.mem.Allocator, opts: FillC
     if (opts.center) |center| {
         builder.appendVertex(.{
             .pos = center,
-            .col = if (opts.gradient != null) .fromColor(fillVertexColor(opts, bounds, center)) else flat_col,
+            .col = flat_col,
         });
     }
 
-    return builder.build();
+    var triangles = builder.build();
+    if (opts.gradient) |g| g.apply(&triangles, opts.color, triangles.bounds);
+    return triangles;
 }
 
 pub const StrokeOptions = struct {
@@ -552,6 +572,10 @@ pub const StrokeOptions = struct {
     /// true => Stroke includes from path end to path start.
     closed: bool = false,
     endcap_style: EndCapStyle = .none,
+
+    /// Optional 2-stop gradient: blends from `color` to `gradient`'s
+    /// `color2` across the stroke's bounding box. See `Gradient`.
+    gradient: ?Gradient = null,
 
     pub const EndCapStyle = enum {
         none,
@@ -616,7 +640,7 @@ pub fn strokeTriangles(path: Path, allocator: std.mem.Allocator, opts: StrokeOpt
         defer tempPath.deinit();
 
         tempPath.addArc(center, opts.thickness, math.pi * 2.0, 0, true);
-        return tempPath.build().fillConvexTriangles(allocator, .{ .color = opts.color, .fade = 1.0 });
+        return tempPath.build().fillConvexTriangles(allocator, .{ .color = opts.color, .fade = 1.0, .gradient = opts.gradient });
     }
 
     const Side = enum {
@@ -973,7 +997,9 @@ pub fn strokeTriangles(path: Path, allocator: std.mem.Allocator, opts: StrokeOpt
         vtx_right = vtx_right_out;
     }
 
-    return builder.build();
+    var triangles = builder.build();
+    if (opts.gradient) |g| g.apply(&triangles, opts.color, triangles.bounds);
+    return triangles;
 }
 
 pub const FillOptions = struct {
@@ -985,6 +1011,10 @@ pub const FillOptions = struct {
     fade: f32 = 0.0,
 
     fill_rule: FillRule = .nonzero,
+
+    /// Optional 2-stop gradient: blends from `color` to `gradient`'s
+    /// `color2` across the fill's bounding box. See `Gradient`.
+    gradient: ?Gradient = null,
 
     pub const FillRule = enum { nonzero, evenodd };
 };
@@ -1103,7 +1133,9 @@ pub fn fillInsideRule(winding: i32, rule: FillOptions.FillRule) bool {
 /// Delegates to `earcut.fillTriangles` - measured faster on real icon data
 /// than prior intersect-everything and trapezoidal-decomposition approaches.
 pub fn fillTriangles(allocator: std.mem.Allocator, contours: []const Path, opts: FillOptions) std.mem.Allocator.Error!Triangles {
-    return @import("earcut.zig").fillTriangles(allocator, contours, opts);
+    var triangles = try @import("earcut.zig").fillTriangles(allocator, contours, opts);
+    if (opts.gradient) |g| g.apply(&triangles, opts.color, triangles.bounds);
+    return triangles;
 }
 
 pub const FillBoundaryEdge = struct { from: Point.Physical, to: Point.Physical };
@@ -1281,13 +1313,116 @@ test "fill gradient" {
 
     var triangles = try square.fillConvexTriangles(std.testing.allocator, .{
         .color = left_color,
-        .gradient = .{ .color2 = right_color, .angle_degrees = 0 },
+        .gradient = .{ .linear = .{ .color2 = right_color, .angle_degrees = 0 } },
     });
     defer triangles.deinit(std.testing.allocator);
 
     // angle_degrees = 0 is left-to-right: vertexes on the left edge should
     // be near `color`, vertexes on the right edge near `gradient.color2`.
     for (triangles.vertexes) |v| {
+        if (v.pos.x < 1) {
+            try std.testing.expect(v.col.r > v.col.b);
+        } else if (v.pos.x > 99) {
+            try std.testing.expect(v.col.b > v.col.r);
+        }
+    }
+}
+
+test "fill gradient radial" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const square: Path = .{ .points = &.{
+        .{ .x = 0, .y = 0 },
+        .{ .x = 0, .y = 100 },
+        .{ .x = 100, .y = 100 },
+        .{ .x = 100, .y = 0 },
+    } };
+
+    const center_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const edge_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    var triangles = try square.fillConvexTriangles(std.testing.allocator, .{
+        .color = center_color,
+        .center = .{ .x = 50, .y = 50 },
+        .gradient = .{ .radial = .{ .color2 = edge_color } },
+    });
+    defer triangles.deinit(std.testing.allocator);
+
+    // the center vertex should be near `color`; the corners (farthest from
+    // center) should be near `gradient.color2`.
+    for (triangles.vertexes) |v| {
+        if (v.pos.x == 50 and v.pos.y == 50) {
+            try std.testing.expect(v.col.r > v.col.b);
+        } else {
+            try std.testing.expect(v.col.b > v.col.r);
+        }
+    }
+}
+
+test "stroke gradient" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const line: Path = .{ .points = &.{
+        .{ .x = 0, .y = 50 },
+        .{ .x = 100, .y = 50 },
+    } };
+
+    const left_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const right_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    var triangles = try line.strokeTriangles(std.testing.allocator, .{
+        .thickness = 5,
+        .color = left_color,
+        .gradient = .{ .linear = .{ .color2 = right_color, .angle_degrees = 0 } },
+    });
+    defer triangles.deinit(std.testing.allocator);
+
+    var saw_left = false;
+    var saw_right = false;
+    for (triangles.vertexes) |v| {
+        if (v.col.a != 255) continue; // skip aa-fade edge vertexes
+        if (v.pos.x < 1) {
+            try std.testing.expect(v.col.r > v.col.b);
+            saw_left = true;
+        } else if (v.pos.x > 99) {
+            try std.testing.expect(v.col.b > v.col.r);
+            saw_right = true;
+        }
+    }
+    try std.testing.expect(saw_left and saw_right);
+}
+
+test "fill (earcut) gradient" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    // donut: outer square CW(y-down), inner square hole (opposite winding)
+    const outer: Path = .{ .points = &.{
+        .{ .x = 0, .y = 0 },
+        .{ .x = 0, .y = 100 },
+        .{ .x = 100, .y = 100 },
+        .{ .x = 100, .y = 0 },
+    } };
+    const hole: Path = .{ .points = &.{
+        .{ .x = 25, .y = 25 },
+        .{ .x = 75, .y = 25 },
+        .{ .x = 75, .y = 75 },
+        .{ .x = 25, .y = 75 },
+    } };
+
+    const left_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const right_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    var triangles = try fillTriangles(std.testing.allocator, &.{ outer, hole }, .{
+        .color = left_color,
+        .gradient = .{ .linear = .{ .color2 = right_color, .angle_degrees = 0 } },
+    });
+    defer triangles.deinit(std.testing.allocator);
+
+    for (triangles.vertexes) |v| {
+        if (v.col.a != 255) continue; // skip aa-fade/hole vertexes
         if (v.pos.x < 1) {
             try std.testing.expect(v.col.r > v.col.b);
         } else if (v.pos.x > 99) {

--- a/src/Path.zig
+++ b/src/Path.zig
@@ -341,6 +341,15 @@ pub fn dupe(path: Path, allocator: std.mem.Allocator) std.mem.Allocator.Error!Pa
     return .{ .points = try allocator.dupe(Point.Physical, path.points) };
 }
 
+/// 2-stop linear gradient: blends from a fill's base color to `color2`
+/// across the shape's bounding box along `angle_degrees`. Shared by
+/// `FillConvexOptions.gradient` and `Options.fill_gradient`.
+pub const Gradient = struct {
+    color2: Color,
+    /// 0 = left-to-right, 90 = top-to-bottom, measured clockwise.
+    angle_degrees: f32 = 90,
+};
+
 pub const FillConvexOptions = struct {
     color: Color,
 
@@ -352,12 +361,6 @@ pub const FillConvexOptions = struct {
     /// Optional 2-stop linear gradient: blends from `color` to `gradient.color2`
     /// across the fill's bounding box along `gradient.angle_degrees`.
     gradient: ?Gradient = null,
-
-    pub const Gradient = struct {
-        color2: Color,
-        /// 0 = left-to-right, 90 = top-to-bottom, measured clockwise.
-        angle_degrees: f32 = 90,
-    };
 };
 
 /// Per-vertex color for a fill: `opts.color`, or interpolated toward
@@ -368,7 +371,7 @@ fn fillVertexColor(opts: FillConvexOptions, bounds: Rect.Physical, pos: Point.Ph
     if (bounds.w <= 0 and bounds.h <= 0) return opts.color;
 
     const rad = std.math.degreesToRadians(g.angle_degrees);
-    const dir: Point.Physical = .{ .x = @sin(rad), .y = -@cos(rad) };
+    const dir: Point.Physical = .{ .x = @cos(rad), .y = @sin(rad) };
 
     const cx = bounds.x + bounds.w / 2;
     const cy = bounds.y + bounds.h / 2;
@@ -1260,6 +1263,37 @@ test fill {
         if (pointInTriangle(ring_pt, v0.pos, v1.pos, v2.pos)) covered = true;
     }
     try std.testing.expect(covered);
+}
+
+test "fill gradient" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const square: Path = .{ .points = &.{
+        .{ .x = 0, .y = 0 },
+        .{ .x = 0, .y = 100 },
+        .{ .x = 100, .y = 100 },
+        .{ .x = 100, .y = 0 },
+    } };
+
+    const left_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
+    const right_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
+
+    var triangles = try square.fillConvexTriangles(std.testing.allocator, .{
+        .color = left_color,
+        .gradient = .{ .color2 = right_color, .angle_degrees = 0 },
+    });
+    defer triangles.deinit(std.testing.allocator);
+
+    // angle_degrees = 0 is left-to-right: vertexes on the left edge should
+    // be near `color`, vertexes on the right edge near `gradient.color2`.
+    for (triangles.vertexes) |v| {
+        if (v.pos.x < 1) {
+            try std.testing.expect(v.col.r > v.col.b);
+        } else if (v.pos.x > 99) {
+            try std.testing.expect(v.col.b > v.col.r);
+        }
+    }
 }
 
 test "fill self-intersecting star" {

--- a/src/Path.zig
+++ b/src/Path.zig
@@ -341,7 +341,6 @@ pub fn dupe(path: Path, allocator: std.mem.Allocator) std.mem.Allocator.Error!Pa
     return .{ .points = try allocator.dupe(Point.Physical, path.points) };
 }
 
-
 pub const FillConvexOptions = struct {
     /// Flat color, or a gradient drawn across the fill's bounding box. See
     /// `ColorOrGradient`.
@@ -1359,7 +1358,6 @@ test fill {
     try std.testing.expect(covered);
 }
 
-
 test "stroke miter default vtx/idx counts" {
     var t = try dvui.testing.init(.{});
     defer t.deinit();
@@ -1657,7 +1655,6 @@ fn opaqueCoverage(triangles: Triangles, p: Point.Physical) usize {
     }
     return count;
 }
-
 
 const std = @import("std");
 const dvui = @import("dvui.zig");

--- a/src/Path.zig
+++ b/src/Path.zig
@@ -516,21 +516,14 @@ pub const StrokeOptions = struct {
     /// true => Render this after normal drawing on that subwindow.  Useful for
     /// debugging on cross-gui drawing.
     after: bool = false,
-
     thickness: f32,
-
-    /// Flat color, or a gradient drawn across the stroke's bounding box. See
-    /// `ColorOrGradient`.
     color: ColorOrGradient,
-
     /// true => Stroke includes from path end to path start.
     closed: bool = false,
     endcap_style: EndCapStyle = .none,
-
     /// Size (physical pixels) of fade to transparent on each edge of the
     /// stroke. Default matches the previous hardcoded ~1px AA fringe.
     fade: f32 = 1.0,
-
     /// How consecutive segments meet. `.miter` is the historical mesh
     /// (icons, `Rect.stroke`, borders). `.strip` shares edge vertices so a
     /// translucent stroke composites once per pixel; corners may thin.
@@ -1066,17 +1059,12 @@ fn strokeStripTriangles(path: Path, allocator: std.mem.Allocator, opts: StrokeOp
 }
 
 pub const FillOptions = struct {
-    /// Flat color, or a gradient drawn across the fill's bounding box. See
-    /// `ColorOrGradient`.
     color: ColorOrGradient,
-
     /// Size (physical pixels) of fade to transparent centered on the true
     /// (resolved) polygon boundary. If >1, then starts a half-pixel inside
     /// and the rest outside.
     fade: f32 = 0.0,
-
     fill_rule: FillRule = .nonzero,
-
     pub const FillRule = enum { nonzero, evenodd };
 };
 

--- a/src/Path.zig
+++ b/src/Path.zig
@@ -257,7 +257,7 @@ test Builder {
     // path does not have to be freed as the memory is still
     // owned by and will be freed by the Path.Builder
     try std.testing.expectEqual(4, path.points.len);
-    var triangles = try path.fillConvexTriangles(std.testing.allocator, .{ .color = Color.white });
+    var triangles = try path.fillConvexTriangles(std.testing.allocator, .{ .color = .{ .color = Color.white } });
     defer triangles.deinit(std.testing.allocator);
     try std.testing.expectApproxEqRel(10, triangles.bounds.x, 0.05);
     try std.testing.expectApproxEqRel(20, triangles.bounds.y, 0.05);
@@ -341,80 +341,16 @@ pub fn dupe(path: Path, allocator: std.mem.Allocator) std.mem.Allocator.Error!Pa
     return .{ .points = try allocator.dupe(Point.Physical, path.points) };
 }
 
-/// 2-stop gradient: blends from a fill's base color to `color2` across the
-/// shape's bounding box. Shared by `FillConvexOptions.gradient`,
-/// `FillOptions.gradient`, `StrokeOptions.gradient` and `Options.fill_gradient`.
-///
-/// Only 2-stop linear/radial gradients are supported; add variants here if
-/// more are needed later.
-pub const Gradient = union(enum) {
-    linear: struct {
-        color2: Color,
-        /// 0 = left-to-right, 90 = top-to-bottom, measured clockwise.
-        angle_degrees: f32 = 90,
-    },
-    radial: struct {
-        color2: Color,
-    },
-
-    fn sample(gradient: Gradient, base: Color, bounds: Rect.Physical, pos: Point.Physical) Color {
-        if (bounds.w <= 0 and bounds.h <= 0) return base;
-        const cx = bounds.x + bounds.w / 2;
-        const cy = bounds.y + bounds.h / 2;
-        switch (gradient) {
-            .linear => |g| {
-                const rad = std.math.degreesToRadians(g.angle_degrees);
-                const dir: Point.Physical = .{ .x = @cos(rad), .y = @sin(rad) };
-                const hx = bounds.w / 2;
-                const hy = bounds.h / 2;
-
-                // Half-extent of the bounding box projected onto dir (distance from
-                // center to the corner furthest along the gradient axis).
-                const half_extent = @abs(dir.x) * hx + @abs(dir.y) * hy;
-                if (half_extent <= 0) return base;
-
-                const proj = (pos.x - cx) * dir.x + (pos.y - cy) * dir.y;
-                const t = std.math.clamp((proj / half_extent + 1) / 2, 0, 1);
-                return base.lerp(g.color2, t);
-            },
-            .radial => |g| {
-                const max_dist = (Point.Physical{ .x = bounds.w / 2, .y = bounds.h / 2 }).length();
-                if (max_dist <= 0) return base;
-
-                const dist = (Point.Physical{ .x = pos.x - cx, .y = pos.y - cy }).length();
-                const t = std.math.clamp(dist / max_dist, 0, 1);
-                return base.lerp(g.color2, t);
-            },
-        }
-    }
-
-    /// Post-process pass over already-built triangles: any vertex colored
-    /// exactly `base` (a fill/stroke's flat color) is replaced by the
-    /// gradient-sampled color at that vertex's position. Vertexes with any
-    /// other color (e.g. faded to transparent at an edge) are left as-is.
-    ///
-    /// `bounds` should be the shape's bounding box, e.g. `Triangles.bounds`.
-    pub fn apply(gradient: Gradient, triangles: *Triangles, base: Color, bounds: Rect.Physical) void {
-        const flat: Color.PMA = .fromColor(base);
-        for (triangles.vertexes) |*v| {
-            if (std.meta.eql(v.col, flat)) {
-                v.col = .fromColor(gradient.sample(base, bounds, v.pos));
-            }
-        }
-    }
-};
 
 pub const FillConvexOptions = struct {
-    color: Color,
+    /// Flat color, or a gradient drawn across the fill's bounding box. See
+    /// `ColorOrGradient`.
+    color: ColorOrGradient,
 
     /// Size (physical pixels) of fade to transparent centered on the edge.
     /// If >1, then starts a half-pixel inside and the rest outside.
     fade: f32 = 0.0,
     center: ?Point.Physical = null,
-
-    /// Optional 2-stop gradient: blends from `color` to `gradient`'s
-    /// `color2` across the fill's bounding box. See `Gradient`.
-    gradient: ?Gradient = null,
 };
 
 /// Fill path (must be convex) with `color` (or `Theme.color_fill`).  See `Rect.fill`.
@@ -448,7 +384,7 @@ pub fn fillConvex(path: Path, opts: FillConvexOptions) void {
         return;
     };
     defer triangles.deinit(cw.lifo());
-    dvui.renderTriangles(triangles, null) catch |err| {
+    dvui.renderTriangles(triangles, triangles.texture) catch |err| {
         dvui.logError(@src(), err, "Could not draw path, opts: {any}", .{options});
         return;
     };
@@ -458,9 +394,26 @@ pub fn fillConvex(path: Path, opts: FillConvexOptions) void {
 ///
 /// Vertexes will have unset uv and color is alpha multiplied opts.color
 /// fading to transparent at the edge if fade is > 0.
-pub fn fillConvexTriangles(path: Path, allocator: std.mem.Allocator, opts: FillConvexOptions) std.mem.Allocator.Error!Triangles {
+pub fn fillConvexTriangles(path: Path, allocator: std.mem.Allocator, opts_in: FillConvexOptions) (std.mem.Allocator.Error || dvui.Backend.TextureError)!Triangles {
     if (path.points.len < 3) {
         return .empty;
+    }
+
+    var opts = opts_in;
+    const split = opts.color.split();
+    if (opts.center == null and split.gradient != null and split.gradient.? == .radial) {
+        // A radial gradient needs a vertex at the shape's actual center so it
+        // samples the base color there; without it the fan pivots on
+        // points[0] (a corner) and the gradient looks lopsided.
+        var min = path.points[0];
+        var max = path.points[0];
+        for (path.points[1..]) |p| {
+            min.x = @min(min.x, p.x);
+            min.y = @min(min.y, p.y);
+            max.x = @max(max.x, p.x);
+            max.y = @max(max.y, p.y);
+        }
+        opts.center = .{ .x = (min.x + max.x) / 2, .y = (min.y + max.y) / 2 };
     }
 
     var vtx_count = path.points.len;
@@ -475,9 +428,8 @@ pub fn fillConvexTriangles(path: Path, allocator: std.mem.Allocator, opts: FillC
     }
 
     var builder = try Triangles.Builder.init(allocator, vtx_count, idx_count);
-    errdefer comptime unreachable; // No errors from this point on
 
-    const flat_col: Color.PMA = .fromColor(opts.color);
+    const flat_col: Color.PMA = .fromColor(split.color);
 
     var i: usize = 0;
     while (i < path.points.len) : (i += 1) {
@@ -557,7 +509,7 @@ pub fn fillConvexTriangles(path: Path, allocator: std.mem.Allocator, opts: FillC
     }
 
     var triangles = builder.build();
-    if (opts.gradient) |g| g.apply(&triangles, opts.color, triangles.bounds);
+    if (split.gradient) |g| triangles.texture = try g.apply(&triangles, triangles.bounds);
     return triangles;
 }
 
@@ -567,19 +519,32 @@ pub const StrokeOptions = struct {
     after: bool = false,
 
     thickness: f32,
-    color: Color,
+
+    /// Flat color, or a gradient drawn across the stroke's bounding box. See
+    /// `ColorOrGradient`.
+    color: ColorOrGradient,
 
     /// true => Stroke includes from path end to path start.
     closed: bool = false,
     endcap_style: EndCapStyle = .none,
 
-    /// Optional 2-stop gradient: blends from `color` to `gradient`'s
-    /// `color2` across the stroke's bounding box. See `Gradient`.
-    gradient: ?Gradient = null,
+    /// Size (physical pixels) of fade to transparent on each edge of the
+    /// stroke. Default matches the previous hardcoded ~1px AA fringe.
+    fade: f32 = 1.0,
+
+    /// How consecutive segments meet. `.miter` is the historical mesh
+    /// (icons, `Rect.stroke`, borders). `.strip` shares edge vertices so a
+    /// translucent stroke composites once per pixel; corners may thin.
+    join: Join = .miter,
 
     pub const EndCapStyle = enum {
         none,
         square,
+    };
+
+    pub const Join = enum {
+        miter,
+        strip,
     };
 };
 
@@ -610,7 +575,7 @@ pub fn stroke(path: Path, opts: StrokeOptions) void {
         return;
     };
     defer triangles.deinit(cw.lifo());
-    dvui.renderTriangles(triangles, null) catch |err| {
+    dvui.renderTriangles(triangles, triangles.texture) catch |err| {
         dvui.logError(@src(), err, "Could not draw path, opts: {any}", .{opts});
         return;
     };
@@ -620,7 +585,7 @@ pub fn stroke(path: Path, opts: StrokeOptions) void {
 ///
 /// Vertexes will have unset uv and color is alpha multiplied opts.color
 /// fading to transparent at the edge.
-pub fn strokeTriangles(path: Path, allocator: std.mem.Allocator, opts: StrokeOptions) std.mem.Allocator.Error!Triangles {
+pub fn strokeTriangles(path: Path, allocator: std.mem.Allocator, opts: StrokeOptions) (std.mem.Allocator.Error || dvui.Backend.TextureError)!Triangles {
     if (dvui.clipGet().empty()) {
         return .empty;
     }
@@ -640,7 +605,11 @@ pub fn strokeTriangles(path: Path, allocator: std.mem.Allocator, opts: StrokeOpt
         defer tempPath.deinit();
 
         tempPath.addArc(center, opts.thickness, math.pi * 2.0, 0, true);
-        return tempPath.build().fillConvexTriangles(allocator, .{ .color = opts.color, .fade = 1.0, .gradient = opts.gradient });
+        return tempPath.build().fillConvexTriangles(allocator, .{ .color = opts.color, .fade = opts.fade });
+    }
+
+    if (opts.join == .strip) {
+        return strokeStripTriangles(path, allocator, opts);
     }
 
     const Side = enum {
@@ -667,9 +636,10 @@ pub fn strokeTriangles(path: Path, allocator: std.mem.Allocator, opts: StrokeOpt
 
     var builder = try Triangles.Builder.init(allocator, vtx_count, idx_count);
 
-    const col: Color.PMA = .fromColor(opts.color);
+    const split = opts.color.split();
+    const col: Color.PMA = .fromColor(split.color);
 
-    const aa_size = 1.0;
+    const aa_size = opts.fade;
     var vtx_left: u16 = 0;
     var vtx_right: u16 = 0;
     var i: usize = 0;
@@ -998,12 +968,108 @@ pub fn strokeTriangles(path: Path, allocator: std.mem.Allocator, opts: StrokeOpt
     }
 
     var triangles = builder.build();
-    if (opts.gradient) |g| g.apply(&triangles, opts.color, triangles.bounds);
+    if (split.gradient) |g| triangles.texture = try g.apply(&triangles, triangles.bounds);
+    return triangles;
+}
+
+fn strokeStripNormal(path: Path, i: usize, closed: bool) Point.Physical {
+    const n = path.points.len;
+    const bb = path.points[i];
+    if (!closed and i == 0) {
+        const t = path.points[1].diff(bb).normalize();
+        return .{ .x = t.y, .y = -t.x };
+    }
+    if (!closed and i + 1 == n) {
+        const t = bb.diff(path.points[n - 2]).normalize();
+        return .{ .x = t.y, .y = -t.x };
+    }
+    const aa = path.points[(i + n - 1) % n];
+    const cc = path.points[(i + 1) % n];
+    const t_in = bb.diff(aa).normalize();
+    const t_out = cc.diff(bb).normalize();
+    const norm: Point.Physical = .{
+        .x = t_in.y + t_out.y,
+        .y = -t_in.x - t_out.x,
+    };
+    const d2 = norm.x * norm.x + norm.y * norm.y;
+    if (d2 > 0.000001) {
+        return norm.scale(1.0 / @sqrt(d2), Point.Physical);
+    }
+    return .{ .x = t_out.y, .y = -t_out.x };
+}
+
+fn strokeStripTriangles(path: Path, allocator: std.mem.Allocator, opts: StrokeOptions) (std.mem.Allocator.Error || dvui.Backend.TextureError)!Triangles {
+    const n = path.points.len;
+    const closed: bool = if (n == 2) false else opts.closed;
+    const has_fade = opts.fade > 0;
+    const vpp: usize = if (has_fade) 4 else 2;
+    const segs: usize = if (closed) n else n - 1;
+    const vtx_count = n * vpp;
+    const idx_count = segs * @as(usize, if (has_fade) 18 else 6);
+
+    var builder = try Triangles.Builder.init(allocator, vtx_count, idx_count);
+    const split = opts.color.split();
+    const col: Color.PMA = .fromColor(split.color);
+    const half = opts.thickness * 0.5;
+    const fade = opts.fade;
+
+    for (0..n) |i| {
+        const p = path.points[i];
+        const nxny = strokeStripNormal(path, i, closed);
+        if (has_fade) {
+            builder.appendVertex(.{
+                .pos = .{ .x = p.x - nxny.x * (half + fade), .y = p.y - nxny.y * (half + fade) },
+                .col = .transparent,
+            });
+        }
+        builder.appendVertex(.{
+            .pos = .{ .x = p.x - nxny.x * half, .y = p.y - nxny.y * half },
+            .col = col,
+        });
+        builder.appendVertex(.{
+            .pos = .{ .x = p.x + nxny.x * half, .y = p.y + nxny.y * half },
+            .col = col,
+        });
+        if (has_fade) {
+            builder.appendVertex(.{
+                .pos = .{ .x = p.x + nxny.x * (half + fade), .y = p.y + nxny.y * (half + fade) },
+                .col = .transparent,
+            });
+        }
+    }
+
+    var s: usize = 0;
+    while (s < segs) : (s += 1) {
+        const a: u16 = @intCast(s * vpp);
+        const c: u16 = @intCast(((s + 1) % n) * vpp);
+        if (has_fade) {
+            const fl0 = a;
+            const l0 = a + 1;
+            const r0 = a + 2;
+            const fr0 = a + 3;
+            const fl1 = c;
+            const l1 = c + 1;
+            const r1 = c + 2;
+            const fr1 = c + 3;
+            builder.appendTriangles(&.{
+                l0,  r0,  r1,  l0,  r1,  l1,
+                fl0, l0,  l1,  fl0, l1,  fl1,
+                r0,  fr0, fr1, r0,  fr1, r1,
+            });
+        } else {
+            builder.appendTriangles(&.{ a, a + 1, c + 1, a, c + 1, c });
+        }
+    }
+
+    var triangles = builder.build();
+    if (split.gradient) |g| triangles.texture = try g.apply(&triangles, triangles.bounds);
     return triangles;
 }
 
 pub const FillOptions = struct {
-    color: Color,
+    /// Flat color, or a gradient drawn across the fill's bounding box. See
+    /// `ColorOrGradient`.
+    color: ColorOrGradient,
 
     /// Size (physical pixels) of fade to transparent centered on the true
     /// (resolved) polygon boundary. If >1, then starts a half-pixel inside
@@ -1011,10 +1077,6 @@ pub const FillOptions = struct {
     fade: f32 = 0.0,
 
     fill_rule: FillRule = .nonzero,
-
-    /// Optional 2-stop gradient: blends from `color` to `gradient`'s
-    /// `color2` across the fill's bounding box. See `Gradient`.
-    gradient: ?Gradient = null,
 
     pub const FillRule = enum { nonzero, evenodd };
 };
@@ -1055,7 +1117,7 @@ pub fn fill(contours: []const Path, opts: FillOptions) void {
         return;
     };
     defer triangles.deinit(cw.lifo());
-    dvui.renderTriangles(triangles, null) catch |err| {
+    dvui.renderTriangles(triangles, triangles.texture) catch |err| {
         dvui.logError(@src(), err, "Could not draw path, opts: {any}", .{options});
         return;
     };
@@ -1132,9 +1194,9 @@ pub fn fillInsideRule(winding: i32, rule: FillOptions.FillRule) bool {
 ///
 /// Delegates to `earcut.fillTriangles` - measured faster on real icon data
 /// than prior intersect-everything and trapezoidal-decomposition approaches.
-pub fn fillTriangles(allocator: std.mem.Allocator, contours: []const Path, opts: FillOptions) std.mem.Allocator.Error!Triangles {
+pub fn fillTriangles(allocator: std.mem.Allocator, contours: []const Path, opts: FillOptions) (std.mem.Allocator.Error || dvui.Backend.TextureError)!Triangles {
     var triangles = try @import("earcut.zig").fillTriangles(allocator, contours, opts);
-    if (opts.gradient) |g| g.apply(&triangles, opts.color, triangles.bounds);
+    if (opts.color.split().gradient) |g| triangles.texture = try g.apply(&triangles, triangles.bounds);
     return triangles;
 }
 
@@ -1267,7 +1329,7 @@ test fill {
         .{ .x = 25, .y = 75 },
     } };
 
-    var triangles = try fillTriangles(std.testing.allocator, &.{ outer, hole }, .{ .color = Color.white, .fade = 1.0 });
+    var triangles = try fillTriangles(std.testing.allocator, &.{ outer, hole }, .{ .color = .{ .color = Color.white }, .fade = 1.0 });
     defer triangles.deinit(std.testing.allocator);
 
     try std.testing.expect(triangles.vertexes.len > 0);
@@ -1297,70 +1359,133 @@ test fill {
     try std.testing.expect(covered);
 }
 
-test "fill gradient" {
+
+test "stroke miter default vtx/idx counts" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const line: Path = .{ .points = &.{
+        .{ .x = 0, .y = 0 },
+        .{ .x = 50, .y = 0 },
+        .{ .x = 100, .y = 0 },
+    } };
+    const lifo = dvui.currentWindow().lifo();
+    var triangles = try line.strokeTriangles(lifo, .{
+        .thickness = 4,
+        .color = .{ .color = Color.white },
+    });
+    defer triangles.deinit(lifo);
+
+    try std.testing.expectEqual(@as(usize, 16), triangles.vertexes.len);
+    try std.testing.expectEqual(@as(usize, 60), triangles.indices.len);
+}
+
+test "stroke strip two-point line" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const line: Path = .{ .points = &.{
+        .{ .x = 0, .y = 50 },
+        .{ .x = 100, .y = 50 },
+    } };
+    const lifo = dvui.currentWindow().lifo();
+
+    {
+        var triangles = try line.strokeTriangles(lifo, .{
+            .thickness = 10,
+            .color = .{ .color = Color.white },
+            .fade = 0,
+            .join = .strip,
+        });
+        defer triangles.deinit(lifo);
+        try std.testing.expectEqual(@as(usize, 4), triangles.vertexes.len);
+        try std.testing.expectEqual(@as(usize, 6), triangles.indices.len);
+    }
+
+    {
+        var triangles = try line.strokeTriangles(lifo, .{
+            .thickness = 10,
+            .color = .{ .color = Color.white },
+            .fade = 1,
+            .join = .strip,
+        });
+        defer triangles.deinit(lifo);
+        try std.testing.expectEqual(@as(usize, 8), triangles.vertexes.len);
+        try std.testing.expectEqual(@as(usize, 18), triangles.indices.len);
+    }
+}
+
+test "stroke strip translucent has no overlapping opaque coverage" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const line: Path = .{ .points = &.{
+        .{ .x = 0, .y = 50 },
+        .{ .x = 40, .y = 50 },
+        .{ .x = 80, .y = 45 },
+    } };
+    const lifo = dvui.currentWindow().lifo();
+    var triangles = try line.strokeTriangles(lifo, .{
+        .thickness = 12,
+        .color = .{ .color = .{ .r = 255, .g = 255, .b = 255, .a = 128 } },
+        .fade = 0,
+        .join = .strip,
+    });
+    defer triangles.deinit(lifo);
+
+    var covered = false;
+    var y: f32 = 44;
+    while (y <= 56) : (y += 0.5) {
+        var x: f32 = 36;
+        while (x <= 44) : (x += 0.5) {
+            const p: Point.Physical = .{ .x = x, .y = y };
+            const n = opaqueCoverage(triangles, p);
+            try std.testing.expect(n <= 1);
+            if (n == 1) covered = true;
+        }
+    }
+    try std.testing.expect(covered);
+}
+
+test "stroke strip closed wraps" {
     var t = try dvui.testing.init(.{});
     defer t.deinit();
 
     const square: Path = .{ .points = &.{
         .{ .x = 0, .y = 0 },
-        .{ .x = 0, .y = 100 },
-        .{ .x = 100, .y = 100 },
         .{ .x = 100, .y = 0 },
+        .{ .x = 100, .y = 100 },
+        .{ .x = 0, .y = 100 },
     } };
-
-    const left_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
-    const right_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
-
-    var triangles = try square.fillConvexTriangles(std.testing.allocator, .{
-        .color = left_color,
-        .gradient = .{ .linear = .{ .color2 = right_color, .angle_degrees = 0 } },
+    const lifo = dvui.currentWindow().lifo();
+    var triangles = try square.strokeTriangles(lifo, .{
+        .thickness = 8,
+        .color = .{ .color = Color.white },
+        .closed = true,
+        .fade = 0,
+        .join = .strip,
     });
-    defer triangles.deinit(std.testing.allocator);
+    defer triangles.deinit(lifo);
 
-    // angle_degrees = 0 is left-to-right: vertexes on the left edge should
-    // be near `color`, vertexes on the right edge near `gradient.color2`.
-    for (triangles.vertexes) |v| {
-        if (v.pos.x < 1) {
-            try std.testing.expect(v.col.r > v.col.b);
-        } else if (v.pos.x > 99) {
-            try std.testing.expect(v.col.b > v.col.r);
+    try std.testing.expectEqual(@as(usize, 8), triangles.vertexes.len);
+    try std.testing.expectEqual(@as(usize, 24), triangles.indices.len);
+
+    var wrapped = false;
+    var i: usize = 0;
+    while (i < triangles.indices.len) : (i += 3) {
+        var uses0 = false;
+        var uses_last = false;
+        for (0..3) |k| {
+            const idx = triangles.indices[i + k];
+            if (idx < 2) uses0 = true;
+            if (idx >= 6) uses_last = true;
         }
+        if (uses0 and uses_last) wrapped = true;
     }
+    try std.testing.expect(wrapped);
 }
 
-test "fill gradient radial" {
-    var t = try dvui.testing.init(.{});
-    defer t.deinit();
-
-    const square: Path = .{ .points = &.{
-        .{ .x = 0, .y = 0 },
-        .{ .x = 0, .y = 100 },
-        .{ .x = 100, .y = 100 },
-        .{ .x = 100, .y = 0 },
-    } };
-
-    const center_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
-    const edge_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
-
-    var triangles = try square.fillConvexTriangles(std.testing.allocator, .{
-        .color = center_color,
-        .center = .{ .x = 50, .y = 50 },
-        .gradient = .{ .radial = .{ .color2 = edge_color } },
-    });
-    defer triangles.deinit(std.testing.allocator);
-
-    // the center vertex should be near `color`; the corners (farthest from
-    // center) should be near `gradient.color2`.
-    for (triangles.vertexes) |v| {
-        if (v.pos.x == 50 and v.pos.y == 50) {
-            try std.testing.expect(v.col.r > v.col.b);
-        } else {
-            try std.testing.expect(v.col.b > v.col.r);
-        }
-    }
-}
-
-test "stroke gradient" {
+test "stroke strip gradient" {
     var t = try dvui.testing.init(.{});
     defer t.deinit();
 
@@ -1372,32 +1497,58 @@ test "stroke gradient" {
     const left_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
     const right_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
 
-    // strokeTriangles' vtx/idx counts are worst-case upper bounds (e.g. for
-    // miter joints) that aren't always fully used, so - like all its
-    // production callers - it needs an arena allocator here rather than
-    // `std.testing.allocator`, which asserts free() size exactly matches
-    // the allocation size.
     const lifo = dvui.currentWindow().lifo();
     var triangles = try line.strokeTriangles(lifo, .{
         .thickness = 5,
-        .color = left_color,
-        .gradient = .{ .linear = .{ .color2 = right_color, .angle_degrees = 0 } },
+        .join = .strip,
+        .color = .{ .gradient = .{ .linear = .{ .stops = &.{ .{ .color = left_color, .offset = 0 }, .{ .color = right_color, .offset = 1 } }, .angle_degrees = 0 } } },
     });
     defer triangles.deinit(lifo);
 
+    try std.testing.expect(triangles.texture != null);
     var saw_left = false;
     var saw_right = false;
     for (triangles.vertexes) |v| {
-        if (v.col.a != 255) continue; // skip aa-fade edge vertexes
+        if (v.col.a != 255) continue;
         if (v.pos.x < 1) {
-            try std.testing.expect(v.col.r > v.col.b);
+            try std.testing.expect(v.uv[0] < 0.5);
             saw_left = true;
         } else if (v.pos.x > 99) {
-            try std.testing.expect(v.col.b > v.col.r);
+            try std.testing.expect(v.uv[0] > 0.5);
             saw_right = true;
         }
     }
     try std.testing.expect(saw_left and saw_right);
+}
+
+test "fill fade 0" {
+    var t = try dvui.testing.init(.{});
+    defer t.deinit();
+
+    const square: Path = .{ .points = &.{
+        .{ .x = 0, .y = 0 },
+        .{ .x = 0, .y = 100 },
+        .{ .x = 100, .y = 100 },
+        .{ .x = 100, .y = 0 },
+    } };
+
+    var triangles = try fillTriangles(std.testing.allocator, &.{square}, .{ .color = .{ .color = Color.white }, .fade = 0 });
+    defer triangles.deinit(std.testing.allocator);
+
+    try std.testing.expect(triangles.vertexes.len > 0);
+    for (triangles.vertexes) |v| {
+        try std.testing.expectEqual(@as(u8, 255), v.col.a);
+    }
+
+    var covered = false;
+    var i: usize = 0;
+    while (i < triangles.indices.len) : (i += 3) {
+        const v0 = triangles.vertexes[triangles.indices[i]];
+        const v1 = triangles.vertexes[triangles.indices[i + 1]];
+        const v2 = triangles.vertexes[triangles.indices[i + 2]];
+        if (pointInTriangle(.{ .x = 50, .y = 50 }, v0.pos, v1.pos, v2.pos)) covered = true;
+    }
+    try std.testing.expect(covered);
 }
 
 test "fill (earcut) gradient" {
@@ -1422,17 +1573,17 @@ test "fill (earcut) gradient" {
     const right_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
 
     var triangles = try fillTriangles(std.testing.allocator, &.{ outer, hole }, .{
-        .color = left_color,
-        .gradient = .{ .linear = .{ .color2 = right_color, .angle_degrees = 0 } },
+        .color = .{ .gradient = .{ .linear = .{ .stops = &.{ .{ .color = left_color, .offset = 0 }, .{ .color = right_color, .offset = 1 } }, .angle_degrees = 0 } } },
     });
     defer triangles.deinit(std.testing.allocator);
 
+    try std.testing.expect(triangles.texture != null);
     for (triangles.vertexes) |v| {
         if (v.col.a != 255) continue; // skip aa-fade/hole vertexes
         if (v.pos.x < 1) {
-            try std.testing.expect(v.col.r > v.col.b);
+            try std.testing.expect(v.uv[0] < 0.5);
         } else if (v.pos.x > 99) {
-            try std.testing.expect(v.col.b > v.col.r);
+            try std.testing.expect(v.uv[0] > 0.5);
         }
     }
 }
@@ -1455,7 +1606,7 @@ test "fill self-intersecting star" {
     }
     const star: Path = .{ .points = &pts };
 
-    var triangles = try fillTriangles(std.testing.allocator, &.{star}, .{ .color = Color.white, .fade = 1.0 });
+    var triangles = try fillTriangles(std.testing.allocator, &.{star}, .{ .color = .{ .color = Color.white }, .fade = 1.0 });
     defer triangles.deinit(std.testing.allocator);
 
     try std.testing.expect(triangles.vertexes.len > 0);
@@ -1483,6 +1634,31 @@ fn pointInTriangle(p: Point.Physical, a: Point.Physical, b: Point.Physical, c: P
     return !(has_neg and has_pos);
 }
 
+fn pointInTriangleStrict(p: Point.Physical, a: Point.Physical, b: Point.Physical, c: Point.Physical) bool {
+    const d1 = (p.x - b.x) * (a.y - b.y) - (a.x - b.x) * (p.y - b.y);
+    const d2 = (p.x - c.x) * (b.y - c.y) - (b.x - c.x) * (p.y - c.y);
+    const d3 = (p.x - a.x) * (c.y - a.y) - (c.x - a.x) * (p.y - a.y);
+    const eps: f32 = 1e-3;
+    const has_neg = (d1 < -eps) or (d2 < -eps) or (d3 < -eps);
+    const has_pos = (d1 > eps) or (d2 > eps) or (d3 > eps);
+    if (has_neg and has_pos) return false;
+    return (@abs(d1) > eps) and (@abs(d2) > eps) and (@abs(d3) > eps);
+}
+
+fn opaqueCoverage(triangles: Triangles, p: Point.Physical) usize {
+    var count: usize = 0;
+    var i: usize = 0;
+    while (i < triangles.indices.len) : (i += 3) {
+        const v0 = triangles.vertexes[triangles.indices[i]];
+        const v1 = triangles.vertexes[triangles.indices[i + 1]];
+        const v2 = triangles.vertexes[triangles.indices[i + 2]];
+        if (v0.col.a == 0 or v1.col.a == 0 or v2.col.a == 0) continue;
+        if (pointInTriangleStrict(p, v0.pos, v1.pos, v2.pos)) count += 1;
+    }
+    return count;
+}
+
+
 const std = @import("std");
 const dvui = @import("dvui.zig");
 
@@ -1494,6 +1670,8 @@ const Point = dvui.Point;
 const Color = dvui.Color;
 const Triangles = dvui.Triangles;
 const Vertex = dvui.Vertex;
+const Gradient = dvui.Gradient;
+const ColorOrGradient = dvui.ColorOrGradient;
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/Path.zig
+++ b/src/Path.zig
@@ -367,11 +367,16 @@ pub fn fillConvex(path: Path, opts: FillConvexOptions) void {
     const cw = dvui.currentWindow();
 
     if (!cw.render_target.rendering) {
+        var new_opts = opts;
         const new_path = path.dupe(cw.arena()) catch |err| {
             dvui.logError(@src(), err, "Could not reallocate path for render command", .{});
             return;
         };
-        cw.addRenderCommand(.{ .pathFillConvex = .{ .path = new_path, .opts = opts } }, false);
+        new_opts.color = opts.color.dupe(cw.arena()) catch |err| {
+            dvui.logError(@src(), err, "Could not reallocate gradient for render command", .{});
+            return;
+        };
+        cw.addRenderCommand(.{ .pathFillConvex = .{ .path = new_path, .opts = new_opts } }, false);
         return;
     }
 
@@ -551,11 +556,16 @@ pub fn stroke(path: Path, opts: StrokeOptions) void {
     const cw = dvui.currentWindow();
 
     if (opts.after or !cw.render_target.rendering) {
+        var new_opts = opts;
         const new_path = path.dupe(cw.arena()) catch |err| {
             dvui.logError(@src(), err, "Could not reallocate path for render command", .{});
             return;
         };
-        cw.addRenderCommand(.{ .pathStroke = .{ .path = new_path, .opts = opts } }, opts.after);
+        new_opts.color = opts.color.dupe(cw.arena()) catch |err| {
+            dvui.logError(@src(), err, "Could not reallocate gradient for render command", .{});
+            return;
+        };
+        cw.addRenderCommand(.{ .pathStroke = .{ .path = new_path, .opts = new_opts } }, opts.after);
         return;
     }
 
@@ -1088,11 +1098,16 @@ pub fn fill(contours: []const Path, opts: FillOptions) void {
     const cw = dvui.currentWindow();
 
     if (!cw.render_target.rendering) {
+        var new_opts = opts;
         const new_contours = dupeContours(contours, cw.arena()) catch |err| {
             dvui.logError(@src(), err, "Could not reallocate path for render command", .{});
             return;
         };
-        cw.addRenderCommand(.{ .pathFill = .{ .contours = new_contours, .opts = opts } }, false);
+        new_opts.color = opts.color.dupe(cw.arena()) catch |err| {
+            dvui.logError(@src(), err, "Could not reallocate gradient for render command", .{});
+            return;
+        };
+        cw.addRenderCommand(.{ .pathFill = .{ .contours = new_contours, .opts = new_opts } }, false);
         return;
     }
 

--- a/src/Path.zig
+++ b/src/Path.zig
@@ -1372,12 +1372,18 @@ test "stroke gradient" {
     const left_color: Color = .{ .r = 255, .g = 0, .b = 0, .a = 255 };
     const right_color: Color = .{ .r = 0, .g = 0, .b = 255, .a = 255 };
 
-    var triangles = try line.strokeTriangles(std.testing.allocator, .{
+    // strokeTriangles' vtx/idx counts are worst-case upper bounds (e.g. for
+    // miter joints) that aren't always fully used, so - like all its
+    // production callers - it needs an arena allocator here rather than
+    // `std.testing.allocator`, which asserts free() size exactly matches
+    // the allocation size.
+    const lifo = dvui.currentWindow().lifo();
+    var triangles = try line.strokeTriangles(lifo, .{
         .thickness = 5,
         .color = left_color,
         .gradient = .{ .linear = .{ .color2 = right_color, .angle_degrees = 0 } },
     });
-    defer triangles.deinit(std.testing.allocator);
+    defer triangles.deinit(lifo);
 
     var saw_left = false;
     var saw_right = false;

--- a/src/Triangles.zig
+++ b/src/Triangles.zig
@@ -1,6 +1,10 @@
 vertexes: []Vertex,
 indices: []Vertex.Index,
 bounds: Rect.Physical,
+/// Set by `Gradient.apply` for linear gradients: the ramp texture whose UV
+/// the vertexes' `uv` field indexes into. Callers must pass this to
+/// `dvui.renderTriangles` instead of `null`.
+texture: ?dvui.Texture = null,
 
 pub const Triangles = @This();
 
@@ -92,6 +96,7 @@ pub fn dupe(self: *const Triangles, allocator: std.mem.Allocator) std.mem.Alloca
         .vertexes = vtx,
         .indices = try allocator.dupe(Vertex.Index, self.indices),
         .bounds = self.bounds,
+        .texture = self.texture,
     };
 }
 

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const dvui = @import("dvui.zig");
 
-const Color = dvui.Color;
 const Ninepatch = dvui.Ninepatch;
 const Options = dvui.Options;
 const Rect = dvui.Rect;
@@ -196,7 +195,7 @@ pub fn visible(self: *const WidgetData) bool {
 }
 
 pub fn borderAndBackground(self: *const WidgetData, opts: struct {
-    fill_color: ?Color = null,
+    fill_color: ?dvui.ColorOrGradient = null,
     ninepatch: ?*const Ninepatch = null,
     /// If null, 1.0 (0.0 when drawing a ninepatch, which already has its
     /// own baked edges).
@@ -212,7 +211,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct {
 
         const prect = rs.r.insetAll(rs.s * bs.shrink).offsetPoint(bs.offset.scale(rs.s, dvui.Point.Physical));
 
-        prect.fill(corners.scale(rs.s, CornerRect.Physical), .{ .color = bs.color.opacity(bs.alpha), .fade = rs.s * bs.fade });
+        prect.fill(corners.scale(rs.s, CornerRect.Physical), .{ .color = .{ .color = bs.color.opacity(bs.alpha) }, .fade = rs.s * bs.fade });
     }
 
     var bg = self.options.backgroundGet();
@@ -226,8 +225,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct {
             const rs = self.rectScale().rectToRectScale(r.offsetNeg(self.rect));
             rs.r.stroke(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{
                 .thickness = b.x * rs.s,
-                .color = self.options.color(.border),
-                .gradient = self.options.border_gradient,
+                .color = self.options.textColor(.border).scale(rs.s),
             });
         } else {
             // non-uniform border, draw it first as large rect with background/ninepatch on top
@@ -249,9 +247,8 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct {
                     rs.r = rs.r.inset(inset);
                 }
                 rs.r.fill(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{
-                    .color = self.options.color(.border),
+                    .color = self.options.textColor(.border).scale(rs.s),
                     .fade = fade,
-                    .gradient = self.options.border_gradient,
                 });
             }
         }
@@ -262,11 +259,9 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct {
     if (bg) {
         const rs = self.backgroundRectScale();
         if (!rs.r.empty()) {
-            const fill = opts.fill_color orelse self.options.color(.fill);
             rs.r.fill(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{
-                .color = fill,
+                .color = (opts.fill_color orelse self.options.textColor(.fill)).scale(rs.s),
                 .fade = opts.fade orelse (if (ninepatch != null) 0.0 else 1.0),
-                .gradient = self.options.fill_gradient,
             });
         }
     }
@@ -285,7 +280,7 @@ pub fn focusBorder(self: *const WidgetData) void {
         const rs = self.borderRectScale();
         const thick = 2 * rs.s;
 
-        rs.r.stroke(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{ .thickness = thick, .color = self.options.themeGet().focus, .after = true });
+        rs.r.stroke(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{ .thickness = thick, .color = .{ .color = self.options.themeGet().focus }, .after = true });
     }
 }
 

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -225,7 +225,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct {
             const rs = self.rectScale().rectToRectScale(r.offsetNeg(self.rect));
             rs.r.stroke(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{
                 .thickness = b.x * rs.s,
-                .color = self.options.textColor(.border).scale(rs.s),
+                .color = self.options.color(.border).scale(rs.s),
             });
         } else {
             // non-uniform border, draw it first as large rect with background/ninepatch on top
@@ -247,7 +247,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct {
                     rs.r = rs.r.inset(inset);
                 }
                 rs.r.fill(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{
-                    .color = self.options.textColor(.border).scale(rs.s),
+                    .color = self.options.color(.border).scale(rs.s),
                     .fade = fade,
                 });
             }
@@ -260,7 +260,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct {
         const rs = self.backgroundRectScale();
         if (!rs.r.empty()) {
             rs.r.fill(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{
-                .color = (opts.fill_color orelse self.options.textColor(.fill)).scale(rs.s),
+                .color = (opts.fill_color orelse self.options.color(.fill)).scale(rs.s),
                 .fade = opts.fade orelse (if (ninepatch != null) 0.0 else 1.0),
             });
         }

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -261,6 +261,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct {
             rs.r.fill(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{
                 .color = fill,
                 .fade = opts.fade orelse (if (ninepatch != null) 0.0 else 1.0),
+                .gradient = if (self.options.fill_gradient) |g| .{ .color2 = g.color2, .angle_degrees = g.angle_degrees } else null,
             });
         }
     }

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -224,7 +224,11 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct {
             // draw border as stroked path
             const r = self.borderRect().inset(b.scale(0.5, Rect));
             const rs = self.rectScale().rectToRectScale(r.offsetNeg(self.rect));
-            rs.r.stroke(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{ .thickness = b.x * rs.s, .color = self.options.color(.border) });
+            rs.r.stroke(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{
+                .thickness = b.x * rs.s,
+                .color = self.options.color(.border),
+                .gradient = self.options.border_gradient,
+            });
         } else {
             // non-uniform border, draw it first as large rect with background/ninepatch on top
             if (!bg) {
@@ -247,6 +251,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct {
                 rs.r.fill(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{
                     .color = self.options.color(.border),
                     .fade = fade,
+                    .gradient = self.options.border_gradient,
                 });
             }
         }

--- a/src/WidgetData.zig
+++ b/src/WidgetData.zig
@@ -261,7 +261,7 @@ pub fn borderAndBackground(self: *const WidgetData, opts: struct {
             rs.r.fill(self.options.cornersGet().scale(rs.s, CornerRect.Physical), .{
                 .color = fill,
                 .fade = opts.fade orelse (if (ninepatch != null) 0.0 else 1.0),
-                .gradient = if (self.options.fill_gradient) |g| .{ .color2 = g.color2, .angle_degrees = g.angle_degrees } else null,
+                .gradient = self.options.fill_gradient,
             });
         }
     }

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1528,21 +1528,21 @@ pub fn renderCommands(self: *Self, queue: []const dvui.RenderCommand) !void {
                 options.color = options.color.opacity(self.alpha);
                 var triangles = try pf.path.fillConvexTriangles(self.lifo(), options);
                 defer triangles.deinit(self.lifo());
-                try dvui.renderTriangles(triangles, null);
+                try dvui.renderTriangles(triangles, triangles.texture);
             },
             .pathFill => |pf| {
                 var options = pf.opts;
                 options.color = options.color.opacity(self.alpha);
                 var triangles = try dvui.Path.fillTriangles(self.lifo(), pf.contours, options);
                 defer triangles.deinit(self.lifo());
-                try dvui.renderTriangles(triangles, null);
+                try dvui.renderTriangles(triangles, triangles.texture);
             },
             .pathStroke => |ps| {
                 var options = ps.opts;
                 options.color = options.color.opacity(self.alpha);
                 var triangles = try ps.path.strokeTriangles(self.lifo(), options);
                 defer triangles.deinit(self.lifo());
-                try dvui.renderTriangles(triangles, null);
+                try dvui.renderTriangles(triangles, triangles.texture);
             },
             .triangles => |t| {
                 try dvui.renderTriangles(t.tri, t.tex);

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -3083,7 +3083,7 @@ pub fn dropdown(src: std.builtin.SourceLocation, entries: []const []const u8, ch
             defer mi.deinit();
             dvui.labelNoFmt(@src(), init_opts.placeholder orelse dropdown_placeholder_default, .{}, opts.strip().override(.{
                 .gravity_y = 0.5,
-                .color_text = opts.textColor(.text).opacity(0.65),
+                .color_text = opts.color(.text).opacity(0.65),
             }));
             if (mi.activeRect()) |_| {
                 dd.close();
@@ -3145,7 +3145,7 @@ pub fn dropdownEnum(src: std.builtin.SourceLocation, T: type, choice: DropdownCh
             defer mi.deinit();
             dvui.labelNoFmt(@src(), init_opts.placeholder orelse dropdown_placeholder_default, .{}, opts.strip().override(.{
                 .gravity_y = 0.5,
-                .color_text = opts.textColor(.text).opacity(0.65),
+                .color_text = opts.color(.text).opacity(0.65),
             }));
             if (mi.activeRect()) |_| {
                 dd.close();
@@ -3779,7 +3779,7 @@ pub fn spinner(src: std.builtin.SourceLocation, opts: Options) void {
     const end = full_circle * easing.inSine(t);
 
     path.addArc(r.center(), @min(r.w, r.h) / 3, start, end, false);
-    path.build().stroke(.{ .thickness = 3.0 * rs.s, .color = .{ .color = options.textColor(.text).toColor() } });
+    path.build().stroke(.{ .thickness = 3.0 * rs.s, .color = .{ .color = options.color(.text).toColor() } });
 }
 
 pub fn scale(src: std.builtin.SourceLocation, init_opts: ScaleWidget.InitOptions, opts: Options) *ScaleWidget {
@@ -4026,7 +4026,7 @@ pub fn image(src: std.builtin.SourceLocation, init_opts: ImageInitOptions, opts:
     // rect is the content rect, so expand to the whole rect
     wd.rect = rect.outset(wd.options.paddingGet()).outset(wd.options.borderGet()).outset(wd.options.marginGet());
 
-    var renderBackground: ?Color = if (wd.options.backgroundGet()) wd.options.textColor(.fill).toColor() else null;
+    var renderBackground: ?Color = if (wd.options.backgroundGet()) wd.options.color(.fill).toColor() else null;
 
     if (wd.options.rotationGet() == 0.0) {
         wd.borderAndBackground(.{});
@@ -4076,7 +4076,7 @@ pub fn debugFontAtlases(src: std.builtin.SourceLocation, opts: Options) void {
     wd.borderAndBackground(.{});
 
     var rs = wd.parent.screenRectScale(placeIn(wd.contentRect(), size, .none, opts.gravityGet()));
-    const color = opts.textColor(.text).toColor();
+    const color = opts.color(.text).toColor();
 
     it = cw.fonts.cache.iterator();
     while (it.next()) |kv| {
@@ -4350,7 +4350,7 @@ pub fn slider(src: std.builtin.SourceLocation, init_opts: SliderInitOptions, opt
         },
     }
     if (b.data().visible()) {
-        part.fill(options.cornersGet().scale(trackrs.s, CornerRect.Physical), .{ .color = options.textColor(.fill), .fade = 1.0 });
+        part.fill(options.cornersGet().scale(trackrs.s, CornerRect.Physical), .{ .color = options.color(.fill), .fade = 1.0 });
     }
 
     const knobRect = switch (init_opts.dir) {
@@ -4360,9 +4360,9 @@ pub fn slider(src: std.builtin.SourceLocation, init_opts: SliderInitOptions, opt
 
     const hover_t = hoverFade(b.data().id, hovered);
     const fill_color: ColorOrGradient = if (captured(b.data().id))
-        options.textColor(.fill_press)
+        options.color(.fill_press)
     else
-        options.textColor(.fill).lerp(options.textColor(.fill_hover), hover_t);
+        options.color(.fill).lerp(options.color(.fill_hover), hover_t);
 
     var knob: BoxWidget = undefined;
     knob.init(@src(), .{ .dir = .horizontal }, .{ .rect = knobRect, .padding = .{}, .margin = .{}, .background = true, .border = Rect.all(1), .corners = .all(100), .color_fill = fill_color });
@@ -4702,7 +4702,7 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
         }
 
         const hover_t = hoverFade(b.data().id, hover);
-        b.data().borderAndBackground(.{ .fill_color = b.data().options.textColor(.fill).lerp(b.data().options.textColor(.fill_hover), hover_t) });
+        b.data().borderAndBackground(.{ .fill_color = b.data().options.color(.fill).lerp(b.data().options.color(.fill_hover), hover_t) });
 
         // only draw handle if we have a min and max
         if (b.data().visible() and init_opts.min != null and init_opts.max != null) {
@@ -4710,7 +4710,7 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
             const knobRect = Rect{ .x = (br.w - knobsize) * math.clamp(how_far, 0, 1), .w = knobsize, .h = knobsize };
             const knobrs = b.widget().screenRectScale(knobRect);
 
-            knobrs.r.fill(options.cornersGet().scale(knobrs.s, CornerRect.Physical), .{ .color = options.textColor(.fill_press), .fade = 1.0 });
+            knobrs.r.fill(options.cornersGet().scale(knobrs.s, CornerRect.Physical), .{ .color = options.color(.fill_press), .fade = 1.0 });
         }
 
         const label_opts = options.strip().override(.{ .gravity_x = 0.5, .gravity_y = 0.5 });
@@ -4830,7 +4830,7 @@ pub fn progress(src: std.builtin.SourceLocation, init_opts: Progress_InitOptions
 
     const rs = b.data().contentRectScale();
     const corner = options.cornersGet().finalize(opts.theme).scale(rs.s, CornerRect.Physical);
-    rs.r.fill(corner, .{ .color = options.textColor(.fill), .fade = 1.0 });
+    rs.r.fill(corner, .{ .color = options.color(.fill), .fade = 1.0 });
 
     const perc = @max(0, @min(1, init_opts.percent));
     if (perc == 0) return;
@@ -4905,7 +4905,7 @@ pub fn checkbox(src: std.builtin.SourceLocation, target: *bool, label_str: ?[]co
 
 pub fn checkmark(checked: bool, focused: bool, rs: RectScale, pressed: bool, hover_t: f32, opts: Options) void {
     const cornerRad = opts.cornersGet().finalize(opts.theme).scale(rs.s, CornerRect.Physical);
-    rs.r.fill(cornerRad, .{ .color = opts.textColor(.border), .fade = 1.0 });
+    rs.r.fill(cornerRad, .{ .color = opts.color(.border), .fade = 1.0 });
 
     if (focused) {
         rs.r.stroke(cornerRad, .{ .thickness = 2 * rs.s, .color = .{ .color = dvui.themeGet().focus } });
@@ -4913,7 +4913,7 @@ pub fn checkmark(checked: bool, focused: bool, rs: RectScale, pressed: bool, hov
 
     var options = opts;
     if (checked) options.style = .highlight;
-    const fill = if (pressed) options.textColor(.fill_press) else options.textColor(.fill).lerp(options.textColor(.fill_hover), hover_t);
+    const fill = if (pressed) options.color(.fill_press) else options.color(.fill).lerp(options.color(.fill_hover), hover_t);
     if (checked) {
         rs.r.insetAll(0.5 * rs.s).fill(cornerRad, .{ .color = fill, .fade = 1.0 });
     } else {
@@ -4937,7 +4937,7 @@ pub fn checkmark(checked: bool, focused: bool, rs: RectScale, pressed: bool, hov
             .{ .x = x, .y = y },
             .{ .x = x + third * 2, .y = y - third * 2 },
         } };
-        path.stroke(.{ .thickness = thick, .color = options.textColor(.text), .endcap_style = .square });
+        path.stroke(.{ .thickness = thick, .color = options.color(.text), .endcap_style = .square });
     }
 }
 
@@ -4991,7 +4991,7 @@ pub fn radio(src: std.builtin.SourceLocation, active: bool, label_str: ?[]const 
 pub fn radioCircle(active: bool, focused: bool, rs: RectScale, pressed: bool, hover_t: f32, opts: Options) void {
     const cornerRad = CornerRect.Physical.round(1000);
     const r = rs.r;
-    r.fill(cornerRad, .{ .color = opts.textColor(.border), .fade = 1.0 });
+    r.fill(cornerRad, .{ .color = opts.color(.border), .fade = 1.0 });
 
     if (focused) {
         r.stroke(cornerRad, .{ .thickness = 2 * rs.s, .color = .{ .color = dvui.themeGet().focus } });
@@ -4999,7 +4999,7 @@ pub fn radioCircle(active: bool, focused: bool, rs: RectScale, pressed: bool, ho
 
     var options = opts;
     if (active) options.style = .highlight;
-    const fill = if (pressed) options.textColor(.fill_press) else options.textColor(.fill).lerp(options.textColor(.fill_hover), hover_t);
+    const fill = if (pressed) options.color(.fill_press) else options.color(.fill).lerp(options.color(.fill_hover), hover_t);
     if (active) {
         r.insetAll(0.5 * rs.s).fill(cornerRad, .{ .color = fill, .fade = 1.0 });
     } else {
@@ -5009,7 +5009,7 @@ pub fn radioCircle(active: bool, focused: bool, rs: RectScale, pressed: bool, ho
     if (active) {
         const thick = @max(1.0, r.w / 6);
 
-        Path.stroke(.{ .points = &.{r.center()} }, .{ .thickness = thick, .color = options.textColor(.text) });
+        Path.stroke(.{ .points = &.{r.center()} }, .{ .thickness = thick, .color = options.color(.text) });
     }
 }
 

--- a/src/dvui.zig
+++ b/src/dvui.zig
@@ -55,6 +55,8 @@ pub const Font = @import("Font.zig");
 pub const Options = @import("Options.zig");
 pub const Point = @import("Point.zig").Point;
 pub const Path = @import("Path.zig");
+pub const Gradient = @import("Gradient.zig").Gradient;
+pub const ColorOrGradient = @import("Gradient.zig").ColorOrGradient;
 pub const Rect = @import("Rect.zig").Rect;
 pub const RectScale = @import("RectScale.zig");
 pub const Corner = @import("Corner.zig").Corner;
@@ -638,12 +640,14 @@ pub fn iconWidth(name: []const u8, tvg_bytes: []const u8, height: f32) TvgError!
     return height * @as(f32, @floatFromInt(parser.header.width)) / @as(f32, @floatFromInt(parser.header.height));
 }
 pub const IconRenderOptions = struct {
-    /// if null uses original fill colors, use .transparent to disable fill
-    fill_color: ?Color = .white,
+    /// if null uses original fill colors, use .transparent to disable fill.
+    /// Flat color, or a gradient drawn across the icon's bounding box.
+    fill_color: ?ColorOrGradient = .white,
     /// if null uses original stroke width
     stroke_width: ?f32 = null,
-    /// if null uses original stroke colors
-    stroke_color: ?Color = .white,
+    /// if null uses original stroke colors. Flat color, or a gradient drawn
+    /// across the icon's bounding box.
+    stroke_color: ?ColorOrGradient = .white,
 
     // note: IconWidget tests against default values
 };
@@ -3079,7 +3083,7 @@ pub fn dropdown(src: std.builtin.SourceLocation, entries: []const []const u8, ch
             defer mi.deinit();
             dvui.labelNoFmt(@src(), init_opts.placeholder orelse dropdown_placeholder_default, .{}, opts.strip().override(.{
                 .gravity_y = 0.5,
-                .color_text = opts.color(.text).opacity(0.65),
+                .color_text = opts.textColor(.text).opacity(0.65),
             }));
             if (mi.activeRect()) |_| {
                 dd.close();
@@ -3141,7 +3145,7 @@ pub fn dropdownEnum(src: std.builtin.SourceLocation, T: type, choice: DropdownCh
             defer mi.deinit();
             dvui.labelNoFmt(@src(), init_opts.placeholder orelse dropdown_placeholder_default, .{}, opts.strip().override(.{
                 .gravity_y = 0.5,
-                .color_text = opts.color(.text).opacity(0.65),
+                .color_text = opts.textColor(.text).opacity(0.65),
             }));
             if (mi.activeRect()) |_| {
                 dd.close();
@@ -3484,7 +3488,7 @@ pub fn groupBox(src: std.builtin.SourceLocation, label_str: []const u8, opts: Op
 
         path.addPoint(.{ .x = right_x, .y = r.y }); // right edge of label
 
-        path.build().stroke(.{ .thickness = options.borderGet().x * rs, .color = dvui.themeGet().border });
+        path.build().stroke(.{ .thickness = options.borderGet().x * rs, .color = .{ .color = dvui.themeGet().border } });
     }
     return b;
 }
@@ -3704,7 +3708,7 @@ pub fn separator(src: std.builtin.SourceLocation, opts: Options) WidgetData {
     const defaults: Options = .{
         .name = "Separator",
         .background = true, // TODO: remove this when border and background are no longer coupled
-        .color_fill = dvui.themeGet().border,
+        .color_fill = .{ .color = dvui.themeGet().border },
         .min_size_content = .{ .w = 1, .h = 1 },
     };
 
@@ -3775,7 +3779,7 @@ pub fn spinner(src: std.builtin.SourceLocation, opts: Options) void {
     const end = full_circle * easing.inSine(t);
 
     path.addArc(r.center(), @min(r.w, r.h) / 3, start, end, false);
-    path.build().stroke(.{ .thickness = 3.0 * rs.s, .color = options.color(.text) });
+    path.build().stroke(.{ .thickness = 3.0 * rs.s, .color = .{ .color = options.textColor(.text).toColor() } });
 }
 
 pub fn scale(src: std.builtin.SourceLocation, init_opts: ScaleWidget.InitOptions, opts: Options) *ScaleWidget {
@@ -3855,7 +3859,7 @@ pub const LinkOptions = struct {
 
 /// A label that calls `openURL` when clicked.
 pub fn link(src: std.builtin.SourceLocation, init_opts: LinkOptions, opts: Options) void {
-    const defaults: Options = .{ .color_text = dvui.themeGet().focus, .font = dvui.Font.theme(.body).withUnderline(.{}) };
+    const defaults: Options = .{ .color_text = .{ .color = dvui.themeGet().focus }, .font = dvui.Font.theme(.body).withUnderline(.{}) };
     var click_event: dvui.Event.EventTypes = undefined;
     if (dvui.labelClick(src, "{s}", .{init_opts.label orelse init_opts.url}, .{ .click_event = &click_event }, defaults.override(opts))) {
         const new_window = (click_event == .mouse and (click_event.mouse.button == .middle or click_event.mouse.mod.matchBind("ctrl/cmd")));
@@ -4022,7 +4026,7 @@ pub fn image(src: std.builtin.SourceLocation, init_opts: ImageInitOptions, opts:
     // rect is the content rect, so expand to the whole rect
     wd.rect = rect.outset(wd.options.paddingGet()).outset(wd.options.borderGet()).outset(wd.options.marginGet());
 
-    var renderBackground: ?Color = if (wd.options.backgroundGet()) wd.options.color(.fill) else null;
+    var renderBackground: ?Color = if (wd.options.backgroundGet()) wd.options.textColor(.fill).toColor() else null;
 
     if (wd.options.rotationGet() == 0.0) {
         wd.borderAndBackground(.{});
@@ -4072,7 +4076,7 @@ pub fn debugFontAtlases(src: std.builtin.SourceLocation, opts: Options) void {
     wd.borderAndBackground(.{});
 
     var rs = wd.parent.screenRectScale(placeIn(wd.contentRect(), size, .none, opts.gravityGet()));
-    const color = opts.color(.text);
+    const color = opts.textColor(.text).toColor();
 
     it = cw.fonts.cache.iterator();
     while (it.next()) |kv| {
@@ -4332,7 +4336,7 @@ pub fn slider(src: std.builtin.SourceLocation, init_opts: SliderInitOptions, opt
         },
     }
     if (b.data().visible()) {
-        part.fill(options.cornersGet().scale(trackrs.s, CornerRect.Physical), .{ .color = init_opts.color_bar orelse dvui.themeGet().color(.highlight, .fill), .fade = 1.0 });
+        part.fill(options.cornersGet().scale(trackrs.s, CornerRect.Physical), .{ .color = .{ .color = init_opts.color_bar orelse dvui.themeGet().color(.highlight, .fill) }, .fade = 1.0 });
     }
 
     switch (init_opts.dir) {
@@ -4346,7 +4350,7 @@ pub fn slider(src: std.builtin.SourceLocation, init_opts: SliderInitOptions, opt
         },
     }
     if (b.data().visible()) {
-        part.fill(options.cornersGet().scale(trackrs.s, CornerRect.Physical), .{ .color = options.color(.fill), .fade = 1.0 });
+        part.fill(options.cornersGet().scale(trackrs.s, CornerRect.Physical), .{ .color = options.textColor(.fill), .fade = 1.0 });
     }
 
     const knobRect = switch (init_opts.dir) {
@@ -4355,10 +4359,10 @@ pub fn slider(src: std.builtin.SourceLocation, init_opts: SliderInitOptions, opt
     };
 
     const hover_t = hoverFade(b.data().id, hovered);
-    const fill_color: Color = if (captured(b.data().id))
-        options.color(.fill_press)
+    const fill_color: ColorOrGradient = if (captured(b.data().id))
+        options.textColor(.fill_press)
     else
-        options.color(.fill).lerp(options.color(.fill_hover), hover_t);
+        options.textColor(.fill).lerp(options.textColor(.fill_hover), hover_t);
 
     var knob: BoxWidget = undefined;
     knob.init(@src(), .{ .dir = .horizontal }, .{ .rect = knobRect, .padding = .{}, .margin = .{}, .background = true, .border = Rect.all(1), .corners = .all(100), .color_fill = fill_color });
@@ -4698,7 +4702,7 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
         }
 
         const hover_t = hoverFade(b.data().id, hover);
-        b.data().borderAndBackground(.{ .fill_color = b.data().options.color(.fill).lerp(b.data().options.color(.fill_hover), hover_t) });
+        b.data().borderAndBackground(.{ .fill_color = b.data().options.textColor(.fill).lerp(b.data().options.textColor(.fill_hover), hover_t) });
 
         // only draw handle if we have a min and max
         if (b.data().visible() and init_opts.min != null and init_opts.max != null) {
@@ -4706,7 +4710,7 @@ pub fn sliderEntry(src: std.builtin.SourceLocation, comptime label_fmt: ?[]const
             const knobRect = Rect{ .x = (br.w - knobsize) * math.clamp(how_far, 0, 1), .w = knobsize, .h = knobsize };
             const knobrs = b.widget().screenRectScale(knobRect);
 
-            knobrs.r.fill(options.cornersGet().scale(knobrs.s, CornerRect.Physical), .{ .color = options.color(.fill_press), .fade = 1.0 });
+            knobrs.r.fill(options.cornersGet().scale(knobrs.s, CornerRect.Physical), .{ .color = options.textColor(.fill_press), .fade = 1.0 });
         }
 
         const label_opts = options.strip().override(.{ .gravity_x = 0.5, .gravity_y = 0.5 });
@@ -4826,7 +4830,7 @@ pub fn progress(src: std.builtin.SourceLocation, init_opts: Progress_InitOptions
 
     const rs = b.data().contentRectScale();
     const corner = options.cornersGet().finalize(opts.theme).scale(rs.s, CornerRect.Physical);
-    rs.r.fill(corner, .{ .color = options.color(.fill), .fade = 1.0 });
+    rs.r.fill(corner, .{ .color = options.textColor(.fill), .fade = 1.0 });
 
     const perc = @max(0, @min(1, init_opts.percent));
     if (perc == 0) return;
@@ -4842,7 +4846,7 @@ pub fn progress(src: std.builtin.SourceLocation, init_opts: Progress_InitOptions
             part.h = rs.r.h - h;
         },
     }
-    part.fill(corner, .{ .color = init_opts.color orelse dvui.themeGet().color(.highlight, .fill), .fade = 1.0 });
+    part.fill(corner, .{ .color = .{ .color = init_opts.color orelse dvui.themeGet().color(.highlight, .fill) }, .fade = 1.0 });
 
     if (b.data().accesskit_node()) |ak_node| {
         AccessKit.nodeSetMinNumericValue(ak_node, 0);
@@ -4901,15 +4905,15 @@ pub fn checkbox(src: std.builtin.SourceLocation, target: *bool, label_str: ?[]co
 
 pub fn checkmark(checked: bool, focused: bool, rs: RectScale, pressed: bool, hover_t: f32, opts: Options) void {
     const cornerRad = opts.cornersGet().finalize(opts.theme).scale(rs.s, CornerRect.Physical);
-    rs.r.fill(cornerRad, .{ .color = opts.color(.border), .fade = 1.0 });
+    rs.r.fill(cornerRad, .{ .color = opts.textColor(.border), .fade = 1.0 });
 
     if (focused) {
-        rs.r.stroke(cornerRad, .{ .thickness = 2 * rs.s, .color = dvui.themeGet().focus });
+        rs.r.stroke(cornerRad, .{ .thickness = 2 * rs.s, .color = .{ .color = dvui.themeGet().focus } });
     }
 
     var options = opts;
     if (checked) options.style = .highlight;
-    const fill = if (pressed) options.color(.fill_press) else options.color(.fill).lerp(options.color(.fill_hover), hover_t);
+    const fill = if (pressed) options.textColor(.fill_press) else options.textColor(.fill).lerp(options.textColor(.fill_hover), hover_t);
     if (checked) {
         rs.r.insetAll(0.5 * rs.s).fill(cornerRad, .{ .color = fill, .fade = 1.0 });
     } else {
@@ -4933,7 +4937,7 @@ pub fn checkmark(checked: bool, focused: bool, rs: RectScale, pressed: bool, hov
             .{ .x = x, .y = y },
             .{ .x = x + third * 2, .y = y - third * 2 },
         } };
-        path.stroke(.{ .thickness = thick, .color = options.color(.text), .endcap_style = .square });
+        path.stroke(.{ .thickness = thick, .color = options.textColor(.text), .endcap_style = .square });
     }
 }
 
@@ -4987,15 +4991,15 @@ pub fn radio(src: std.builtin.SourceLocation, active: bool, label_str: ?[]const 
 pub fn radioCircle(active: bool, focused: bool, rs: RectScale, pressed: bool, hover_t: f32, opts: Options) void {
     const cornerRad = CornerRect.Physical.round(1000);
     const r = rs.r;
-    r.fill(cornerRad, .{ .color = opts.color(.border), .fade = 1.0 });
+    r.fill(cornerRad, .{ .color = opts.textColor(.border), .fade = 1.0 });
 
     if (focused) {
-        r.stroke(cornerRad, .{ .thickness = 2 * rs.s, .color = dvui.themeGet().focus });
+        r.stroke(cornerRad, .{ .thickness = 2 * rs.s, .color = .{ .color = dvui.themeGet().focus } });
     }
 
     var options = opts;
     if (active) options.style = .highlight;
-    const fill = if (pressed) options.color(.fill_press) else options.color(.fill).lerp(options.color(.fill_hover), hover_t);
+    const fill = if (pressed) options.textColor(.fill_press) else options.textColor(.fill).lerp(options.textColor(.fill_hover), hover_t);
     if (active) {
         r.insetAll(0.5 * rs.s).fill(cornerRad, .{ .color = fill, .fade = 1.0 });
     } else {
@@ -5005,7 +5009,7 @@ pub fn radioCircle(active: bool, focused: bool, rs: RectScale, pressed: bool, ho
     if (active) {
         const thick = @max(1.0, r.w / 6);
 
-        Path.stroke(.{ .points = &.{r.center()} }, .{ .thickness = thick, .color = options.color(.text) });
+        Path.stroke(.{ .points = &.{r.center()} }, .{ .thickness = thick, .color = options.textColor(.text) });
     }
 }
 
@@ -5216,7 +5220,7 @@ pub fn textEntryNumber(src: std.builtin.SourceLocation, comptime T: type, init_o
 
     if (result.value != .Valid and (init_opts.value != null or result.value != .Empty)) {
         const rs = te.data().borderRectScale();
-        rs.r.outsetAll(1).stroke(te.data().options.cornersGet().scale(rs.s, CornerRect.Physical), .{ .thickness = 3 * rs.s, .color = dvui.themeGet().err.fill orelse .red, .after = true });
+        rs.r.outsetAll(1).stroke(te.data().options.cornersGet().scale(rs.s, CornerRect.Physical), .{ .thickness = 3 * rs.s, .color = .{ .color = dvui.themeGet().err.fill orelse .red }, .after = true });
     }
 
     if (te.data().accesskit_node()) |ak_node| {
@@ -5381,7 +5385,7 @@ pub fn textEntryColor(src: std.builtin.SourceLocation, init_opts: TextEntryColor
 
     if (result.value != .Valid and (init_opts.value != null or result.value != .Empty)) {
         const rs = te.data().borderRectScale();
-        rs.r.outsetAll(1).stroke(te.data().options.cornersGet().scale(rs.s, CornerRect.Physical), .{ .thickness = 3 * rs.s, .color = dvui.themeGet().err.fill orelse .red, .after = true });
+        rs.r.outsetAll(1).stroke(te.data().options.cornersGet().scale(rs.s, CornerRect.Physical), .{ .thickness = 3 * rs.s, .color = .{ .color = dvui.themeGet().err.fill orelse .red }, .after = true });
     }
 
     te.deinit();

--- a/src/earcut.zig
+++ b/src/earcut.zig
@@ -824,7 +824,7 @@ pub fn fillTriangles(allocator: std.mem.Allocator, contours: []const Path, opts:
     const arena = arena_state.allocator();
 
     var sink: Path.FillSink = .{};
-    const col: Color.PMA = .fromColor(opts.color);
+    const col: Color.PMA = .fromColor(opts.color.split().color);
     var boundary: std.ArrayList(Path.FillBoundaryEdge) = .empty;
 
     if (contours.len == 1) {
@@ -963,7 +963,7 @@ test fillTriangles {
         .{ .x = 25, .y = 75 },
     } };
 
-    var triangles = try fillTriangles(std.testing.allocator, &.{ outer, hole }, .{ .color = Color.white, .fade = 1.0 });
+    var triangles = try fillTriangles(std.testing.allocator, &.{ outer, hole }, .{ .color = .{ .color = Color.white }, .fade = 1.0 });
     defer triangles.deinit(std.testing.allocator);
 
     try std.testing.expect(triangles.vertexes.len > 0);

--- a/src/render.zig
+++ b/src/render.zig
@@ -163,6 +163,7 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
         var opts_copy = opts;
         opts_copy.text = try cw.arena().dupe(u8, utf8_text);
         if (opts.kern_in) |ki| opts_copy.kern_in = try cw.arena().dupe(u32, ki);
+        if (opts.gradient) |g| opts_copy.gradient = try g.dupe(cw.arena());
         cw.addRenderCommand(.{ .text = opts_copy }, false);
         return;
     }

--- a/src/render.zig
+++ b/src/render.zig
@@ -492,7 +492,7 @@ pub fn renderIcon(name: []const u8, tvg_bytes: []const u8, rs: RectScale, opts: 
             .font = (dvui.Options{}).fontGet().withSize(0.5 * rs.r.h / rs.s),
             .text = name,
             .rs = rs,
-            .color = (dvui.Options{}).textColor(.text).toColor(),
+            .color = (dvui.Options{}).color(.text).toColor(),
         });
         return;
     }

--- a/src/render.zig
+++ b/src/render.zig
@@ -118,6 +118,12 @@ pub const TextOptions = struct {
     /// use rs.r.topLeft().
     p: ?Point.Physical = null,
     color: Color,
+    /// If set, overrides `color` per-vertex via `Gradient.sample`, sampled
+    /// against `rs.r` (or `gradient.anchor` if that's set). Glyph quads are
+    /// small enough that Gouraud-interpolating the 4 corners' exact samples
+    /// is visually identical to resampling per-pixel -- unlike fills, which
+    /// need the ramp-texture trick in `Gradient.apply` for 3+ stops.
+    gradient: ?Gradient = null,
     background_color: ?Color = null,
 
     /// radians clockwise, rotates around top-left corner (rs.x/rs.y)
@@ -203,6 +209,10 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
 
     const color = opts.color.opacity(cw.alpha);
     const col: Color.PMA = .fromColor(color);
+
+    // Sample fresh per-vertex below when set; leave `col` as the flat
+    // fallback for background/selection/underline/strike, which stay flat.
+    const gradient_bounds = opts.rs.r;
 
     var start = opts.p orelse opts.rs.r.topLeft();
     if (cw.snap_to_pixels) {
@@ -318,7 +328,7 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
 
             v.pos.x = leftx;
             v.pos.y = start.y + (fce_ascent - gi.topBearing) * target_fraction;
-            v.col = col;
+            v.col = if (opts.gradient) |g| .fromColor(g.sample(gradient_bounds, v.pos).opacity(cw.alpha)) else col;
             v.uv = gi.uv;
             builder.appendVertex(v);
 
@@ -334,15 +344,18 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
             v.pos.x = x + (gi.leftBearing + gi.w) * target_fraction;
             max_x = v.pos.x;
             v.uv[0] = gi.uv[0] + gi.w / atlas_size.w;
+            if (opts.gradient) |g| v.col = .fromColor(g.sample(gradient_bounds, v.pos).opacity(cw.alpha));
             builder.appendVertex(v);
 
             v.pos.y = start.y + (fce_ascent - gi.topBearing + gi.h) * target_fraction;
             sel_max_y = @max(sel_max_y, v.pos.y);
             v.uv[1] = gi.uv[1] + gi.h / atlas_size.h;
+            if (opts.gradient) |g| v.col = .fromColor(g.sample(gradient_bounds, v.pos).opacity(cw.alpha));
             builder.appendVertex(v);
 
             v.pos.x = leftx;
             v.uv[0] = gi.uv[0];
+            if (opts.gradient) |g| v.col = .fromColor(g.sample(gradient_bounds, v.pos).opacity(cw.alpha));
             builder.appendVertex(v);
 
             // triangles must be counter-clockwise (y going down) to avoid backface culling
@@ -359,7 +372,7 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
         opts.rs.r.toPoint(.{
             .x = max_x,
             .y = @max(sel_max_y, opts.rs.r.y + fce.height * target_fraction * opts.font.line_height_factor),
-        }).fill(.{}, .{ .color = bgcol, .fade = 0 });
+        }).fill(.{}, .{ .color = .{ .color = bgcol }, .fade = 0 });
     }
 
     if (sel) {
@@ -368,7 +381,7 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
                 .x = sel_end_x,
                 .y = @max(sel_max_y, start.y + fce.height * target_fraction * opts.font.line_height_factor),
             })
-            .fill(.{}, .{ .color = opts.sel_color orelse dvui.themeGet().focus, .fade = 0 });
+            .fill(.{}, .{ .color = .{ .color = opts.sel_color orelse dvui.themeGet().focus }, .fade = 0 });
     }
 
     if (opts.font.underline) |u| {
@@ -381,7 +394,7 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
 
             const botright: dvui.Point.Physical = .{ .x = max_x, .y = topleft.y + @max(1.0 * opts.rs.s, fce.em_height * u.thick) };
 
-            Rect.Physical.fromPoint(topleft).toPoint(botright).fill(.{}, .{ .color = color, .fade = 0 });
+            Rect.Physical.fromPoint(topleft).toPoint(botright).fill(.{}, .{ .color = .{ .color = color }, .fade = 0 });
         }
     }
 
@@ -396,7 +409,7 @@ pub fn renderText(opts: TextOptions) Backend.GenericError!void {
 
             const botright: dvui.Point.Physical = .{ .x = max_x, .y = topleft.y + thick };
 
-            Rect.Physical.fromPoint(topleft).toPoint(botright).fill(.{}, .{ .color = color, .fade = 0 });
+            Rect.Physical.fromPoint(topleft).toPoint(botright).fill(.{}, .{ .color = .{ .color = color }, .fade = 0 });
         }
     }
 
@@ -427,7 +440,7 @@ pub const TextureOptions = struct {
 };
 
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn renderTexture(tex: Texture, rs: RectScale, opts: TextureOptions) Backend.GenericError!void {
+pub fn renderTexture(tex: Texture, rs: RectScale, opts: TextureOptions) Backend.TextureError!void {
     if (rs.s == 0) return;
     if (dvui.clipGet().intersect(rs.r).empty()) return;
 
@@ -449,7 +462,7 @@ pub fn renderTexture(tex: Texture, rs: RectScale, opts: TextureOptions) Backend.
 
     path.addRect(rect, opts.corners.scale(rs.s, CornerRect.Physical));
 
-    var triangles = try path.build().fillConvexTriangles(cw.lifo(), .{ .color = opts.colormod.opacity(cw.alpha), .fade = opts.fade });
+    var triangles = try path.build().fillConvexTriangles(cw.lifo(), .{ .color = .{ .color = opts.colormod.opacity(cw.alpha) }, .fade = opts.fade });
     defer triangles.deinit(cw.lifo());
 
     const uvRect = opts.uv_rect orelse rect;
@@ -470,7 +483,7 @@ pub fn renderTexture(tex: Texture, rs: RectScale, opts: TextureOptions) Backend.
 /// Calls `renderTexture` with the texture created from `tvg_bytes`
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn renderIcon(name: []const u8, tvg_bytes: []const u8, rs: RectScale, opts: TextureOptions, icon_opts: IconRenderOptions) Backend.GenericError!void {
+pub fn renderIcon(name: []const u8, tvg_bytes: []const u8, rs: RectScale, opts: TextureOptions, icon_opts: IconRenderOptions) Backend.TextureError!void {
     if (rs.s == 0) return;
     if (dvui.clipGet().intersect(rs.r).empty()) return;
 
@@ -479,7 +492,7 @@ pub fn renderIcon(name: []const u8, tvg_bytes: []const u8, rs: RectScale, opts: 
             .font = (dvui.Options{}).fontGet().withSize(0.5 * rs.r.h / rs.s),
             .text = name,
             .rs = rs,
-            .color = (dvui.Options{}).color(.text),
+            .color = (dvui.Options{}).textColor(.text).toColor(),
         });
         return;
     }
@@ -515,7 +528,7 @@ pub const NinepatchOptions = struct {
 /// Renders a ninepatch with the given parameters.
 ///
 /// Only valid between `Window.begin`and `Window.end`.
-pub fn renderNinepatch(ninepatch: Ninepatch, rs: RectScale, opts: NinepatchOptions) Backend.GenericError!void {
+pub fn renderNinepatch(ninepatch: Ninepatch, rs: RectScale, opts: NinepatchOptions) Backend.TextureError!void {
     if (ninepatch.source.imageFile.bytes.len == 0) return;
     if (rs.s == 0) return;
     if (rs.r.empty()) return;
@@ -750,6 +763,7 @@ const Rect = dvui.Rect;
 const RectScale = dvui.RectScale;
 const Triangles = dvui.Triangles;
 const Path = dvui.Path;
+const Gradient = dvui.Gradient;
 const Texture = dvui.Texture;
 const Vertex = dvui.Vertex;
 const ImageSource = dvui.ImageSource;

--- a/src/render_tvg.zig
+++ b/src/render_tvg.zig
@@ -14,13 +14,12 @@
 
 /// Render options for a TVG render.
 pub const RenderOptions = struct {
-    /// If set, overrides every flat-fill / stroke color.  Gradients are
-    /// flattened to a single flat color when an override is active.
-    color_override: ?Color = null,
+    /// If set, overrides every fill / stroke color or gradient in the TVG.
+    color_override: ?ColorOrGradient = null,
     /// If set, overrides only fill colors (does not affect strokes).
-    fill_color_override: ?Color = null,
+    fill_color_override: ?ColorOrGradient = null,
     /// If set, overrides only stroke colors (does not affect fills).
-    stroke_color_override: ?Color = null,
+    stroke_color_override: ?ColorOrGradient = null,
     /// If set, overrides the stroke width for all stroked paths.
     stroke_width_override: ?f32 = null,
     /// When true, all fill operations are skipped (only strokes are drawn).
@@ -28,11 +27,14 @@ pub const RenderOptions = struct {
     /// Preserve TVG aspect ratio inside `rect` (letterbox).  When false the
     /// icon is stretched to fill the rect.
     keep_aspect: bool = true,
-    /// Edge feather (physical px) for anti-aliasing of flat-colored fills
-    /// and stroke caps/joins.  0 disables fill AA - sharp edges, useful for
-    /// pixel-aligned UI strokes.  Gradient fills are never AA'd (see
-    /// `fillContoursPhysical`).
+    /// Edge feather (physical px) for anti-aliasing of fills and stroke
+    /// caps/joins (flat or gradient - see `fillContoursPhysical`).  0
+    /// disables fill AA - sharp edges, useful for pixel-aligned UI strokes.
     fade: f32 = 1.0,
+    /// Physical-pixel bounds a `color_override`/`fill_color_override`/
+    /// `stroke_color_override` gradient is sampled against. Set by
+    /// `appendTvg` from `rect`.
+    bounds: Rect = .{},
 };
 
 /// Caller-owned accumulator that collects ALL triangles for a TVG render
@@ -130,11 +132,53 @@ pub const MeshCache = struct {
     }
 };
 
+/// Hashes `v` field-by-field, following only the active tag of unions and
+/// the contents (not pointer) of slices. `icon_opts.fill_color`/
+/// `stroke_color` are `?ColorOrGradient`, a union whose `.gradient` payload
+/// is much larger than `.color` - `std.mem.asBytes` on the union would read
+/// uninitialized trailing bytes whenever the active tag is `.color`, making
+/// the cache key nondeterministic. `std.hash.autoHashStrat` can't be used
+/// directly since it rejects float fields (`Gradient` has many); bitcast
+/// floats to same-width ints ourselves instead.
+fn hashValue(h: *dvui.fnv, v: anytype) void {
+    const T = @TypeOf(v);
+    switch (@typeInfo(T)) {
+        .float => |f| {
+            const Bits = std.meta.Int(.unsigned, f.bits);
+            const bits: Bits = @bitCast(v);
+            h.update(std.mem.asBytes(&bits));
+        },
+        .optional => {
+            h.update(&[_]u8{if (v == null) 0 else 1});
+            if (v) |val| hashValue(h, val);
+        },
+        .pointer => |p| switch (p.size) {
+            .slice => {
+                h.update(std.mem.asBytes(&v.len));
+                for (v) |item| hashValue(h, item);
+            },
+            else => @compileError("hashValue: unsupported pointer type " ++ @typeName(T)),
+        },
+        .@"struct" => |s| inline for (s.fields) |field| hashValue(h, @field(v, field.name)),
+        .@"union" => |u| {
+            const tag = std.meta.activeTag(v);
+            hashValue(h, tag);
+            inline for (u.fields) |field| {
+                if (@field(std.meta.Tag(T), field.name) == tag) {
+                    if (field.type != void) hashValue(h, @field(v, field.name));
+                }
+            }
+        },
+        .@"enum" => h.update(std.mem.asBytes(&@intFromEnum(v))),
+        else => h.update(std.mem.asBytes(&v)),
+    }
+}
+
 /// Draws `tvg_bytes` scaled to fit `rs`, using `Window.icon_mesh_cache` to
 /// avoid re-triangulating unchanged icons every frame.
 ///
 /// Only valid between `Window.begin` and `Window.end`.
-pub fn renderIcon(name: []const u8, tvg_bytes: []const u8, rs: dvui.RectScale, opts: dvui.render.TextureOptions, icon_opts: dvui.IconRenderOptions) Backend.GenericError!void {
+pub fn renderIcon(name: []const u8, tvg_bytes: []const u8, rs: dvui.RectScale, opts: dvui.render.TextureOptions, icon_opts: dvui.IconRenderOptions) Backend.TextureError!void {
     if (rs.s == 0) return;
     if (dvui.clipGet().intersect(rs.r).empty()) return;
 
@@ -146,7 +190,7 @@ pub fn renderIcon(name: []const u8, tvg_bytes: []const u8, rs: dvui.RectScale, o
     var h = dvui.fnv.init();
     h.update(std.mem.asBytes(&tvg_bytes.ptr));
     h.update(std.mem.asBytes(&ask_height));
-    h.update(std.mem.asBytes(&icon_opts));
+    hashValue(&h, icon_opts);
     const hash = h.final();
 
     const cw = dvui.currentWindow();
@@ -163,7 +207,7 @@ pub fn renderIcon(name: []const u8, tvg_bytes: []const u8, rs: dvui.RectScale, o
             .fill_color_override = icon_opts.fill_color,
             .stroke_color_override = icon_opts.stroke_color,
             .stroke_width_override = icon_opts.stroke_width,
-            .disable_fill = if (icon_opts.fill_color) |c| c.a == 0 else false,
+            .disable_fill = if (icon_opts.fill_color) |c| c.toColor().a == 0 else false,
             .keep_aspect = true,
             .fade = 1.0,
         };
@@ -234,8 +278,11 @@ pub fn appendTvg(
 
     const xf = Transform.fromRect(rect, @floatFromInt(parser.header.width), @floatFromInt(parser.header.height), opts.keep_aspect);
 
+    var opts_with_bounds = opts;
+    opts_with_bounds.bounds = rect;
+
     while (try parser.next()) |cmd| {
-        try renderCommand(scratch_alloc, mesh, parser.color_table, cmd, xf, opts);
+        try renderCommand(scratch_alloc, mesh, parser.color_table, cmd, xf, opts_with_bounds);
     }
 }
 
@@ -382,6 +429,13 @@ const ColorSource = union(enum) {
         center: Point,
         edge: Point,
     },
+    /// A caller-supplied `dvui.Gradient` override (from
+    /// `IconRenderOptions.fill_color`/`stroke_color`), sampled analytically
+    /// against the icon's bounding box.
+    dvui_gradient: struct {
+        gradient: Gradient,
+        bounds: Rect,
+    },
 
     fn sampleColor(self: ColorSource, p: Point) Color {
         return switch (self) {
@@ -404,6 +458,7 @@ const ColorSource = union(enum) {
                 const t = math.clamp(@sqrt(dx * dx + dy * dy) / radius, 0, 1);
                 break :blk lerpColor(g.c0, g.c1, t);
             },
+            .dvui_gradient => |g| g.gradient.sample(g.bounds, p),
         };
     }
 
@@ -433,12 +488,19 @@ fn lerpColor(a: Color, b: Color, t: f32) Color {
 /// Build a `ColorSource` from a TVG style.  Override forces flat.  Gradient
 /// endpoints are transformed into physical pixel space so per-vertex
 /// sampling is a single dot product / distance.
+fn colorSourceFromOverride(c: ColorOrGradient, bounds: Rect) ColorSource {
+    return switch (c) {
+        .color => |col| .{ .flat = .fromColor(col) },
+        .gradient => |g| .{ .dvui_gradient = .{ .gradient = g, .bounds = bounds } },
+    };
+}
+
 fn resolveStyleSource(style: tvg.Style, color_table: []const tvg.Color, opts: RenderOptions, xf: Transform, is_stroke: bool) ColorSource {
-    if (opts.color_override) |c| return .{ .flat = .fromColor(c) };
+    if (opts.color_override) |c| return colorSourceFromOverride(c, opts.bounds);
     if (is_stroke) {
-        if (opts.stroke_color_override) |c| return .{ .flat = .fromColor(c) };
+        if (opts.stroke_color_override) |c| return colorSourceFromOverride(c, opts.bounds);
     } else {
-        if (opts.fill_color_override) |c| return .{ .flat = .fromColor(c) };
+        if (opts.fill_color_override) |c| return colorSourceFromOverride(c, opts.bounds);
     }
     return switch (style) {
         .flat => |idx| .{ .flat = .fromColor(tvgColorToDvui(color_table[idx])) },
@@ -491,11 +553,12 @@ fn strokeLine(allocator: std.mem.Allocator, mesh: *MeshBuilder, p0: Point, p1: P
 /// concave shapes, holes, and small self-intersections (left over from
 /// bezier/arc flattening) are all handled without a bespoke triangulator.
 ///
-/// Flat colors get real edge AA (`opts.fade`).  Gradients can't ride that
-/// fade (it assumes a single flat color fading to transparent, not a
-/// varying interior color), so gradient fills disable it and Gouraud-shade
-/// every vertex from `source` instead - still correctly filled, just
-/// without edge AA.
+/// Flat colors get their edge AA from `Path.fillTriangles`'s `fade` (a
+/// uniform fade-to-transparent band works for a single color). Gradients
+/// can't reuse that band directly - color varies across it - so instead we
+/// Gouraud-shade the opaque interior (unchanged) and add a second band,
+/// `gouraudFadeBand`, that analytically samples `source` per boundary vertex
+/// while fading alpha to 0, giving gradients the same edge AA flat fills get.
 fn fillContoursPhysical(
     allocator: std.mem.Allocator,
     mesh: *MeshBuilder,
@@ -512,7 +575,7 @@ fn fillContoursPhysical(
     switch (source) {
         .flat => |pma| {
             var tri = try Path.fillTriangles(allocator, paths, .{
-                .color = pma.toColor(),
+                .color = .{ .color = pma.toColor() },
                 .fade = fade,
                 .fill_rule = .nonzero,
             });
@@ -526,10 +589,201 @@ fn fillContoursPhysical(
                 .fill_rule = .nonzero,
             });
             defer tri.deinit(allocator);
-            for (tri.vertexes) |*v| v.col = source.sample(v.pos);
-            try mesh.appendMesh(tri);
+            var shaded = try gouraudShade(allocator, tri, source);
+            defer shaded.deinit(allocator);
+            try mesh.appendMesh(shaded);
+
+            if (fade > 0) {
+                var band = try gouraudFadeBand(allocator, contours, source, fade);
+                defer band.deinit(allocator);
+                try mesh.appendMesh(band);
+            }
         },
     }
+}
+
+/// Edge-AA band for non-flat `ColorSource`s: same outward-normal offset
+/// technique as `Path.fillConvexTriangles`/`fillAppendFade` (inner vertex on
+/// the true boundary minus half the fade, outer vertex plus the rest, faded
+/// to transparent), but sampling `source` analytically per boundary vertex
+/// instead of using one flat color.
+///
+/// Operates on the raw per-subpath contours rather than `Path.fillTriangles`'s
+/// resolved boundary, so overlapping/self-intersecting contours (rare - left
+/// over from bezier/arc flattening) can double up faded coverage at the
+/// overlap. Icons don't hit this in practice; revisit if one does.
+///
+/// `fillConvexTriangles`/`fillAppendFade` can hardcode which way the offset
+/// formula points because their input winding is caller-controlled or
+/// already normalized by earcut's boundary resolution. Raw TVG contours
+/// carry whatever winding the source file used, so each contour's own
+/// signed area decides which sign makes the offset point outward.
+fn gouraudFadeBand(allocator: std.mem.Allocator, contours: []const []const Point, source: ColorSource, fade: f32) !Triangles {
+    var vtx: std.ArrayList(Vertex) = .empty;
+    errdefer vtx.deinit(allocator);
+    var idx: std.ArrayList(Vertex.Index) = .empty;
+    errdefer idx.deinit(allocator);
+
+    const inside_len = @min(0.5, fade / 2);
+    const outside_len = if (fade <= 1) fade / 2 else fade - 0.5;
+
+    for (contours) |pts| {
+        const n = pts.len;
+        if (n < 3) continue;
+
+        var area2: f32 = 0;
+        for (0..n) |i| {
+            const p = pts[i];
+            const q = pts[(i + 1) % n];
+            area2 += p.x * q.y - q.x * p.y;
+        }
+        const sign: f32 = if (area2 > 0) -1 else 1;
+
+        const inner_idx = try allocator.alloc(Vertex.Index, n);
+        defer allocator.free(inner_idx);
+        const outer_idx = try allocator.alloc(Vertex.Index, n);
+        defer allocator.free(outer_idx);
+
+        for (0..n) |i| {
+            const aa = pts[(i + n - 1) % n];
+            const bb = pts[i];
+            const cc = pts[(i + 1) % n];
+            const diffab = aa.diff(bb).normalize();
+            const diffbc = bb.diff(cc).normalize();
+            var norm: Point = .{
+                .x = sign * (diffab.y + diffbc.y) / 2,
+                .y = sign * (-diffab.x - diffbc.x) / 2,
+            };
+
+            inner_idx[i] = @intCast(vtx.items.len);
+            try vtx.append(allocator, .{
+                .pos = .{ .x = bb.x - norm.x * inside_len, .y = bb.y - norm.y * inside_len },
+                .col = .fromColor(source.sampleColor(bb)),
+            });
+
+            const d2 = norm.x * norm.x + norm.y * norm.y;
+            if (d2 > 0.000001) norm = norm.scale(1.0 / d2, Point);
+            const l = norm.length();
+            if (l > 2.0) norm = norm.scale(2.0 / l, Point);
+
+            outer_idx[i] = @intCast(vtx.items.len);
+            try vtx.append(allocator, .{
+                .pos = .{ .x = bb.x + norm.x * outside_len, .y = bb.y + norm.y * outside_len },
+                .col = .transparent,
+            });
+        }
+
+        for (0..n) |i| {
+            const j = (i + 1) % n;
+            try idx.appendSlice(allocator, &.{ inner_idx[i], outer_idx[i], inner_idx[j] });
+            try idx.appendSlice(allocator, &.{ outer_idx[i], outer_idx[j], inner_idx[j] });
+        }
+    }
+
+    return .{
+        .vertexes = try vtx.toOwnedSlice(allocator),
+        .indices = try idx.toOwnedSlice(allocator),
+        .bounds = .{},
+    };
+}
+
+/// Re-triangulates `tri` (a flat, white-colored fill straight out of
+/// `Path.fillTriangles`) with per-vertex colors from `source`, adaptively
+/// splitting each triangle wherever plain Gouraud interpolation (lerping the
+/// 3 corner colors) would visibly diverge from the source's true analytic
+/// color. Icon fills are just the polygon's own outline vertices - large,
+/// sparse triangles - so a corner-only sample is exact for an affine color
+/// function (flat, or 2-stop `linear`) but visibly wrong for anything
+/// curved (`radial`, `scattered`, multi-stop `linear`): edge midpoints then
+/// read closer to a straight blend of the corners than to the source's
+/// actual (e.g. circular) isolines. Recursion bottoms out once every edge's
+/// analytic midpoint color is within tolerance of its Gouraud-lerped color,
+/// or at `max_depth`.
+fn gouraudShade(allocator: std.mem.Allocator, tri: Triangles, source: ColorSource) !Triangles {
+    var vtx = std.ArrayList(Vertex).empty;
+    errdefer vtx.deinit(allocator);
+    var idx = std.ArrayList(Vertex.Index).empty;
+    errdefer idx.deinit(allocator);
+
+    var i: usize = 0;
+    while (i < tri.indices.len) : (i += 3) {
+        const v0 = tri.vertexes[tri.indices[i]];
+        const v1 = tri.vertexes[tri.indices[i + 1]];
+        const v2 = tri.vertexes[tri.indices[i + 2]];
+        try subdivideGouraudTri(
+            allocator,
+            &vtx,
+            &idx,
+            .{ .pos = v0.pos, .col = source.sample(v0.pos) },
+            .{ .pos = v1.pos, .col = source.sample(v1.pos) },
+            .{ .pos = v2.pos, .col = source.sample(v2.pos) },
+            source,
+            6, // max_depth: caps worst-case blowup at 4^6 leaf tris per source triangle
+        );
+    }
+
+    return .{
+        .vertexes = try vtx.toOwnedSlice(allocator),
+        .indices = try idx.toOwnedSlice(allocator),
+        .bounds = tri.bounds,
+    };
+}
+
+/// Per-channel tolerance (out of 255) for `gouraudShade`'s divergence test.
+const gouraud_tolerance: u8 = 6;
+
+fn pmaClose(a: Color.PMA, b: Color.PMA) bool {
+    return @abs(@as(i16, a.r) - b.r) <= gouraud_tolerance and
+        @abs(@as(i16, a.g) - b.g) <= gouraud_tolerance and
+        @abs(@as(i16, a.b) - b.b) <= gouraud_tolerance and
+        @abs(@as(i16, a.a) - b.a) <= gouraud_tolerance;
+}
+
+fn pmaMid(a: Color.PMA, b: Color.PMA) Color.PMA {
+    return .{
+        .r = lerpU8(a.r, b.r, 0.5),
+        .g = lerpU8(a.g, b.g, 0.5),
+        .b = lerpU8(a.b, b.b, 0.5),
+        .a = lerpU8(a.a, b.a, 0.5),
+    };
+}
+
+fn subdivideGouraudTri(
+    allocator: std.mem.Allocator,
+    vtx: *std.ArrayList(Vertex),
+    idx: *std.ArrayList(Vertex.Index),
+    v0: Vertex,
+    v1: Vertex,
+    v2: Vertex,
+    source: ColorSource,
+    depth: u8,
+) !void {
+    if (depth > 0) {
+        const m01p = mid(v0.pos, v1.pos);
+        const m12p = mid(v1.pos, v2.pos);
+        const m20p = mid(v2.pos, v0.pos);
+        const m01c = source.sample(m01p);
+        const m12c = source.sample(m12p);
+        const m20c = source.sample(m20p);
+
+        if (!pmaClose(m01c, pmaMid(v0.col, v1.col)) or
+            !pmaClose(m12c, pmaMid(v1.col, v2.col)) or
+            !pmaClose(m20c, pmaMid(v2.col, v0.col)))
+        {
+            const m01: Vertex = .{ .pos = m01p, .col = m01c };
+            const m12: Vertex = .{ .pos = m12p, .col = m12c };
+            const m20: Vertex = .{ .pos = m20p, .col = m20c };
+            try subdivideGouraudTri(allocator, vtx, idx, v0, m01, m20, source, depth - 1);
+            try subdivideGouraudTri(allocator, vtx, idx, m01, v1, m12, source, depth - 1);
+            try subdivideGouraudTri(allocator, vtx, idx, m20, m12, v2, source, depth - 1);
+            try subdivideGouraudTri(allocator, vtx, idx, m01, m12, m20, source, depth - 1);
+            return;
+        }
+    }
+
+    const base: Vertex.Index = @intCast(vtx.items.len);
+    try vtx.appendSlice(allocator, &.{ v0, v1, v2 });
+    try idx.appendSlice(allocator, &.{ base, base + 1, base + 2 });
 }
 
 /// Spec-compliant-ish stroke with round joins AND round caps - the style
@@ -568,7 +822,7 @@ fn strokePolylineRoundJoined(
         };
         var tri = try edge_path.strokeTriangles(allocator, .{
             .thickness = thickness,
-            .color = col,
+            .color = .{ .color = col },
             .closed = false,
             .endcap_style = .none,
         });
@@ -585,7 +839,7 @@ fn strokePolylineRoundJoined(
             .flat => |pma| pma.toColor(),
             else => source.sampleColor(p),
         };
-        var tri = try disc.fillConvexTriangles(allocator, .{ .color = col, .fade = 1.0 });
+        var tri = try disc.fillConvexTriangles(allocator, .{ .color = .{ .color = col }, .fade = 1.0 });
         defer tri.deinit(allocator);
         try mesh.appendMesh(tri);
     }
@@ -688,10 +942,11 @@ fn flattenSegment(
     }
 }
 
-/// Adaptive subdivision of a cubic Bezier - emits points up to a chord
-/// tolerance of ~0.5 px in the OUTPUT (physical pixel) space.  Endpoint p0
-/// is assumed already in `out`; only p1, intermediate, and final points
-/// are appended.
+/// Adaptive subdivision of a cubic Bezier, delegating to
+/// `Path.Builder.addCubicBezier` (same 0.5px chord-deviation tolerance
+/// already used everywhere else in dvui) instead of reimplementing de
+/// Casteljau subdivision here. Endpoint p0 is assumed already in `out`;
+/// only p1, intermediate, and final points are appended.
 fn flattenCubic(
     out: *std.ArrayList(Point),
     alloc: std.mem.Allocator,
@@ -701,46 +956,11 @@ fn flattenCubic(
     p2: tvg.Point,
     p3: tvg.Point,
 ) !void {
-    const tol_sq: f32 = 0.25;
-
-    const Frame = struct { p0: Point, p1: Point, p2: Point, p3: Point, depth: u8 };
-    var stack: [32]Frame = undefined;
-    var sp: usize = 0;
-    stack[sp] = .{
-        .p0 = xf.apply(p0),
-        .p1 = xf.apply(p1),
-        .p2 = xf.apply(p2),
-        .p3 = xf.apply(p3),
-        .depth = 24,
-    };
-    sp += 1;
-
-    while (sp > 0) {
-        sp -= 1;
-        const f = stack[sp];
-
-        // Flatness test: max distance from p1, p2 to chord p0-p3.
-        const d1 = pointLineDistSq(f.p1, f.p0, f.p3);
-        const d2 = pointLineDistSq(f.p2, f.p0, f.p3);
-        if (f.depth == 0 or @max(d1, d2) <= tol_sq) {
-            try out.append(alloc, f.p3);
-            continue;
-        }
-
-        // de Casteljau split.
-        const m01 = mid(f.p0, f.p1);
-        const m12 = mid(f.p1, f.p2);
-        const m23 = mid(f.p2, f.p3);
-        const m012 = mid(m01, m12);
-        const m123 = mid(m12, m23);
-        const m0123 = mid(m012, m123);
-
-        // Push RIGHT half first so LEFT is processed next (preserves order).
-        stack[sp] = .{ .p0 = m0123, .p1 = m123, .p2 = m23, .p3 = f.p3, .depth = f.depth - 1 };
-        sp += 1;
-        stack[sp] = .{ .p0 = f.p0, .p1 = m01, .p2 = m012, .p3 = m0123, .depth = f.depth - 1 };
-        sp += 1;
-    }
+    var builder: Path.Builder = .init(alloc);
+    defer builder.deinit();
+    builder.addCubicBezier(xf.apply(p0), xf.apply(p1), xf.apply(p2), xf.apply(p3));
+    // `addCubicBezier` includes p0, which is already in `out`.
+    try out.appendSlice(alloc, builder.build().points[1..]);
 }
 
 fn flattenQuadratic(
@@ -751,16 +971,10 @@ fn flattenQuadratic(
     p1: tvg.Point,
     p2: tvg.Point,
 ) !void {
-    // Promote to cubic: c0 = p0 + 2/3 (p1 - p0), c1 = p2 + 2/3 (p1 - p2).
-    const c0 = tvg.Point{
-        .x = p0.x + (2.0 / 3.0) * (p1.x - p0.x),
-        .y = p0.y + (2.0 / 3.0) * (p1.y - p0.y),
-    };
-    const c1 = tvg.Point{
-        .x = p2.x + (2.0 / 3.0) * (p1.x - p2.x),
-        .y = p2.y + (2.0 / 3.0) * (p1.y - p2.y),
-    };
-    try flattenCubic(out, alloc, xf, p0, c0, c1, p2);
+    var builder: Path.Builder = .init(alloc);
+    defer builder.deinit();
+    builder.addQuadBezier(xf.apply(p0), xf.apply(p1), xf.apply(p2));
+    try out.appendSlice(alloc, builder.build().points[1..]);
 }
 
 /// SVG arc -> center-parameterization -> sampled chord.  Reference:
@@ -920,21 +1134,6 @@ fn mid(a: Point, b: Point) Point {
     return .{ .x = (a.x + b.x) * 0.5, .y = (a.y + b.y) * 0.5 };
 }
 
-fn pointLineDistSq(p: Point, a: Point, b: Point) f32 {
-    const dx = b.x - a.x;
-    const dy = b.y - a.y;
-    const len_sq = dx * dx + dy * dy;
-    if (len_sq < 1e-12) {
-        const ex = p.x - a.x;
-        const ey = p.y - a.y;
-        return ex * ex + ey * ey;
-    }
-    // Perpendicular distance^2 from p to infinite line a-b (sufficient for
-    // adaptive subdivision flatness).
-    const num = dx * (a.y - p.y) - (a.x - p.x) * dy;
-    return (num * num) / len_sq;
-}
-
 fn approxEqPoint(a: Point, b: Point) bool {
     const dx = a.x - b.x;
     const dy = a.y - b.y;
@@ -964,6 +1163,108 @@ fn collapseRunDuplicates(pts: *std.ArrayList(Point)) void {
     pts.shrinkRetainingCapacity(w);
 }
 
+// Manual visual-verification tool (no assertions): renders an icon with a
+// radial gradient fill so the adaptive Gouraud subdivision in
+// `gouraudShade` can be screenshotted. Star/circle fills are just their
+// outline vertices - large, sparse triangles where naive per-vertex
+// Gouraud shading of a non-affine (radial) color function visibly
+// diverges from a true circular gradient.
+//
+// Run with (from repo root): zig build test -Dtest-filter="DOCIMG icon gradient" -Dimage-dir=/tmp/gradient-compare/dvui
+test "DOCIMG icon gradient radial" {
+    const size: dvui.Size = .{ .w = 200, .h = 200 };
+    var t = try dvui.testing.init(.{ .window_size = size });
+    defer t.deinit();
+
+    const red: Color = .{ .r = 255, .g = 80, .b = 80, .a = 255 };
+    const blue: Color = .{ .r = 80, .g = 120, .b = 255, .a = 255 };
+
+    const Sample = struct {
+        fn frame() !dvui.App.Result {
+            dvui.icon(@src(), "star", dvui.entypo.star, .{
+                .fill_color = .{ .gradient = .{ .radial = .{
+                    .stops = &.{ .{ .color = red, .offset = 0 }, .{ .color = blue, .offset = 1 } },
+                } } },
+            }, .{ .expand = .both });
+            return .ok;
+        }
+    };
+    try t.saveImage(Sample.frame, null, "icon-star-radial-gradient.png");
+}
+
+/// Mirrors `dvui.testing.capturePng`'s frame/Picture dance but returns raw
+/// premultiplied pixels instead of encoding, so a test can inspect alpha
+/// directly (e.g. to compare edge-AA ramps between two renders).
+fn captureIconPixels(alloc: std.mem.Allocator, frame: dvui.App.frameFunction, rect: Rect) ![]Color.PMA {
+    var picture = dvui.Picture.start(rect) orelse return error.Unsupported;
+    if (try frame() == .close) return error.Closed;
+    _ = dvui.currentWindow().endRendering(.{});
+    picture.stop();
+    const pixels = try dvui.textureReadTarget(alloc, picture.texture);
+    picture.deinit();
+
+    const cw = dvui.currentWindow();
+    _ = try cw.end(.{});
+    try cw.begin(cw.frame_time_ns + 100 * std.time.ns_per_ms);
+    return pixels;
+}
+
+// Regression test for the "gradient icons look pixelated compared to flat
+// icons" bug: a flat fill and a same-colored 2-stop gradient fill of the
+// same icon should produce (almost) identical rendered alpha, including the
+// partially-transparent edge-AA ring. Before `gouraudFadeBand`, the
+// gradient render had zero partially-transparent pixels (fade was forced to
+// 0), so this would have failed on `partial_alpha_grad > 20`.
+test "gradient icon fill AA matches flat" {
+    const size: dvui.Size = .{ .w = 60, .h = 60 };
+    var t = try dvui.testing.init(.{ .window_size = size });
+    defer t.deinit();
+
+    const white: Color = .{ .r = 255, .g = 255, .b = 255, .a = 255 };
+
+    const FlatSample = struct {
+        fn frame() !dvui.App.Result {
+            dvui.icon(@src(), "star", dvui.entypo.star, .{
+                .fill_color = .{ .color = white },
+            }, .{ .expand = .both });
+            return .ok;
+        }
+    };
+    const GradientSample = struct {
+        fn frame() !dvui.App.Result {
+            dvui.icon(@src(), "star", dvui.entypo.star, .{
+                .fill_color = .{ .gradient = .{ .linear = .{
+                    .stops = &.{ .{ .color = white, .offset = 0 }, .{ .color = white, .offset = 1 } },
+                } } },
+            }, .{ .expand = .both });
+            return .ok;
+        }
+    };
+
+    const rect = dvui.windowRectPixels();
+    const flat = try captureIconPixels(std.testing.allocator, FlatSample.frame, rect);
+    defer std.testing.allocator.free(flat);
+    const grad = try captureIconPixels(std.testing.allocator, GradientSample.frame, rect);
+    defer std.testing.allocator.free(grad);
+
+    try std.testing.expectEqual(flat.len, grad.len);
+
+    var partial_alpha_flat: usize = 0;
+    var partial_alpha_grad: usize = 0;
+    var max_alpha_diff: u8 = 0;
+    for (flat, grad) |f, g| {
+        if (f.a > 0 and f.a < 255) partial_alpha_flat += 1;
+        if (g.a > 0 and g.a < 255) partial_alpha_grad += 1;
+        const d: u8 = if (f.a > g.a) f.a - g.a else g.a - f.a;
+        max_alpha_diff = @max(max_alpha_diff, d);
+    }
+
+    std.debug.print("partial_alpha_flat={d} partial_alpha_grad={d} max_alpha_diff={d}\n", .{ partial_alpha_flat, partial_alpha_grad, max_alpha_diff });
+    try std.testing.expect(partial_alpha_flat > 20);
+    try std.testing.expect(partial_alpha_grad > 20);
+    try std.testing.expect(max_alpha_diff <= 2);
+}
+
 const std = @import("std");
 const math = std.math;
 const dvui = @import("dvui.zig");
@@ -979,6 +1280,8 @@ const Color = dvui.Color;
 const Vertex = dvui.Vertex;
 const Triangles = dvui.Triangles;
 const Path = dvui.Path;
+const Gradient = dvui.Gradient;
+const ColorOrGradient = dvui.ColorOrGradient;
 
 test {
     std.testing.refAllDecls(@This());

--- a/src/render_tvg.zig
+++ b/src/render_tvg.zig
@@ -107,9 +107,6 @@ pub const MeshBuilder = struct {
     }
 };
 
-/// Per-icon triangle-mesh cache.  Entries are keyed by a hash of the tvg
-/// bytes pointer, authoring height, and icon render options; evicted if
-/// not accessed since the previous `reset`.
 pub const MeshCache = struct {
     cache: Storage = .empty,
 
@@ -614,6 +611,10 @@ fn withDefaultAnchor(g: Gradient, bounds: Rect) Gradient {
     return out;
 }
 
+/// Fill one or more closed contours (outers AND holes, any winding) via
+/// `dvui.Path.fillTriangles`'s nonzero-winding trapezoidal decomposition -
+/// concave shapes, holes, and small self-intersections (left over from
+/// bezier/arc flattening) are all handled without a bespoke triangulator.
 fn fillContoursPhysical(
     allocator: std.mem.Allocator,
     mesh: *MeshBuilder,
@@ -642,6 +643,15 @@ fn fillContoursPhysical(
     try mesh.appendMesh(tri, tex_key);
 }
 
+/// Spec-compliant-ish stroke with round joins AND round caps - the style
+/// SVG-origin icons (feather, lucide, entypo, ...) are authored for.
+///
+/// `dvui.Path.strokeTriangles` only does miter joins and square/none caps,
+/// so each edge is stroked separately with butt caps (no overlap, no miter
+/// spikes at sharp corners), and a filled disc is placed at every vertex to
+/// act as the round join (filling the wedge between adjacent edges) and,
+/// for open paths, the round cap at each endpoint.  Both primitives get
+/// `dvui`'s normal 1px AA fade.
 fn strokePolylineRoundJoined(
     allocator: std.mem.Allocator,
     mesh: *MeshBuilder,
@@ -733,7 +743,9 @@ fn strokePolylineTvg(
 // ---------------------------------------------------------------------------
 
 /// Flatten one TVG path segment into a polyline of physical points.
-/// Per-node `line_width` is ignored
+/// Per-node `line_width` is ignored - fills don't use it, and strokes use
+/// the command-level line_width (per-node widths would need segment-wise
+/// stroking, which isn't supported).
 fn flattenSegment(
     segment: tvg.Path.Segment,
     xf: Transform,

--- a/src/render_tvg.zig
+++ b/src/render_tvg.zig
@@ -51,6 +51,17 @@ pub const MeshBuilder = struct {
     bounds_min_y: f32 = math.floatMax(f32),
     bounds_max_x: f32 = -math.floatMax(f32),
     bounds_max_y: f32 = -math.floatMax(f32),
+    /// Ramp texture from the first gradient fill appended, if any - see
+    /// `appendMesh`. `renderIcon` binds this for the whole mesh's one draw
+    /// call.
+    tex: ?dvui.Texture = null,
+    /// `dvui.textureRetain`/`textureRelease` key for `tex`, if set - see
+    /// `renderIcon`. This mesh (unlike a normal per-frame gradient fill)
+    /// gets cached and replayed across frames without re-touching `tex` in
+    /// the global texture cache, so whoever puts this mesh in
+    /// `Window.icon_mesh_cache` must retain `tex_key` explicitly or it gets
+    /// destroyed out from under the cached mesh after one frame.
+    tex_key: ?dvui.Texture.Cache.Key = null,
 
     pub fn init(alloc: std.mem.Allocator) MeshBuilder {
         return .{ .alloc = alloc };
@@ -61,10 +72,7 @@ pub const MeshBuilder = struct {
         self.idx.deinit(self.alloc);
     }
 
-    /// Append another mesh's vertices/indices into this one, rebasing
-    /// indices by the current vertex count.  Borrows `src` - caller still
-    /// owns and must free it.
-    fn appendMesh(self: *MeshBuilder, src: Triangles) !void {
+    fn appendMesh(self: *MeshBuilder, src: Triangles, tex_key: ?dvui.Texture.Cache.Key) !void {
         if (src.vertexes.len == 0 or src.indices.len == 0) return;
         const base: Vertex.Index = @intCast(self.vtx.items.len);
         try self.vtx.appendSlice(self.alloc, src.vertexes);
@@ -75,6 +83,10 @@ pub const MeshBuilder = struct {
             if (v.pos.y < self.bounds_min_y) self.bounds_min_y = v.pos.y;
             if (v.pos.x > self.bounds_max_x) self.bounds_max_x = v.pos.x;
             if (v.pos.y > self.bounds_max_y) self.bounds_max_y = v.pos.y;
+        }
+        if (self.tex == null) {
+            self.tex = src.texture;
+            if (src.texture != null) self.tex_key = tex_key;
         }
     }
 
@@ -90,6 +102,7 @@ pub const MeshBuilder = struct {
                 .w = self.bounds_max_x - self.bounds_min_x,
                 .h = self.bounds_max_y - self.bounds_min_y,
             },
+            .texture = self.tex,
         };
     }
 };
@@ -106,20 +119,23 @@ pub const MeshCache = struct {
         return self.cache.get(key);
     }
 
-    /// Add a mesh to the cache. Frees any mesh it replaces.
     pub fn add(self: *MeshCache, gpa: std.mem.Allocator, key: u64, mesh: MeshBuilder) std.mem.Allocator.Error!void {
         const prev = try self.cache.fetchPut(gpa, key, mesh);
         if (prev) |kv| {
             var m = kv.value;
+            if (m.tex_key) |k| dvui.textureRelease(k);
             m.deinit();
         }
     }
 
-    /// Frees every mesh that was not accessed since the last call to `reset`.
+    /// Frees every mesh that was not accessed since the last call to
+    /// `reset`, releasing its retained gradient texture (see
+    /// `MeshBuilder.tex_key`) first.
     pub fn reset(self: *MeshCache) void {
         var it = self.cache.iterator();
         while (it.next_resetting()) |kv| {
             var m = kv.value;
+            if (m.tex_key) |k| dvui.textureRelease(k);
             m.deinit();
         }
     }
@@ -132,14 +148,6 @@ pub const MeshCache = struct {
     }
 };
 
-/// Hashes `v` field-by-field, following only the active tag of unions and
-/// the contents (not pointer) of slices. `icon_opts.fill_color`/
-/// `stroke_color` are `?ColorOrGradient`, a union whose `.gradient` payload
-/// is much larger than `.color` - `std.mem.asBytes` on the union would read
-/// uninitialized trailing bytes whenever the active tag is `.color`, making
-/// the cache key nondeterministic. `std.hash.autoHashStrat` can't be used
-/// directly since it rejects float fields (`Gradient` has many); bitcast
-/// floats to same-width ints ourselves instead.
 fn hashValue(h: *dvui.fnv, v: anytype) void {
     const T = @TypeOf(v);
     switch (@typeInfo(T)) {
@@ -174,9 +182,6 @@ fn hashValue(h: *dvui.fnv, v: anytype) void {
     }
 }
 
-/// Draws `tvg_bytes` scaled to fit `rs`, using `Window.icon_mesh_cache` to
-/// avoid re-triangulating unchanged icons every frame.
-///
 /// Only valid between `Window.begin` and `Window.end`.
 pub fn renderIcon(name: []const u8, tvg_bytes: []const u8, rs: dvui.RectScale, opts: dvui.render.TextureOptions, icon_opts: dvui.IconRenderOptions) Backend.TextureError!void {
     if (rs.s == 0) return;
@@ -218,13 +223,34 @@ pub fn renderIcon(name: []const u8, tvg_bytes: []const u8, rs: dvui.RectScale, o
             return;
         };
 
+        // `mesh` outlives this single render call (it's about to go into
+        // `icon_mesh_cache` and get replayed frame after frame), but its
+        // gradient ramp texture (if any) lives in the global texture cache,
+        // which frees anything not re-touched within one frame. Retain it
+        // now so `MeshCache.add`'s errdefer path below can safely release
+        // it; the retain that keeps it alive long-term is re-asserted
+        // every frame this entry is actually used (see below).
+        if (mesh.tex_key) |k| dvui.textureRetain(k);
+
         cw.icon_mesh_cache.add(cw.gpa, hash, mesh) catch |err| {
+            if (mesh.tex_key) |k| dvui.textureRelease(k);
             mesh.deinit();
             dvui.logError(@src(), err, "Could not cache mesh for icon \"{s}\"", .{name});
             return;
         };
         break :blk mesh;
     };
+
+    // Re-touch the retain every frame this cache entry is used (not just
+    // when it's built): a gradient's ramp texture is keyed only by its
+    // stops/alpha, so a *different* mesh entry can share this same
+    // `tex_key` (e.g. this same icon rebuilt every frame while an angle
+    // animates, evicting the previous frame's entry each time). Evicting
+    // that other entry releases the shared key (see `MeshCache.reset`),
+    // which would otherwise leave this still-live entry's texture
+    // unretained and unretouched (a cache hit skips `Gradient.apply`)
+    // until it's destroyed out from under a later frame's render.
+    if (mesh.tex_key) |k| dvui.textureRetain(k);
 
     if (mesh.idx.items.len == 0) return;
 
@@ -255,16 +281,9 @@ pub fn renderIcon(name: []const u8, tvg_bytes: []const u8, rs: dvui.RectScale, o
 
     tri.color(opts.colormod.opacity(cw.alpha));
 
-    try dvui.renderTriangles(tri, null);
+    try dvui.renderTriangles(tri, tri.texture);
 }
 
-/// Walk a TVG byte stream and APPEND its triangles to `mesh`, anchored at
-/// `rect`'s origin in physical pixels.  No submission happens - caller
-/// decides when (and how many times) to draw the resulting mesh.
-///
-/// `scratch_alloc` is used for the parser and all transient triangle data;
-/// pass an arena so it can be freed in bulk.  The persistent vertex/index
-/// storage lives in `mesh.alloc`.
 pub fn appendTvg(
     scratch_alloc: std.mem.Allocator,
     mesh: *MeshBuilder,
@@ -411,10 +430,6 @@ fn tvgColorToDvui(c: tvg.Color) Color {
     };
 }
 
-/// A position-keyed color source used to colour every vertex of a fill or
-/// stroke primitive.  Gradients are sampled per-vertex (Gouraud-shaded -
-/// close enough to a true gradient at icon resolutions).  Override
-/// short-circuits gradients to a flat color.
 const ColorSource = union(enum) {
     flat: Color.PMA,
     linear: struct {
@@ -430,35 +445,30 @@ const ColorSource = union(enum) {
         edge: Point,
     },
     /// A caller-supplied `dvui.Gradient` override (from
-    /// `IconRenderOptions.fill_color`/`stroke_color`), sampled analytically
-    /// against the icon's bounding box.
-    dvui_gradient: struct {
-        gradient: Gradient,
-        bounds: Rect,
-    },
+    /// `IconRenderOptions.fill_color`/`stroke_color`), already anchored to
+    /// the icon's bounding box by `colorSourceFromOverride`.
+    dvui_gradient: Gradient,
+
+    /// Builds the equivalent `dvui.Gradient` for any non-`.flat` source.
+    /// `storage` backs the synthesized 2-stop slice for `.linear`/`.radial`
+    /// and must outlive the returned `Gradient`'s use (`.dvui_gradient`
+    /// already owns caller-provided stops and ignores it).
+    fn toGradient(self: ColorSource, storage: *[2]Gradient.Stop) Gradient {
+        return switch (self) {
+            .flat => unreachable,
+            .linear => |g| linearGradientBetween(storage, g.c0, g.c1, g.p0, g.p1),
+            .radial => |g| radialGradientBetween(storage, g.c0, g.c1, g.center, g.edge),
+            .dvui_gradient => |g| g,
+        };
+    }
 
     fn sampleColor(self: ColorSource, p: Point) Color {
         return switch (self) {
             .flat => |pma| pma.toColor(),
-            .linear => |g| blk: {
-                const dx = g.p1.x - g.p0.x;
-                const dy = g.p1.y - g.p0.y;
-                const dlen_sq = dx * dx + dy * dy;
-                if (dlen_sq < 1e-9) break :blk g.c0;
-                const t = math.clamp(((p.x - g.p0.x) * dx + (p.y - g.p0.y) * dy) / dlen_sq, 0, 1);
-                break :blk lerpColor(g.c0, g.c1, t);
+            else => blk: {
+                var storage: [2]Gradient.Stop = undefined;
+                break :blk self.toGradient(&storage).sample(.{}, p);
             },
-            .radial => |g| blk: {
-                const rdx = g.edge.x - g.center.x;
-                const rdy = g.edge.y - g.center.y;
-                const radius = @sqrt(rdx * rdx + rdy * rdy);
-                if (radius < 1e-9) break :blk g.c0;
-                const dx = p.x - g.center.x;
-                const dy = p.y - g.center.y;
-                const t = math.clamp(@sqrt(dx * dx + dy * dy) / radius, 0, 1);
-                break :blk lerpColor(g.c0, g.c1, t);
-            },
-            .dvui_gradient => |g| g.gradient.sample(g.bounds, p),
         };
     }
 
@@ -470,19 +480,59 @@ const ColorSource = union(enum) {
     }
 };
 
-fn lerpU8(a: u8, b: u8, t: f32) u8 {
-    const af = @as(f32, @floatFromInt(a));
-    const bf = @as(f32, @floatFromInt(b));
-    return @intFromFloat(math.clamp(af + (bf - af) * t, 0, 255));
+/// Builds a `dvui.Gradient.linear` whose `t=0`/`t=1` points are exactly
+/// `p0`/`p1` - not derived from any shape's bounding box - by picking a
+/// synthetic `anchor` sized so `Gradient.linearT`'s box-projection formula
+/// reduces to a plain projection onto the `p0->p1` segment (all the
+/// projected half-extent is put on whichever axis the segment is more
+/// aligned with; the other axis gets a zero half-extent, which
+/// `Gradient.sampleRaw`'s degenerate check tolerates as long as the other
+/// axis is nonzero). Lets TVG's native 2-point linear gradient style go
+/// through `Path.fillTriangles`'s gradient support (ramp texture + UV)
+/// instead of a bespoke per-vertex Gouraud shader.
+fn linearGradientBetween(storage: *[2]Gradient.Stop, c0: Color, c1: Color, p0: Point, p1: Point) Gradient {
+    storage.* = .{ .{ .color = c0, .offset = 0 }, .{ .color = c1, .offset = 1 } };
+    const dx = p1.x - p0.x;
+    const dy = p1.y - p0.y;
+    const len = @sqrt(dx * dx + dy * dy);
+    if (len < 1e-6) {
+        return .{ .linear = .{ .stops = storage, .anchor = .{ .x = p0.x, .y = p0.y, .w = 0, .h = 0 } } };
+    }
+    const adx = @abs(dx) / len;
+    const ady = @abs(dy) / len;
+    const half = len / 2;
+    var hx: f32 = 0;
+    var hy: f32 = 0;
+    if (adx >= ady) hx = half / adx else hy = half / ady;
+    return .{ .linear = .{
+        .stops = storage,
+        .angle_degrees = math.radiansToDegrees(math.atan2(dy, dx)),
+        .anchor = .{
+            .x = (p0.x + p1.x) / 2 - hx,
+            .y = (p0.y + p1.y) / 2 - hy,
+            .w = 2 * hx,
+            .h = 2 * hy,
+        },
+    } };
 }
 
-fn lerpColor(a: Color, b: Color, t: f32) Color {
-    return .{
-        .r = lerpU8(a.r, b.r, t),
-        .g = lerpU8(a.g, b.g, t),
-        .b = lerpU8(a.b, b.b, t),
-        .a = lerpU8(a.a, b.a, t),
-    };
+/// Builds a `dvui.Gradient.radial` whose ending circle is exactly
+/// `center`/`|edge - center|` - not derived from any shape's bounding box -
+/// via an explicit `.circle{.radius=}` and an `anchor` centered on `center`.
+/// See `linearGradientBetween`.
+fn radialGradientBetween(storage: *[2]Gradient.Stop, c0: Color, c1: Color, center: Point, edge: Point) Gradient {
+    storage.* = .{ .{ .color = c0, .offset = 0 }, .{ .color = c1, .offset = 1 } };
+    const dx = edge.x - center.x;
+    const dy = edge.y - center.y;
+    const radius = @sqrt(dx * dx + dy * dy);
+    if (radius < 1e-6) {
+        return .{ .radial = .{ .stops = storage, .anchor = .{ .x = center.x, .y = center.y, .w = 0, .h = 0 } } };
+    }
+    return .{ .radial = .{
+        .stops = storage,
+        .shape = .{ .circle = .{ .radius = radius } },
+        .anchor = .{ .x = center.x - radius, .y = center.y - radius, .w = 2 * radius, .h = 2 * radius },
+    } };
 }
 
 /// Build a `ColorSource` from a TVG style.  Override forces flat.  Gradient
@@ -491,7 +541,7 @@ fn lerpColor(a: Color, b: Color, t: f32) Color {
 fn colorSourceFromOverride(c: ColorOrGradient, bounds: Rect) ColorSource {
     return switch (c) {
         .color => |col| .{ .flat = .fromColor(col) },
-        .gradient => |g| .{ .dvui_gradient = .{ .gradient = g, .bounds = bounds } },
+        .gradient => |g| .{ .dvui_gradient = withDefaultAnchor(g, bounds) },
     };
 }
 
@@ -548,17 +598,22 @@ fn strokeLine(allocator: std.mem.Allocator, mesh: *MeshBuilder, p0: Point, p1: P
     try strokePolylineRoundJoined(allocator, mesh, &pts, false, thickness, source);
 }
 
-/// Fill one or more closed contours (outers AND holes, any winding) via
-/// `dvui.Path.fillTriangles`'s nonzero-winding trapezoidal decomposition -
-/// concave shapes, holes, and small self-intersections (left over from
-/// bezier/arc flattening) are all handled without a bespoke triangulator.
-///
-/// Flat colors get their edge AA from `Path.fillTriangles`'s `fade` (a
-/// uniform fade-to-transparent band works for a single color). Gradients
-/// can't reuse that band directly - color varies across it - so instead we
-/// Gouraud-shade the opaque interior (unchanged) and add a second band,
-/// `gouraudFadeBand`, that analytically samples `source` per boundary vertex
-/// while fading alpha to 0, giving gradients the same edge AA flat fills get.
+fn withDefaultAnchor(g: Gradient, bounds: Rect) Gradient {
+    var out = g;
+    switch (out) {
+        .linear => |*l| if (l.anchor == null) {
+            l.anchor = bounds;
+        },
+        .radial => |*r| if (r.anchor == null) {
+            r.anchor = bounds;
+        },
+        .scattered => |*s| if (s.anchor == null) {
+            s.anchor = bounds;
+        },
+    }
+    return out;
+}
+
 fn fillContoursPhysical(
     allocator: std.mem.Allocator,
     mesh: *MeshBuilder,
@@ -572,229 +627,21 @@ fn fillContoursPhysical(
     defer allocator.free(paths);
     for (contours, 0..) |c, i| paths[i] = .{ .points = c };
 
-    switch (source) {
-        .flat => |pma| {
-            var tri = try Path.fillTriangles(allocator, paths, .{
-                .color = .{ .color = pma.toColor() },
-                .fade = fade,
-                .fill_rule = .nonzero,
-            });
-            defer tri.deinit(allocator);
-            try mesh.appendMesh(tri);
-        },
-        else => {
-            var tri = try Path.fillTriangles(allocator, paths, .{
-                .color = .white,
-                .fade = 0,
-                .fill_rule = .nonzero,
-            });
-            defer tri.deinit(allocator);
-            var shaded = try gouraudShade(allocator, tri, source);
-            defer shaded.deinit(allocator);
-            try mesh.appendMesh(shaded);
-
-            if (fade > 0) {
-                var band = try gouraudFadeBand(allocator, contours, source, fade);
-                defer band.deinit(allocator);
-                try mesh.appendMesh(band);
-            }
-        },
-    }
-}
-
-/// Edge-AA band for non-flat `ColorSource`s: same outward-normal offset
-/// technique as `Path.fillConvexTriangles`/`fillAppendFade` (inner vertex on
-/// the true boundary minus half the fade, outer vertex plus the rest, faded
-/// to transparent), but sampling `source` analytically per boundary vertex
-/// instead of using one flat color.
-///
-/// Operates on the raw per-subpath contours rather than `Path.fillTriangles`'s
-/// resolved boundary, so overlapping/self-intersecting contours (rare - left
-/// over from bezier/arc flattening) can double up faded coverage at the
-/// overlap. Icons don't hit this in practice; revisit if one does.
-///
-/// `fillConvexTriangles`/`fillAppendFade` can hardcode which way the offset
-/// formula points because their input winding is caller-controlled or
-/// already normalized by earcut's boundary resolution. Raw TVG contours
-/// carry whatever winding the source file used, so each contour's own
-/// signed area decides which sign makes the offset point outward.
-fn gouraudFadeBand(allocator: std.mem.Allocator, contours: []const []const Point, source: ColorSource, fade: f32) !Triangles {
-    var vtx: std.ArrayList(Vertex) = .empty;
-    errdefer vtx.deinit(allocator);
-    var idx: std.ArrayList(Vertex.Index) = .empty;
-    errdefer idx.deinit(allocator);
-
-    const inside_len = @min(0.5, fade / 2);
-    const outside_len = if (fade <= 1) fade / 2 else fade - 0.5;
-
-    for (contours) |pts| {
-        const n = pts.len;
-        if (n < 3) continue;
-
-        var area2: f32 = 0;
-        for (0..n) |i| {
-            const p = pts[i];
-            const q = pts[(i + 1) % n];
-            area2 += p.x * q.y - q.x * p.y;
-        }
-        const sign: f32 = if (area2 > 0) -1 else 1;
-
-        const inner_idx = try allocator.alloc(Vertex.Index, n);
-        defer allocator.free(inner_idx);
-        const outer_idx = try allocator.alloc(Vertex.Index, n);
-        defer allocator.free(outer_idx);
-
-        for (0..n) |i| {
-            const aa = pts[(i + n - 1) % n];
-            const bb = pts[i];
-            const cc = pts[(i + 1) % n];
-            const diffab = aa.diff(bb).normalize();
-            const diffbc = bb.diff(cc).normalize();
-            var norm: Point = .{
-                .x = sign * (diffab.y + diffbc.y) / 2,
-                .y = sign * (-diffab.x - diffbc.x) / 2,
-            };
-
-            inner_idx[i] = @intCast(vtx.items.len);
-            try vtx.append(allocator, .{
-                .pos = .{ .x = bb.x - norm.x * inside_len, .y = bb.y - norm.y * inside_len },
-                .col = .fromColor(source.sampleColor(bb)),
-            });
-
-            const d2 = norm.x * norm.x + norm.y * norm.y;
-            if (d2 > 0.000001) norm = norm.scale(1.0 / d2, Point);
-            const l = norm.length();
-            if (l > 2.0) norm = norm.scale(2.0 / l, Point);
-
-            outer_idx[i] = @intCast(vtx.items.len);
-            try vtx.append(allocator, .{
-                .pos = .{ .x = bb.x + norm.x * outside_len, .y = bb.y + norm.y * outside_len },
-                .col = .transparent,
-            });
-        }
-
-        for (0..n) |i| {
-            const j = (i + 1) % n;
-            try idx.appendSlice(allocator, &.{ inner_idx[i], outer_idx[i], inner_idx[j] });
-            try idx.appendSlice(allocator, &.{ outer_idx[i], outer_idx[j], inner_idx[j] });
-        }
-    }
-
-    return .{
-        .vertexes = try vtx.toOwnedSlice(allocator),
-        .indices = try idx.toOwnedSlice(allocator),
-        .bounds = .{},
+    var storage: [2]Gradient.Stop = undefined;
+    const color: ColorOrGradient = switch (source) {
+        .flat => |pma| .{ .color = pma.toColor() },
+        else => .{ .gradient = source.toGradient(&storage) },
     };
+    const tex_key: ?dvui.Texture.Cache.Key = if (color == .gradient) color.gradient.textureCacheKey(.{}) else null;
+    var tri = try Path.fillTriangles(allocator, paths, .{
+        .color = color,
+        .fade = fade,
+        .fill_rule = .nonzero,
+    });
+    defer tri.deinit(allocator);
+    try mesh.appendMesh(tri, tex_key);
 }
 
-/// Re-triangulates `tri` (a flat, white-colored fill straight out of
-/// `Path.fillTriangles`) with per-vertex colors from `source`, adaptively
-/// splitting each triangle wherever plain Gouraud interpolation (lerping the
-/// 3 corner colors) would visibly diverge from the source's true analytic
-/// color. Icon fills are just the polygon's own outline vertices - large,
-/// sparse triangles - so a corner-only sample is exact for an affine color
-/// function (flat, or 2-stop `linear`) but visibly wrong for anything
-/// curved (`radial`, `scattered`, multi-stop `linear`): edge midpoints then
-/// read closer to a straight blend of the corners than to the source's
-/// actual (e.g. circular) isolines. Recursion bottoms out once every edge's
-/// analytic midpoint color is within tolerance of its Gouraud-lerped color,
-/// or at `max_depth`.
-fn gouraudShade(allocator: std.mem.Allocator, tri: Triangles, source: ColorSource) !Triangles {
-    var vtx = std.ArrayList(Vertex).empty;
-    errdefer vtx.deinit(allocator);
-    var idx = std.ArrayList(Vertex.Index).empty;
-    errdefer idx.deinit(allocator);
-
-    var i: usize = 0;
-    while (i < tri.indices.len) : (i += 3) {
-        const v0 = tri.vertexes[tri.indices[i]];
-        const v1 = tri.vertexes[tri.indices[i + 1]];
-        const v2 = tri.vertexes[tri.indices[i + 2]];
-        try subdivideGouraudTri(
-            allocator,
-            &vtx,
-            &idx,
-            .{ .pos = v0.pos, .col = source.sample(v0.pos) },
-            .{ .pos = v1.pos, .col = source.sample(v1.pos) },
-            .{ .pos = v2.pos, .col = source.sample(v2.pos) },
-            source,
-            6, // max_depth: caps worst-case blowup at 4^6 leaf tris per source triangle
-        );
-    }
-
-    return .{
-        .vertexes = try vtx.toOwnedSlice(allocator),
-        .indices = try idx.toOwnedSlice(allocator),
-        .bounds = tri.bounds,
-    };
-}
-
-/// Per-channel tolerance (out of 255) for `gouraudShade`'s divergence test.
-const gouraud_tolerance: u8 = 6;
-
-fn pmaClose(a: Color.PMA, b: Color.PMA) bool {
-    return @abs(@as(i16, a.r) - b.r) <= gouraud_tolerance and
-        @abs(@as(i16, a.g) - b.g) <= gouraud_tolerance and
-        @abs(@as(i16, a.b) - b.b) <= gouraud_tolerance and
-        @abs(@as(i16, a.a) - b.a) <= gouraud_tolerance;
-}
-
-fn pmaMid(a: Color.PMA, b: Color.PMA) Color.PMA {
-    return .{
-        .r = lerpU8(a.r, b.r, 0.5),
-        .g = lerpU8(a.g, b.g, 0.5),
-        .b = lerpU8(a.b, b.b, 0.5),
-        .a = lerpU8(a.a, b.a, 0.5),
-    };
-}
-
-fn subdivideGouraudTri(
-    allocator: std.mem.Allocator,
-    vtx: *std.ArrayList(Vertex),
-    idx: *std.ArrayList(Vertex.Index),
-    v0: Vertex,
-    v1: Vertex,
-    v2: Vertex,
-    source: ColorSource,
-    depth: u8,
-) !void {
-    if (depth > 0) {
-        const m01p = mid(v0.pos, v1.pos);
-        const m12p = mid(v1.pos, v2.pos);
-        const m20p = mid(v2.pos, v0.pos);
-        const m01c = source.sample(m01p);
-        const m12c = source.sample(m12p);
-        const m20c = source.sample(m20p);
-
-        if (!pmaClose(m01c, pmaMid(v0.col, v1.col)) or
-            !pmaClose(m12c, pmaMid(v1.col, v2.col)) or
-            !pmaClose(m20c, pmaMid(v2.col, v0.col)))
-        {
-            const m01: Vertex = .{ .pos = m01p, .col = m01c };
-            const m12: Vertex = .{ .pos = m12p, .col = m12c };
-            const m20: Vertex = .{ .pos = m20p, .col = m20c };
-            try subdivideGouraudTri(allocator, vtx, idx, v0, m01, m20, source, depth - 1);
-            try subdivideGouraudTri(allocator, vtx, idx, m01, v1, m12, source, depth - 1);
-            try subdivideGouraudTri(allocator, vtx, idx, m20, m12, v2, source, depth - 1);
-            try subdivideGouraudTri(allocator, vtx, idx, m01, m12, m20, source, depth - 1);
-            return;
-        }
-    }
-
-    const base: Vertex.Index = @intCast(vtx.items.len);
-    try vtx.appendSlice(allocator, &.{ v0, v1, v2 });
-    try idx.appendSlice(allocator, &.{ base, base + 1, base + 2 });
-}
-
-/// Spec-compliant-ish stroke with round joins AND round caps - the style
-/// SVG-origin icons (feather, lucide, entypo, ...) are authored for.
-///
-/// `dvui.Path.strokeTriangles` only does miter joins and square/none caps,
-/// so each edge is stroked separately with butt caps (no overlap, no miter
-/// spikes at sharp corners), and a filled disc is placed at every vertex to
-/// act as the round join (filling the wedge between adjacent edges) and,
-/// for open paths, the round cap at each endpoint.  Both primitives get
-/// `dvui`'s normal 1px AA fade.
 fn strokePolylineRoundJoined(
     allocator: std.mem.Allocator,
     mesh: *MeshBuilder,
@@ -827,7 +674,7 @@ fn strokePolylineRoundJoined(
             .endcap_style = .none,
         });
         defer tri.deinit(allocator);
-        try mesh.appendMesh(tri);
+        try mesh.appendMesh(tri, null);
     }
 
     for (pts) |p| {
@@ -841,7 +688,7 @@ fn strokePolylineRoundJoined(
         };
         var tri = try disc.fillConvexTriangles(allocator, .{ .color = .{ .color = col }, .fade = 1.0 });
         defer tri.deinit(allocator);
-        try mesh.appendMesh(tri);
+        try mesh.appendMesh(tri, null);
     }
 }
 
@@ -886,9 +733,7 @@ fn strokePolylineTvg(
 // ---------------------------------------------------------------------------
 
 /// Flatten one TVG path segment into a polyline of physical points.
-/// Per-node `line_width` is ignored - fills don't use it, and strokes use
-/// the command-level line_width (per-node widths would need segment-wise
-/// stroking, which isn't supported).
+/// Per-node `line_width` is ignored
 fn flattenSegment(
     segment: tvg.Path.Segment,
     xf: Transform,
@@ -1161,108 +1006,6 @@ fn collapseRunDuplicates(pts: *std.ArrayList(Point)) void {
         }
     }
     pts.shrinkRetainingCapacity(w);
-}
-
-// Manual visual-verification tool (no assertions): renders an icon with a
-// radial gradient fill so the adaptive Gouraud subdivision in
-// `gouraudShade` can be screenshotted. Star/circle fills are just their
-// outline vertices - large, sparse triangles where naive per-vertex
-// Gouraud shading of a non-affine (radial) color function visibly
-// diverges from a true circular gradient.
-//
-// Run with (from repo root): zig build test -Dtest-filter="DOCIMG icon gradient" -Dimage-dir=/tmp/gradient-compare/dvui
-test "DOCIMG icon gradient radial" {
-    const size: dvui.Size = .{ .w = 200, .h = 200 };
-    var t = try dvui.testing.init(.{ .window_size = size });
-    defer t.deinit();
-
-    const red: Color = .{ .r = 255, .g = 80, .b = 80, .a = 255 };
-    const blue: Color = .{ .r = 80, .g = 120, .b = 255, .a = 255 };
-
-    const Sample = struct {
-        fn frame() !dvui.App.Result {
-            dvui.icon(@src(), "star", dvui.entypo.star, .{
-                .fill_color = .{ .gradient = .{ .radial = .{
-                    .stops = &.{ .{ .color = red, .offset = 0 }, .{ .color = blue, .offset = 1 } },
-                } } },
-            }, .{ .expand = .both });
-            return .ok;
-        }
-    };
-    try t.saveImage(Sample.frame, null, "icon-star-radial-gradient.png");
-}
-
-/// Mirrors `dvui.testing.capturePng`'s frame/Picture dance but returns raw
-/// premultiplied pixels instead of encoding, so a test can inspect alpha
-/// directly (e.g. to compare edge-AA ramps between two renders).
-fn captureIconPixels(alloc: std.mem.Allocator, frame: dvui.App.frameFunction, rect: Rect) ![]Color.PMA {
-    var picture = dvui.Picture.start(rect) orelse return error.Unsupported;
-    if (try frame() == .close) return error.Closed;
-    _ = dvui.currentWindow().endRendering(.{});
-    picture.stop();
-    const pixels = try dvui.textureReadTarget(alloc, picture.texture);
-    picture.deinit();
-
-    const cw = dvui.currentWindow();
-    _ = try cw.end(.{});
-    try cw.begin(cw.frame_time_ns + 100 * std.time.ns_per_ms);
-    return pixels;
-}
-
-// Regression test for the "gradient icons look pixelated compared to flat
-// icons" bug: a flat fill and a same-colored 2-stop gradient fill of the
-// same icon should produce (almost) identical rendered alpha, including the
-// partially-transparent edge-AA ring. Before `gouraudFadeBand`, the
-// gradient render had zero partially-transparent pixels (fade was forced to
-// 0), so this would have failed on `partial_alpha_grad > 20`.
-test "gradient icon fill AA matches flat" {
-    const size: dvui.Size = .{ .w = 60, .h = 60 };
-    var t = try dvui.testing.init(.{ .window_size = size });
-    defer t.deinit();
-
-    const white: Color = .{ .r = 255, .g = 255, .b = 255, .a = 255 };
-
-    const FlatSample = struct {
-        fn frame() !dvui.App.Result {
-            dvui.icon(@src(), "star", dvui.entypo.star, .{
-                .fill_color = .{ .color = white },
-            }, .{ .expand = .both });
-            return .ok;
-        }
-    };
-    const GradientSample = struct {
-        fn frame() !dvui.App.Result {
-            dvui.icon(@src(), "star", dvui.entypo.star, .{
-                .fill_color = .{ .gradient = .{ .linear = .{
-                    .stops = &.{ .{ .color = white, .offset = 0 }, .{ .color = white, .offset = 1 } },
-                } } },
-            }, .{ .expand = .both });
-            return .ok;
-        }
-    };
-
-    const rect = dvui.windowRectPixels();
-    const flat = try captureIconPixels(std.testing.allocator, FlatSample.frame, rect);
-    defer std.testing.allocator.free(flat);
-    const grad = try captureIconPixels(std.testing.allocator, GradientSample.frame, rect);
-    defer std.testing.allocator.free(grad);
-
-    try std.testing.expectEqual(flat.len, grad.len);
-
-    var partial_alpha_flat: usize = 0;
-    var partial_alpha_grad: usize = 0;
-    var max_alpha_diff: u8 = 0;
-    for (flat, grad) |f, g| {
-        if (f.a > 0 and f.a < 255) partial_alpha_flat += 1;
-        if (g.a > 0 and g.a < 255) partial_alpha_grad += 1;
-        const d: u8 = if (f.a > g.a) f.a - g.a else g.a - f.a;
-        max_alpha_diff = @max(max_alpha_diff, d);
-    }
-
-    std.debug.print("partial_alpha_flat={d} partial_alpha_grad={d} max_alpha_diff={d}\n", .{ partial_alpha_flat, partial_alpha_grad, max_alpha_diff });
-    try std.testing.expect(partial_alpha_flat > 20);
-    try std.testing.expect(partial_alpha_grad > 20);
-    try std.testing.expect(max_alpha_diff <= 2);
 }
 
 const std = @import("std");

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -50,7 +50,7 @@ click: bool = false,
 pub fn init(self: *ButtonWidget, src: std.builtin.SourceLocation, init_options: InitOptions, opts: Options) void {
     var options = defaults.override(opts);
     if (init_options.grayed) {
-        options.color_text = .{ .color = dvui.Color.average(options.textColor(.text).toColor(), options.textColor(.fill).toColor()) };
+        options.color_text = .{ .color = dvui.Color.average(options.color(.text).toColor(), options.color(.fill).toColor()) };
     }
     self.* = .{
         .wd = .init(src, .{}, options),
@@ -110,11 +110,11 @@ pub fn style(self: *ButtonWidget) Options {
     var opts = self.data().options.styleOnly();
     const t = dvui.hoverFade(self.data().id, self.hover);
     if (dvui.captured(self.data().id)) {
-        opts.color_fill = self.data().options.textColor(.fill_press);
-        opts.color_text = self.data().options.textColor(.text_press);
+        opts.color_fill = self.data().options.color(.fill_press);
+        opts.color_text = self.data().options.color(.text_press);
     } else if (t > 0) {
-        opts.color_fill = self.data().options.textColor(.fill).lerp(self.data().options.textColor(.fill_hover), t);
-        opts.color_text = self.data().options.textColor(.text).lerp(self.data().options.textColor(.text_hover), t);
+        opts.color_fill = self.data().options.color(.fill).lerp(self.data().options.color(.fill_hover), t);
+        opts.color_text = self.data().options.color(.text).lerp(self.data().options.color(.text_hover), t);
     }
     return opts;
 }

--- a/src/widgets/ButtonWidget.zig
+++ b/src/widgets/ButtonWidget.zig
@@ -50,7 +50,7 @@ click: bool = false,
 pub fn init(self: *ButtonWidget, src: std.builtin.SourceLocation, init_options: InitOptions, opts: Options) void {
     var options = defaults.override(opts);
     if (init_options.grayed) {
-        options.color_text = dvui.Color.average(options.color(.text), options.color(.fill));
+        options.color_text = .{ .color = dvui.Color.average(options.textColor(.text).toColor(), options.textColor(.fill).toColor()) };
     }
     self.* = .{
         .wd = .init(src, .{}, options),
@@ -110,11 +110,11 @@ pub fn style(self: *ButtonWidget) Options {
     var opts = self.data().options.styleOnly();
     const t = dvui.hoverFade(self.data().id, self.hover);
     if (dvui.captured(self.data().id)) {
-        opts.color_fill = self.data().options.color(.fill_press);
-        opts.color_text = self.data().options.color(.text_press);
+        opts.color_fill = self.data().options.textColor(.fill_press);
+        opts.color_text = self.data().options.textColor(.text_press);
     } else if (t > 0) {
-        opts.color_fill = self.data().options.color(.fill).lerp(self.data().options.color(.fill_hover), t);
-        opts.color_text = self.data().options.color(.text).lerp(self.data().options.color(.text_hover), t);
+        opts.color_fill = self.data().options.textColor(.fill).lerp(self.data().options.textColor(.fill_hover), t);
+        opts.color_text = self.data().options.textColor(.text).lerp(self.data().options.textColor(.text_hover), t);
     }
     return opts;
 }

--- a/src/widgets/ColorPickerWidget.zig
+++ b/src/widgets/ColorPickerWidget.zig
@@ -168,7 +168,7 @@ pub fn valueSaturationBox(src: std.builtin.SourceLocation, hsv: *Color.HSV, opts
         .background = true,
         .border = .all(1),
         .corners = .all(100),
-        .color_fill = hsv.toColor(),
+        .color_fill = .{ .color = hsv.toColor() },
     });
     if (b.data().id == dvui.focusedWidgetId()) {
         indicator.data().focusBorder();
@@ -332,7 +332,7 @@ pub fn hueSlider(src: std.builtin.SourceLocation, dir: dvui.enums.Direction, hue
         .background = true,
         .border = .all(1),
         .corners = .all(100),
-        .color_fill = (Color.HSV{ .h = hue.* }).toColor(),
+        .color_fill = .{ .color = (Color.HSV{ .h = hue.* }).toColor() },
     });
     if (b.data().id == dvui.focusedWidgetId()) {
         knob.data().focusBorder();

--- a/src/widgets/DockingWidget.zig
+++ b/src/widgets/DockingWidget.zig
@@ -537,7 +537,7 @@ pub fn deinit(self: *Dockspace) void {
     self.checkRootZones();
     if (self.hover_target != null) {
         // Drawn last (on top of everything else this widget drew this frame).
-        self.hover_rect.fill(dvui.CornerRect.Physical.all(0), .{ .color = dvui.themeGet().focus.opacity(0.25) });
+        self.hover_rect.fill(dvui.CornerRect.Physical.all(0), .{ .color = .{ .color = dvui.themeGet().focus.opacity(0.25) } });
     }
 
     if (self.pending_drop) |pd| {

--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -90,7 +90,7 @@ pub fn init(self: *DropdownWidget, src: std.builtin.SourceLocation, init_opts: I
         var lw: LabelWidget = undefined;
         lw.initNoFmt(@src(), ll, .{}, self.options.strip().override(.{
             .gravity_y = 0.5,
-            .color_text = if (self.init_options.selected_index == null and self.init_options.placeholder != null) self.data().options.color(.text).opacity(0.65) else null,
+            .color_text = if (self.init_options.selected_index == null and self.init_options.placeholder != null) self.data().options.textColor(.text).opacity(0.65) else null,
         }));
         lw.draw();
         lw.deinit();

--- a/src/widgets/DropdownWidget.zig
+++ b/src/widgets/DropdownWidget.zig
@@ -90,7 +90,7 @@ pub fn init(self: *DropdownWidget, src: std.builtin.SourceLocation, init_opts: I
         var lw: LabelWidget = undefined;
         lw.initNoFmt(@src(), ll, .{}, self.options.strip().override(.{
             .gravity_y = 0.5,
-            .color_text = if (self.init_options.selected_index == null and self.init_options.placeholder != null) self.data().options.textColor(.text).opacity(0.65) else null,
+            .color_text = if (self.init_options.selected_index == null and self.init_options.placeholder != null) self.data().options.color(.text).opacity(0.65) else null,
         }));
         lw.draw();
         lw.deinit();

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -280,7 +280,7 @@ pub fn init(self: *FloatingWindowWidget, src: std.builtin.SourceLocation, init_o
 pub fn drawBackground(self: *FloatingWindowWidget) void {
     if (self.init_options.modal and !dvui.firstFrame(self.data().id)) {
         // paint over everything below
-        var col = self.options.textColor(.text).toColor();
+        var col = self.options.color(.text).toColor();
         col.a = self.init_options.modal_alpha orelse (if (dvui.themeGet().dark) 60 else 80);
         dvui.windowRectPixels().fill(.{}, .{ .color = .{ .color = col } });
     }

--- a/src/widgets/FloatingWindowWidget.zig
+++ b/src/widgets/FloatingWindowWidget.zig
@@ -280,9 +280,9 @@ pub fn init(self: *FloatingWindowWidget, src: std.builtin.SourceLocation, init_o
 pub fn drawBackground(self: *FloatingWindowWidget) void {
     if (self.init_options.modal and !dvui.firstFrame(self.data().id)) {
         // paint over everything below
-        var col = self.options.color(.text);
+        var col = self.options.textColor(.text).toColor();
         col.a = self.init_options.modal_alpha orelse (if (dvui.themeGet().dark) 60 else 80);
-        dvui.windowRectPixels().fill(.{}, .{ .color = col });
+        dvui.windowRectPixels().fill(.{}, .{ .color = .{ .color = col } });
     }
 
     // we are using BoxWidget to do border/background

--- a/src/widgets/GridWidget.zig
+++ b/src/widgets/GridWidget.zig
@@ -392,7 +392,7 @@ pub const CellWidget = struct {
             const rs = self.data().backgroundRectScale();
             if (!rs.r.empty()) {
                 const fill = (dvui.themeGet().text_select orelse dvui.themeGet().color(.highlight, .fill)).opacity(0.75);
-                rs.r.fill(self.data().options.cornersGet().scale(rs.s, dvui.CornerRect.Physical), .{ .color = fill });
+                rs.r.fill(self.data().options.cornersGet().scale(rs.s, dvui.CornerRect.Physical), .{ .color = .{ .color = fill } });
             }
         }
     }

--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -58,7 +58,7 @@ pub fn draw(self: *IconWidget) void {
     if (std.meta.eql(self.icon_opts.fill_color, white) and std.meta.eql(self.icon_opts.stroke_color, white)) {
         // user is rasterizing icon with defaults (white), so always use
         // colormod (so icons default to text color)
-        texOpts.colormod = self.data().options.textColor(.text).toColor();
+        texOpts.colormod = self.data().options.color(.text).toColor();
     } else if (self.data().options.color_text) |ct| {
         // user is customizing icon rasterization, only colormod if they passed
         // a text color

--- a/src/widgets/IconWidget.zig
+++ b/src/widgets/IconWidget.zig
@@ -54,18 +54,15 @@ pub fn draw(self: *IconWidget) void {
     const rs = self.data().parent.screenRectScale(self.data().contentRect());
     var texOpts: dvui.RenderTextureOptions = .{ .rotation = self.data().options.rotationGet() };
 
-    const white: ?dvui.Color = .white;
-    const as_bytes = std.mem.asBytes;
-    if (std.mem.eql(u8, as_bytes(&self.icon_opts.fill_color), as_bytes(&white)) and
-        std.mem.eql(u8, as_bytes(&self.icon_opts.stroke_color), as_bytes(&white)))
-    {
+    const white: ?dvui.ColorOrGradient = .white;
+    if (std.meta.eql(self.icon_opts.fill_color, white) and std.meta.eql(self.icon_opts.stroke_color, white)) {
         // user is rasterizing icon with defaults (white), so always use
         // colormod (so icons default to text color)
-        texOpts.colormod = self.data().options.color(.text);
+        texOpts.colormod = self.data().options.textColor(.text).toColor();
     } else if (self.data().options.color_text) |ct| {
         // user is customizing icon rasterization, only colormod if they passed
         // a text color
-        texOpts.colormod = ct;
+        texOpts.colormod = ct.toColor();
     }
 
     dvui.renderIcon(

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -198,7 +198,7 @@ pub fn draw(self: *LabelWidget) void {
             //r.stroke(.all(0), .{ .after = true, .thickness = 1.0, .color = .red });
         }
 
-        const text_col = self.data().options.textColor(.text).split();
+        const text_col = self.data().options.color(.text).split();
         dvui.renderText(.{
             .font = self.data().options.fontGet(),
             .text = line,

--- a/src/widgets/LabelWidget.zig
+++ b/src/widgets/LabelWidget.zig
@@ -198,12 +198,14 @@ pub fn draw(self: *LabelWidget) void {
             //r.stroke(.all(0), .{ .after = true, .thickness = 1.0, .color = .red });
         }
 
+        const text_col = self.data().options.textColor(.text).split();
         dvui.renderText(.{
             .font = self.data().options.fontGet(),
             .text = line,
             .p = render_p,
             .rs = rs,
-            .color = self.data().options.color(.text),
+            .color = text_col.color,
+            .gradient = text_col.gradient,
             .rotation = rot,
             .sel_start = if (sel_start) |ss| ss -| line_start else null,
             .sel_end = if (sel_end) |se| se -| line_start else null,
@@ -218,7 +220,8 @@ pub fn draw(self: *LabelWidget) void {
                 .font = self.data().options.fontGet(),
                 .text = ellip,
                 .rs = .{ .r = r, .s = rs.s },
-                .color = self.data().options.color(.text),
+                .color = text_col.color,
+                .gradient = text_col.gradient,
             }) catch |err| {
                 dvui.logError(@src(), err, "Failed to render ellipses after text: {s}", .{line});
             };

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -100,15 +100,15 @@ pub fn drawBackground(self: *MenuItemWidget) void {
             if (self.init_opts.focus_as_outline) {
                 self.data().focusBorder();
                 if (self.highlight) {
-                    rs.r.fill(cr, .{ .color = cols.color(.fill), .fade = 1.0 });
+                    rs.r.fill(cr, .{ .color = cols.textColor(.fill), .fade = 1.0 });
                 }
             } else {
-                rs.r.fill(cr, .{ .color = cols.color(.fill), .fade = 1.0 });
+                rs.r.fill(cr, .{ .color = cols.textColor(.fill), .fade = 1.0 });
             }
         } else if ((self.data().id == dvui.focusedWidgetIdInCurrentSubwindow()) or self.highlight or self.hover_t > 0) {
-            rs.r.fill(cr, .{ .color = cols.color(.fill), .fade = 1.0 });
+            rs.r.fill(cr, .{ .color = cols.textColor(.fill), .fade = 1.0 });
         } else if (self.data().options.backgroundGet()) {
-            rs.r.fill(cr, .{ .color = cols.color(.fill), .fade = 1.0 });
+            rs.r.fill(cr, .{ .color = cols.textColor(.fill), .fade = 1.0 });
         }
     }
 }
@@ -117,10 +117,10 @@ pub fn drawBackground(self: *MenuItemWidget) void {
 pub fn style(self: *MenuItemWidget) Options {
     var opts: Options = self.data().options.styleOnly();
     if (self.show_active and !self.init_opts.focus_as_outline) {
-        const rest_fill = opts.color(.fill);
+        const rest_fill = opts.textColor(.fill);
         opts.style = .highlight;
-        const active_fill = opts.color_fill_hover orelse opts.color(.fill);
-        const active_text = opts.color_text_hover orelse opts.color(.text_hover);
+        const active_fill = opts.color_fill_hover orelse opts.textColor(.fill);
+        const active_text = opts.color_text_hover orelse opts.textColor(.text_hover);
         if (self.highlight) {
             opts.color_fill = rest_fill.lerp(active_fill, self.hover_t);
             opts.color_text = active_text;
@@ -130,8 +130,8 @@ pub fn style(self: *MenuItemWidget) Options {
         }
     } else if (self.hover_t > 0) {
         // mouse is over us (or just left us)
-        opts.color_fill = opts.color(.fill).lerp(opts.color_fill_hover orelse opts.color(.fill_hover), self.hover_t);
-        opts.color_text = opts.color(.text).lerp(opts.color_text_hover orelse opts.color(.text_hover), self.hover_t);
+        opts.color_fill = opts.textColor(.fill).lerp(opts.color_fill_hover orelse opts.textColor(.fill_hover), self.hover_t);
+        opts.color_text = opts.textColor(.text).lerp(opts.color_text_hover orelse opts.textColor(.text_hover), self.hover_t);
     }
 
     return opts;

--- a/src/widgets/MenuItemWidget.zig
+++ b/src/widgets/MenuItemWidget.zig
@@ -100,15 +100,15 @@ pub fn drawBackground(self: *MenuItemWidget) void {
             if (self.init_opts.focus_as_outline) {
                 self.data().focusBorder();
                 if (self.highlight) {
-                    rs.r.fill(cr, .{ .color = cols.textColor(.fill), .fade = 1.0 });
+                    rs.r.fill(cr, .{ .color = cols.color(.fill), .fade = 1.0 });
                 }
             } else {
-                rs.r.fill(cr, .{ .color = cols.textColor(.fill), .fade = 1.0 });
+                rs.r.fill(cr, .{ .color = cols.color(.fill), .fade = 1.0 });
             }
         } else if ((self.data().id == dvui.focusedWidgetIdInCurrentSubwindow()) or self.highlight or self.hover_t > 0) {
-            rs.r.fill(cr, .{ .color = cols.textColor(.fill), .fade = 1.0 });
+            rs.r.fill(cr, .{ .color = cols.color(.fill), .fade = 1.0 });
         } else if (self.data().options.backgroundGet()) {
-            rs.r.fill(cr, .{ .color = cols.textColor(.fill), .fade = 1.0 });
+            rs.r.fill(cr, .{ .color = cols.color(.fill), .fade = 1.0 });
         }
     }
 }
@@ -117,10 +117,10 @@ pub fn drawBackground(self: *MenuItemWidget) void {
 pub fn style(self: *MenuItemWidget) Options {
     var opts: Options = self.data().options.styleOnly();
     if (self.show_active and !self.init_opts.focus_as_outline) {
-        const rest_fill = opts.textColor(.fill);
+        const rest_fill = opts.color(.fill);
         opts.style = .highlight;
-        const active_fill = opts.color_fill_hover orelse opts.textColor(.fill);
-        const active_text = opts.color_text_hover orelse opts.textColor(.text_hover);
+        const active_fill = opts.color_fill_hover orelse opts.color(.fill);
+        const active_text = opts.color_text_hover orelse opts.color(.text_hover);
         if (self.highlight) {
             opts.color_fill = rest_fill.lerp(active_fill, self.hover_t);
             opts.color_text = active_text;
@@ -130,8 +130,8 @@ pub fn style(self: *MenuItemWidget) Options {
         }
     } else if (self.hover_t > 0) {
         // mouse is over us (or just left us)
-        opts.color_fill = opts.textColor(.fill).lerp(opts.color_fill_hover orelse opts.textColor(.fill_hover), self.hover_t);
-        opts.color_text = opts.textColor(.text).lerp(opts.color_text_hover orelse opts.textColor(.text_hover), self.hover_t);
+        opts.color_fill = opts.color(.fill).lerp(opts.color_fill_hover orelse opts.color(.fill_hover), self.hover_t);
+        opts.color_text = opts.color(.text).lerp(opts.color_text_hover orelse opts.color(.text_hover), self.hover_t);
     }
 
     return opts;

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -239,7 +239,7 @@ pub fn draw(self: *PanedWidget) void {
         },
     }
     const corner = CornerRect.all(thick).finalize(self.data().options.theme).scale(1, CornerRect.Physical);
-    r.fill(corner, .{ .color = self.data().options.textColor(.text).opacity(0.5), .fade = 1.0 });
+    r.fill(corner, .{ .color = self.data().options.color(.text).opacity(0.5), .fade = 1.0 });
 }
 
 pub fn collapsed(self: *PanedWidget) bool {

--- a/src/widgets/PanedWidget.zig
+++ b/src/widgets/PanedWidget.zig
@@ -239,7 +239,7 @@ pub fn draw(self: *PanedWidget) void {
         },
     }
     const corner = CornerRect.all(thick).finalize(self.data().options.theme).scale(1, CornerRect.Physical);
-    r.fill(corner, .{ .color = self.data().options.color(.text).opacity(0.5), .fade = 1.0 });
+    r.fill(corner, .{ .color = self.data().options.textColor(.text).opacity(0.5), .fade = 1.0 });
 }
 
 pub fn collapsed(self: *PanedWidget) bool {

--- a/src/widgets/PlotWidget.zig
+++ b/src/widgets/PlotWidget.zig
@@ -499,7 +499,7 @@ pub fn init(self: *PlotWidget, src: std.builtin.SourceLocation, init_opts: InitO
     data_box.deinit();
 
     const bt: f32 = self.init_options.border_thick orelse 0.0;
-    const bc: dvui.Color = self.init_options.spine_color orelse self.box.data().options.textColor(.text).toColor();
+    const bc: dvui.Color = self.init_options.spine_color orelse self.box.data().options.color(.text).toColor();
 
     const pad = 2 * self.data_rs.s;
 
@@ -567,7 +567,7 @@ pub fn init(self: *PlotWidget, src: std.builtin.SourceLocation, init_opts: InitO
                 .font = tick_font,
                 .text = tick_str,
                 .rs = tick_rs,
-                .color = self.box.data().options.textColor(.text).toColor(),
+                .color = self.box.data().options.color(.text).toColor(),
             }) catch |err| {
                 dvui.logError(@src(), err, "y axis tick text for {d}", .{ytick});
             };
@@ -614,7 +614,7 @@ pub fn init(self: *PlotWidget, src: std.builtin.SourceLocation, init_opts: InitO
                 .font = tick_font,
                 .text = tick_str,
                 .rs = tick_rs,
-                .color = self.box.data().options.textColor(.text).toColor(),
+                .color = self.box.data().options.color(.text).toColor(),
             }) catch |err| {
                 dvui.logError(@src(), err, "x axis tick text for {d}", .{xtick});
             };

--- a/src/widgets/PlotWidget.zig
+++ b/src/widgets/PlotWidget.zig
@@ -351,7 +351,7 @@ pub const Line = struct {
     }
 
     pub fn stroke(self: *Line, thick: f32, color: dvui.Color) void {
-        self.path.build().stroke(.{ .thickness = thick * self.plot.data_rs.s, .color = color });
+        self.path.build().stroke(.{ .thickness = thick * self.plot.data_rs.s, .color = .{ .color = color } });
     }
 
     pub fn deinit(self: *Line) void {
@@ -499,7 +499,7 @@ pub fn init(self: *PlotWidget, src: std.builtin.SourceLocation, init_opts: InitO
     data_box.deinit();
 
     const bt: f32 = self.init_options.border_thick orelse 0.0;
-    const bc: dvui.Color = self.init_options.spine_color orelse self.box.data().options.color(.text);
+    const bc: dvui.Color = self.init_options.spine_color orelse self.box.data().options.textColor(.text).toColor();
 
     const pad = 2 * self.data_rs.s;
 
@@ -567,7 +567,7 @@ pub fn init(self: *PlotWidget, src: std.builtin.SourceLocation, init_opts: InitO
                 .font = tick_font,
                 .text = tick_str,
                 .rs = tick_rs,
-                .color = self.box.data().options.color(.text),
+                .color = self.box.data().options.textColor(.text).toColor(),
             }) catch |err| {
                 dvui.logError(@src(), err, "y axis tick text for {d}", .{ytick});
             };
@@ -614,7 +614,7 @@ pub fn init(self: *PlotWidget, src: std.builtin.SourceLocation, init_opts: InitO
                 .font = tick_font,
                 .text = tick_str,
                 .rs = tick_rs,
-                .color = self.box.data().options.color(.text),
+                .color = self.box.data().options.textColor(.text).toColor(),
             }) catch |err| {
                 dvui.logError(@src(), err, "x axis tick text for {d}", .{xtick});
             };
@@ -635,7 +635,7 @@ pub fn init(self: *PlotWidget, src: std.builtin.SourceLocation, init_opts: InitO
     }
 
     if (bt > 0) {
-        self.data_rs.r.stroke(.{}, .{ .thickness = bt * self.data_rs.s, .color = bc });
+        self.data_rs.r.stroke(.{}, .{ .thickness = bt * self.data_rs.s, .color = .{ .color = bc } });
     }
 
     self.old_clip = dvui.clip(self.data_rs.r);
@@ -702,7 +702,7 @@ fn drawTickline(
         dvui.Path.stroke(.{
             .points = &.{ gridline_start, gridline_end },
         }, .{
-            .color = col,
+            .color = .{ .color = col },
             .thickness = 1,
         });
     }
@@ -723,23 +723,23 @@ fn drawTickline(
         .none => {},
         .left_or_top => {
             dvui.Path.stroke(.{ .points = left_or_top_pts }, .{
-                .color = tick_line_color,
+                .color = .{ .color = tick_line_color },
                 .thickness = 1,
             });
         },
         .right_or_bottom => {
             dvui.Path.stroke(.{ .points = right_or_bottom_pts }, .{
-                .color = tick_line_color,
+                .color = .{ .color = tick_line_color },
                 .thickness = 1,
             });
         },
         .both => {
             dvui.Path.stroke(.{ .points = left_or_top_pts }, .{
-                .color = tick_line_color,
+                .color = .{ .color = tick_line_color },
                 .thickness = 1,
             });
             dvui.Path.stroke(.{ .points = right_or_bottom_pts }, .{
-                .color = tick_line_color,
+                .color = .{ .color = tick_line_color },
                 .thickness = 1,
             });
         },
@@ -800,7 +800,7 @@ pub fn bar(self: *PlotWidget, opts: BarOptions) void {
                 .{ .x = sp1.x, .y = sp2.y },
             },
         },
-        .{ .color = opts.color orelse dvui.themeGet().focus },
+        .{ .color = .{ .color = opts.color orelse dvui.themeGet().focus } },
     );
 }
 

--- a/src/widgets/ReorderWidget.zig
+++ b/src/widgets/ReorderWidget.zig
@@ -296,7 +296,7 @@ pub const Reorderable = struct {
                     self.reorder.found_slot = true;
 
                     if (self.init_options.draw_target) {
-                        rs.r.fill(.{}, .{ .color = dvui.themeGet().focus, .fade = 1.0 });
+                        rs.r.fill(.{}, .{ .color = .{ .color = dvui.themeGet().focus }, .fade = 1.0 });
                     }
 
                     if (self.init_options.reinstall and !self.init_options.last_slot) {

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -206,12 +206,12 @@ pub const Grab = struct {
 
     pub fn draw(self: Grab) void {
         var corners = dvui.CornerRect.all(100).finalize(null);
-        self.rect.fill(corners.scale(1, dvui.CornerRect.Physical), .{ .color = self.color, .fade = 1.0 });
+        self.rect.fill(corners.scale(1, dvui.CornerRect.Physical), .{ .color = .{ .color = self.color }, .fade = 1.0 });
     }
 };
 
 pub fn grab(self: *ScrollBarWidget) Grab {
-    const text = self.data().options.color(.text);
+    const text = self.data().options.textColor(.text).toColor();
     const hover_t = dvui.hoverFade(self.data().id, self.highlight);
     const fill = if (dvui.captured(self.data().id))
         text.opacity(0.3)

--- a/src/widgets/ScrollBarWidget.zig
+++ b/src/widgets/ScrollBarWidget.zig
@@ -211,7 +211,7 @@ pub const Grab = struct {
 };
 
 pub fn grab(self: *ScrollBarWidget) Grab {
-    const text = self.data().options.textColor(.text).toColor();
+    const text = self.data().options.color(.text).toColor();
     const hover_t = dvui.hoverFade(self.data().id, self.highlight);
     const fill = if (dvui.captured(self.data().id))
         text.opacity(0.3)

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -60,7 +60,7 @@ pub fn init(self: *TabsWidget, src: std.builtin.SourceLocation, init_opts: InitO
                 r.w -= 1.0;
                 r.y = @floor(r.y) - 0.5;
             }
-            dvui.Path.stroke(.{ .points = &.{ r.bottomLeft(), r.bottomRight() } }, .{ .thickness = 1, .color = self.scroll.data().options.textColor(.border) });
+            dvui.Path.stroke(.{ .points = &.{ r.bottomLeft(), r.bottomRight() } }, .{ .thickness = 1, .color = self.scroll.data().options.color(.border) });
         },
         .vertical => {
             if (dvui.currentWindow().snap_to_pixels) {
@@ -68,7 +68,7 @@ pub fn init(self: *TabsWidget, src: std.builtin.SourceLocation, init_opts: InitO
                 r.h -= 1.0;
                 r.x = @floor(r.x) - 0.5;
             }
-            dvui.Path.stroke(.{ .points = &.{ r.topRight(), r.bottomRight() } }, .{ .thickness = 1, .color = self.scroll.data().options.textColor(.border) });
+            dvui.Path.stroke(.{ .points = &.{ r.topRight(), r.bottomRight() } }, .{ .thickness = 1, .color = self.scroll.data().options.color(.border) });
         },
     }
 }
@@ -79,7 +79,7 @@ pub fn addTabLabel(self: *TabsWidget, selected: bool, text: []const u8, opts: Op
 
     var label_opts = tab.data().options.strip();
     if (dvui.captured(tab.data().id)) {
-        label_opts.color_text = label_opts.textColor(.text_press);
+        label_opts.color_text = label_opts.color(.text_press);
     }
 
     dvui.labelNoFmt(@src(), text, .{}, label_opts);

--- a/src/widgets/TabsWidget.zig
+++ b/src/widgets/TabsWidget.zig
@@ -60,7 +60,7 @@ pub fn init(self: *TabsWidget, src: std.builtin.SourceLocation, init_opts: InitO
                 r.w -= 1.0;
                 r.y = @floor(r.y) - 0.5;
             }
-            dvui.Path.stroke(.{ .points = &.{ r.bottomLeft(), r.bottomRight() } }, .{ .thickness = 1, .color = self.scroll.data().options.color(.border) });
+            dvui.Path.stroke(.{ .points = &.{ r.bottomLeft(), r.bottomRight() } }, .{ .thickness = 1, .color = self.scroll.data().options.textColor(.border) });
         },
         .vertical => {
             if (dvui.currentWindow().snap_to_pixels) {
@@ -68,7 +68,7 @@ pub fn init(self: *TabsWidget, src: std.builtin.SourceLocation, init_opts: InitO
                 r.h -= 1.0;
                 r.x = @floor(r.x) - 0.5;
             }
-            dvui.Path.stroke(.{ .points = &.{ r.topRight(), r.bottomRight() } }, .{ .thickness = 1, .color = self.scroll.data().options.color(.border) });
+            dvui.Path.stroke(.{ .points = &.{ r.topRight(), r.bottomRight() } }, .{ .thickness = 1, .color = self.scroll.data().options.textColor(.border) });
         },
     }
 }
@@ -79,7 +79,7 @@ pub fn addTabLabel(self: *TabsWidget, selected: bool, text: []const u8, opts: Op
 
     var label_opts = tab.data().options.strip();
     if (dvui.captured(tab.data().id)) {
-        label_opts.color_text = label_opts.color(.text_press);
+        label_opts.color_text = label_opts.textColor(.text_press);
     }
 
     dvui.labelNoFmt(@src(), text, .{}, label_opts);
@@ -153,7 +153,7 @@ pub fn addTab(self: *TabsWidget, selected: bool, at_options: AddTabOptions, opts
 
                 path.addPoint(r.bottomLeft());
 
-                path.build().stroke(.{ .thickness = 2 * rs.s, .color = dvui.themeGet().focus, .after = true });
+                path.build().stroke(.{ .thickness = 2 * rs.s, .color = .{ .color = dvui.themeGet().focus }, .after = true });
             },
             .vertical => {
                 var path: dvui.Path.Builder = .init(dvui.currentWindow().lifo());
@@ -171,7 +171,7 @@ pub fn addTab(self: *TabsWidget, selected: bool, at_options: AddTabOptions, opts
 
                 path.addPoint(r.bottomRight());
 
-                path.build().stroke(.{ .thickness = 2 * rs.s, .color = dvui.themeGet().focus, .after = true });
+                path.build().stroke(.{ .thickness = 2 * rs.s, .color = .{ .color = dvui.themeGet().focus }, .after = true });
             },
         }
     }

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -327,7 +327,7 @@ pub fn draw(self: *TextEntryWidget) void {
                 // prevent textLayout from making a text run for the placeholder text
                 dvui.currentWindow().accesskit.text_run_parent = null;
             }
-            self.textLayout.addText(placeholder, .{ .color_text = self.textLayout.data().options.color(.text).opacity(0.65) });
+            self.textLayout.addText(placeholder, .{ .color_text = self.textLayout.data().options.textColor(.text).opacity(0.65) });
         }
     }
 
@@ -497,7 +497,7 @@ pub fn drawCursor(self: *TextEntryWidget) void {
 
         var crect = self.textLayout.cursor_rect.plus(.{ .x = -1 });
         crect.w = 2;
-        self.textLayout.screenRectScale(crect).r.fill(.{}, .{ .color = dvui.themeGet().focus, .fade = 1.0 });
+        self.textLayout.screenRectScale(crect).r.fill(.{}, .{ .color = .{ .color = dvui.themeGet().focus }, .fade = 1.0 });
     }
 }
 

--- a/src/widgets/TextEntryWidget.zig
+++ b/src/widgets/TextEntryWidget.zig
@@ -327,7 +327,7 @@ pub fn draw(self: *TextEntryWidget) void {
                 // prevent textLayout from making a text run for the placeholder text
                 dvui.currentWindow().accesskit.text_run_parent = null;
             }
-            self.textLayout.addText(placeholder, .{ .color_text = self.textLayout.data().options.textColor(.text).opacity(0.65) });
+            self.textLayout.addText(placeholder, .{ .color_text = self.textLayout.data().options.color(.text).opacity(0.65) });
         }
     }
 

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -425,8 +425,8 @@ pub fn init(self: *TextLayoutWidget, src: std.builtin.SourceLocation, init_opts:
                 path.addPoint(.{ .x = fcrs.r.x + fcrs.r.w, .y = fcrs.r.y });
                 path.addArc(.{ .x = fcrs.r.x + fcrs.r.w / 2, .y = fcrs.r.y + fcrs.r.h / 2 }, fcrs.r.w / 2, std.math.pi, 0, true);
 
-                path.build().fillConvex(.{ .color = control_opts.color(.fill) });
-                path.build().stroke(.{ .thickness = 1.0 * fcrs.s, .color = self.data().options.color(.border), .closed = true });
+                path.build().fillConvex(.{ .color = control_opts.textColor(.fill) });
+                path.build().stroke(.{ .thickness = 1.0 * fcrs.s, .color = self.data().options.textColor(.border), .closed = true });
             }
 
             dvui.dataSet(null, fc.data().id, "_offset", offset);
@@ -494,8 +494,8 @@ pub fn init(self: *TextLayoutWidget, src: std.builtin.SourceLocation, init_opts:
                 path.addPoint(.{ .x = fcrs.r.x, .y = fcrs.r.y });
                 path.addArc(.{ .x = fcrs.r.x + fcrs.r.w / 2, .y = fcrs.r.y + fcrs.r.h / 2 }, fcrs.r.w / 2, std.math.pi, 0, true);
 
-                path.build().fillConvex(.{ .color = control_opts.color(.fill) });
-                path.build().stroke(.{ .thickness = 1.0 * fcrs.s, .color = self.data().options.color(.border), .closed = true });
+                path.build().fillConvex(.{ .color = control_opts.textColor(.fill) });
+                path.build().stroke(.{ .thickness = 1.0 * fcrs.s, .color = self.data().options.textColor(.border), .closed = true });
             }
 
             dvui.dataSet(null, fc.data().id, "_offset", offset);
@@ -544,7 +544,7 @@ pub const AddLinkOptions = struct {
 };
 
 pub fn addLink(self: *TextLayoutWidget, init_opts: AddLinkOptions, opts: Options) void {
-    const defs: Options = .{ .color_text = dvui.themeGet().focus, .font = dvui.Font.theme(.body).withUnderline(.{}) };
+    const defs: Options = .{ .color_text = .{ .color = dvui.themeGet().focus }, .font = dvui.Font.theme(.body).withUnderline(.{}) };
     if (self.addTextClick(init_opts.text orelse init_opts.url, defs.override(opts))) |click_event| {
         const new_window = (click_event == .mouse and (click_event.mouse.button == .middle or click_event.mouse.mod.matchBind("ctrl/cmd")));
         _ = dvui.openURL(.{ .url = init_opts.url, .new_window = new_window });
@@ -1575,13 +1575,19 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
                 break :info null;
             };
 
+            // Sampled against this run's own `rs.r`, so a gradient resets at
+            // each line/style-run boundary; set `gradient.anchor` to a
+            // shared rect (e.g. the whole TextLayoutWidget) for a continuous
+            // sweep across multiple lines/runs.
+            const text_col = options.textColor(.text).split();
             dvui.renderText(.{
                 .font = font,
                 .text = rtxt,
                 .rs = rs,
-                .color = options.color(.text),
+                .color = text_col.color,
+                .gradient = text_col.gradient,
                 // TODO: Should this take `options.background` into account?
-                .background_color = options.color_fill,
+                .background_color = if (options.color_fill) |cog| cog.toColor() else null,
                 .sel_start = self.selection.start -| self.bytes_seen,
                 .sel_end = self.selection.end -| self.bytes_seen,
                 .sel_color = (dvui.themeGet().text_select orelse dvui.themeGet().color(.highlight, .fill)).opacity(0.75),

--- a/src/widgets/TextLayoutWidget.zig
+++ b/src/widgets/TextLayoutWidget.zig
@@ -425,8 +425,8 @@ pub fn init(self: *TextLayoutWidget, src: std.builtin.SourceLocation, init_opts:
                 path.addPoint(.{ .x = fcrs.r.x + fcrs.r.w, .y = fcrs.r.y });
                 path.addArc(.{ .x = fcrs.r.x + fcrs.r.w / 2, .y = fcrs.r.y + fcrs.r.h / 2 }, fcrs.r.w / 2, std.math.pi, 0, true);
 
-                path.build().fillConvex(.{ .color = control_opts.textColor(.fill) });
-                path.build().stroke(.{ .thickness = 1.0 * fcrs.s, .color = self.data().options.textColor(.border), .closed = true });
+                path.build().fillConvex(.{ .color = control_opts.color(.fill) });
+                path.build().stroke(.{ .thickness = 1.0 * fcrs.s, .color = self.data().options.color(.border), .closed = true });
             }
 
             dvui.dataSet(null, fc.data().id, "_offset", offset);
@@ -494,8 +494,8 @@ pub fn init(self: *TextLayoutWidget, src: std.builtin.SourceLocation, init_opts:
                 path.addPoint(.{ .x = fcrs.r.x, .y = fcrs.r.y });
                 path.addArc(.{ .x = fcrs.r.x + fcrs.r.w / 2, .y = fcrs.r.y + fcrs.r.h / 2 }, fcrs.r.w / 2, std.math.pi, 0, true);
 
-                path.build().fillConvex(.{ .color = control_opts.textColor(.fill) });
-                path.build().stroke(.{ .thickness = 1.0 * fcrs.s, .color = self.data().options.textColor(.border), .closed = true });
+                path.build().fillConvex(.{ .color = control_opts.color(.fill) });
+                path.build().stroke(.{ .thickness = 1.0 * fcrs.s, .color = self.data().options.color(.border), .closed = true });
             }
 
             dvui.dataSet(null, fc.data().id, "_offset", offset);
@@ -1579,7 +1579,7 @@ fn addTextEx(self: *TextLayoutWidget, text_in: []const u8, action: AddTextExActi
             // each line/style-run boundary; set `gradient.anchor` to a
             // shared rect (e.g. the whole TextLayoutWidget) for a continuous
             // sweep across multiple lines/runs.
-            const text_col = options.textColor(.text).split();
+            const text_col = options.color(.text).split();
             dvui.renderText(.{
                 .font = font,
                 .text = rtxt,

--- a/src/widgets/TreeWidget.zig
+++ b/src/widgets/TreeWidget.zig
@@ -308,7 +308,7 @@ pub const Branch = struct {
 
                     if (self.target_rs != null) {
                         rs.r.h = 2.0;
-                        rs.r.fill(.{}, .{ .color = dvui.themeGet().focus, .fade = 1.0 });
+                        rs.r.fill(.{}, .{ .color = .{ .color = dvui.themeGet().focus }, .fade = 1.0 });
                     }
                 }
             }
@@ -330,7 +330,7 @@ pub const Branch = struct {
             var rs = self.data().rectScale();
             self.target_rs = rs;
             rs.r.h = 2.0;
-            rs.r.fill(.{}, .{ .color = dvui.themeGet().focus, .fade = 1.0 });
+            rs.r.fill(.{}, .{ .color = .{ .color = dvui.themeGet().focus }, .fade = 1.0 });
         }
 
         self.tree.branch_size = self.button.data().rect.size();


### PR DESCRIPTION
Related Issues: #923 #120
Add Gradient Support to following items:
- Text
- Icons
- Path draw fns
- Options (fill, border, text):  where supported option fields are transitioning from Color -> ColorOrGradient
```zig
color_fill: ?ColorOrGradient = null,
color_fill_hover: ?ColorOrGradient = null,
color_fill_press: ?ColorOrGradient = null,
color_text: ?ColorOrGradient = null,
color_text_hover: ?ColorOrGradient = null,
color_text_press: ?ColorOrGradient = null,
color_border: ?ColorOrGradient = null,
```
Gradient Features:
- linear Multi Stop Gradients, angle, external rect anchoring
- Radial Multi Stop Gradients (ellipse, circle), angle, anchoring, focal point
- Scattered Multi Color Gradient, individual position

<img width="389" height="305" alt="Bildschirmfoto 2026-08-26 um 08 51 23" src="https://github.com/user-attachments/assets/3fc50146-e5b1-47a0-8a3b-0bb6f81f62e6" />

the example was added under styling where the old gradient demo was.

note: i accidently merged #970 and reverted it, this is the current gradient PR.