### PR TITLE
Strip dvui dependencies to reduce diskspace and complexity, strip bundled proprietary sdks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,74 @@ jobs:
 
       - name: Compile
         run: zig build -Dbackend=${{ matrix.backend }} ${{ matrix.args }}
+
+  macos-sdk:
+    runs-on: macos-latest
+    name: Extract macOS SDK sysroot
+    outputs:
+      sdk-version: ${{ steps.version.outputs.sdk-version }}
+    steps:
+      - id: version
+        name: Get SDK version
+        run: echo "sdk-version=$(xcrun --sdk macosx --show-sdk-version)" >> "$GITHUB_OUTPUT"
+
+      - id: cache
+        name: Restore cached sysroot tarball
+        uses: actions/cache@v4
+        with:
+          path: macos-sysroot.tar.zst
+          key: macos-sysroot-${{ steps.version.outputs.sdk-version }}
+
+      - name: Build sysroot tarball
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          set -e
+          sdk="$(xcrun --sdk macosx --show-sdk-path)"
+          # Headers + .tbd stub libs only (no compiled binaries) -- everything a
+          # cross-compiling linker/translate-c step needs, nothing Apple ships as
+          # a redistributable binary.
+          tar -c -C "$sdk" usr/include usr/lib System/Library/Frameworks \
+            | zstd -T0 -o macos-sysroot.tar.zst
+
+      - name: Upload sysroot tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-sysroot
+          path: macos-sysroot.tar.zst
+          retention-days: 14
+
+  compile-macos-cross:
+    needs: macos-sdk
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [sdl2, sdl3, sdl3gpu, raylib, raylib_zig, glfw, wio, pugl]
+    runs-on: ubuntu-latest
+    # sdl2/glfw/wio/pugl needed their own framework/include/library search-path fixes
+    # (see nat3Github forks + addMacosSdkSearchPaths in build.zig); sdl3/sdl3gpu already
+    # had this wiring, raylib/raylib_zig share the raylib fork's fix. continue-on-error
+    # stays on until this job has actually run green in CI at least once.
+    continue-on-error: true
+
+    name: Cross-compile ${{ matrix.backend }} to macOS
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mlugg/setup-zig@v2
+
+      - name: Download macOS sysroot
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-sysroot
+
+      - name: Extract sysroot
+        run: |
+          mkdir -p macos-sysroot
+          zstd -d -c macos-sysroot.tar.zst | tar -x -C macos-sysroot
+          echo "MACOS_SYSROOT=$PWD/macos-sysroot" >> "$GITHUB_ENV"
+
+      - name: Compile
+        run: |
+          zig build -Dbackend=${{ matrix.backend }} -Dtarget=aarch64-macos \
+            --sysroot "$MACOS_SYSROOT" \
+            -Dsystem_include_path="$MACOS_SYSROOT/usr/include" \
+            -Dsystem_framework_path="$MACOS_SYSROOT/System/Library/Frameworks"

--- a/CROSSCOMPILE.md
+++ b/CROSSCOMPILE.md
@@ -1,0 +1,84 @@
+# Cross-compiling dvui backends
+
+Exactly which native libraries each backend links, per target OS. Pulled
+straight from each fork's `build.zig` (`linkSystemLibrary`/`linkFramework`
+calls) — the sibling dirs `../lib-sdl-dev`, `../raylib-dev-fork`,
+`../wio-dev-fork`, `../pugl-dev-fork`, and the `zglfw` package.
+
+Windows never needs a sysroot: Zig bundles mingw-w64 headers/import libs, so
+`-Dtarget=x86_64-windows-gnu` alone is enough — the libs listed below are
+already in that bundle. Linux and macOS need a real sysroot (see below) with
+these headers+libs present, passed via `-Dsystem_include_path=...
+-Dlibrary_path=...` (Linux) or `--sysroot ... -Dsystem_include_path=...
+-Dsystem_framework_path=...` (macOS).
+
+custom / testing / proxy: no native deps anywhere, libc only.
+web: n/a, always builds to `wasm32-freestanding` regardless of host.
+dx11: Windows-only backend, build steps don't even register for Linux/macOS targets.
+
+## Windows (libs, all bundled by zig's mingw-w64 — nothing to install)
+
+- sdl2 / sdl3 / sdl3gpu: `user32 shell32 advapi32 setupapi winmm gdi32 imm32 version oleaut32 ole32`
+- raylib / raylib_zig: `opengl32 winmm gdi32` (+ `shcore` if HiDPI)
+- glfw: `gdi32 user32 shell32`
+- wio: `user32 shell32 ole32 gdi32 opengl32 hid` + `xinput9_1_0`/`xinput1_4`
+- pugl: `user32 shlwapi dwmapi gdi32 opengl32`
+- dx11: `win32`/zigwin32 bindings, `comdlg32 ole32`
+
+## Linux (apt packages, install into the sysroot)
+
+- sdl2 / sdl3 / sdl3gpu: links `X11 Xext pulse` → `libx11-dev libxext-dev libpulse-dev`
+- raylib / raylib_zig (X11 backend, default): links `GL X11 Xrandr Xinerama Xi Xcursor` → `libgl-dev libx11-dev libxrandr-dev libxinerama-dev libxi-dev libxcursor-dev`
+- raylib / raylib_zig (`-Dlinux_display_backend=Wayland`): links `wayland-client wayland-cursor wayland-egl xkbcommon` → `libwayland-dev libxkbcommon-dev`
+- glfw: links `X11` → `libx11-dev`
+- wio (X11 backend): links `x11 xrandr xcursor xext` (+`gl` if OpenGL renderer) → `libx11-dev libxrandr-dev libxcursor-dev libxext-dev libgl-dev`
+- wio (Wayland backend): links `wayland-client xkbcommon libdecor-0` (+`wayland-egl egl` for GL) → `libwayland-dev libxkbcommon-dev libdecor-0-dev libegl-dev`
+- wio (Vulkan renderer, either backend): + `vulkan` → `libvulkan-dev`
+- wio (`-Dwio_audio=true`): + `libpulse` → `libpulse-dev`
+- pugl: links `m X11 Xrender` (+`Xcursor Xrandr Xext` if enabled) + `GL` or `vulkan` depending on renderer → `libx11-dev libxrender-dev libgl-dev` (+`libxcursor-dev libxrandr-dev libxext-dev libvulkan-dev` as needed)
+
+Don't want to scope packages per backend? The superset apt line already used
+in `.github/workflows/test.yml`'s "Install libraries" step covers every case
+above in one shot:
+
+```
+sudo apt-get install mesa-common-dev libgl-dev libglx-dev libegl-dev \
+  libpulse-dev libxext-dev libxfixes-dev libxrender-dev libasound2-dev \
+  libx11-dev libxrandr-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev \
+  libxcursor-dev libxinerama-dev libwayland-dev libxkbcommon-dev
+```
+
+## macOS (frameworks, extract from Xcode's SDK into the sysroot)
+
+- sdl2 / sdl3 / sdl3gpu: `OpenGL Metal CoreVideo Cocoa IOKit ForceFeedback Carbon CoreAudio AudioToolbox AVFoundation Foundation`
+- raylib / raylib_zig: `Foundation CoreServices CoreGraphics AppKit IOKit OpenGL`
+- glfw: `IOKit CoreFoundation Metal AppKit CoreServices CoreGraphics Foundation` + `objc`
+- wio: `Cocoa QuartzCore IOKit` (+ `CoreAudio AudioUnit AudioToolbox` with `-Dwio_audio=true`)
+- pugl: `Cocoa CoreVideo` (+ `Metal QuartzCore` for the Vulkan/Metal renderer)
+
+## Building a sysroot
+
+**Linux** — install the packages above into a real (or containerized) Linux
+system, or `apt-get download` + `dpkg -x` them into a scratch dir without
+installing, so you end up with a tree containing `usr/include` and
+`usr/lib/x86_64-linux-gnu`, e.g. `/tmp/linux-sysroot`. Then:
+
+```
+-Dsystem_include_path=/tmp/linux-sysroot/usr/include \
+-Dlibrary_path=/tmp/linux-sysroot/usr/lib/x86_64-linux-gnu
+```
+
+**macOS** — on any Mac, run `xcrun --sdk macosx --show-sdk-path` and tar up
+`usr/include`, `usr/lib`, and `System/Library/Frameworks` from that path
+(headers + `.tbd` stub libs only — no compiled Apple binaries, so it's fine
+to redistribute/cache in CI). Extract it somewhere, e.g. `/tmp/macos-sysroot`,
+then:
+
+```
+-Dtarget=aarch64-macos --sysroot /tmp/macos-sysroot \
+-Dsystem_include_path=/tmp/macos-sysroot/usr/include \
+-Dsystem_framework_path=/tmp/macos-sysroot/System/Library/Frameworks
+```
+
+This is exactly what the `macos-sdk` + `compile-macos-cross` jobs in
+`test.yml` already automate.

--- a/build.zig
+++ b/build.zig
@@ -674,6 +674,11 @@ pub fn buildBackend(
             dvui_opts.addChecks(sdl_mod, "sdl3gpu-backend");
             dvui_opts.addTests(sdl_mod, "sdl3gpu-backend");
 
+            // sdl_mod itself (not just the SDL3 fork's own module) links the frameworks
+            // SDL3 needs -- see addMacosSdkSearchPaths doc comment for why this needs to
+            // be explicit here rather than inherited from the SDL3 fork's build.zig.
+            addMacosSdkSearchPaths(b, dvui_opts_in, &.{sdl_mod});
+
             const sdl3_options = b.addOptions();
             // sdl3_options.addOption(
             //     ?bool,
@@ -946,6 +951,10 @@ pub fn buildBackend(
             });
             dvui_opts.addChecks(raylib_backend_mod, "raylib-zig-backend");
             dvui_opts.addTests(raylib_backend_mod, "raylib-zig-backend");
+
+            // raylib_zig's raylib/zglfw imports link Cocoa/AppKit/etc frameworks on their
+            // own modules, which doesn't propagate here -- see addMacosSdkSearchPaths doc.
+            addMacosSdkSearchPaths(b, dvui_opts_in, &.{raylib_backend_mod});
 
             const maybe_ray = b.lazyDependency(
                 "raylib_zig",

--- a/build.zig
+++ b/build.zig
@@ -808,6 +808,36 @@ pub fn buildBackend(
                     },
                 },
             });
+
+            // raylib-c.h pulls in GLFW/glfw3.h, which on macOS includes <OpenGL/gl.h> —
+            // a framework header, so this translate-c and module both need the SDK
+            // framework/include paths explicitly (they don't inherit them from the raylib
+            // dependency's own build.zig, which only applies its sysroot paths to its own
+            // compileRaylib step).
+            if (target.result.os.tag == .macos) {
+                var sdk: ?[]const u8 = null;
+                if (b.graph.host.result.os.tag.isDarwin()) {
+                    sdk = resolveMacosSdkPath(b) catch null;
+                }
+
+                if (dvui_opts_in.sdl3_system_include_path) |p| {
+                    raylib_translate_c.addSystemIncludePath(p);
+                    raylib_backend_mod.addSystemIncludePath(p);
+                } else if (sdk) |path| {
+                    const p: std.Build.LazyPath = .{ .cwd_relative = b.pathJoin(&.{ path, "usr/include" }) };
+                    raylib_translate_c.addSystemIncludePath(p);
+                    raylib_backend_mod.addSystemIncludePath(p);
+                }
+
+                if (dvui_opts_in.sdl3_system_framework_path) |p| {
+                    raylib_translate_c.addSystemFrameworkPath(p);
+                    raylib_backend_mod.addSystemFrameworkPath(p);
+                } else if (sdk) |path| {
+                    const p: std.Build.LazyPath = .{ .cwd_relative = b.pathJoin(&.{ path, "System/Library/Frameworks" }) };
+                    raylib_translate_c.addSystemFrameworkPath(p);
+                    raylib_backend_mod.addSystemFrameworkPath(p);
+                }
+            }
             dvui_opts.addChecks(raylib_backend_mod, "raylib-backend");
             dvui_opts.addTests(raylib_backend_mod, "raylib-backend");
 

--- a/build.zig
+++ b/build.zig
@@ -157,6 +157,34 @@ fn resolveMacosSdkPath(b: *std.Build) ![]const u8 {
     return b.dupePath(path);
 }
 
+// Framework/include/library search paths added to a dependency's own build.zig module
+// (e.g. via a fork's linkMacOS) do not propagate to a *different* module that links
+// against it (a translate-c step, or a dvui-side wrapper module) — each such module
+// needs these paths explicitly. Reuses the sdl3_system_*/library_path options since
+// they're backed by generic -Dsystem_include_path/-Dsystem_framework_path/-Dlibrary_path
+// flags, not actually SDL3-specific.
+fn addMacosSdkSearchPaths(b: *std.Build, dvui_opts_in: DvuiModuleOptions, mods: []const *std.Build.Module) void {
+    var sdk: ?[]const u8 = null;
+    if (b.graph.host.result.os.tag.isDarwin()) {
+        sdk = resolveMacosSdkPath(b) catch null;
+    }
+    for (mods) |m| {
+        if (dvui_opts_in.sdl3_system_include_path) |p| {
+            m.addSystemIncludePath(p);
+        } else if (sdk) |path| {
+            m.addSystemIncludePath(.{ .cwd_relative = b.pathJoin(&.{ path, "usr/include" }) });
+        }
+        if (dvui_opts_in.sdl3_system_framework_path) |p| {
+            m.addSystemFrameworkPath(p);
+        } else if (sdk) |path| {
+            m.addSystemFrameworkPath(.{ .cwd_relative = b.pathJoin(&.{ path, "System/Library/Frameworks" }) });
+        }
+        if (dvui_opts_in.sdl3_library_path) |p| {
+            m.addLibraryPath(p);
+        }
+    }
+}
+
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -595,6 +623,13 @@ pub fn buildBackend(
                     .file = objc_file,
                     .language = .objective_c,
                 });
+
+                // config.mm needs <Foundation/Foundation.h>, and sdl_mod needs the
+                // framework search path for its own -framework links (added on the
+                // SDL2 fork's module don't propagate to sdl_mod's link command) —
+                // module-scoped search paths don't propagate across module boundaries.
+                addMacosSdkSearchPaths(b, dvui_opts_in, &.{ lib.root_module, sdl_mod });
+
                 sdl_mod.linkLibrary(lib);
             }
 
@@ -1021,6 +1056,18 @@ pub fn buildBackend(
                 glfw_mod.linkLibrary(glfw.artifact("glfw"));
             }
 
+            // zglfw links Cocoa/IOKit/objc etc. on macOS, but that module's own search
+            // paths don't propagate to glfw_mod's final link command.
+            if (target.result.os.tag == .macos) {
+                addMacosSdkSearchPaths(b, dvui_opts_in, &.{glfw_mod});
+                if (dvui_opts_in.sdl3_library_path == null and b.sysroot != null) {
+                    // -lobjc needs an explicit -L; passed as plain "/usr/lib" because
+                    // Zig rejoins a cwd_relative library path onto --sysroot itself
+                    // (joining it with the sysroot again here would double it).
+                    glfw_mod.addLibraryPath(.{ .cwd_relative = "/usr/lib" });
+                }
+            }
+
             const dvui_glfw = addDvuiModule("dvui_glfw", dvui_opts);
             linkBackend(dvui_glfw, glfw_mod);
 
@@ -1158,6 +1205,12 @@ pub fn buildBackend(
                 dvui_opts.wio_module = wio.module("wio");
             }
 
+            // wio links Cocoa/Metal etc. on macOS, but that module's own search paths
+            // don't propagate to wio_backend_mod's final link command.
+            if (target.result.os.tag == .macos) {
+                addMacosSdkSearchPaths(b, dvui_opts_in, &.{wio_backend_mod});
+            }
+
             const dvui_wio = addDvuiModule("dvui_wio", dvui_opts);
             dvui_opts.addChecks(dvui_wio, "dvui_wio");
             if (test_dvui_and_app) {
@@ -1202,6 +1255,12 @@ pub fn buildBackend(
             })) |pugl| {
                 pugl_backend_mod.addImport("pugl", pugl.module("pugl"));
                 pugl_backend_mod.addImport("pugl-opengl", pugl.module("backend_opengl"));
+            }
+
+            // pugl links Cocoa/CoreVideo on macOS, but that module's own search paths
+            // don't propagate to pugl_backend_mod's final link command.
+            if (target.result.os.tag == .macos) {
+                addMacosSdkSearchPaths(b, dvui_opts_in, &.{pugl_backend_mod});
             }
 
             const dvui_pugl = addDvuiModule("dvui_pugl", dvui_opts);

--- a/build.zig
+++ b/build.zig
@@ -584,6 +584,10 @@ pub fn buildBackend(
                         // have /usr/include/gles/gl.h
                         // https://github.com/david-vanderson/dvui/issues/131
                         .render_driver_ogl_es = false,
+                        // Forwarded for cross-compiling to Linux from a non-Linux host --
+                        // see the SDL2 fork's build.zig for why these aren't --sysroot.
+                        .system_include_path = dvui_opts_in.sdl3_system_include_path,
+                        .library_path = dvui_opts_in.sdl3_library_path,
                     });
                     if (sdl_dep) |sd| {
                         sdl_translate_c.addIncludePath(sd.artifact("SDL2").getEmittedIncludeTree());
@@ -598,6 +602,21 @@ pub fn buildBackend(
                 }
             }
             sdl_mod.addOptions("sdl_options", sdl2_options);
+
+            // Cross-compiling to Linux from a non-Linux host: sdl2-c.h pulls in
+            // <X11/Xlib.h> via SDL_syswm.h, but this translate-c step is a separate
+            // module scope from the SDL2 fork's own module, so it needs the sysroot
+            // include/library paths explicitly (same reasoning as addMacosSdkSearchPaths).
+            // These come from plain absolute -Dsystem_include_path/-Dlibrary_path
+            // (NOT --sysroot, which would also break native host-tool builds elsewhere
+            // in the graph -- see the SDL2 fork's build.zig for the full reasoning).
+            if (target.result.os.tag == .linux and b.graph.host.result.os.tag != .linux) {
+                if (dvui_opts_in.sdl3_system_include_path) |p| {
+                    sdl_translate_c.addSystemIncludePath(p);
+                    sdl_mod.addSystemIncludePath(p);
+                }
+                if (dvui_opts_in.sdl3_library_path) |p| sdl_mod.addLibraryPath(p);
+            }
 
             // Enable smooth scrolling on mac
             if (target.result.os.tag == .macos) {
@@ -878,6 +897,19 @@ pub fn buildBackend(
                     raylib_backend_mod.addSystemFrameworkPath(p);
                 }
             }
+
+            // Cross-compiling to Linux from a non-Linux host: raylib-c.h pulls in
+            // GLFW/glfw3.h, which includes <GL/gl.h> -- needs the sysroot include path
+            // explicitly, same reasoning as the macOS block above. The raylib artifact's
+            // own -lX11/-lGL search paths also don't propagate to this module, which
+            // links the artifact but re-resolves those system libs at its own link step.
+            if (target.result.os.tag == .linux and b.graph.host.result.os.tag != .linux) {
+                if (dvui_opts_in.sdl3_system_include_path) |p| {
+                    raylib_translate_c.addSystemIncludePath(p);
+                    raylib_backend_mod.addSystemIncludePath(p);
+                }
+                if (dvui_opts_in.sdl3_library_path) |p| raylib_backend_mod.addLibraryPath(p);
+            }
             dvui_opts.addChecks(raylib_backend_mod, "raylib-backend");
             dvui_opts.addTests(raylib_backend_mod, "raylib-backend");
 
@@ -887,6 +919,8 @@ pub fn buildBackend(
                     .target = target,
                     .optimize = optimize,
                     .linux_display_backend = dvui_opts.linux_display_backend.?,
+                    .system_include_path = dvui_opts_in.sdl3_system_include_path,
+                    .library_path = dvui_opts_in.sdl3_library_path,
                 },
             );
             if (maybe_ray) |ray| {
@@ -956,12 +990,22 @@ pub fn buildBackend(
             // own modules, which doesn't propagate here -- see addMacosSdkSearchPaths doc.
             addMacosSdkSearchPaths(b, dvui_opts_in, &.{raylib_backend_mod});
 
+            // Cross-compiling to Linux from a non-Linux host: same reasoning as the
+            // .raylib case above -- raylib/zglfw's own -lX11/-lGL search paths don't
+            // propagate to this module, which re-resolves those system libs itself.
+            if (target.result.os.tag == .linux and b.graph.host.result.os.tag != .linux) {
+                if (dvui_opts_in.sdl3_system_include_path) |p| raylib_backend_mod.addSystemIncludePath(p);
+                if (dvui_opts_in.sdl3_library_path) |p| raylib_backend_mod.addLibraryPath(p);
+            }
+
             const maybe_ray = b.lazyDependency(
                 "raylib_zig",
                 .{
                     .target = target,
                     .optimize = optimize,
                     .linux_display_backend = dvui_opts.linux_display_backend.?,
+                    .system_include_path = dvui_opts_in.sdl3_system_include_path,
+                    .library_path = dvui_opts_in.sdl3_library_path,
                 },
             );
             if (maybe_ray) |ray| {
@@ -975,6 +1019,8 @@ pub fn buildBackend(
                 .{
                     .target = target,
                     .optimize = optimize,
+                    .system_include_path = dvui_opts_in.sdl3_system_include_path,
+                    .library_path = dvui_opts_in.sdl3_library_path,
                 },
             );
             if (maybe_glfw) |glfw| {
@@ -1057,6 +1103,8 @@ pub fn buildBackend(
                     .optimize = optimize,
                     .x11 = if (dvui_opts.glfw_linux_display) |gld| gld.x11 else null,
                     .wayland = if (dvui_opts.glfw_linux_display) |gld| gld.wayland else null,
+                    .system_include_path = dvui_opts_in.sdl3_system_include_path,
+                    .library_path = dvui_opts_in.sdl3_library_path,
                 },
             );
 
@@ -1075,6 +1123,14 @@ pub fn buildBackend(
                     // (joining it with the sysroot again here would double it).
                     glfw_mod.addLibraryPath(.{ .cwd_relative = "/usr/lib" });
                 }
+            }
+
+            // Cross-compiling to Linux from a non-Linux host: same reasoning as the
+            // raylib/pugl cases above -- zglfw's own -lX11 search path doesn't
+            // propagate to this module, which re-resolves that system lib itself.
+            if (target.result.os.tag == .linux and b.graph.host.result.os.tag != .linux) {
+                if (dvui_opts_in.sdl3_system_include_path) |p| glfw_mod.addSystemIncludePath(p);
+                if (dvui_opts_in.sdl3_library_path) |p| glfw_mod.addLibraryPath(p);
             }
 
             const dvui_glfw = addDvuiModule("dvui_glfw", dvui_opts);
@@ -1096,7 +1152,17 @@ pub fn buildBackend(
                 const zgl_mod = zgl.module("zgl");
                 switch (target.result.os.tag) {
                     .windows => zgl_mod.linkSystemLibrary("opengl32", .{}),
-                    .linux => zgl_mod.linkSystemLibrary("GL", .{}),
+                    .linux => {
+                        // Cross-compiling to Linux from a non-Linux host: same reasoning
+                        // as the sdl2/raylib/glfw sysroot wiring above -- host pkg-config
+                        // resolves GL to host-arch libs.
+                        const cross_linux = b.graph.host.result.os.tag != .linux;
+                        if (cross_linux) {
+                            if (dvui_opts_in.sdl3_system_include_path) |p| zgl_mod.addSystemIncludePath(p);
+                            if (dvui_opts_in.sdl3_library_path) |p| zgl_mod.addLibraryPath(p);
+                        }
+                        zgl_mod.linkSystemLibrary("GL", .{ .use_pkg_config = if (cross_linux) .no else .yes });
+                    },
                     .macos => {
                         zgl_mod.linkFramework("OpenGL", .{});
                         zgl_mod.linkFramework("Cocoa", .{});
@@ -1261,6 +1327,8 @@ pub fn buildBackend(
                 .target = target,
                 .optimize = optimize,
                 .opengl = true,
+                .system_include_path = dvui_opts_in.sdl3_system_include_path,
+                .library_path = dvui_opts_in.sdl3_library_path,
             })) |pugl| {
                 pugl_backend_mod.addImport("pugl", pugl.module("pugl"));
                 pugl_backend_mod.addImport("pugl-opengl", pugl.module("backend_opengl"));
@@ -1270,6 +1338,14 @@ pub fn buildBackend(
             // don't propagate to pugl_backend_mod's final link command.
             if (target.result.os.tag == .macos) {
                 addMacosSdkSearchPaths(b, dvui_opts_in, &.{pugl_backend_mod});
+            }
+
+            // Cross-compiling to Linux from a non-Linux host: same reasoning as the
+            // raylib/glfw cases above -- pugl's own -lX11/-lGL search paths don't
+            // propagate to this module, which re-resolves those system libs itself.
+            if (target.result.os.tag == .linux and b.graph.host.result.os.tag != .linux) {
+                if (dvui_opts_in.sdl3_system_include_path) |p| pugl_backend_mod.addSystemIncludePath(p);
+                if (dvui_opts_in.sdl3_library_path) |p| pugl_backend_mod.addLibraryPath(p);
             }
 
             const dvui_pugl = addDvuiModule("dvui_pugl", dvui_opts);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,16 +21,16 @@
     },
     .dependencies = .{
         .sdl = .{
-            .url = "git+https://github.com/david-vanderson/SDL#b25735a465f7db1c160d2eca8ac46dde9ec41cfb",
-            .hash = "SDL-2.32.10-JToi37G3EgG0eraPos4vhCwC6vVgyB1FYf1SxxhpBr_Y",
+            .url = "git+https://github.com/nat3Github/zig-lib-sdl2-dev-fork#a7cc312755364cea993e5b55cd32dc6b0b50e109",
+            .hash = "SDL-2.32.10-JToi3wSNDgEJBnijet0mJnM5egbGpRBl_Zu-d5zJrILd",
             .lazy = true,
         },
         // Fork of david-vanderson/SDL with an .ios case added to build.zig (upstream's
         // target-OS switch has none; see linkSdl3 in build.zig and examples/ios-example/README.md).
         // Additive only — every other target builds identically to the plain upstream fork.
         .sdl3 = .{
-            .url = "git+https://github.com/nat3Github/lib-sdl3-dev-fork#3aec7d397ca8997725dcb624f7470a60c9b33734",
-            .hash = "sdl-0.4.2+3.4.4-SDL--gqNpQF1CjofImvjmIBRf7mkJns3eCFIsRbucO1m",
+            .url = "git+https://github.com/nat3Github/lib-sdl3-dev-fork?ref=ios-support#4b452f77bbce509d40664bb6f580d4846a718b4a",
+            .hash = "sdl-0.4.2+3.4.4-SDL--l77ngEMpAPw_lapBlyaTJFXIncEGnPPNHAsdEzC",
             .lazy = true,
         },
         .freetype = .{
@@ -39,11 +39,13 @@
             .lazy = true,
         },
         .raylib = .{
-            .path = "../raylib-dev-fork",
+            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev-fork#02880226b9c47e35704b914cdc231ca3b714b0de",
+            .hash = "raylib-6.0.0-whq8uBmC7AA3lM_OwQ6yWE1Oppiyoee2IyGzgbEBkr3L",
             .lazy = true,
         },
         .wio = .{
-            .path = "../wio-dev-fork",
+            .url = "git+https://github.com/nat3Github/zig-lib-wio-dev-fork#8381ca0c4d4c84f7a9fa1d0a475ffbbd5fe6b59a",
+            .hash = "wio-0.0.0-8xHrryoECAB7XM0Uary4h2mm4S4iGAwFLGYEgtnq5xLY",
             .lazy = true,
         },
         .opengl = .{
@@ -63,8 +65,8 @@
         },
         //used in the raylib-ontop example
         .raygui = .{
-            .url = "https://github.com/raysan5/raygui/archive/33f1659.tar.gz",
-            .hash = "N-V-__8AAAHFTwBfBg00dnFXcYkNbjC8BSyi1CDcrnh12ypL",
+            .url = "git+https://github.com/nat3Github/zig-lib-raygui-dev-fork#62a3b50b71c271ab1afbf201d168c08dccc5c40c",
+            .hash = "N-V-__8AAIppBAC5cWi-1ZeNAWCL-wnmk1C5Trtdhu1w3NAs",
             .lazy = true,
         },
         // required for the directx11 backend
@@ -87,20 +89,23 @@
 
         // Experimental zig bindings, any zig based backend will be located here
         .raylib_zig = .{
-            .path = "../raylib-zig-dev-fork",
+            .url = "git+https://github.com/nat3Github/zig-lib-raylib-zig-dev-fork#286dd3518da077c0989a06d39f5c38142bacfd0b",
+            .hash = "raylib_zig-6.0.0-KE8REO58BQCzNPBGTU2WbcPrj4HLvRyfXkqw2XW4Bm9L",
             .lazy = true,
         },
         .zglfw = .{
-            .path = "../zglfw-dev-fork",
+            .url = "git+https://github.com/nat3Github/zig-lib-zglfw-dev-fork#9665cd606526406f34f56addb722e3d01665c370",
+            .hash = "zglfw-0.10.0-dev-zgVDNPeyIQCvez7MinH6mwntQBeBHJqxhwagyhYnGWm2",
             .lazy = true,
         },
         .tree_sitter = .{
-            .path = "../lib-treesitter-dev-fork",
+            .url = "git+https://github.com/nat3Github/zig-lib-treesitter-dev-fork#f7e4a1b093a95e9fb64ad253697cac8bd60238dd",
+            .hash = "tree_sitter-0.27.0-Tw2sR1qNCwBw_B0VhkJL6S55tX5cjhbYGueUs4tSbV__",
             .lazy = true,
         },
         .tree_sitter_json = .{
-            .url = "git+https://github.com/tree-sitter/tree-sitter-json#001c28d7a29832b06b0e831ec77845553c89b56d",
-            .hash = "N-V-__8AAHNaAgD6kjK3HX6lAf89chPqS5zIm0tLpvBQLOtX",
+            .url = "git+https://github.com/nat3Github/zig-lib-treesitter-json-dev-fork#d4875df5ab194cf1aff7ba962f2dec6f643090a6",
+            .hash = "N-V-__8AAFi4AABrZPLLDnDv2DvihRUbM7ZzHtJYLoqx-gHr",
             .lazy = true,
         },
         .tree_sitter_zig = .{
@@ -114,8 +119,8 @@
             .lazy = true,
         },
         .pugl = .{
-            .url = "git+https://github.com/bandithedoge/pugl.zig.git#e9dee6e301bd936d1b6a082352de6f80e27bcbc9",
-            .hash = "pugl-0.1.0-CUvtTsddAQAKB-zCXPw0YayfuVFRGB-ATuYPP1Nb3Xmv",
+            .url = "git+https://github.com/nat3Github/zig-lib-pugl-dev-fork#3b6406b913e1e01c340cebd7eb5392de70c48025",
+            .hash = "pugl-0.1.0-CUvtThZeAQC7kezuc8jm1piz6mHH6Hl5e1JrBkcvwYco",
             .lazy = true,
         },
     },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -39,8 +39,8 @@
             .lazy = true,
         },
         .raylib = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev-fork#02880226b9c47e35704b914cdc231ca3b714b0de",
-            .hash = "raylib-6.0.0-whq8uBmC7AA3lM_OwQ6yWE1Oppiyoee2IyGzgbEBkr3L",
+            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev-fork#51b19a9759289cede2dc07a45dca1cd0c64f51d8",
+            .hash = "raylib-6.0.0-whq8uFFx7ABiA8UA7mW35st_T2lTi7RGBB0oPZOvQF5r",
             .lazy = true,
         },
         .wio = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -39,8 +39,7 @@
             .lazy = true,
         },
         .raylib = .{
-            .url = "git+https://github.com/raysan5/raylib?ref=master#e9caf5a9811a9c1a126398795915b13ef488618e",
-            .hash = "raylib-6.0.0-whq8uOmvLgUktXC94fZkRLK2dQA75X2pMwZYj2X3EZl8",
+            .path = "../raylib-dev-fork",
             .lazy = true,
         },
         .wio = .{
@@ -89,8 +88,7 @@
 
         // Experimental zig bindings, any zig based backend will be located here
         .raylib_zig = .{
-            .url = "git+https://github.com/raylib-zig/raylib-zig?ref=devel#4b6a05cd102d51f00523dd5c5e18e628df359d20",
-            .hash = "raylib_zig-5.6.0-dev-KE8REKNmBQDek2Sz27ULioxYpY9IYR0K0CeIC-iJRLCI",
+            .path = "../raylib-zig-dev-fork",
             .lazy = true,
         },
         .zglfw = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -43,8 +43,7 @@
             .lazy = true,
         },
         .wio = .{
-            .url = "git+https://github.com/ypsvlq/wio.git#c7a0b1ec889c8c17841ffb04ae3d31810328cc64",
-            .hash = "wio-0.0.0-8xHrr_kECABNBaGmnTW2ymwtaa-Oqg3CWN_tXK6KGFkZ",
+            .path = "../wio-dev-fork",
             .lazy = true,
         },
         .opengl = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -39,8 +39,8 @@
             .lazy = true,
         },
         .raylib = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev#75f750636ef0f92e4edc292eda3b590889a6783a",
-            .hash = "raylib-6.0.0-whq8uK76MwXEkoikCffqNyrF-jotnRfOM7tAkp6m2bY2",
+            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev#279a8e300f729be6450752bf86d38dbe18ef73d1",
+            .hash = "raylib-6.0.0-whq8uH37MwVkuXk1gUGy3kz-O6HlvOGF66QgU4KnYiY9",
             .lazy = true,
         },
         .wio = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,8 +21,8 @@
     },
     .dependencies = .{
         .sdl = .{
-            .url = "git+https://github.com/nat3Github/c-sdl2-dev#3a661945f06c169e3c8164aab445cc1003564228",
-            .hash = "SDL-2.32.10-JToi3xWNDwHurZ0fauisXvz7KLk930LjMx4jMj2thbwt",
+            .url = "git+https://github.com/nat3Github/c-sdl2-dev?ref=c-sdl2-dev#64a7bf92d8d0b3fab6f6fec9b897615ea47a2bb6",
+            .hash = "SDL-2.32.10-JToi32WQDwGibHGY8qzkZmk9gDnGEqfr-qzTBJuJ6URg",
             .lazy = true,
         },
         // Fork of castholm/SDL with an .ios case added to build.zig (upstream's
@@ -44,8 +44,8 @@
             .lazy = true,
         },
         .wio = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-wio-dev#d8ef0f367cc63433b23b6ac7de417d7c6b851e99",
-            .hash = "wio-0.0.0-8xHrrxZWCAC1PHJiqowfiV0BeVDEXDZgHn44OQw95hfd",
+            .url = "git+https://github.com/nat3Github/zig-lib-wio-dev?ref=lean-deps-macos-sysroot#eff2460a53c33f8f33c0826d88a51acadb0b3cbf",
+            .hash = "wio-0.0.0-8xHrrzVYCAAuQsPnX6D1I0eHVrcWxn_eFoexzUm87HEI",
             .lazy = true,
         },
         .opengl = .{
@@ -94,8 +94,8 @@
             .lazy = true,
         },
         .zglfw = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-zglfw-dev#ad7052461440f4bd62fa27e25d466ee102608baf",
-            .hash = "zglfw-0.10.0-dev-zgVDNKS0IQCR2YnCqqLHjIyUcob4yEWqFoqzSYO1ofJ_",
+            .url = "git+https://github.com/nat3Github/zig-lib-zglfw-dev#9dac2daa9563d12b7c820adee3677b45f7fa3bcc",
+            .hash = "zglfw-0.10.0-dev-zgVDNCC3IQCUP2jIyVcHINGT4nuRaw0zddXOLHMLDD7i",
             .lazy = true,
         },
         .tree_sitter = .{
@@ -119,8 +119,8 @@
             .lazy = true,
         },
         .pugl = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-pugl-dev#4739855ba315d4ea90bb3a5a4f8b8fcaa41260ad",
-            .hash = "pugl-0.1.0-CUvtTg1eAQB2opdYQMqLobxrYZ7M8US1AEYdXCVtplQ_",
+            .url = "git+https://github.com/nat3Github/zig-lib-pugl-dev#47cf10dd039ba31eee2e72dc7ef77c46feeb1f7a",
+            .hash = "pugl-0.1.0-CUvtTlhhAQA-RfDm3c_ca42T3ZFNWV5_fYs-PocTj6L8",
             .lazy = true,
         },
     },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -95,8 +95,7 @@
             .lazy = true,
         },
         .tree_sitter = .{
-            .url = "git+https://github.com/david-vanderson/tree-sitter#c8cad6e16017a6bb6eb8a61fb1c1e7f23c552b4f",
-            .hash = "tree_sitter-0.27.0-Tw2sR72eCwCRZKEZND6TJIgdWq9ZnPV9g_syCHLyNEGe",
+            .path = "../lib-treesitter-dev-fork",
             .lazy = true,
         },
         .tree_sitter_json = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -25,12 +25,12 @@
             .hash = "SDL-2.32.10-JToi3xWNDwHurZ0fauisXvz7KLk930LjMx4jMj2thbwt",
             .lazy = true,
         },
-        // Fork of david-vanderson/SDL with an .ios case added to build.zig (upstream's
+        // Fork of castholm/SDL with an .ios case added to build.zig (upstream's
         // target-OS switch has none; see linkSdl3 in build.zig and examples/ios-example/README.md).
         // Additive only — every other target builds identically to the plain upstream fork.
         .sdl3 = .{
-            .url = "git+https://github.com/nat3Github/c-sdl3-dev?ref=c-sdl3-dev#1b6327496297ba0497b564e11f6701c8dffe6511",
-            .hash = "sdl-0.4.2+3.4.4-SDL--rzLpQH3XiTCKkSB_53M1pcNOpS3M4wJR9UwX7Lw",
+            .url = "git+https://github.com/nat3Github/c-lib-sdl3?ref=c-lib-sdl3#882cc1be83c54dfae94efc5e290057ff5b3a4559",
+            .hash = "sdl-0.5.4+3.4.16-SDL--rCOqAHObLVZlfe8mcfP70Q6IpV1b0IRpE4XecZs",
             .lazy = true,
         },
         .freetype = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -39,7 +39,7 @@
             .lazy = true,
         },
         .raylib = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev#18be7d3237a847d587354d20f8f4235fb8dbedf8",
+            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev#75f750636ef0f92e4edc292eda3b590889a6783a",
             .hash = "raylib-6.0.0-whq8uK76MwXEkoikCffqNyrF-jotnRfOM7tAkp6m2bY2",
             .lazy = true,
         },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -29,7 +29,7 @@
         // target-OS switch has none; see linkSdl3 in build.zig and examples/ios-example/README.md).
         // Additive only — every other target builds identically to the plain upstream fork.
         .sdl3 = .{
-            .url = "git+https://github.com/nat3Github/lib-sdl3-dev-fork?ref=ios-support#1b6327496297ba0497b564e11f6701c8dffe6511",
+            .url = "git+https://github.com/nat3Github/c-sdl3-dev?ref=c-sdl3-dev#1b6327496297ba0497b564e11f6701c8dffe6511",
             .hash = "sdl-0.4.2+3.4.4-SDL--rzLpQH3XiTCKkSB_53M1pcNOpS3M4wJR9UwX7Lw",
             .lazy = true,
         },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,7 +21,7 @@
     },
     .dependencies = .{
         .sdl = .{
-            .url = "git+https://github.com/nat3Github/c-sdl2-dev#a218e5dd4d9377ec6853e7f840196f9e7467501c",
+            .url = "git+https://github.com/nat3Github/c-sdl2-dev#3a661945f06c169e3c8164aab445cc1003564228",
             .hash = "SDL-2.32.10-JToi3xWNDwHurZ0fauisXvz7KLk930LjMx4jMj2thbwt",
             .lazy = true,
         },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,7 +21,7 @@
     },
     .dependencies = .{
         .sdl = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-sdl2-dev-fork#8eba48d19d43ae1f59043fea21d252c4205543fd",
+            .url = "git+https://github.com/nat3Github/c-sdl2-dev#a218e5dd4d9377ec6853e7f840196f9e7467501c",
             .hash = "SDL-2.32.10-JToi3xWNDwHurZ0fauisXvz7KLk930LjMx4jMj2thbwt",
             .lazy = true,
         },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,16 +21,16 @@
     },
     .dependencies = .{
         .sdl = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-sdl2-dev-fork#a7cc312755364cea993e5b55cd32dc6b0b50e109",
-            .hash = "SDL-2.32.10-JToi3wSNDgEJBnijet0mJnM5egbGpRBl_Zu-d5zJrILd",
+            .url = "git+https://github.com/nat3Github/zig-lib-sdl2-dev-fork#8eba48d19d43ae1f59043fea21d252c4205543fd",
+            .hash = "SDL-2.32.10-JToi3xWNDwHurZ0fauisXvz7KLk930LjMx4jMj2thbwt",
             .lazy = true,
         },
         // Fork of david-vanderson/SDL with an .ios case added to build.zig (upstream's
         // target-OS switch has none; see linkSdl3 in build.zig and examples/ios-example/README.md).
         // Additive only — every other target builds identically to the plain upstream fork.
         .sdl3 = .{
-            .url = "git+https://github.com/nat3Github/lib-sdl3-dev-fork?ref=ios-support#4b452f77bbce509d40664bb6f580d4846a718b4a",
-            .hash = "sdl-0.4.2+3.4.4-SDL--l77ngEMpAPw_lapBlyaTJFXIncEGnPPNHAsdEzC",
+            .url = "git+https://github.com/nat3Github/lib-sdl3-dev-fork?ref=ios-support#1b6327496297ba0497b564e11f6701c8dffe6511",
+            .hash = "sdl-0.4.2+3.4.4-SDL--rzLpQH3XiTCKkSB_53M1pcNOpS3M4wJR9UwX7Lw",
             .lazy = true,
         },
         .freetype = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -39,8 +39,8 @@
             .lazy = true,
         },
         .raylib = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev#5f00727dd6004d7a0d7bd59286ecdf9a4ab046f1",
-            .hash = "raylib-6.0.0-whq8uOzG3gCV-6hEKfFK620jOk0xn7ixJZinzpJA_bMV",
+            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev#18be7d3237a847d587354d20f8f4235fb8dbedf8",
+            .hash = "raylib-6.0.0-whq8uK76MwXEkoikCffqNyrF-jotnRfOM7tAkp6m2bY2",
             .lazy = true,
         },
         .wio = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -91,8 +91,7 @@
             .lazy = true,
         },
         .zglfw = .{
-            .url = "git+https://github.com/zig-gamedev/zglfw.git#d9c06187e8b23e91b2ba6865d265e4213e5e7d09",
-            .hash = "zglfw-0.10.0-dev-zgVDNC64IQCeL-_eVOA27Wa50WVitrJswOZVvgcXmIsy",
+            .path = "../zglfw-dev-fork",
             .lazy = true,
         },
         .tree_sitter = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -39,13 +39,13 @@
             .lazy = true,
         },
         .raylib = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev-fork#51b19a9759289cede2dc07a45dca1cd0c64f51d8",
+            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev#5eba2ba9523dbca8dc28cadb4b76e92996b0a2e6",
             .hash = "raylib-6.0.0-whq8uFFx7ABiA8UA7mW35st_T2lTi7RGBB0oPZOvQF5r",
             .lazy = true,
         },
         .wio = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-wio-dev-fork#8381ca0c4d4c84f7a9fa1d0a475ffbbd5fe6b59a",
-            .hash = "wio-0.0.0-8xHrryoECAB7XM0Uary4h2mm4S4iGAwFLGYEgtnq5xLY",
+            .url = "git+https://github.com/nat3Github/zig-lib-wio-dev#d8ef0f367cc63433b23b6ac7de417d7c6b851e99",
+            .hash = "wio-0.0.0-8xHrrxZWCAC1PHJiqowfiV0BeVDEXDZgHn44OQw95hfd",
             .lazy = true,
         },
         .opengl = .{
@@ -65,8 +65,8 @@
         },
         //used in the raylib-ontop example
         .raygui = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-raygui-dev-fork#62a3b50b71c271ab1afbf201d168c08dccc5c40c",
-            .hash = "N-V-__8AAIppBAC5cWi-1ZeNAWCL-wnmk1C5Trtdhu1w3NAs",
+            .url = "git+https://github.com/nat3Github/zig-lib-raygui-dev#940f944e00080635a364cf9b8ca69c5bc0a15100",
+            .hash = "raygui-4.0.0-AQz3LsDDBAD57ud6MkxGfe6VSUVUvnjvATWq-wo5-JOc",
             .lazy = true,
         },
         // required for the directx11 backend
@@ -89,22 +89,22 @@
 
         // Experimental zig bindings, any zig based backend will be located here
         .raylib_zig = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-raylib-zig-dev-fork#286dd3518da077c0989a06d39f5c38142bacfd0b",
-            .hash = "raylib_zig-6.0.0-KE8REO58BQCzNPBGTU2WbcPrj4HLvRyfXkqw2XW4Bm9L",
+            .url = "git+https://github.com/nat3Github/zig-lib-raylib-zig-dev#d8b71917cf4d5ade69d9e2bbd561a80dbd223a34",
+            .hash = "raylib_zig-6.0.0-KE8RENp8BQBLOkZKnMBkFX3RUVr27QDed9YgrDhmMQQQ",
             .lazy = true,
         },
         .zglfw = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-zglfw-dev-fork#9665cd606526406f34f56addb722e3d01665c370",
+            .url = "git+https://github.com/nat3Github/zig-lib-zglfw-dev#9d666196a159bf7a87c9492bd0b3c5fb4cb484ab",
             .hash = "zglfw-0.10.0-dev-zgVDNPeyIQCvez7MinH6mwntQBeBHJqxhwagyhYnGWm2",
             .lazy = true,
         },
         .tree_sitter = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-treesitter-dev-fork#f7e4a1b093a95e9fb64ad253697cac8bd60238dd",
+            .url = "git+https://github.com/nat3Github/zig-lib-treesitter-dev#7ebdcc10dc0cc5a6e19f693d959b2609f3e55666",
             .hash = "tree_sitter-0.27.0-Tw2sR1qNCwBw_B0VhkJL6S55tX5cjhbYGueUs4tSbV__",
             .lazy = true,
         },
         .tree_sitter_json = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-treesitter-json-dev-fork#d4875df5ab194cf1aff7ba962f2dec6f643090a6",
+            .url = "git+https://github.com/nat3Github/zig-lib-treesitter-json-dev#d4875df5ab194cf1aff7ba962f2dec6f643090a6",
             .hash = "N-V-__8AAFi4AABrZPLLDnDv2DvihRUbM7ZzHtJYLoqx-gHr",
             .lazy = true,
         },
@@ -119,8 +119,8 @@
             .lazy = true,
         },
         .pugl = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-pugl-dev-fork#3b6406b913e1e01c340cebd7eb5392de70c48025",
-            .hash = "pugl-0.1.0-CUvtThZeAQC7kezuc8jm1piz6mHH6Hl5e1JrBkcvwYco",
+            .url = "git+https://github.com/nat3Github/zig-lib-pugl-dev#4739855ba315d4ea90bb3a5a4f8b8fcaa41260ad",
+            .hash = "pugl-0.1.0-CUvtTg1eAQB2opdYQMqLobxrYZ7M8US1AEYdXCVtplQ_",
             .lazy = true,
         },
     },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -29,7 +29,7 @@
         // target-OS switch has none; see linkSdl3 in build.zig and examples/ios-example/README.md).
         // Additive only — every other target builds identically to the plain upstream fork.
         .sdl3 = .{
-            .url = "git+https://github.com/nat3Github/c-lib-sdl3?ref=c-lib-sdl3#882cc1be83c54dfae94efc5e290057ff5b3a4559",
+            .url = "git+https://github.com/nat3Github/c-lib-sdl-dev?ref=c-lib-sdl3#8cf6ebc9b2b0826c9005a106721ed828d3e85dfc",
             .hash = "sdl-0.5.4+3.4.16-SDL--rCOqAHObLVZlfe8mcfP70Q6IpV1b0IRpE4XecZs",
             .lazy = true,
         },
@@ -89,8 +89,8 @@
 
         // Experimental zig bindings, any zig based backend will be located here
         .raylib_zig = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-raylib-zig-dev#d8b71917cf4d5ade69d9e2bbd561a80dbd223a34",
-            .hash = "raylib_zig-6.0.0-KE8RENp8BQBLOkZKnMBkFX3RUVr27QDed9YgrDhmMQQQ",
+            .url = "git+https://github.com/nat3Github/zig-lib-raylib-zig-dev#7077a4e9f4997423f411eef38908be17893c4617",
+            .hash = "raylib_zig-6.0.0-KE8REKh-BQDegWBNAy1CgDXbLExyDeNeTXEhJwyGGfUY",
             .lazy = true,
         },
         .zglfw = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -39,8 +39,8 @@
             .lazy = true,
         },
         .raylib = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev#5eba2ba9523dbca8dc28cadb4b76e92996b0a2e6",
-            .hash = "raylib-6.0.0-whq8uFFx7ABiA8UA7mW35st_T2lTi7RGBB0oPZOvQF5r",
+            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev#5f00727dd6004d7a0d7bd59286ecdf9a4ab046f1",
+            .hash = "raylib-6.0.0-whq8uOzG3gCV-6hEKfFK620jOk0xn7ixJZinzpJA_bMV",
             .lazy = true,
         },
         .wio = .{
@@ -94,12 +94,12 @@
             .lazy = true,
         },
         .zglfw = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-zglfw-dev#9d666196a159bf7a87c9492bd0b3c5fb4cb484ab",
-            .hash = "zglfw-0.10.0-dev-zgVDNPeyIQCvez7MinH6mwntQBeBHJqxhwagyhYnGWm2",
+            .url = "git+https://github.com/nat3Github/zig-lib-zglfw-dev#ad7052461440f4bd62fa27e25d466ee102608baf",
+            .hash = "zglfw-0.10.0-dev-zgVDNKS0IQCR2YnCqqLHjIyUcob4yEWqFoqzSYO1ofJ_",
             .lazy = true,
         },
         .tree_sitter = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-treesitter-dev#7ebdcc10dc0cc5a6e19f693d959b2609f3e55666",
+            .url = "git+https://github.com/nat3Github/zig-lib-treesitter-dev#6658c8dafbdcb5b0720a3baf45ecbc675f579dd2",
             .hash = "tree_sitter-0.27.0-Tw2sR1qNCwBw_B0VhkJL6S55tX5cjhbYGueUs4tSbV__",
             .lazy = true,
         },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -39,8 +39,8 @@
             .lazy = true,
         },
         .raylib = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev?ref=lean-on-upstream#b3e0b32f95225a7309b18b0d8c37ae93a74aaf9b",
-            .hash = "raylib-6.0.0-whq8uHh67AA24bxniQFN1_c6vp8zbqiBSbMHg-2csfEa",
+            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev?ref=lean-on-upstream#e6e1161b438833ee4d79b35cc6032911c501d5d3",
+            .hash = "raylib-6.0.0-whq8uG167ADPog0Ws1cktWwXEbL7bIimtix37He3Bjlp",
             .lazy = true,
         },
         .wio = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,8 +21,8 @@
     },
     .dependencies = .{
         .sdl = .{
-            .url = "git+https://github.com/nat3Github/c-sdl2-dev?ref=c-sdl2-dev#64a7bf92d8d0b3fab6f6fec9b897615ea47a2bb6",
-            .hash = "SDL-2.32.10-JToi32WQDwGibHGY8qzkZmk9gDnGEqfr-qzTBJuJ6URg",
+            .url = "git+https://github.com/nat3Github/c-lib-sdl-dev?ref=c-sdl2-dev#55565e6de57dec3ce60247b9e3356b0fd08e12bd",
+            .hash = "SDL-2.32.10-JToi33WWDwHaviWWy6kQLPI3_sImfmM18_2H91tblgpN",
             .lazy = true,
         },
         // Fork of castholm/SDL with an .ios case added to build.zig (upstream's
@@ -39,8 +39,8 @@
             .lazy = true,
         },
         .raylib = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev#279a8e300f729be6450752bf86d38dbe18ef73d1",
-            .hash = "raylib-6.0.0-whq8uH37MwVkuXk1gUGy3kz-O6HlvOGF66QgU4KnYiY9",
+            .url = "git+https://github.com/nat3Github/zig-lib-raylib-dev?ref=lean-on-upstream#b3e0b32f95225a7309b18b0d8c37ae93a74aaf9b",
+            .hash = "raylib-6.0.0-whq8uHh67AA24bxniQFN1_c6vp8zbqiBSbMHg-2csfEa",
             .lazy = true,
         },
         .wio = .{
@@ -89,13 +89,13 @@
 
         // Experimental zig bindings, any zig based backend will be located here
         .raylib_zig = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-raylib-zig-dev#7077a4e9f4997423f411eef38908be17893c4617",
-            .hash = "raylib_zig-6.0.0-KE8REKh-BQDegWBNAy1CgDXbLExyDeNeTXEhJwyGGfUY",
+            .url = "git+https://github.com/nat3Github/zig-lib-raylib-zig-dev?ref=lean-main#59941caa7cc24f823203365a6e29cc6f76cc3ab5",
+            .hash = "raylib_zig-6.0.0-KE8REPp-BQD57qo2-MaQZDZbK09Xm3qet_Mp5T_ybJv-",
             .lazy = true,
         },
         .zglfw = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-zglfw-dev#9dac2daa9563d12b7c820adee3677b45f7fa3bcc",
-            .hash = "zglfw-0.10.0-dev-zgVDNCC3IQCUP2jIyVcHINGT4nuRaw0zddXOLHMLDD7i",
+            .url = "git+https://github.com/nat3Github/zig-lib-zglfw-dev?ref=main#1fea9e454205946e8fafc2ed0f52f1864d320306",
+            .hash = "zglfw-0.10.0-dev-zgVDNBnAIQAX3KpjOkP4rpnmC0sdHtVRGHNebQWcbadU",
             .lazy = true,
         },
         .tree_sitter = .{
@@ -119,8 +119,8 @@
             .lazy = true,
         },
         .pugl = .{
-            .url = "git+https://github.com/nat3Github/zig-lib-pugl-dev#47cf10dd039ba31eee2e72dc7ef77c46feeb1f7a",
-            .hash = "pugl-0.1.0-CUvtTlhhAQA-RfDm3c_ca42T3ZFNWV5_fYs-PocTj6L8",
+            .url = "git+https://github.com/nat3Github/zig-lib-pugl-dev?ref=main#7724d02801cb9262f389c271369a75bbe05b9f36",
+            .hash = "pugl-0.1.0-CUvtTrtoAQBoQlzyCNlhdKGZMSasOzlnpgdal4UltfjD",
             .lazy = true,
         },
     },

--- a/examples/glfw-opengl-ontop.zig
+++ b/examples/glfw-opengl-ontop.zig
@@ -28,7 +28,7 @@ pub fn main(main_init: std.process.Init) !void {
     zglfw.windowHint(.client_api, .opengl_api);
     // Optional
     zglfw.windowHint(.doublebuffer, true);
-    window = try zglfw.Window.create(640, 480, "Hello World", null);
+    window = try zglfw.Window.create(640, 480, "Hello World", null, null);
     // You need to call makeContextCurrent before calling any of the
     // backend functions
     zglfw.makeContextCurrent(window);

--- a/src/backends/glfw.zig
+++ b/src/backends/glfw.zig
@@ -671,6 +671,7 @@ pub fn main(main_init: std.process.Init) !void {
         @trunc(config.size.h),
         config.title,
         null,
+        null,
     );
 
     var renderer = blk: switch (dvui.render_backend.kind) {

--- a/src/backends/wio.zig
+++ b/src/backends/wio.zig
@@ -75,7 +75,16 @@ pub fn contentScale(self: *@This()) f32 {
 }
 
 pub fn clipboardText(self: *@This()) ![]const u8 {
-    return self.window.getClipboardText(self.arena) orelse "";
+    // wio's getClipboardText is callback-based to support async platforms (wasm/wayland),
+    // but win32/macos/x11 invoke the callback synchronously, so bridge to a sync return here.
+    var result: []const u8 = "";
+    self.window.getClipboardText(clipboardTextCallback, @ptrCast(&result));
+    return self.arena.dupe(u8, result) catch "";
+}
+
+fn clipboardTextCallback(data: ?*anyopaque, text: []const u8) void {
+    const result: *[]const u8 = @ptrCast(@alignCast(data.?));
+    result.* = text;
 }
 
 pub fn clipboardTextSet(self: *@This(), text: []const u8) !void {
@@ -131,7 +140,7 @@ pub fn renderPresent(_: *@This()) void {}
 pub fn textInputRect(self: *@This(), maybe_rect: ?dvui.Rect.Natural) void {
     if (maybe_rect) |rect| {
         // FIXME: not actually the cursor position
-        self.window.enableTextInput(.{ .cursor = .{ .x = std.math.lossyCast(u16, rect.x), .y = std.math.lossyCast(u16, rect.y) } });
+        self.window.enableTextInput(.{ .cursor = .{ .x = std.math.lossyCast(i16, rect.x), .y = std.math.lossyCast(i16, rect.y) } });
     } else {
         self.window.disableTextInput();
     }


### PR DESCRIPTION
tldr: our deps bundle a lot of stuff not actually needed for compilation, we also bundle apple sdks which is a legal risk.
closes #926 

```
# before
nat3@MacBookPro dvui % du -sh zig-pkg
427M    zig-pkg
  106.6 MiB ██▏       ▏/N-V-__8AALShqgXkvqYU6f__FrA22SMWmi2TXCJjNTO1m8XJ
   85.4 MiB █▋        ▏/raylib-6.0.0-whq8uOmvLgUktXC94fZkRLK2dQA75X2pMwZYj2X3EZl8
   85.1 MiB █▋        ▏/raylib-5.6.0-dev-whq8uGJqKQUEDd38DCov-XG29PYzw3kM_LNbPUkcDGyM
   45.1 MiB ▉         ▏/system_sdk-0.3.0-dev-alwUNnYaaAJAtIdE2fg4NQfDqEKs7QCXy_qYukAOBfmF
   30.7 MiB ▌         ▏/wio_macos_sdk-15.5.0-Q4Y7wxqRsAE1ifcDVRYPyFChElssvep3qd5-A_fPS5Jp
   30.0 MiB ▌         ▏/sdl-0.4.2+3.4.4-SDL--gqNpQF1CjofImvjmIBRf7mkJns3eCFIsRbucO1m
   29.9 MiB ▌         ▏/sdl-0.4.2+3.4.4-SDL--tB1pQFLgwvCakiiOSoZIuVaz6a6-_gOZC66AGRD
   20.7 MiB ▍         ▏/SDL-2.32.10-JToi37G3EgG0eraPos4vhCwC6vVgyB1FYf1SxxhpBr_Y
   12.6 MiB ▏         ▏/freetype-2.14.1-alzUkceCqgDRZIP8PnxnNCd8jwfbwY0k1VhlTV2O5Ivo
    7.7 MiB           ▏/N-V-__8AAHvybwBw1kyBGn0BW_s1RqIpycNjLf_XbE-fpLUF
    5.8 MiB           ▏/tree_sitter_zig-1.1.2-YNf2GAt8XACdbaWHHiNMMfw--bLN1Av1rMsnq6bokMdL
    5.6 MiB           ▏/N-V-__8AAAHFTwBfBg00dnFXcYkNbjC8BSyi1CDcrnh12ypL
    2.7 MiB           ▏/opengl-0.0.0-_Vp8-EjsKgDhnkUWeb8Nmr2oEdvsCsDq9bUgmcNi0SuQ
    2.3 MiB           ▏/zglfw-0.10.0-dev-zgVDNC64IQCeL-_eVOA27Wa50WVitrJswOZVvgcXmIsy
    1.7 MiB           ▏/N-V-__8AAKCfEACshieF5wx0Tk_fJ8iH9esTMxceOLIrEyvj
    1.4 MiB           ▏/N-V-__8AAJl1DwBezhYo_VE6f53mPVm00R-Fk28NPW7P14EQ
  920.0 KiB           ▏/tree_sitter-0.27.0-Tw2sR72eCwCRZKEZND6TJIgdWq9ZnPV9g_syCHLyNEGe
  684.0 KiB           ▏/zgl-1.1.0-p_NpAJNECgCzUGx0aF5KFsmD5VOwfw8LaOsN0fcoU2bi
  612.0 KiB           ▏/wio-0.0.0-8xHrr_kECABNBaGmnTW2ymwtaa-Oqg3CWN_tXK6KGFkZ
  424.0 KiB           ▏/svg2tvg-0.0.0-HpMZuaP8BQALdwSolfst0dPGUUn2ptqgfSxVs8RoQJ6K
  376.0 KiB           ▏/N-V-__8AAHNaAgD6kjK3HX6lAf89chPqS5zIm0tLpvBQLOtX
  372.0 KiB           ▏/raylib_zig-5.6.0-dev-KE8REKNmBQDek2Sz27ULioxYpY9IYR0K0CeIC-iJRLCI
  172.0 KiB           ▏/xml-0.2.0-ZTbP3yI6AgB9Rpd2hQrueO63ib0Bm6mQiL_WB1t7JAmP
  132.0 KiB           ▏/pugl-0.1.0-CUvtTsddAQAKB-zCXPw0YayfuVFRGB-ATuYPP1Nb3Xmv
  132.0 KiB           ▏/pugl-0.1.0-CUvtTm5dAQB7DY_J0RHTxDGSz1JNul6YlBpt_bp38kMe
   40.0 KiB           ▏/zemscripten-0.2.0-dev-sRlDqFJSAAB8hgnRt5DDMKP3zLlDtMnUDwYRJVCa5lGY
   40.0 KiB           ▏/zemscripten-0.2.0-dev-sRlDqApRAACspTbAZnuNKWIzfWzSYgYkb2nWAXZ-tqqt


# this branch
nat3@MacBookPro lib-dvui-lean-deps % du -sh zig-pkg  
90M    zig-pkg
   29.4 MiB ███       ▏/sdl-0.4.2+3.4.4-SDL--l77ngEMpAPw_lapBlyaTJFXIncEGnPPNHAsdEzC                
   20.3 MiB ██        ▏/SDL-2.32.10-JToi3wSNDgEJBnijet0mJnM5egbGpRBl_Zu-d5zJrILd                    
   15.2 MiB █▌        ▏/raylib-6.0.0-whq8uBmC7AA3lM_OwQ6yWE1Oppiyoee2IyGzgbEBkr3L                   
   12.6 MiB █▎        ▏/freetype-2.14.1-alzUkceCqgDRZIP8PnxnNCd8jwfbwY0k1VhlTV2O5Ivo                
    5.8 MiB ▌         ▏/tree_sitter_zig-1.1.2-YNf2GAt8XACdbaWHHiNMMfw--bLN1Av1rMsnq6bokMdL          
    2.7 MiB ▏         ▏/opengl-0.0.0-_Vp8-EjsKgDhnkUWeb8Nmr2oEdvsCsDq9bUgmcNi0SuQ                   
    2.3 MiB ▏         ▏/zglfw-0.10.0-dev-zgVDNPeyIQCvez7MinH6mwntQBeBHJqxhwagyhYnGWm2               
  916.0 KiB           ▏/tree_sitter-0.27.0-Tw2sR1qNCwBw_B0VhkJL6S55tX5cjhbYGueUs4tSbV__             
  684.0 KiB           ▏/zgl-1.1.0-p_NpAJNECgCzUGx0aF5KFsmD5VOwfw8LaOsN0fcoU2bi                      
  612.0 KiB           ▏/wio-0.0.0-8xHrryoECAB7XM0Uary4h2mm4S4iGAwFLGYEgtnq5xLY                      
  476.0 KiB           ▏/pugl-0.4.0-sVTl0TNnBQBSjAyctAh5h6b6dAWgH36eN9OOywpCF8BT                     
  424.0 KiB           ▏/svg2tvg-0.0.0-HpMZuaP8BQALdwSolfst0dPGUUn2ptqgfSxVs8RoQJ6K                  
  380.0 KiB           ▏/raylib_zig-6.0.0-KE8REO58BQCzNPBGTU2WbcPrj4HLvRyfXkqw2XW4Bm9L               
  304.0 KiB           ▏/N-V-__8AAIppBAC5cWi-1ZeNAWCL-wnmk1C5Trtdhu1w3NAs                            
  180.0 KiB           ▏/emsdk-4.0.9-AsAhn3VZAgD1hm4JoUhnXFy52dLjEFXBmYvo2ObTosCR                    
  172.0 KiB           ▏/xml-0.2.0-ZTbP3yI6AgB9Rpd2hQrueO63ib0Bm6mQiL_WB1t7JAmP                      
  132.0 KiB           ▏/pugl-0.1.0-CUvtThZeAQC7kezuc8jm1piz6mHH6Hl5e1JrBkcvwYco                     
   68.0 KiB           ▏/N-V-__8AAFi4AABrZPLLDnDv2DvihRUbM7ZzHtJYLoqx-gHr                            
   40.0 KiB           ▏/zemscripten-0.2.0-dev-sRlDqApRAACspTbAZnuNKWIzfWzSYgYkb2nWAXZ-tqqt   
```
- strips most binaries that are used for building (cross-compiling some targets), especially apple sdks (legal importance)
- strips other build systems, unneeded examples, sources, tests, images etc. from dependencies
- deduplicates deps



TODO(future):
think about how we (dvui main) keep our dependencies lean.
add documentation table for cross compilation that exactly documents system sdk build dependencies across backends and configurations and a Help Section how to set up sysroot for cross compilation
