### PR TITLE
std3gpu: reset manage backend tracker for external cmdbuffer case/lqvqklltsmur

### DIFF
--- a/examples/sdl3gpu-ontop.zig
+++ b/examples/sdl3gpu-ontop.zig
@@ -76,13 +76,11 @@ pub fn main(main_init: std.process.Init) !void {
                     const kmod_ctrl = c.SDL_KMOD_CTRL;
                     if (((mod & kmod_ctrl) > 0) and key == key_q) {
                         _ = try win.end(.{});
-                        backend.renderPresent();
                         break :main_loop;
                     }
                 },
                 c.SDL_EVENT_QUIT => {
                     _ = try win.end(.{});
-                    backend.renderPresent();
                     break :main_loop;
                 },
                 else => {},

--- a/src/backends/sdl3gpu.zig
+++ b/src/backends/sdl3gpu.zig
@@ -1134,6 +1134,7 @@ pub fn prefersReducedMotion(_: *@This()) bool {
 pub fn begin(self: *SDLBackend, arena: std.mem.Allocator) !void {
     self.arena = arena;
     self.frame_uploads.reset();
+    self.manage_backend_tracking.reset_begin();
     if (self.cmd != null) {
         self.external_cmdbuffer = true;
         return;
@@ -1158,7 +1159,6 @@ pub fn begin(self: *SDLBackend, arena: std.mem.Allocator) !void {
         self.swapchain_texture = null;
         return;
     }
-    self.manage_backend_tracking.reset_begin();
 }
 
 pub fn finishRenderingCurrentTarget(self: *SDLBackend, final: bool) !void {


### PR DESCRIPTION
In case of externally managed command buffer (sdl3gpu-ontop example) it was never reset which caused it to spam incorrect warnings.

Also removed calls to `renderPresent` for this example since they are already called in `win.end`