### PR TITLE
Change render_backend selection behaivior

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -163,7 +163,7 @@ pub fn build(b: *std.Build) !void {
 
     var back_to_build = b.option(Backend, "backend", "Backend to build");
     const render_backend = b.option(RenderBackend, "renderer", "Render backend to build (default: implied by backend)") orelse .default;
-    if (render_backend == .vulkan) {
+    if (render_backend == .vulkan or render_backend == .vulkan_external) {
         if (back_to_build) |backend| {
             if (backend != .wio and backend != .custom) @panic("the Vulkan render backend currently supports -Dbackend=wio or -Dbackend=custom");
         } else {
@@ -440,7 +440,7 @@ pub fn buildBackend(
     switch (backend) {
         .custom => {
             dvui_opts.setDefaults(.{ .libc = false, .freetype = false, .tiny_file_dialogs = false, .stb_image = false, .tree_sitter = true });
-            const expose_vulkan_renderer = dvui_opts.render_backend == .vulkan;
+            const expose_vulkan_renderer = dvui_opts.render_backend == .vulkan_external;
             if (expose_vulkan_renderer) dvui_opts.render_backend = .default;
 
             // For export to users who are bringing their own backend.  Use in your build.zig:
@@ -1119,7 +1119,7 @@ pub fn buildBackend(
                 .target = target,
                 .optimize = optimize,
                 .enable_opengl = (dvui_opts.render_backend == .opengl),
-                .enable_vulkan = (dvui_opts.render_backend == .vulkan),
+                .enable_vulkan = (dvui_opts.render_backend == .vulkan or dvui_opts.render_backend == .vulkan_external),
                 .enable_joystick = dvui_opts.wio_joystick,
                 .enable_audio = dvui_opts.wio_audio,
                 .unix_backends = dvui_opts.wio_unix_backends,
@@ -1417,6 +1417,15 @@ pub fn addDvuiModule(
             const vulkan = b.lazyDependency("vulkan", .{ .registry = registry }) orelse return dvui_mod;
             renderer_mod.addImport("vk", vulkan.module("vulkan-zig"));
             renderer_mod.addImport("wio", opts.wio_module orelse @panic("Vulkan renderer requires the wio module"));
+        },
+        .vulkan_external => {
+            renderer_mod.root_source_file = b.path("src/backends/render/vulkan/renderer.zig");
+            const registry = if (b.graph.environ_map.get("VULKAN_SDK")) |sdk|
+                std.Build.LazyPath{ .cwd_relative = b.pathJoin(&.{ sdk, "share", "vulkan", "registry", "vk.xml" }) }
+            else
+                (b.lazyDependency("vulkan_headers", .{}) orelse return dvui_mod).path("registry/vk.xml");
+            const vulkan = b.lazyDependency("vulkan", .{ .registry = registry }) orelse return dvui_mod;
+            renderer_mod.addImport("vk", vulkan.module("vulkan-zig"));
         },
     }
     renderer_mod.addImport("dvui", dvui_mod);

--- a/src/backends/render/vulkan.zig
+++ b/src/backends/render/vulkan.zig
@@ -324,7 +324,7 @@ fn beginInternal(self: *@This(), arena: std.mem.Allocator, physical_size: dvui.S
     if (self.dvui_frame_active) return error.FrameAlreadyActive;
 
     try self.renderer.beginFrame(self.slots[self.current_slot].command_buffer, self.extent);
-    self.renderer.begin(arena, physical_size);
+    try self.renderer.beginWithSize(arena, physical_size);
     self.dvui_frame_active = true;
 }
 
@@ -694,8 +694,8 @@ fn present(self: *@This()) !void {
 
 pub fn clear(_: *@This()) void {}
 
-pub fn drawClippedTriangles(self: *@This(), _: dvui.Size.Physical, texture: ?dvui.Texture, vertices: []const dvui.Vertex, indices: []const dvui.Vertex.Index, clip: ?dvui.Rect.Physical) dvui.Backend.GenericError!void {
-    if (self.frame_active) self.renderer.drawClippedTriangles(texture, vertices, indices, clip);
+pub fn drawClippedTriangles(self: *@This(), size: dvui.Size.Physical, texture: ?dvui.Texture, vertices: []const dvui.Vertex, indices: []const dvui.Vertex.Index, clip: ?dvui.Rect.Physical) dvui.Backend.GenericError!void {
+    if (self.frame_active) try self.renderer.drawClippedTriangles(size, texture, vertices, indices, clip);
 }
 
 pub fn textureCreate(self: *@This(), pixels: [*]const u8, options: dvui.Texture.CreateOptions) dvui.Backend.TextureError!dvui.Texture {
@@ -719,7 +719,7 @@ pub fn textureClearTarget(self: *@This(), texture: dvui.Texture.Target) void {
 }
 
 pub fn textureDestroyTarget(self: *@This(), texture: dvui.Texture.Target) void {
-    self.renderer.textureDestroy(dvui.Texture.cast(texture));
+    self.renderer.textureDestroyTarget(texture);
 }
 
 pub fn textureFromTarget(self: *@This(), texture: dvui.TextureTarget) dvui.Backend.TextureError!dvui.Texture {

--- a/src/backends/render/vulkan/renderer.zig
+++ b/src/backends/render/vulkan/renderer.zig
@@ -35,6 +35,8 @@ const fs_spv align(64) = @embedFile("dvui.frag.spv").*;
 
 const Self = @This();
 
+pub const kind: dvui.enums.RenderBackend = .vulkan_external;
+
 /// Vulkan declarations used by this renderer. Custom backends should use this
 /// re-export so their handles have the same generated Zig types.
 pub const vulkan = vk;
@@ -880,7 +882,7 @@ pub fn endFrame(self: *Self) !RecordedFrame {
 //
 const Backend = Self;
 
-pub fn begin(self: *Self, arena: std.mem.Allocator, framebuffer_size: dvui.Size.Physical) void {
+pub fn beginWithSize(self: *Self, arena: std.mem.Allocator, framebuffer_size: dvui.Size.Physical) !void {
     _ = arena; // autofix
     self.active_render_target = null;
     if (self.cmdbuf == .null_handle) @panic("dvui_vulkan_renderer: Command bufer not set! (missing beginFrame()?)");
@@ -906,7 +908,7 @@ pub fn begin(self: *Self, arena: std.mem.Allocator, framebuffer_size: dvui.Size.
     dev.cmdPushConstants(cmdbuf, self.pipeline_layout, .{ .vertex_bit = true }, 0, @sizeOf(PushConstants), &push_constants);
 }
 
-pub fn end(self: *Backend) void {
+pub fn end(self: *Backend) !void {
     defer self.frame_active = false;
     const prepass = self.finishPrepass() catch |err| {
         slog.err("failed to finalize renderer prepass: {}", .{err});
@@ -1002,7 +1004,7 @@ pub fn pixelSize(self: *Backend) Size {
     return .{ .w = @floatFromInt(self.framebuffer_size.width), .h = @floatFromInt(self.framebuffer_size.height) };
 }
 
-pub fn drawClippedTriangles(self: *Backend, texture_: ?dvui.Texture, vtx: []const Vertex, idx: []const Index, clipr: ?dvui.Rect.Physical) void {
+pub fn drawClippedTriangles(self: *Backend, _: dvui.Size.Physical, texture_: ?dvui.Texture, vtx: []const Vertex, idx: []const Index, clipr: ?dvui.Rect.Physical) !void {
     const texture: ?*anyopaque = if (texture_) |t| @as(*anyopaque, @ptrCast(@alignCast(t.ptr))) else null;
     if (texture != null and texture.? != invalid_texture) {
         const tex: *Texture = @ptrCast(@alignCast(texture.?));
@@ -1210,6 +1212,10 @@ pub fn textureDestroy(self: *Backend, texture: dvui.Texture) void {
     self.destroy_textures[dslot] = @intCast((@intFromPtr(texture.ptr) - @intFromPtr(self.textures.ptr)) / @sizeOf(Texture));
     self.current_frame.destroy_textures_len += 1;
     // slog.debug("schedule destroy texture: {} ({x})", .{ self.destroy_textures[dslot], @intFromPtr(texture) });
+}
+
+pub fn textureDestroyTarget(self: *@This(), texture: dvui.Texture.Target) void {
+    self.textureDestroy(dvui.Texture.cast(texture));
 }
 
 /// Read pixel data (RGBA) from `texture` into `pixels_out`.

--- a/src/enums_backend.zig
+++ b/src/enums_backend.zig
@@ -26,4 +26,5 @@ pub const RenderBackend = enum {
     default,
     opengl,
     vulkan,
+    vulkan_external,
 };


### PR DESCRIPTION
When implementing my vulkan App i noticed that the wio backend can be used nicely on custom a vulkan Context with few changes. Without this change the wio_backend implementation has to be copied to the app even if it could reuse its code (saves the app 500 Lines of code). The names are a bit confusing but i think they are now more clear than before. The vulkan_wio render_backend creates the vulkan context and is dependent on wio, the vulkan render_backend is the dvui_vulkan_renderer now and can also be used with the wio backend, when provided a vulkan context.

The code that is now possible without creating a custom backend when selecting .wio and .vulkan:
```
   const backend_ptr: *dvui.backend = try self.alloc.create(dvui.backend);
    backend_ptr.* = try dvui.backend.init(
        .{
            .io = self.io,
            .window = self.window,
        },
    );

    const backend_renderer: *dvui.render_backend = try self.alloc.create(dvui.render_backend);
    backend_renderer.* = try dvui.render_backend.init(
        self.alloc,
        .{
            .dev = self.device,
            .gpu_allocator = .{ .builtin = memory },
            .render_pass = .{ .static = .{
                .render_pass = self.render_pass,
                .subpass = 0,
            } },
            .graphics_queue_family_index = self.graphics_queue_index,
            .max_frames_in_flight = 4,
        },
    );

    try self.dvui_win = dvui.Window.init(@src(), self.alloc, backend_ptr.backend(&backend_renderer.*), .{});

```

Would you be interested in a example application which renders a triangle and floating window with wio and a simple vulkan context. It has about 700 lines of code and build.zig with about 170 which runs on at least linux and android.